### PR TITLE
Enable `quick-comment-edit` for users with write acess

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -8,16 +8,17 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditEveryComment(): boolean {
-	return pageDetect.canUserEditRepo() || select.exists([
-		// These are only found if you left any comments on the page
+	return select.exists([
+		// If you can lock conversations, you have write access
+		'.lock-toggle-link',
+
+		// Some pages like `isPRFiles` does not have a lock button
+		// These elements only exist if you commented on the page
 		'[aria-label^="You have been invited to collaborate"]',
 		'[aria-label^="You are the owner"]',
 		'[title^="You are a maintainer"]',
 		'[title^="You are a collaborator"]',
-
-		// If you can lock conversations, you have write access
-		'.lock-toggle-link',
-	]);
+	]) || pageDetect.canUserEditRepo();
 }
 
 function init(): void {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4889

According to https://docs.github.com/en/communities/moderating-comments-and-conversations/locking-conversations, if you have write access, then you can lock conversations, and vice versa. So we look for a lock link as well.

## Test URLs

Here? 😃

This should work on pages with "Lock conversation" links, as far as I know that includes:

- `isIssue`
- `isPRConversation`
- `isSingleCommit`

## Screenshot

Before:
![image](https://user-images.githubusercontent.com/44045911/136434957-4147d96b-416d-40fb-88f3-4158c0be8122.png)


After: 
![image](https://user-images.githubusercontent.com/44045911/136434981-80add999-1289-42a3-aaaa-94d61484eea4.png)

