### PR TITLE
Fix order of actions in `quick-review-buttons`

### DIFF
--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -23,7 +23,8 @@ function init(): false | void {
 			<input
 				type="hidden"
 				name="pull_request_review[event]"
-				value="comment"/>,
+				value="comment"
+			/>,
 		);
 	}
 
@@ -59,16 +60,7 @@ function init(): false | void {
 			button.prepend(<FileDiffIcon className="color-fg-danger"/>);
 		}
 
-		container.append(button);
-	}
-
-	// Cancel button must be first
-	if (radios.length > 1) {
-		const cancelReview = select('.review-cancel-button', form);
-		if (cancelReview) {
-			cancelReview.classList.add('float-left');
-			container.prepend(cancelReview);
-		}
+		container.prepend(button);
 	}
 
 	// Remove original fields at last to avoid leaving a broken form

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -28,9 +28,9 @@ function init(): false | void {
 		);
 	}
 
-	// "Approve" button must be last
+	// "Comment" button must be first
 	if (radios.length > 1) {
-		radios.push(radios.splice(1, 1)[0]);
+		radios.push(radios.shift()!);
 	}
 
 	// Generate the new buttons
@@ -65,7 +65,7 @@ function init(): false | void {
 			button.prepend(<FileDiffIcon className="color-fg-danger"/>);
 		}
 
-		container.prepend(button);
+		container.append(button);
 	}
 
 	// Remove original fields at last to avoid leaving a broken form

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -28,6 +28,11 @@ function init(): false | void {
 		);
 	}
 
+	// "Approve" button must be last
+	if (radios.length > 1) {
+		radios.push(radios.splice(1, 1)[0]);
+	}
+
 	// Generate the new buttons
 	for (const radio of radios) {
 		const tooltip = radio.parentElement!.getAttribute('aria-label');


### PR DESCRIPTION
Fixes #5010 

## Test URLs

 * https://togithub.com/refined-github/sandbox/pull/4/files

## Screenshots

<table>
<tr>
	<th colspan="2" align="center">Open PR
<tr>
	<td>Before
	<td>After
<tr>
	<td>

![screenshot-1636294365](https://user-images.githubusercontent.com/46634000/140650544-6dc91cab-c32b-4741-8014-7a1b8716a284.png)
	<td>

![screenshot-1636297425](https://user-images.githubusercontent.com/46634000/140650548-9e89c72d-b539-48e6-a235-66e708aca677.png)
<tr>
	<th colspan="2" align="center">Own open PR
<tr>
	<td>Before
	<td>After
<tr>
	<td>

![screenshot-1636294415](https://user-images.githubusercontent.com/46634000/140650546-1a9db986-d2e5-4d64-a173-d3d83a52161a.png)
	<td>

![screenshot-1636297479](https://user-images.githubusercontent.com/46634000/140650551-4afe77ee-457d-40b6-a900-c8e67acc444f.png)
</table>