### PR TITLE
Hide duplicate `quick-pr-diff-options` buttons on commit and compare pages

### DIFF
--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -73,7 +73,7 @@ function createWhitespaceButton(): HTMLElement {
 	);
 }
 
-function initPR(): false | void {
+function init(): false | void {
 	// TODO [2022-05-01]: Remove `.js-diff-settings` from the selector (kept for GHE)
 	const originalToggle = select('.js-diff-settings, [aria-label="Diff settings"]')!.closest('details')!.parentElement!;
 
@@ -103,18 +103,6 @@ function initPR(): false | void {
 	select('.subset-files-tab')?.classList.replace('px-sm-3', 'ml-sm-2');
 }
 
-function initCommitAndCompare(): false | void {
-	select('#toc')!.prepend(
-		<div className="float-right d-flex">
-			<div className="d-flex ml-3 BtnGroup">{createDiffStyleToggle()}</div>
-			<div className="d-flex ml-3 BtnGroup">{createWhitespaceButton()}</div>
-		</div>,
-	);
-
-	// Remove previous options UI
-	select('[action="/users/diffview"]')!.parentElement!.remove();
-}
-
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
@@ -127,14 +115,5 @@ void features.add(__filebasename, {
 		'd w': 'Show/hide whitespaces in diffs',
 	},
 	deduplicate: 'has-rgh-inner',
-	init: initPR,
-}, {
-	include: [
-		pageDetect.isSingleCommit,
-		pageDetect.isCompare,
-	],
-	shortcuts: {
-		'd w': 'Show/hide whitespaces in diffs',
-	},
-	init: initCommitAndCompare,
+	init,
 });

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -73,7 +73,7 @@ function createWhitespaceButton(): HTMLElement {
 	);
 }
 
-function init(): false | void {
+function initPR(): false | void {
 	// TODO [2022-05-01]: Remove `.js-diff-settings` from the selector (kept for GHE)
 	const originalToggle = select('.js-diff-settings, [aria-label="Diff settings"]')!.closest('details')!.parentElement!;
 
@@ -103,6 +103,14 @@ function init(): false | void {
 	select('.subset-files-tab')?.classList.replace('px-sm-3', 'ml-sm-2');
 }
 
+function initCommitAndCompare(): false | void {
+	select('#toc')!.prepend(
+		<div className="float-right d-flex">
+			<div className="d-flex ml-3 BtnGroup">{createWhitespaceButton()}</div>
+		</div>,
+	);
+}
+
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
@@ -115,5 +123,14 @@ void features.add(__filebasename, {
 		'd w': 'Show/hide whitespaces in diffs',
 	},
 	deduplicate: 'has-rgh-inner',
-	init,
+	init: initPR,
+}, {
+	include: [
+		pageDetect.isSingleCommit,
+		pageDetect.isCompare,
+	],
+	shortcuts: {
+		'd w': 'Show/hide whitespaces in diffs',
+	},
+	init: initCommitAndCompare,
 });

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -112,7 +112,7 @@ function initCommitAndCompare(): false | void {
 	);
 
 	// Remove previous options UI
-	select('[data-ga-load^="Diff, view"]')!.remove();
+	select('[action="/users/diffview"]')!.parentElement!.remove();
 }
 
 void features.add(__filebasename, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Tackle https://github.com/refined-github/refined-github/issues/5009#issuecomment-955777413

## Test URLs

- [`isSingleCommit`](https://github.com/refined-github/refined-github/commit/49fd6261e21d69bd62094bf0b38783a7e06020d1)
- [`isCompare`](https://github.com/refined-github/refined-github/compare/main...add-multiple-prs-dropdown)

## Screenshot

Before:

![image](https://user-images.githubusercontent.com/44045911/139598291-28f8caa3-ebd1-466f-bed1-00151e4dc2c2.png)

![image](https://user-images.githubusercontent.com/44045911/139598284-946a03ca-3df8-470a-aa16-a52f62a64ba7.png)

After:

![image](https://user-images.githubusercontent.com/44045911/139718439-55e9e1d5-5435-4ac6-b1af-2e9172cfefd9.png)


![image](https://user-images.githubusercontent.com/44045911/139718433-00e4ea52-03a1-47c7-881f-c32db06c3fda.png)

