### PR TITLE
Fix: `conflict-marker` icon doesn't align with check icon

### DIFF
--- a/source/features/conflict-marker.css
+++ b/source/features/conflict-marker.css
@@ -1,4 +1,3 @@
 .rgh-conflict-marker svg {
-	vertical-align: middle;
 	color: var(--color-icon-tertiary, #ccc);
 }

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -64,7 +64,7 @@ async function init(): Promise<false | void> {
 					aria-label="This PR has conflicts that must be resolved"
 					href={`${pr.link.pathname}#partial-pull-merging`}
 				>
-					<AlertIcon/>
+					<AlertIcon className="v-align-middle"/>
 				</a>,
 			);
 		}


### PR DESCRIPTION
Fixes #4976 

## Test URLs
https://github.com/npm/cli/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

## Screenshot

Before
![screenshot-1635497535](https://user-images.githubusercontent.com/46634000/139406812-d65a13a3-653b-447f-9e31-f48d698d3c44.png)

After
![screenshot-1635497373](https://user-images.githubusercontent.com/46634000/139406810-ce591a40-49d0-4aa7-8604-52cb60660e91.png)