### PR TITLE
Meta: Drop automated release notes creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,7 @@ jobs:
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version
-      - uses: notlmn/release-with-changelog@v3
-        if: steps.daily-version.outputs.created
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          exclude: true
+
   Submit:
     needs: Version
     if: github.event_name == 'workflow_dispatch' || needs.Version.outputs.created


### PR DESCRIPTION
For the past couple of releases I used GitHub’s new release generation, which better highlight the contributors in each release:

- https://github.com/refined-github/refined-github/releases/tag/21.10.18
- https://github.com/refined-github/refined-github/releases

For this reason I think I will be clicking that button after our workflow creates a tag.

Ideally this release will be created automatically again, but until then…