### PR TITLE
Fix `show-names` on PR files tab

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -11,7 +11,8 @@ import {getUsername, compareNames} from '../github-helpers';
 
 async function init(): Promise<false | void> {
 	const usernameElements = select.all([
-		'.js-discussion a.author:not(.rgh-fullname, [href*="/apps/"], [href*="/marketplace/"], [data-hovercard-type="organization"])', // `a` selector needed to skip commits by non-GitHub users.
+		// `a` selector needed to skip commits by non-GitHub users.
+		':is(.js-discussion, .inline-comments) a.author:not(.rgh-fullname, [href*="/apps/"], [href*="/marketplace/"], [data-hovercard-type="organization"])',
 		'#dashboard a.text-bold[data-hovercard-type="user"]:not(.rgh-fullname)', // On dashboard `.text-bold` is required to not fetch avatars.
 	]);
 


### PR DESCRIPTION
Follow-up of https://github.com/refined-github/refined-github/pull/4927#pullrequestreview-781344700

## Test URLs
* https://github.com/refined-github/refined-github/pull/4851/files#r721125661
* https://github.com/refined-github/refined-github/pull/4851

## Screenshot

**Before**
![screenshot-1634564383](https://user-images.githubusercontent.com/46634000/137747708-92128b1d-c775-48f0-a3cb-4d0df78f1342.png)

**After**
![screenshot-1634564340](https://user-images.githubusercontent.com/46634000/137747705-e0531a23-3c20-4dd0-8f04-9fc8e168061f.png)