### PR TITLE
Remove migration for the `collapse-wiki-sections` feature that was recently removed

### DIFF
--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -20,7 +20,6 @@ const defaults = Object.assign({
 
 // TODO[2021-10-01]: Drop classes `muted-link`, `link-gray`, `link-gray-dark`, `text-gray`, `text-gray-light`, `text-gray-dark`, `text-green`, `text-red` `text-blue` #4021
 const migrations = [
-	featureWasRenamed('collapse-markdown-sections', 'collapse-wiki-sections'), // Merged in May
 	featureWasRenamed('separate-draft-pr-button', 'one-click-pr-or-gist'), // Merged in May
 	featureWasRenamed('prevent-pr-commit-link-loss', 'prevent-link-loss'), // Merged in May
 	featureWasRenamed('remove-projects-tab', 'remove-unused-repo-tabs'), // Merged in July


### PR DESCRIPTION
The `collapse-wiki-sections` feature was dropped in 732206658130af044c6ab6c5dc2a4c878e4b82ae (#4690), so it's no longer necessary to migrate the value from its old name