### PR TITLE
Meta: drop magic globals in favor of `import`ing the readme

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -5,8 +5,6 @@
 	"extends": "xo-react",
 	"globals": [
 		"browser",
-		"__features__",
-		"__featuresMeta__",
 		"__filebasename"
 	],
 	"rules": {

--- a/build/readme.loader.cts
+++ b/build/readme.loader.cts
@@ -2,7 +2,7 @@
 module.exports = async function ReadmeLoader () {
 	const {getFeatures, getFeaturesMeta} = await import("./readme-parser.js");
 	return `
-		export const features = ${JSON.stringify(getFeatures())};
+		export const featureList = ${JSON.stringify(getFeatures())};
 		export const featuresMeta = ${JSON.stringify(getFeaturesMeta())};
 	`;
 }

--- a/build/readme.loader.cts
+++ b/build/readme.loader.cts
@@ -1,0 +1,8 @@
+// Can't use modules because this is a bizarropackscript world
+module.exports = async function ReadmeLoader () {
+	const { getFeatures, getFeaturesMeta } = await import("./readme-parser.js");
+  return `
+		export const features = ${JSON.stringify(getFeatures())}
+		export const featuresMeta = [${JSON.stringify(getFeaturesMeta())}]
+  `;
+}

--- a/build/readme.loader.cts
+++ b/build/readme.loader.cts
@@ -1,8 +1,8 @@
 // Can't use modules because this is a bizarropackscript world
 module.exports = async function ReadmeLoader () {
-	const { getFeatures, getFeaturesMeta } = await import("./readme-parser.js");
-  return `
-		export const features = ${JSON.stringify(getFeatures())}
-		export const featuresMeta = [${JSON.stringify(getFeaturesMeta())}]
-  `;
+	const {getFeatures, getFeaturesMeta} = await import("./readme-parser.js");
+	return `
+		export const features = ${JSON.stringify(getFeatures())};
+		export const featuresMeta = ${JSON.stringify(getFeaturesMeta())};
+	`;
 }

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -298,8 +298,6 @@ const features = {
 	addCssFeature,
 	log,
 	shortcutMap,
-	list: __features__,
-	meta: __featuresMeta__,
 };
 
 export default features;

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -3,8 +3,8 @@ import elementReady from 'element-ready';
 
 import features from '.';
 import {wrapAll} from '../helpers/dom-utils';
-import {getNewFeatureName} from '../options-storage';
 import {featuresMeta} from '../../readme.md';
+import {getNewFeatureName} from '../options-storage';
 
 async function init(): Promise<void | false> {
 	const [, currentFeature] = /features\/([^.]+)/.exec(location.pathname)!;

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -4,12 +4,13 @@ import elementReady from 'element-ready';
 import features from '.';
 import {wrapAll} from '../helpers/dom-utils';
 import {getNewFeatureName} from '../options-storage';
+import {featuresMeta} from '../../readme.md';
 
 async function init(): Promise<void | false> {
 	const [, currentFeature] = /features\/([^.]+)/.exec(location.pathname)!;
 	// Enable link even on past commits
 	const currentFeatureName = getNewFeatureName(currentFeature);
-	const feature = features.meta.find(feature => feature.id === currentFeatureName);
+	const feature = featuresMeta.find(feature => feature.id === currentFeatureName);
 	if (!feature) {
 		return false;
 	}

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -6,11 +6,12 @@ import {wrap} from '../helpers/dom-utils';
 import features from '.';
 import {getNewFeatureName} from '../options-storage';
 import {isNotRefinedGitHubRepo} from '../github-helpers';
+import {features as featureList} from '../../readme.md';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 function linkifyFeature(codeElement: HTMLElement): void {
 	const id = getNewFeatureName(codeElement.textContent!) as FeatureID;
-	if (features.list.includes(id) && !codeElement.closest('a')) {
+	if (featureList.includes(id) && !codeElement.closest('a')) {
 		wrap(codeElement, <a href={`/refined-github/refined-github/blob/main/source/features/${id}.tsx`}/>);
 	}
 }

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -4,9 +4,9 @@ import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
 import features from '.';
+import {featureList} from '../../readme.md';
 import {getNewFeatureName} from '../options-storage';
 import {isNotRefinedGitHubRepo} from '../github-helpers';
-import {featureList} from '../../readme.md';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 function linkifyFeature(codeElement: HTMLElement): void {

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -6,7 +6,7 @@ import {wrap} from '../helpers/dom-utils';
 import features from '.';
 import {getNewFeatureName} from '../options-storage';
 import {isNotRefinedGitHubRepo} from '../github-helpers';
-import {features as featureList} from '../../readme.md';
+import {featureList} from '../../readme.md';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 function linkifyFeature(codeElement: HTMLElement): void {

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -9,8 +9,6 @@ interface FeatureMeta {
 	screenshot?: string;
 }
 
-declare const __features__: FeatureID[];
-declare const __featuresMeta__: FeatureMeta[];
 declare const __filebasename: FeatureID;
 
 interface Window {
@@ -20,6 +18,11 @@ interface Window {
 declare module 'markdown-wasm/dist/markdown.node.js';
 
 declare module 'size-plugin';
+
+declare module '*.md' { // It should be just for readme.md, but 🤷‍♂️
+	export const featuresMeta: FeatureMeta[];
+	export const features: FeatureID[];
+}
 
 // Custom UI events specific to RGH
 interface GlobalEventHandlersEventMap {

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -21,7 +21,7 @@ declare module 'size-plugin';
 
 declare module '*.md' { // It should be just for readme.md, but 🤷‍♂️
 	export const featuresMeta: FeatureMeta[];
-	export const features: FeatureID[];
+	export const featureList: FeatureID[];
 }
 
 // Custom UI events specific to RGH

--- a/source/helpers/bisect.tsx
+++ b/source/helpers/bisect.tsx
@@ -3,8 +3,8 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 
-import {features} from '../../readme.md';
 import pluralize from './pluralize';
+import {features} from '../../readme.md';
 
 // Split current list of features in half and create an options-like object to be applied on load
 // Bisecting 4 features: enable 2

--- a/source/helpers/bisect.tsx
+++ b/source/helpers/bisect.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 
 import pluralize from './pluralize';
-import {features} from '../../readme.md';
+import {featureList} from '../../readme.md';
 
 // Split current list of features in half and create an options-like object to be applied on load
 // Bisecting 4 features: enable 2
@@ -100,7 +100,7 @@ export default async function bisectFeatures(): Promise<Record<string, boolean> 
 
 	const half = getMiddleStep(bisectedFeatures);
 	const temporaryOptions: Record<string, boolean> = {};
-	for (const feature of features) {
+	for (const feature of featureList) {
 		const index = bisectedFeatures.indexOf(feature);
 		temporaryOptions[`feature:${feature}`] = index > -1 && index < half;
 	}

--- a/source/helpers/bisect.tsx
+++ b/source/helpers/bisect.tsx
@@ -3,7 +3,7 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 
-import features from '../features';
+import {features} from '../../readme.md';
 import pluralize from './pluralize';
 
 // Split current list of features in half and create an options-like object to be applied on load
@@ -100,7 +100,7 @@ export default async function bisectFeatures(): Promise<Record<string, boolean> 
 
 	const half = getMiddleStep(bisectedFeatures);
 	const temporaryOptions: Record<string, boolean> = {};
-	for (const feature of features.list) {
+	for (const feature of features) {
 		const index = bisectedFeatures.indexOf(feature);
 		temporaryOptions[`feature:${feature}`] = index > -1 && index < half;
 	}

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -1,4 +1,5 @@
 import OptionsSyncPerDomain from 'webext-options-sync-per-domain';
+import {features} from '../readme.md';
 
 export type RGHOptions = typeof defaults;
 
@@ -8,7 +9,7 @@ const defaults = Object.assign({
 	personalToken: '',
 	logging: false,
 	logHTTP: false,
-}, Object.fromEntries(__features__.map(id => [`feature:${id}`, true])));
+}, Object.fromEntries(features.map(id => [`feature:${id}`, true])));
 
 export const renamedFeatures = new Map<string, string>([
 	['separate-draft-pr-button', 'one-click-pr-or-gist'],

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -1,4 +1,5 @@
 import OptionsSyncPerDomain from 'webext-options-sync-per-domain';
+
 import {features} from '../readme.md';
 
 export type RGHOptions = typeof defaults;

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -1,6 +1,6 @@
 import OptionsSyncPerDomain from 'webext-options-sync-per-domain';
 
-import {features} from '../readme.md';
+import {featureList} from '../readme.md';
 
 export type RGHOptions = typeof defaults;
 
@@ -10,7 +10,7 @@ const defaults = Object.assign({
 	personalToken: '',
 	logging: false,
 	logHTTP: false,
-}, Object.fromEntries(features.map(id => [`feature:${id}`, true])));
+}, Object.fromEntries(featureList.map(id => [`feature:${id}`, true])));
 
 export const renamedFeatures = new Map<string, string>([
 	['separate-draft-pr-button', 'one-click-pr-or-gist'],

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -8,9 +8,9 @@ import delegate from 'delegate-it';
 import fitTextarea from 'fit-textarea';
 import * as indentTextarea from 'indent-textarea';
 
+import {featuresMeta} from '../readme.md';
 import {getLocalHotfixes} from './helpers/hotfix';
 import {createRghIssueLink} from './helpers/rgh-issue-link';
-import {featuresMeta} from '../readme.md';
 import {perDomainOptions, renamedFeatures} from './options-storage';
 
 interface Status {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -10,8 +10,8 @@ import * as indentTextarea from 'indent-textarea';
 
 import {getLocalHotfixes} from './helpers/hotfix';
 import {createRghIssueLink} from './helpers/rgh-issue-link';
-import {perDomainOptions, renamedFeatures} from './options-storage';
 import {featuresMeta as features} from '../readme.md';
+import {perDomainOptions, renamedFeatures} from './options-storage';
 
 interface Status {
 	error?: true;

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -10,7 +10,7 @@ import * as indentTextarea from 'indent-textarea';
 
 import {getLocalHotfixes} from './helpers/hotfix';
 import {createRghIssueLink} from './helpers/rgh-issue-link';
-import {featuresMeta as features} from '../readme.md';
+import {featuresMeta} from '../readme.md';
 import {perDomainOptions, renamedFeatures} from './options-storage';
 
 interface Status {
@@ -19,7 +19,7 @@ interface Status {
 	scopes?: string[];
 }
 
-const featureList = features.map(({id}) => id);
+const featureList = featuresMeta.map(({id}) => id);
 const {version} = browser.runtime.getManifest();
 
 function reportStatus({error, text, scopes}: Status): void {
@@ -218,7 +218,7 @@ async function getLocalHotfixesAsNotice(): Promise<HTMLElement> {
 
 async function generateDom(): Promise<void> {
 	// Generate list
-	select('.js-features')!.append(...features.map(feature => buildFeatureCheckbox(feature)));
+	select('.js-features')!.append(...featuresMeta.map(feature => buildFeatureCheckbox(feature)));
 
 	// Add notice for features disabled via hotfix
 	select('.js-features')!.before(await getLocalHotfixesAsNotice());
@@ -238,7 +238,7 @@ async function generateDom(): Promise<void> {
 	}
 
 	// Add feature count. CSS-only features are added approximately
-	select('.features-header')!.append(` (${features.length + 25})`);
+	select('.features-header')!.append(` (${featuresMeta.length + 25})`);
 }
 
 function addEventListeners(): void {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -11,6 +11,7 @@ import * as indentTextarea from 'indent-textarea';
 import {getLocalHotfixes} from './helpers/hotfix';
 import {createRghIssueLink} from './helpers/rgh-issue-link';
 import {perDomainOptions, renamedFeatures} from './options-storage';
+import {featuresMeta as features} from '../readme.md';
 
 interface Status {
 	error?: true;
@@ -18,8 +19,6 @@ interface Status {
 	scopes?: string[];
 }
 
-// Don't repeat the magic variable, or its content will be inlined multiple times
-const features = __featuresMeta__;
 const featureList = features.map(({id}) => id);
 const {version} = browser.runtime.getManifest();
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,8 +8,6 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack, {Configuration} from 'webpack';
 
-import {getFeatures, getFeaturesMeta} from './build/readme-parser.js';
-
 const {resolve: resolvePackage} = createRequire(import.meta.url);
 
 const config: Configuration = {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -30,6 +30,10 @@ const config: Configuration = {
 	module: {
 		rules: [
 			{
+				test: /readme\.md?$/,
+				loader: './build/readme.loader.cts',
+			},
+			{
 				test: /\.tsx?$/,
 				loader: 'esbuild-loader',
 				options: {
@@ -49,8 +53,6 @@ const config: Configuration = {
 	plugins: [
 		new webpack.DefinePlugin({
 			// Passing `true` as the second argument makes these values dynamic — so every file change will update their value.
-			__features__: webpack.DefinePlugin.runtimeValue(() => JSON.stringify(getFeatures()), true),
-			__featuresMeta__: webpack.DefinePlugin.runtimeValue(() => JSON.stringify(getFeaturesMeta()), true),
 			__filebasename: webpack.DefinePlugin.runtimeValue(info => JSON.stringify(path.parse(info.module.resource).name)),
 		}),
 		new MiniCssExtractPlugin(),

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -28,7 +28,7 @@ const config: Configuration = {
 	module: {
 		rules: [
 			{
-				test: /readme\.md?$/,
+				test: /\/readme\.md$/,
 				loader: './build/readme.loader.cts',
 			},
 			{


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/4320

## Pros

- Readme.md becomes part of the webpack dependency tree, which means it's watched just like other files 
- No magic/global variables that need special handling (e.g. "Don't repeat the magic variable, it will be inlined multiple times")
- More portable codebase, the loader can be more easily ported to esbuild [or something](https://github.com/refined-github/refined-github/pull/5014)
- It makes it more clear that the data is coming from the readme - https://github.com/refined-github/refined-github/pull/3678


## Cons

- A lil hacky because it doesn't use the correct webpack APIs