### PR TITLE
Fix: `hide-watch-and-fork-count` removes native border radius

### DIFF
--- a/source/features/forked-to.css
+++ b/source/features/forked-to.css
@@ -4,7 +4,7 @@
 }
 
 /* Play nice with `hide-watch-and-fork-count` feature */
-.rgh-forked-to.rgh-hide-watch-and-fork-count .btn-with-count[title^='Fork your own'] {
+.rgh-forked-to.rgh-hide-watch-and-fork-count .btn-with-count:is([title^='Fork your own'], [aria-label^='Fork your own']) {
 	border-bottom-right-radius: unset;
 	border-top-right-radius: unset;
 }

--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -9,7 +9,7 @@
 }
 
 @media (max-width: 1000px) {
-	.rgh-hide-watch-and-fork-count:not(.rgh-forked-to) :is(.btn[title^='Fork your own'], .btn[aria-label^='Cannot fork']) {
+	.rgh-hide-watch-and-fork-count:not(.rgh-forked-to) .btn:is([title^='Fork your own'], [aria-label^='Fork your own'], [aria-label^='Cannot fork']) {
 		border-radius: 6px !important; /* Matches GitHub's default */
 	}
 


### PR DESCRIPTION
Fixes #4975 

## Test URLs
Any repo page (with & without fork)

## Screenshots
![screenshot-1635437913](https://user-images.githubusercontent.com/46634000/139296434-5b2cfaa2-2816-41db-a23c-0be86bf2286a.png)
![screenshot-1635438039](https://user-images.githubusercontent.com/46634000/139296437-722306a0-2e4d-4758-94c8-ab9529b305c3.png)
![screenshot-1635438101](https://user-images.githubusercontent.com/46634000/139296439-643fb906-ceef-4281-8fd5-aaa36272ff73.png)