### PR TITLE
Add browser icon to version badges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,8 @@ GitHub Enterprise is also supported. More info in the options.
 
 ## Install
 
-- [**Chrome** extension][link-cws] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?label=%20">][link-cws]
-- [**Firefox** add-on][link-amo] [<img valign="middle" src="https://img.shields.io/amo/v/refined-github-.svg?label=%20">][link-amo]
+- [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?logo=google%20chrome&label=Chrome%20Extension">][link-cws]
+- [<img valign="middle" src="https://img.shields.io/amo/v/refined-github-.svg?logo=mozilla%20firefox&label=Firefox%20Add-On">][link-amo]
 - **Opera** extension: Use [this Opera extension](https://addons.opera.com/en/extensions/details/download-chrome-extension-9/) to install the Chrome version.
 
 


### PR DESCRIPTION
Shields recently added support for [simple-icons](https://simpleicons.org) for using various icons on badges.

### Before

![Without browser icon](https://user-images.githubusercontent.com/10276208/45677742-8fdae580-bb52-11e8-8744-311f2a11d809.png)


### After

![Browser icon with description](https://user-images.githubusercontent.com/10276208/45677792-b39e2b80-bb52-11e8-83d4-5c9707409e48.png)

<details>
<summary>Alternate: Just add icon to badge without modifying the labels</summary>

![Browser icon only](https://user-images.githubusercontent.com/10276208/45677698-776acb00-bb52-11e8-9d2b-7dda65a4aa50.png)

</details>



