### PR TITLE
Split `hide-own-stars` feature into forks and stars

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -347,6 +347,7 @@ Thanks for contributing! 🦋🙌
 
 - [](# "clean-dashboard") 🔥 [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
 - [](# "hide-own-stars") Hides "starred" events for your own repos on the newsfeed.
+- [](# "hide-own-forks") Hides "forked" events for your own repos on the newsfeed.
 - [](# "hide-noisy-newsfeed-events") Hides other inutile newsfeed events (commits, forks, new followers).
 - [](# "infinite-scroll") Automagically expands the newsfeed when you scroll down.
 

--- a/source/features/hide-own-forks.tsx
+++ b/source/features/hide-own-forks.tsx
@@ -7,7 +7,7 @@ import features from '.';
 import {getUsername} from '../github-helpers';
 
 function init(): void {
-	observe('#dashboard .news .watch_started', {
+	observe('#dashboard .news .fork', {
 		constructor: HTMLElement,
 		add(item) {
 			if (select.exists(`a[href^="/${getUsername()!}"]`, item)) {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -54,6 +54,7 @@ import './features/improve-shortcut-help';
 import './features/deprioritize-marketplace-link';
 import './features/view-markdown-source';
 import './features/copy-file';
+import './features/hide-own-forks';
 import './features/hide-own-stars';
 import './features/infinite-scroll';
 import './features/shorten-links';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

The hide-own-stars feature currently hides "starred" AND "forked" events for your own repos.

This PR splits the hide-own-stars feature into two settings for star and fork events.

This is beneficial if you are interested in who forks your repos because they might be contributing something useful in their forks and you want to check out their progress. (just an example)

Also, the feature description currently doesn't mention that it also hides "forked" events.

## Test URLs

affects the main newsfeed (https://github.com/)