### PR TITLE
Save unnecessary redirects in `reactions-avatars`

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -43,7 +43,8 @@ function getParticipants(button: HTMLButtonElement): Participant[] {
 
 		// If it's not a bot, use a shortcut URL #2125
 		if (cleanName === username) {
-			const imageUrl = `https://avatars.githubusercontent.com/${username}?size=${window.devicePixelRatio * 20}`;
+			const size = `?size=${window.devicePixelRatio * 20}`;
+			const imageUrl = (pageDetect.isEnterprise() ? `/${username}.png` : `https://avatars.githubusercontent.com/${username}`) + size;
 			participants.push({button, imageUrl});
 		}
 	}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

When I was working on https://github.com/refined-github/refined-github/issues/4906#issuecomment-940602726 (P.S. you may like it), I stumbled upon [this Stack Overflow question](https://stackoverflow.com/questions/22932422/get-github-avatar-from-email-or-name) (spoiler: the accepted answer doesn't answer the original question at all), which provides an avatars endpoint `https://avatars.githubusercontent.com/<username>` that **doesn't send redirects** like `https://github.com/<username>.png`.


## Test URLs
https://togithub.com/refined-github/refined-github/issues/4901

## Screenshot
Before:

![image](https://user-images.githubusercontent.com/44045911/137346764-a42907bf-81de-4f5b-a0e0-b8cd6a42fce1.png)

(Yup, it's a 302 - Eternal Penalty.)

After:

![image](https://user-images.githubusercontent.com/44045911/137346779-69d57148-272f-4903-8dc1-1d4c91f95478.png)

