### PR TITLE
Add `expand-releases` feature

### DIFF
--- a/source/features/expand-releases.tsx
+++ b/source/features/expand-releases.tsx
@@ -1,0 +1,14 @@
+import select from 'select-dom';
+
+import features from '.';
+
+function init(): void {
+	const releasesLinks = select.all('a:is([href$="/releases"])');
+	for (const link of releasesLinks) {
+		link.href = link.href += `?expanded=true`
+	}
+}
+
+void features.add(__filebasename, {
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -216,3 +216,4 @@ import './features/list-prs-for-branch';
 import './features/comment-on-draft-pr-indicator';
 import './features/select-notifications';
 import './features/clean-repo-tabs';
+import './features/expand-releases';


### PR DESCRIPTION
Resolves #4941

## Test URLs

Enable Releases UI Refresh (under Feature preview atm) and navigate to Releases from https://github.com/evanw/esbuild, the `expanded=true` query is added to href, paginated links are decorated by GitHub automatically when present on a page.

## Screenshot

releases UI Refresh default
<img width="869" alt="Screenshot 2021-10-19 at 9 22 58" src="https://user-images.githubusercontent.com/241506/137862543-569c5e19-9e45-4116-ac8a-d3098338d8e2.png">

with `expand-releases`
<img width="872" alt="Screenshot 2021-10-19 at 9 23 17" src="https://user-images.githubusercontent.com/241506/137862583-321e353b-a7e0-4b85-b8de-b675c354965b.png">