### PR TITLE
Fix deduplication of `next-scheduled-github-action`

### DIFF
--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -87,5 +87,6 @@ void features.add(__filebasename, {
 		pageDetect.isRepositoryActions,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 });


### PR DESCRIPTION
Follow-up of #4825 

## Test URLs
1. Refresh this page
2. Click on the "Actions" tab
3. `(next in 18 days)` should appear next to the "Release" workflow

## Screenshot
https://user-images.githubusercontent.com/46634000/137347007-2b150b36-b9c5-450f-bfdd-e899d7ec7411.mp4