### PR TITLE
Fix: `conversation-activity-filter` doesn't reset its state when navigating

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -152,6 +152,10 @@ async function addWidget(header: string): Promise<void> {
 }
 
 async function init(): Promise<void> {
+	// Reset the dropdown state #4997
+	currentSetting = 'default';
+	select('.repository-content')!.classList.remove('rgh-conversation-activity-is-filtered');
+
 	await addWidget('#partial-discussion-header .gh-header-meta :is(clipboard-copy, .flex-auto)');
 	await addWidget('#partial-discussion-header .gh-header-sticky :is(clipboard-copy, relative-time)');
 }


### PR DESCRIPTION
Fixes #4997 

## Test URLs

https://togithub.com/refined-github/refined-github/issues/4997

## Screenshot

https://user-images.githubusercontent.com/46634000/141775695-a611f3e4-bbf7-493a-b805-56f787db7fdd.mp4