### PR TITLE
Make "Marketplace" menu item focusable via keyboard

### DIFF
--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<void> {
 		await onProfileDropdownLoad();
 		select.last('.header-nav-current-user ~ .dropdown-divider')!.before(
 			<div className="dropdown-divider"/>,
-			<a className="dropdown-item" href="/marketplace">Marketplace</a>,
+			<a role="menuitem" className="dropdown-item" href="/marketplace">Marketplace</a>,
 		);
 	}
 }


### PR DESCRIPTION
Makes the Marketplace link in the dropdown accessible via the up and down arrows on the keyboard.

## Video

https://user-images.githubusercontent.com/73734376/140486207-de4a5790-86ab-492d-9ba6-0d14f2e4834a.mp4


