### PR TITLE
Fix `sticky-sidebar` on repo root

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -8,8 +8,8 @@
 	display: none;
 }
 
-/* Align the top of the sidebar with the main page content */
-/* Avoid breaking the sidebar alignment in PR discussions #4642 */
-.rgh-clean-repo-sidebar div:not(#discussion_bucket) > .gutter-condensed > :last-child {
+/* Align the top of the repo root sidebar with the main page content */
+/* `:not(#discussion_bucket)` avoids breaking the sidebar alignment in PR discussions #4642 */
+.rgh-clean-repo-sidebar div:not(#discussion_bucket) > div > .Layout-sidebar {
 	margin-top: -16px !important;
 }

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -7,11 +7,13 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 const deinit: VoidFunction[] = [];
-// Both selectors are present on conversation pages so we need to discriminate
-const sidebarSelector = pageDetect.isRepoRoot() ? '.repository-content .flex-column > .flex-shrink-0 > [data-pjax]' : '#partial-discussion-sidebar';
+
+function getSidebarSelector(): string {
+	return pageDetect.isRepoRoot() ? '.Layout-sidebar > .BorderGrid' : '#partial-discussion-sidebar';
+}
 
 function updateStickiness(): void {
-	const sidebar = select(sidebarSelector)!;
+	const sidebar = select(getSidebarSelector())!;
 	const margin = pageDetect.isConversation() ? 60 : 0; // 60 matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebar.offsetHeight + margin < window.innerHeight);
 }
@@ -20,7 +22,7 @@ const onResize = debounce(updateStickiness, {wait: 100});
 
 function init(): void {
 	const resizeObserver = new ResizeObserver(onResize);
-	const selectObserver = observe(sidebarSelector, {
+	const selectObserver = observe(getSidebarSelector(), {
 		add(sidebar) {
 			resizeObserver.observe(sidebar, {box: 'border-box'});
 		},

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -8,12 +8,10 @@ import features from '.';
 
 const deinit: VoidFunction[] = [];
 
-function getSidebarSelector(): string {
-	return pageDetect.isRepoRoot() ? '.Layout-sidebar > .BorderGrid' : '#partial-discussion-sidebar';
-}
+const sidebarSelector = '.Layout-sidebar > div';
 
 function updateStickiness(): void {
-	const sidebar = select(getSidebarSelector())!;
+	const sidebar = select(sidebarSelector)!;
 	const margin = pageDetect.isConversation() ? 60 : 0; // 60 matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebar.offsetHeight + margin < window.innerHeight);
 }
@@ -22,7 +20,7 @@ const onResize = debounce(updateStickiness, {wait: 100});
 
 function init(): void {
 	const resizeObserver = new ResizeObserver(onResize);
-	const selectObserver = observe(getSidebarSelector(), {
+	const selectObserver = observe(sidebarSelector, {
 		add(sidebar) {
 			resizeObserver.observe(sidebar, {box: 'border-box'});
 		},

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -8,7 +8,7 @@ import features from '.';
 
 const deinit: VoidFunction[] = [];
 
-// The first class in parentheses is for the repo root, the second one for conversation pages
+// The first selector in the parentheses is for the repo root, the second one for conversation pages
 const sidebarSelector = '.Layout-sidebar :is(.BorderGrid, #partial-discussion-sidebar)';
 
 function updateStickiness(): void {

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -8,7 +8,8 @@ import features from '.';
 
 const deinit: VoidFunction[] = [];
 
-const sidebarSelector = '.Layout-sidebar > div';
+// The first class in parentheses is for the repo root, the second one for conversation pages
+const sidebarSelector = '.Layout-sidebar > :is(.Border-grid, #partial-discussion-sidebar)';
 
 function updateStickiness(): void {
 	const sidebar = select(sidebarSelector)!;

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -9,7 +9,7 @@ import features from '.';
 const deinit: VoidFunction[] = [];
 
 // The first class in parentheses is for the repo root, the second one for conversation pages
-const sidebarSelector = '.Layout-sidebar > :is(.Border-grid, #partial-discussion-sidebar)';
+const sidebarSelector = '.Layout-sidebar :is(.BorderGrid, #partial-discussion-sidebar)';
 
 function updateStickiness(): void {
 	const sidebar = select(sidebarSelector)!;


### PR DESCRIPTION
Fixes #5008 

## Test URLs
 * this page (PR conversation sidebar)
 * [issue page](https://togithub.com/refined-github/refined-github/issues/4941)
 * [repo root](https://github.com/refined-github/refined-github)

## Screenshot
![image](https://user-images.githubusercontent.com/46634000/139539177-c590a0d6-7839-4535-90d4-2a063ccaf3c6.png)