### PR TITLE
Fix `prevent-link-loss` on new release and custom issue forms

### DIFF
--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -19,7 +19,7 @@ import {createRghIssueLink} from '../helpers/rgh-issue-link';
 
 function handleButtonClick({delegateTarget: fixButton}: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #4678 */
-	const field = fixButton.form!.querySelector('textarea.comment-form-textarea')!;
+	const field = fixButton.form!.querySelector('textarea.js-comment-field')!;
 	textFieldEdit.replace(field, prCommitUrlRegex, preventPrCommitLinkLoss);
 	textFieldEdit.replace(field, prCompareUrlRegex, preventPrCompareLinkLoss);
 	textFieldEdit.replace(field, discussionUrlRegex, preventDiscussionLinkLoss);
@@ -45,7 +45,7 @@ function isVulnerableToLinkLoss(value: string): boolean {
 const updateUI = debounceFn(({delegateTarget: field}: delegate.Event<Event, HTMLTextAreaElement>): void => {
 	if (!isVulnerableToLinkLoss(field.value)) {
 		getUI(field).remove();
-	} else if (pageDetect.isNewIssue() || pageDetect.isCompare()) {
+	} else if (pageDetect.isNewIssue() || pageDetect.isNewRelease() || pageDetect.isCompare()) {
 		select('file-attachment', field.form!)!.append(
 			<div className="mt-2">{getUI(field)}</div>,
 		);
@@ -59,7 +59,7 @@ const updateUI = debounceFn(({delegateTarget: field}: delegate.Event<Event, HTML
 });
 
 function init(): void {
-	delegate(document, 'form#new_issue textarea, form.js-new-comment-form textarea, textarea.comment-form-textarea', 'input', updateUI);
+	delegate(document, 'form:is(#new_issue, #new_release) textarea, form.js-new-comment-form textarea, textarea.comment-form-textarea', 'input', updateUI);
 	delegate(document, '.rgh-prevent-link-loss', 'click', handleButtonClick);
 }
 


### PR DESCRIPTION
Fixes #4678 

## Test URLs
Try to paste `https://github.com/sindresorhus/refined-github/pull/4677/commits/419c37c29ed4f4961d48495fadc951140c249f99` in:
* The comment field at the bottom of this page
* [New review comments & main review comment fields](https://github.com/refined-github/refined-github/pull/4912/files)
* [New issue description (classic)](https://github.com/fregante/github-url-detection/issues/new)
* [Custom new issue form fields](https://github.com/refined-github/refined-github/issues/new?assignees=&labels=enhancement%2C+under+discussion&template=2_feature_request.yml)
* [New release description](https://github.com/refined-github/refined-github/releases/new)
* [Compare page (new PR body text)](https://github.com/refined-github/refined-github/compare/main...3128113902:incremental-tag-changelog-link)

## Screenshot

https://user-images.githubusercontent.com/46634000/136904669-b49c6126-351f-4640-9b67-d1512257f8d7.mp4