### PR TITLE
Add `hide-public-badge` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,7 +386,7 @@ Thanks for contributing! 🦋🙌
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
 - [](# "global-search-filters") [Adds search filters in global search page: forks, private repos, own repos, authored commits.](https://user-images.githubusercontent.com/44045911/112261285-88a66c80-8ca6-11eb-82cb-933b72c57abd.png)
-- [](# "hide-public-badge") [Hides "Public" repository badge or removes "Public" prefix](https://user-images.githubusercontent.com/44045911/132693134-ffa6a0fa-5366-447f-8e49-deda12884bd7.png)
+- [](# "hide-public-badge") [Hides "Public" repository badge or removes "Public" prefix.](https://user-images.githubusercontent.com/44045911/132693134-ffa6a0fa-5366-447f-8e49-deda12884bd7.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -386,6 +386,7 @@ Thanks for contributing! 🦋🙌
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
 - [](# "global-search-filters") [Adds search filters in global search page: forks, private repos, own repos, authored commits.](https://user-images.githubusercontent.com/44045911/112261285-88a66c80-8ca6-11eb-82cb-933b72c57abd.png)
+- [](# "hide-public-badge") [Hides "Public" repository badge or removes "Public" prefix](https://user-images.githubusercontent.com/44045911/132693134-ffa6a0fa-5366-447f-8e49-deda12884bd7.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -7,6 +7,6 @@
 }
 
 /* Adds space between `ci-link` and "Private" label, if present */
-.rgh-ci-link .Label + .commit-build-statuses {
+.rgh-ci-link .Label:not([hidden]) + .commit-build-statuses {
 	margin-left: 8px;
 }

--- a/source/features/hide-public-badge.tsx
+++ b/source/features/hide-public-badge.tsx
@@ -8,7 +8,7 @@ function init(): void {
 	observe('[itemprop^="name"] + .Label, .pinned-item-list-item-content .Label, .Popover .f5 + .Label', {
 		constructor: HTMLElement,
 		add(badge) {
-			const newText = badge.textContent!.replace(/Public ?/, '');
+			const newText = badge.textContent!.replace(/^Public ?/, '');
 
 			if (newText === '') {
 				badge.hidden = true;
@@ -20,6 +20,5 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	awaitDomReady: false,
 	init: onetime(init),
 });

--- a/source/features/hide-public-badge.tsx
+++ b/source/features/hide-public-badge.tsx
@@ -1,0 +1,25 @@
+import onetime from 'onetime';
+import {observe} from 'selector-observer';
+
+import features from '.';
+import {upperCaseFirst} from '../github-helpers';
+
+function init(): void {
+	observe('[itemprop^="name"] + .Label, .pinned-item-list-item-content .Label, .Popover .f5 + .Label', {
+		constructor: HTMLElement,
+		add(badge) {
+			const newText = badge.textContent!.replace(/Public ?/, '');
+
+			if (newText === '') {
+				badge.hidden = true;
+			} else {
+				badge.textContent = upperCaseFirst(newText);
+			}
+		},
+	});
+}
+
+void features.add(__filebasename, {
+	awaitDomReady: false,
+	init: onetime(init),
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -213,3 +213,4 @@ import './features/list-prs-for-branch';
 import './features/comment-on-draft-pr-indicator';
 import './features/select-notifications';
 import './features/clean-repo-tabs';
+import './features/hide-public-badge';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Close #4767

~~I wonder if it's fine to put this in `refined-github.css` since it also hides other badges on repository home. But as I mentioned the icon already indicates that and myself are voting for hiding that even if GitHub didn't make this change.~~

~~Also, the margin for `ci-link` is dropped but GHE may still need it. I'm not sure how to handle...~~

## Test URLs

> * Profile page: https://github.com/sindresorhus
> * Repo list: https://github.com/sindresorhus?tab=repositories&type=source
> * Repo page: https://github.com/sindresorhus/refined-github

## Screenshot

