### PR TITLE
Sort projects by update time

### DIFF
--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -17,7 +17,7 @@ function init(): void {
 
 		if (pageDetect.utils.getRepositoryInfo(link)?.path === 'projects' && link.host === location.host && !link.closest('.table-list-header-toggle')) {
 			const search = new URLSearchParams(link.search);
-			const query = search.get('query') ?? 'is:open';
+			const query = search.get('query') ?? 'is:open'; // Default value query is missing
 			search.set('query', `${query} sort:updated-desc`);
 			link.search = search.toString();
 		}

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -19,6 +19,7 @@ function init(): void {
 			new SearchQuery(link).add('sort:updated-desc');
 		}
 
+		// Also sort projects #4957
 		if (pageDetect.utils.getRepositoryInfo(link)?.path === 'projects') {
 			// Projects use a different parameter name so don't use SearchQuery
 			const search = new URLSearchParams(link.search);

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -8,14 +8,19 @@ function init(): void {
 	// Get issues links that don't already have a specific sorting applied
 	const issueLinks = select.all('a:is([href*="/issues"], [href*="/pulls"], [href*="/projects"]):not([href*="sort%3A"], .issues-reset-query)');
 	for (const link of issueLinks) {
+		if (link.host !== location.host || link.closest('.pagination, .table-list-header-toggle')) {
+			return;
+		}
+
 		// Pick only links to lists, not single issues
 		// + skip pagination links
 		// + skip pr/issue filter dropdowns (some are lazyloaded)
-		if (pageDetect.isConversationList(link) && link.host === location.host && !link.closest('.pagination, .table-list-filters')) {
+		if (pageDetect.isConversationList(link)) {
 			new SearchQuery(link).add('sort:updated-desc');
 		}
 
-		if (pageDetect.utils.getRepositoryInfo(link)?.path === 'projects' && link.host === location.host && !link.closest('.table-list-header-toggle')) {
+		if (pageDetect.utils.getRepositoryInfo(link)?.path === 'projects') {
+			// Projects use a different parameter name so don't use SearchQuery
 			const search = new URLSearchParams(link.search);
 			const query = search.get('query') ?? 'is:open'; // Default value query is missing
 			search.set('query', `${query} sort:updated-desc`);

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -6,13 +6,20 @@ import SearchQuery from '../github-helpers/search-query';
 
 function init(): void {
 	// Get issues links that don't already have a specific sorting applied
-	const issueLinks = select.all('a:is([href*="/issues"], [href*="/pulls"]):not([href*="sort%3A"], .issues-reset-query)');
+	const issueLinks = select.all('a:is([href*="/issues"], [href*="/pulls"], [href*="/projects"]):not([href*="sort%3A"], .issues-reset-query)');
 	for (const link of issueLinks) {
 		// Pick only links to lists, not single issues
 		// + skip pagination links
 		// + skip pr/issue filter dropdowns (some are lazyloaded)
 		if (pageDetect.isConversationList(link) && link.host === location.host && !link.closest('.pagination, .table-list-filters')) {
 			new SearchQuery(link).add('sort:updated-desc');
+		}
+
+		if (pageDetect.utils.getRepositoryInfo(link)?.path === 'projects' && link.host === location.host && !link.closest('.table-list-header-toggle')) {
+			const search = new URLSearchParams(link.search);
+			const query = search.get('query') ?? 'is:open';
+			search.set('query', `${query} sort:updated-desc`);
+			link.search = search.toString();
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Resolve #4957

This is a small addition to the existing `sort-conversations-by-update-time` feature.

In spite of https://github.com/refined-github/refined-github/issues/2960#issuecomment-619437895, I think this change is beneficial:

- Unlike what I stated in #4891 (which asks to drop a similar feature), this change is valid, refined and would indeed help those who do use Projects
- It is only a few lines of code, built upon an existing feature. One question though, it doesn't fit the feature name closely 🤷

## Test URLs

https://github.com/worldbank/gld/projects

## Screenshot

N/A