### PR TITLE
Limit width of comment form on commit pages

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -46,3 +46,8 @@
 :is(.new_public_key, .new_gpg_key) textarea { /* Monospace textareas for new SSH/GPG keys #4917 */
 	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace !important;
 }
+
+/* Limit width of comment form on commit pages #5032 */
+#all_commit_comments .timeline-comment-wrapper {
+	max-width: 780px;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -49,5 +49,5 @@
 
 /* Limit width of comment form on commit pages #5032 */
 #all_commit_comments .timeline-comment-wrapper {
-	max-width: 780px;
+	max-width: 780px; /* This is the limit applied on the comment thread by `.comment-holder` */
 }


### PR DESCRIPTION
Fixes #5032 

## Test URLs
 * https://github.com/refined-github/refined-github/commit/fb7726a2335204d1cd33721b32b6e7b284c7397b

## Screenshot

**Before**

![screenshot-1635784246](https://user-images.githubusercontent.com/46634000/139706637-146eaa33-b689-427d-8af6-a9f1aeb3ada2.png)


**After**

![screenshot-1635784165](https://user-images.githubusercontent.com/46634000/139706635-578f018c-0c0a-439e-a084-36eecfa4d13d.png)