### PR TITLE
Fix: `user-local-time` breaks positioning of some hovercards

### DIFF
--- a/source/features/user-local-time.css
+++ b/source/features/user-local-time.css
@@ -1,5 +1,5 @@
 /* Reserve some space in the hovercard to fix #4345 */
-.js-hovercard-content .Popover-message div.d-flex.mt-3 > div.overflow-hidden.ml-3:not(.rgh-user-local-time-container-added) {
+.js-hovercard-content .Popover-message div.d-flex.mt-3 > div.overflow-hidden.ml-3:not(.rgh-user-local-time-added) {
 	/* 26px is the height of the div that is being inserted plus its margin https://user-images.githubusercontent.com/46634000/120511483-bf95ae80-c3ca-11eb-8a97-310b32ae96c0.png */
 	padding-bottom: 26px !important;
 }

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -90,7 +90,7 @@ async function insertUserLocalTime(hovercardContainer: Element): Promise<void> {
 		return;
 	}
 
-	hovercardContainer.classList.add('rgh-user-local-time-container-added');
+	hovercardContainer.classList.add('rgh-user-local-time');
 
 	const datePromise = getLastCommitDate(login);
 	const race = await Promise.race([delay(300), datePromise]);
@@ -109,6 +109,8 @@ async function insertUserLocalTime(hovercardContainer: Element): Promise<void> {
 	// Adding the time element might change the height of the hovercard and thus break its positioning
 	const hovercardHeight = hovercard.offsetHeight;
 
+	// Only remove the reserved space when the time element is actually inserted in the hovercard to avoid #4527
+	hovercardContainer.classList.add('rgh-user-local-time-added');
 	hovercardContainer.append(container);
 
 	if (hovercard.matches('.Popover-message--bottom-right, .Popover-message--bottom-left')) {
@@ -141,7 +143,7 @@ async function insertUserLocalTime(hovercardContainer: Element): Promise<void> {
 }
 
 function init(): void {
-	observe('.js-hovercard-content .Popover-message div.d-flex.mt-3 > div.overflow-hidden.ml-3:not(.rgh-user-local-time-container-added)', {
+	observe('.js-hovercard-content .Popover-message div.d-flex.mt-3 > div.overflow-hidden.ml-3:not(.rgh-user-local-time)', {
 		add: insertUserLocalTime,
 	});
 }

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -109,7 +109,7 @@ async function insertUserLocalTime(hovercardContainer: Element): Promise<void> {
 	// Adding the time element might change the height of the hovercard and thus break its positioning
 	const hovercardHeight = hovercard.offsetHeight;
 
-	// Only remove the reserved space when the time element is actually inserted in the hovercard to avoid #4527
+	// Only remove the space reserved via CSS when the element is actually inserted in the hovercard #4527
 	hovercardContainer.classList.add('rgh-user-local-time-added');
 	hovercardContainer.append(container);
 


### PR DESCRIPTION
Fixes #4527 

## Test URLs

To check the cropping issue isn't back:
 * https://togithub.com/refined-github/refined-github/issues/4285
 * https://togithub.com/hexalellogram/iPhoneBatteryClient

## Screenshot

https://user-images.githubusercontent.com/46634000/141319805-305ded44-20a2-4f85-b0bd-ae33d2679661.mp4