### PR TITLE
Meta: Remove leftover `collapse-markdown-sections.css`

### DIFF
--- a/source/features/collapse-markdown-sections.css
+++ b/source/features/collapse-markdown-sections.css
@@ -1,7 +1,0 @@
-.markdown-body a :is(h1, h2, h3, h4, h5, h6) {
-	cursor: initial;
-}
-
-.rgh-collapse-markdown-selections .markdown-body > :is(h1, h2, h3, h4, h5, h6) {
-	cursor: pointer;
-}


### PR DESCRIPTION
The `collapse-markdown-sections` feature was renamed to `collapse-wiki-sections` in 36a5a736471879e2515c12d0ba5e60ddcf8b37b2 (#4335) and the `collapse-wiki-sections` feature was dropped in 732206658130af044c6ab6c5dc2a4c878e4b82ae (#4690), so this CSS file is now dead code.