### PR TITLE
Fix `quick review buttons` bugs

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -231,6 +231,7 @@ function ajaxedPagesHandler() {
 		enableFeature(waitForBuild);
 		enableFeature(hideInactiveDeployments);
 		enableFeature(addPullRequestHotkey);
+		enableFeature(addQuickReviewButtons);
 	}
 
 	if (pageDetect.isPR() || pageDetect.isIssue()) {
@@ -283,7 +284,6 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 		enableFeature(addPrevNextButtonsToPRs);
 		enableFeature(preserveWhitespaceOptionInNav);
-		enableFeature(addQuickReviewButtons);
 	}
 
 	if (pageDetect.isPRFiles()) {

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -7,13 +7,15 @@ const btnClassMap = {
 };
 
 export default function () {
-	const submitButton = select('#submit-review [type="submit"]');
-	const container = select('#submit-review .form-actions');
-	const radios = select.all('#submit-review [type="radio"][name="pull_request_review[event]"]');
+	const form = select('[action$="/reviews"]');
+	const radios = select.all('[type="radio"][name="pull_request_review[event]"]', form);
 
 	if (radios.length === 0) {
 		return;
 	}
+
+	const submitButton = select('[type="submit"]', form);
+	const container = select('.form-actions', form);
 
 	// Set the default action for cmd+enter to Comment
 	if (radios.length > 1) {
@@ -21,8 +23,7 @@ export default function () {
 			<input
 				type="hidden"
 				name="pull_request_review[event]"
-				value="comment"/>,
-
+				value="comment"/>
 		);
 	}
 
@@ -40,13 +41,13 @@ export default function () {
 		}
 	}
 
-	// Make sure that the comment and cancel buttons are last
+	// Comment button must be last; cancel button must be first
 	if (radios.length > 1) {
-		container.append(select('#submit-review button[value="comment"]'));
-		const cancelReview = select('#submit-review .review-cancel-button');
+		container.append(select('button[value="comment"]', form));
+		const cancelReview = select('.review-cancel-button', form);
 		if (cancelReview) {
 			cancelReview.classList.add('float-left');
-			container.append(cancelReview);
+			container.prepend(cancelReview);
 		}
 	}
 
@@ -57,10 +58,10 @@ export default function () {
 	submitButton.remove();
 
 	// Freeze form to avoid duplicate submissions
-	select('#submit-review').addEventListener('submit', () => {
+	form.addEventListener('submit', () => {
 		// Delay disabling the fields to let them be submitted first
 		setTimeout(() => {
-			for (const control of select.all('#submit-review button, #submit-review textarea')) {
+			for (const control of select.all('button, textarea', form)) {
 				control.disabled = true;
 			}
 		});


### PR DESCRIPTION
Fixes #1290 

# Test 1

[`8dce75d`@#1241](https://github.com/sindresorhus/refined-github/pull/1241/commits/8dce75db4fd9d30a5aff460f62b83d0032c67fd6) (the _Review_ dropdown should not have radios)

# Test 2

1. Start a review by leaving a comment
2. visit the Conversation tab
3. refresh
4. your pending content should be there + the Review form should not have radios.