### PR TITLE
Fix `releases-tab` highlighting

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -46,10 +46,6 @@ const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? par
 const deinit: VoidFunction[] = [];
 
 async function updateReleasesTabHighlighting(): Promise<void> {
-	if (!pageDetect.isReleasesOrTags()) {
-		return;
-	}
-
 	const selectorObserver = observe('.UnderlineNav-item.selected:not(.rgh-releases-tab)', {
 		add(selected) {
 			selected.classList.remove('selected');
@@ -117,7 +113,7 @@ void features.add(__filebasename, {
 	init,
 }, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.isReleasesOrTags,
 	],
 	awaitDomReady: false,
 	deduplicate: false,


### PR DESCRIPTION
Fixes #4903 

## Test URLs
Go to https://github.com/refined-github/refined-github and click on the latest release tag in the sidebar

## Screenshot
https://user-images.githubusercontent.com/46634000/136914956-83b957ae-88c4-49f6-8fc6-4b4126a84965.mp4
