### PR TITLE
Restore `restore-file` on forks

### DIFF
--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -186,7 +186,7 @@ export const v4 = mem(async (
 			Authorization: `bearer ${personalToken}`,
 		},
 		method: 'POST',
-		body: JSON.stringify({query: query.trimStart().startsWith('mutation') ? query : `{${query}}`}),
+		body: JSON.stringify({query: `{${query}}`}),
 	});
 
 	const apiResponse: GraphQLResponse = await response.json();


### PR DESCRIPTION
Reverts refined-github/refined-github#4803 in whole

It doesn't work in forks 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 

Yet another half-assed feature by GitHub. Sad.

## Main


![](https://user-images.githubusercontent.com/1402241/136661660-e6cd4f17-5f36-4368-a857-43660c65d70b.gif)



## This PR

![](https://user-images.githubusercontent.com/1402241/136661828-5642ecef-0c9e-409a-b3bd-d95ce8297b49.gif)


