### PR TITLE
Fix: `file-finder-buffer` doesn't remove itself when opening another page

### DIFF
--- a/source/features/file-finder-buffer.css
+++ b/source/features/file-finder-buffer.css
@@ -1,3 +1,4 @@
+/* Hide everything after the repo title */
 .rgh-file-finder-buffer :is(.pagehead-actions, .rgh-ci-link :is(details, .Label), .octotree-bookmark-btn) {
 	display: none !important;
 }

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -34,6 +34,8 @@ function pjaxStartHandler(event: CustomEvent): void {
 		<span className="flex-self-stretch mr-2">{bufferField}</span>,
 	);
 	bufferField.focus();
+
+	// Hide the header elements instead of removing them so they can be restored #4999
 	document.body.classList.add('rgh-file-finder-buffer');
 }
 
@@ -47,6 +49,7 @@ function pjaxCompleteHandler(): void {
 		fileFinderInput.dispatchEvent(new Event('input')); // Trigger search
 	}
 
+	// Make sure to clean up the repo header #4999
 	if (document.body.classList.contains('rgh-file-finder-buffer')) {
 		bufferField.parentElement!.previousElementSibling!.remove();
 		bufferField.parentElement!.remove();


### PR DESCRIPTION
Fix #4999 

## Test URLs
1. Go to [repo home](https://github.com/refined-github/refined-github) & refresh the page
2. Trigger the file finder
3. Click on the "Code" tab
4. Everything should look normal :eyes: 

## Screenshot

https://user-images.githubusercontent.com/46634000/139235124-4482d170-e707-45e0-b523-b3afde47f3d6.mp4