### PR TITLE
Avoid duplicating native button in `quick-pr-diff-options`

### DIFF
--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -43,33 +43,39 @@ function createDiffStyleToggle(): DocumentFragment {
 	);
 }
 
-function isHidingWhitespace() : boolean {
-	 // The selector is the native button
+function isHidingWhitespace(): boolean {
+	// The selector is the native button
 	return new URL(location.href).searchParams.get('w') === '1' || select.exists('button[name="w"][value="0"]');
 }
 
 function createWhitespaceButton(): HTMLElement {
 	const url = new URL(location.href);
-	url.searchParams.set('w', '1');
+
+	if (isHidingWhitespace()) {
+		url.searchParams.delete('w');
+	} else {
+		url.searchParams.set('w', '1');
+	}
 
 	const classes = pageDetect.isPR()
-		? 'tooltipped tooltipped-s d-none d-lg-block color-icon-secondary color-fg-muted color-icon-info color-fg-accent'
-		: 'tooltipped tooltipped-s btn btn-sm tooltipped';
+		? 'tooltipped tooltipped-s d-none d-lg-block color-icon-secondary color-fg-muted ' + (isHidingWhitespace() ? '' : 'color-icon-info color-fg-accent')
+		: 'tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-text-tertiary color-fg-subtle' : '');
 
 	return (
 		<a
 			href={url.href}
 			data-hotkey="d w"
 			className={classes}
-			aria-label="Hide whitespace changes"
+			aria-label={`${isHidingWhitespace() ? 'Show' : 'Hide'} whitespace changes`}
 		>
-			{pageDetect.isPR() ? <DiffModifiedIcon/> : <><CheckIcon/> No Whitespace</>}
+			{pageDetect.isPR() ? <DiffModifiedIcon/> : <>{isHidingWhitespace() && <CheckIcon/>} No Whitespace</>}
 		</a>
 	);
 }
+
 function initPR(): false | void {
 	// TODO [2022-05-01]: Remove `.js-diff-settings` from the selector (kept for GHE)
-	const originalToggle = select('.js-diff-settings, [aria-label="Diff settings"]')!.closest('details')!.parentElement!
+	const originalToggle = select('.js-diff-settings, [aria-label="Diff settings"]')!.closest('details')!.parentElement!;
 
 	if (!isHidingWhitespace()) {
 		originalToggle.after(

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -104,17 +104,6 @@ function initPR(): false | void {
 }
 
 function initCommitAndCompare(): false | void {
-	const container = select('#toc')!;
-	container.append(
-		<div className="diffbar-item d-flex">{createDiffStyleToggle()}</div>,
-	);
-
-	if (!isHidingWhitespace()) {
-		container.append(
-			<div className="diffbar-item d-flex">{createWhitespaceButton()}</div>,
-		);
-	}
-
 	select('#toc')!.prepend(
 		<div className="float-right d-flex">
 			<div className="d-flex ml-3 BtnGroup">{createDiffStyleToggle()}</div>

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -45,7 +45,7 @@ function createDiffStyleToggle(): DocumentFragment {
 
 function isHidingWhitespace(): boolean {
 	// The selector is the native button
-	return new URL(location.href).searchParams.get('w') === '1' || select.exists('button[name="w"][value="0"]');
+	return new URL(location.href).searchParams.get('w') === '1' || select.exists('button[name="w"][value="0"]:not([hidden])');
 }
 
 function createWhitespaceButton(): HTMLElement {
@@ -58,7 +58,7 @@ function createWhitespaceButton(): HTMLElement {
 	}
 
 	const classes = pageDetect.isPR()
-		? 'tooltipped tooltipped-s d-none d-lg-block color-icon-secondary color-fg-muted ' + (isHidingWhitespace() ? '' : 'color-icon-info color-fg-accent')
+		? 'tooltipped tooltipped-s d-none d-lg-block color-icon-secondary color-fg-muted'
 		: 'tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-text-tertiary color-fg-subtle' : '');
 
 	return (
@@ -68,7 +68,7 @@ function createWhitespaceButton(): HTMLElement {
 			className={classes}
 			aria-label={`${isHidingWhitespace() ? 'Show' : 'Hide'} whitespace changes`}
 		>
-			{pageDetect.isPR() ? <DiffModifiedIcon/> : <>{isHidingWhitespace() && <CheckIcon/>} No Whitespace</>}
+			{pageDetect.isPR() ? <DiffModifiedIcon className="v-align-middle"/> : <>{isHidingWhitespace() && <CheckIcon/>} No Whitespace</>}
 		</a>
 	);
 }


### PR DESCRIPTION
Part of https://github.com/refined-github/refined-github/issues/5009

This PR only avoids the duplication and slightly improves consistency, but @kidonng’s suggestions in the original issue are valid and should be followed or discussed further.

## Test URLs

- https://github.com/refined-github/refined-github/pull/5022/files?w=0 // whitespace
- https://github.com/refined-github/refined-github/pull/5022/files?w=1 // no whitespace

Unchanged:


- https://github.com/refined-github/refined-github/commit/db1e5682e925cdc7bf3b6e091befe51a3c703b7e?w=0
- https://github.com/refined-github/refined-github/commit/db1e5682e925cdc7bf3b6e091befe51a3c703b7e?w=1

## Screenshot

Whitespace shown (the style has been reversed to match the "on" style of the "whitespace hidden" one)

<img width="343" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/139579780-8ab37a55-bcfc-4865-adb5-4e7785b16f6c.png">

Whitespace hidden

<img width="345" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/139579765-41ec52ec-2a56-458c-b8cd-023bf300c98b.png">


