### PR TITLE
Remove `beforeunload` event listener in `wait-for-build`

### DIFF
--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -75,6 +75,12 @@ async function handleMergeConfirmation(event: delegate.Event<Event, HTMLButtonEl
 	}
 }
 
+function onBeforeunload(event: BeforeUnloadEvent): void {
+	if (waiting) {
+		event.returnValue = '';
+	}
+}
+
 function init(): void {
 	// Watch for new commits and their statuses
 	prCiStatus.addEventListener(showCheckboxIfNecessary);
@@ -90,11 +96,11 @@ function init(): void {
 	});
 
 	// Warn user if it's not yet submitted.
-	window.addEventListener('beforeunload', event => {
-		if (waiting) {
-			event.returnValue = '';
-		}
-	});
+	window.addEventListener('beforeunload', onBeforeunload);
+}
+
+function deinit(): void {
+	window.removeEventListener('beforeunload', onBeforeunload);
 }
 
 void features.add(__filebasename, {
@@ -107,4 +113,5 @@ void features.add(__filebasename, {
 	],
 	deduplicate: 'has-rgh-inner',
 	init,
+	deinit,
 });

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -90,10 +90,9 @@ function init(): void {
 	});
 
 	// Warn user if it's not yet submitted.
-	// Sadly the message isn't shown
 	window.addEventListener('beforeunload', event => {
 		if (waiting) {
-			event.returnValue = 'The PR hasn’t merged yet.';
+			event.returnValue = '';
 		}
 	});
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Properly remove `beforeunload` event listener with `deinit`.

Also remove the unnecessary message.

Background: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event

From my tests, only assigning a string to `event.returnValue` works on Chrome, plus both Chrome and Firefox won't show the string you provided.

## Test URLs

Here maybe?

## Screenshot

N/A