### PR TITLE
Fix `tag-changes-link` for tags without release

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -120,20 +120,24 @@ async function init(): Promise<void> {
 				</a>
 			);
 
-			if (pageDetect.isEnterprise() || pageDetect.isTags()) {
+			// The page of a tag without a release still uses the old layout #5037
+			if (pageDetect.isEnterprise() || pageDetect.isTags() || (pageDetect.isSingleTag() && select.exists('.release'))) {
 				lastLink.after(
 					<li className={lastLink.className + ' rgh-changelog-link'}>
 						{compareLink}
 					</li>,
 				);
-				/* Fix spacing issue when the window is < 700px wide https://github.com/refined-github/refined-github/pull/3841#issuecomment-754325056 */
+				// Fix spacing issue when the window is < 700px wide https://github.com/refined-github/refined-github/pull/3841#issuecomment-754325056
 				lastLink.classList.remove('flex-auto');
-			} else {
-				lastLink.parentElement!.after(
-					<div className="mb-md-2 mr-3 mr-md-0 rgh-changelog-link">
-						{compareLink}
-					</div>,
-				);
+				continue;
+			}
+
+			lastLink.parentElement!.after(
+				<div className={'rgh-changelog-link ' + (pageDetect.isReleases() ? 'mb-md-2 mr-3 mr-md-0' : 'mr-4 mb-2')}>
+					{compareLink}
+				</div>,
+			);
+			if (pageDetect.isReleases()) {
 				lastLink.classList.remove('mb-2');
 				lastLink.parentElement!.classList.remove('mb-md-2');
 			}


### PR DESCRIPTION
Fixes #5037 

## Test URLs

* [Release list](https://github.com/refined-github/refined-github/releases)
* [Regular release](https://github.com/refined-github/refined-github/releases/tag/21.11.1)
* [Tag without release](https://github.com/torvalds/linux/releases/tag/v5.15)

## Screenshots

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![image](https://user-images.githubusercontent.com/46634000/140727731-baac924f-ed36-4eac-ab0b-15087f82fb6e.png)
	<td>

![image](https://user-images.githubusercontent.com/46634000/140727414-2c8ba166-9b5d-47a6-8f5c-545d613923e7.png)
</table>

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![image](https://user-images.githubusercontent.com/46634000/140727627-6fa94a38-9ec9-47eb-89fb-c91628c95ce1.png)
	<td>

![image](https://user-images.githubusercontent.com/46634000/140727504-c261de65-6805-4275-ae81-2ed1f4729b20.png)
</table>