### PR TITLE
Meta: Ensure features are described only once in the readme

### DIFF
--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -4,9 +4,15 @@ import regexJoin from 'regex-join';
 import {readFileSync} from 'node:fs';
 import {parse as parseMarkdown} from 'markdown-wasm/dist/markdown.node.js';
 
+export function findFeatureRegex(id: FeatureID): RegExp {
+	return regexJoin(/^/, `- [](# "${id}")`, /(?: 🔥)? (.+)$/mg);
+}
+export function findHighlightedFeatureRegex(id: FeatureID): RegExp {
+	return regexJoin(`<p><a title="${id}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/);
+}
+
 function searchInList(readmeContent: string, id: FeatureID): FeatureMeta | void {
-	const lineRegex = regexJoin(/^/, `- [](# "${id}")`, /(?: 🔥)? (.+)$/m);
-	const lineMatch = lineRegex.exec(readmeContent);
+	const lineMatch = findFeatureRegex(id).exec(readmeContent);
 	if (!lineMatch) {
 		return;
 	}
@@ -26,8 +32,7 @@ function searchInList(readmeContent: string, id: FeatureID): FeatureMeta | void 
 }
 
 function searchInHighlights(readmeContent: string, id: FeatureID): FeatureMeta | void {
-	const imageRegex = regexJoin(`<p><a title="${id}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/);
-	const imageMatch = imageRegex.exec(readmeContent);
+	const imageMatch = findHighlightedFeatureRegex(id).exec(readmeContent);
 	if (imageMatch) {
 		return {
 			id,

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -9,7 +9,7 @@ export function findFeatureRegex(id: FeatureID): RegExp {
 }
 
 export function findHighlightedFeatureRegex(id: FeatureID): RegExp {
-	return regexJoin(`<p><a title="${id}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/);
+	return regexJoin(`<p><a title="${id}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/g);
 }
 
 function searchInList(readmeContent: string, id: FeatureID): FeatureMeta | void {

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -5,8 +5,9 @@ import {readFileSync} from 'node:fs';
 import {parse as parseMarkdown} from 'markdown-wasm/dist/markdown.node.js';
 
 export function findFeatureRegex(id: FeatureID): RegExp {
-	return regexJoin(/^/, `- [](# "${id}")`, /(?: 🔥)? (.+)$/mg);
+	return regexJoin(/^/, `- [](# "${id}")`, /(?: 🔥)? (.+)$/gm);
 }
+
 export function findHighlightedFeatureRegex(id: FeatureID): RegExp {
 	return regexJoin(`<p><a title="${id}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/);
 }

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -55,7 +55,7 @@ function findError(filename: string): string | void {
 
 	const featureMeta = featuresInReadme.find(feature => feature.id === featureId);
 	if (!featureMeta) {
-		return `ERR: The feature ${featureId} should be described in the readme`;
+		return `ERR: ${featureId} should be described in the readme`;
 	}
 
 	if (featureMeta.description.length < 20) {
@@ -70,7 +70,13 @@ function findError(filename: string): string | void {
 		(lineMatch && lineMatch.length > 1) // If the description occurs more than once in the large list of features
 		|| (imageMatch && lineMatch) // If the description appears in both the feature list and the highlighted features section
 	) {
-		return `ERR: ${featureId} should be described only once in the readme`;
+		const matches = readmeContent.split(/\r?\n/).map((lineContent: string, lineNumber: number) =>
+			lineRegex.test(lineContent)
+				|| regexJoin(`<p><a title="${featureId}"></a> `).test(lineContent)
+				? lineNumber + 1 : -1,
+		).filter(lineNumber => lineNumber > 0);
+
+		return `ERR: ${featureId} is described more than once on lines ${matches.join(', ')}`;
 	}
 }
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -67,35 +67,35 @@ function findError(filename: string): string | void {
 		isHighlightedFeature = true;
 	}
 
-	const lines = [];
+	let duplicates = 0;
 	let highlightedFeatureMatch;
 	do {
 		highlightedFeatureMatch = highlightedFeatureRegex.exec(readmeContent);
 		if (highlightedFeatureMatch) {
-			lines.push(readmeContent.slice(0, highlightedFeatureMatch.index).split(/\r?\n/).length);
+			duplicates++;
 		}
 	} while (highlightedFeatureMatch);
 
-	if (lines.length > 0) {
-		return `ERR: ${featureId} should be described only once in the readme, but it is also described on line(s) ${lines.join(', ')}`;
+	if (duplicates > 0) {
+		return `ERR: ${featureId} should be described only once in the readme`;
 	}
 
-	lines.length = 0;
+	let occurrences = 0;
 	const featureRegex = findFeatureRegex(featureId);
 	let listedFeatureMatch;
 	do {
 		listedFeatureMatch = featureRegex.exec(readmeContent);
 		if (listedFeatureMatch) {
-			lines.push(readmeContent.slice(0, listedFeatureMatch.index).split(/\r?\n/).length);
+			occurrences++;
 		}
 	} while (listedFeatureMatch);
 
-	if (isHighlightedFeature && lines.length > 0) {
-		return `ERR: ${featureId} should be described only once in the readme, but it is described in the highlights section and on line(s) ${lines.join(', ')}`;
+	if (isHighlightedFeature && occurrences > 0) {
+		return `ERR: ${featureId} should be described only once in the readme`;
 	}
 
-	if (!isHighlightedFeature && lines.length > 1) {
-		return `ERR: ${featureId} should be described only once in the readme, but it is described on lines ${lines.join(', ')}`;
+	if (!isHighlightedFeature && occurrences > 1) {
+		return `ERR: ${featureId} should be described only once in the readme`;
 	}
 }
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -61,8 +61,10 @@ function findError(filename: string): string | void {
 		return `ERR: ${featureId} should be described better in the readme (at least 20 characters)`;
 	}
 
-	const featureMatch = findFeatureRegex(featureId as FeatureID).exec(readmeContent);
-	const highlightedFeatureMatch = findHighlightedFeatureRegex(featureId as FeatureID).exec(readmeContent);
+	// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+	const featureMatch = readmeContent.match(findFeatureRegex(featureId as FeatureID));
+	// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+	const highlightedFeatureMatch = readmeContent.match(findHighlightedFeatureRegex(featureId as FeatureID));
 	if (
 		(featureMatch && featureMatch.length > 1) // If the description occurs more than once in the large list of features
 		|| (highlightedFeatureMatch && featureMatch) // If the description appears in both the feature list and the highlighted features section

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -67,8 +67,21 @@ function findError(filename: string): string | void {
 		isHighlightedFeature = true;
 	}
 
-	const featureRegex = findFeatureRegex(featureId);
 	const lines = [];
+	let highlightedFeatureMatch;
+	do {
+		highlightedFeatureMatch = highlightedFeatureRegex.exec(readmeContent);
+		if (highlightedFeatureMatch) {
+			lines.push(readmeContent.slice(0, highlightedFeatureMatch.index).split(/\r?\n/).length);
+		}
+	} while (highlightedFeatureMatch);
+
+	if (lines.length > 0) {
+		return `ERR: ${featureId} should be described only once in the readme, but it is also described on line(s) ${lines.join(', ')}`;
+	}
+
+	lines.length = 0;
+	const featureRegex = findFeatureRegex(featureId);
 	let listedFeatureMatch;
 	do {
 		listedFeatureMatch = featureRegex.exec(readmeContent);

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -67,8 +67,8 @@ function findError(filename: string): string | void {
 	const lineMatch = readmeContent.match(lineRegex);
 	const imageMatch = readmeContent.match(imageRegex);
 	if (
-		(lineMatch && lineMatch.length > 1) || // If the description occurs more than once in the large list of features
-		(imageMatch && lineMatch) // If the description appears in both the feature list and the highlighted features section
+		(lineMatch && lineMatch.length > 1) // If the description occurs more than once in the large list of features
+		|| (imageMatch && lineMatch) // If the description appears in both the feature list and the highlighted features section
 	) {
 		return `ERR: ${featureId} should be described only once in the readme`;
 	}

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -1,10 +1,12 @@
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import regexJoin from 'regex-join';
 
 import {getFeatures, getFeaturesMeta} from './readme-parser.js'; // Must import as `.js`
 
 const featuresDirContents = readdirSync('source/features/');
 const entryPoint = 'source/refined-github.ts';
 const entryPointSource = readFileSync(entryPoint);
+const readmeContent = readFileSync('readme.md', 'utf-8');
 const importedFeatures = getFeatures();
 const featuresInReadme = getFeaturesMeta();
 
@@ -58,6 +60,14 @@ function findError(filename: string): string | void {
 
 	if (featureMeta.description.length < 20) {
 		return `ERR: ${featureId} should be described better in the readme (at least 20 characters)`;
+	}
+
+	const lineRegex = regexJoin(/^/, `- [](# "${featureId}")`, /(?: 🔥)? (.+)$/gm);
+	const lineMatch = readmeContent.match(lineRegex);
+	// `lineMatch` might be null, but in that case the feature might be described
+	// as a highlight. Also, line 56-59 checks if all features are described already
+	if (lineMatch && lineMatch.length > 1) {
+		return `ERR: ${featureId} should be described only once in the readme`;
 	}
 }
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -1,5 +1,5 @@
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import regexJoin from 'regex-join';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
 
 import {getFeatures, getFeaturesMeta} from './readme-parser.js'; // Must import as `.js`
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -61,19 +61,19 @@ function findError(filename: string): string | void {
 		return `ERR: ${featureId} should be described better in the readme (at least 20 characters)`;
 	}
 
-	const featureMatch = readmeContent.match(findFeatureRegex(featureId as FeatureID));
-	const highlightedFeatureMatch = readmeContent.match(findHighlightedFeatureRegex(featureId as FeatureID));
+	const featureMatch = findFeatureRegex(featureId as FeatureID).exec(readmeContent);
+	const highlightedFeatureMatch = findHighlightedFeatureRegex(featureId as FeatureID).exec(readmeContent);
 	if (
 		(featureMatch && featureMatch.length > 1) // If the description occurs more than once in the large list of features
 		|| (highlightedFeatureMatch && featureMatch) // If the description appears in both the feature list and the highlighted features section
 	) {
 		// Uncomment the following to print out line numbers
-		//const matches = readmeContent.split(/\r?\n/).map((lineContent: string, lineNumber: number) =>
+		// const matches = readmeContent.split(/\r?\n/).map((lineContent: string, lineNumber: number) =>
 		//	findFeatureRegex(featureId).test(lineContent)
 		//		|| regexJoin(`<p><a title="${featureId}"></a> `).test(lineContent)
 		//		? lineNumber + 1 : -1,
-		//).filter(lineNumber => lineNumber > 0);
-		//return `ERR: ${featureId} is described more than once in the readme on lines ${matches.join(', ')}`;
+		// ).filter(lineNumber => lineNumber > 0);
+		// return `ERR: ${featureId} is described more than once in the readme on lines ${matches.join(', ')}`;
 
 		return `ERR: ${featureId} should be described only once in the readme`;
 	}

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -63,10 +63,13 @@ function findError(filename: string): string | void {
 	}
 
 	const lineRegex = regexJoin(/^/, `- [](# "${featureId}")`, /(?: 🔥)? (.+)$/gm);
+	const imageRegex = regexJoin(`<p><a title="${featureId}"></a> `, /(.+?)\n\t+<p><img src="(.+?)">/);
 	const lineMatch = readmeContent.match(lineRegex);
-	// `lineMatch` might be null, but in that case the feature might be described
-	// as a highlight. Also, line 56-59 checks if all features are described already
-	if (lineMatch && lineMatch.length > 1) {
+	const imageMatch = readmeContent.match(imageRegex);
+	if (
+		(lineMatch && lineMatch.length > 1) || // If the description occurs more than once in the large list of features
+		(imageMatch && lineMatch) // If the description appears in both the feature list and the highlighted features section
+	) {
 		return `ERR: ${featureId} should be described only once in the readme`;
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,8 @@ Thanks for contributing! 🦋🙌
 
 ### Repositories
 
+- [](# "follow-file-renames") [Enhances files’ commit lists navigation to follow file renames](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
+- [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [](# "ci-link") 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [](# "hide-watch-and-fork-count") [Hides watcher counter and on smaller screens the fork counter too.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
 - [](# "more-dropdown-links") [Adds useful links to the repository navigation dropdown](https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png)

--- a/readme.md
+++ b/readme.md
@@ -160,8 +160,6 @@ Thanks for contributing! 🦋🙌
 
 ### Repositories
 
-- [](# "follow-file-renames") [Enhances files’ commit lists navigation to follow file renames](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
-- [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [](# "ci-link") 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [](# "hide-watch-and-fork-count") [Hides watcher counter and on smaller screens the fork counter too.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
 - [](# "more-dropdown-links") [Adds useful links to the repository navigation dropdown](https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png)


### PR DESCRIPTION
## Related Issues

Mentioned in https://github.com/refined-github/refined-github/pull/4699#issuecomment-962593291.

## What this PR does

It ensures that all features are described only once in [`readme.md`](readme.md).