### PR TITLE
Preserve name of other repos in `prevent-pr-commit-link-loss`

### DIFF
--- a/source/github-helpers/prevent-link-loss.ts
+++ b/source/github-helpers/prevent-link-loss.ts
@@ -1,40 +1,43 @@
+import {getRepo} from '.';
+
+const currentRepo = getRepo() ?? {nameWithOwner: 'refined-github/refined-github'};
+function getRepoReference(repoNameWithOwner: string, delemiter = ''): string {
+	return repoNameWithOwner === currentRepo.nameWithOwner ? '' : repoNameWithOwner + delemiter;
+}
+
 const escapeRegex = (string: string): string => string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
-const prCommitPathnameRegex = /[/][^/]+[/][^/]+[/]pull[/](\d+)[/]commits[/]([\da-f]{7})[\da-f]{33}(?:#[\w-]+)?\b/; // eslint-disable-line unicorn/better-regex
+const prCommitPathnameRegex = /[/]([^/]+[/][^/]+)[/]pull[/](\d+)[/]commits[/]([\da-f]{7})[\da-f]{33}(?:#[\w-]+)?\b/; // eslint-disable-line unicorn/better-regex
 export const prCommitUrlRegex = new RegExp('\\b' + escapeRegex(location.origin) + prCommitPathnameRegex.source, 'gi');
 
-const prComparePathnameRegex = /[/][^/]+[/][^/]+[/]compare[/](.+)(#diff-[\da-fR-]+)/; // eslint-disable-line unicorn/better-regex
+const prComparePathnameRegex = /[/]([^/]+[/][^/]+)[/]compare[/](.+)(#diff-[\da-fR-]+)/; // eslint-disable-line unicorn/better-regex
 export const prCompareUrlRegex = new RegExp('\\b' + escapeRegex(location.origin) + prComparePathnameRegex.source, 'gi');
 
-const discussionPathnameRegex = /[/][^/]+[/][^/]+[/]discussions[/](\d+)[?][^#\s]+(#discussioncomment-\w+)?\b/; // eslint-disable-line unicorn/better-regex
+const discussionPathnameRegex = /[/]([^/]+[/][^/]+)[/]discussions[/](\d+)[?][^#\s]+(#discussioncomment-\w+)?\b/; // eslint-disable-line unicorn/better-regex
 export const discussionUrlRegex = new RegExp('\\b' + escapeRegex(location.origin) + discussionPathnameRegex.source, 'gi');
 
 // To be used as replacer callback in string.replace() for PR commit links
-export function preventPrCommitLinkLoss(url: string, pr: string, commit: string, index: number, fullText: string): string {
+export function preventPrCommitLinkLoss(url: string, repoNameWithOwner: string, pr: string, commit: string, index: number, fullText: string): string {
 	if (fullText[index + url.length] === ')') {
 		return url;
 	}
 
-	return `[\`${commit}\` (#${pr})](${url})`;
+	return `[${getRepoReference(repoNameWithOwner, '@')}\`${commit}\` (#${pr})](${url})`;
 }
 
 // To be used as replacer callback in string.replace() for compare links
-export function preventPrCompareLinkLoss(url: string, compare: string, hash: string, index: number, fullText: string): string {
+export function preventPrCompareLinkLoss(url: string, repoNameWithOwner: string, compare: string, hash: string, index: number, fullText: string): string {
 	if (fullText[index + url.length] === ')') {
 		return url;
 	}
 
-	return `[\`${compare}\`${hash.slice(0, 16)}](${url})`;
+	return `[${getRepoReference(repoNameWithOwner, '@')}\`${compare}\`${hash.slice(0, 16)}](${url})`;
 }
 
 // To be used as replacer callback in string.replace() for discussion links
-export function preventDiscussionLinkLoss(url: string, discussion: string, comment: string, index: number, fullText: string): string {
+export function preventDiscussionLinkLoss(url: string, repoNameWithOwner: string, discussion: string, comment: string, index: number, fullText: string): string {
 	if (fullText[index + url.length] === ')') {
 		return url;
 	}
 
-	if (comment) {
-		return `[#${discussion} (comment)](${url})`;
-	}
-
-	return `[#${discussion}](${url})`;
+	return `[${getRepoReference(repoNameWithOwner)}#${discussion}${comment ? ' (comment)' : ''}](${url})`;
 }

--- a/test/prevent-link-loss.ts
+++ b/test/prevent-link-loss.ts
@@ -57,6 +57,10 @@ test('preventPrCommitLinkLoss', t => {
 		'lorem ipsum dolor [`1da152b` (#3205)](https://github.com/refined-github/refined-github/pull/3205/commits/1da152b3f8c51dd72d8ae6ad9cc96e0c2d8716f5#diff-932095cc3c0dff00495b4c392d78f0afR60) some random string',
 		'It should not apply it twice even with hashes',
 	);
+	t.is(
+		replacePrCommitLink('https://github.com/refined-github/shorten-repo-url/pull/33/commits/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658'),
+		'[refined-github/shorten-repo-url@`3d8d1cc` (#33)](https://github.com/refined-github/shorten-repo-url/pull/33/commits/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658)',
+	);
 });
 
 test('preventPrCompareLinkLoss', t => {
@@ -67,7 +71,7 @@ test('preventPrCompareLinkLoss', t => {
 	);
 	t.is(
 		replacePrCompareLink('https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191'),
-		'[`v11.5.2...v11.6.0`#diff-6be2971b2b](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)',
+		'[sindresorhus/got@`v11.5.2...v11.6.0`#diff-6be2971b2b](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)',
 	);
 	t.is(
 		replacePrCompareLink('lorem ipsum dolor https://github.com/refined-github/refined-github/compare/main...incremental-tag-changelog-link#diff-5b3cf6bcc7c5b1373313553dc6f93a5eR7-R9 some random string'),
@@ -75,7 +79,7 @@ test('preventPrCompareLinkLoss', t => {
 	);
 	t.is(
 		replacePrCompareLink(replacePrCompareLink('lorem ipsum dolor https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191 some random string')),
-		'lorem ipsum dolor [`v11.5.2...v11.6.0`#diff-6be2971b2b](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191) some random string',
+		'lorem ipsum dolor [sindresorhus/got@`v11.5.2...v11.6.0`#diff-6be2971b2b](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191) some random string',
 		'It should not apply it twice',
 	);
 	t.is(
@@ -87,31 +91,35 @@ test('preventPrCompareLinkLoss', t => {
 
 test('preventDiscussionLinkLoss', t => {
 	t.is(
-		replaceDiscussionLink('https://github.com/streetcomplete/StreetComplete/discussions/2789'),
-		'https://github.com/streetcomplete/StreetComplete/discussions/2789',
+		replaceDiscussionLink('https://github.com/refined-github/refined-github/discussions/2789'),
+		'https://github.com/refined-github/refined-github/discussions/2789',
 		'It should not affect discussion URLs without a query parameter',
 	);
 	t.is(
-		replaceDiscussionLink('https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707'),
-		'[#2789 (comment)](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707)',
+		replaceDiscussionLink('https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707'),
+		'[#2789 (comment)](https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707)',
 	);
 	t.is(
-		replaceDiscussionLink('https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top\nhttps://github.com/streetcomplete/StreetComplete/discussions/2789#discussioncomment-646707'),
-		'[#2789](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top)\nhttps://github.com/streetcomplete/StreetComplete/discussions/2789#discussioncomment-646707',
+		replaceDiscussionLink('https://github.com/refined-github/refined-github/discussions/2789?sort=top\nhttps://github.com/refined-github/refined-github/discussions/2789#discussioncomment-646707'),
+		'[#2789](https://github.com/refined-github/refined-github/discussions/2789?sort=top)\nhttps://github.com/refined-github/refined-github/discussions/2789#discussioncomment-646707',
 		'It should work separately on links.',
 	);
 	t.is(
-		replaceDiscussionLink('lorem ipsum dolor https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top some random string'),
-		'lorem ipsum dolor [#2789](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top) some random string',
+		replaceDiscussionLink('lorem ipsum dolor https://github.com/refined-github/refined-github/discussions/2789?sort=top some random string'),
+		'lorem ipsum dolor [#2789](https://github.com/refined-github/refined-github/discussions/2789?sort=top) some random string',
 	);
 	t.is(
-		replaceDiscussionLink(replaceDiscussionLink('lorem ipsum dolor https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707 some random string')),
-		'lorem ipsum dolor [#2789 (comment)](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707) some random string',
+		replaceDiscussionLink(replaceDiscussionLink('lorem ipsum dolor https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707 some random string')),
+		'lorem ipsum dolor [#2789 (comment)](https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707) some random string',
 		'It should not apply it twice',
 	);
 	t.is(
-		replaceDiscussionLink('I like [turtles](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707)'),
-		'I like [turtles](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707)',
+		replaceDiscussionLink('I like [turtles](https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707)'),
+		'I like [turtles](https://github.com/refined-github/refined-github/discussions/2789?sort=top#discussioncomment-646707)',
 		'It should ignore Markdown links',
+	);
+	t.is(
+		replaceDiscussionLink('https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707'),
+		'[streetcomplete/StreetComplete#2789 (comment)](https://github.com/streetcomplete/StreetComplete/discussions/2789?sort=top#discussioncomment-646707)',
 	);
 });


### PR DESCRIPTION
Fix #4228 

## Test URLs
Copy these links in the comment textarea below:
 * `https://github.com/refined-github/shorten-repo-url/pull/33/commits/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658`
 * `https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191`
 * `https://github.com/eslint/eslint/discussions/15305#discussioncomment-1634740`

## Screenshot

https://user-images.githubusercontent.com/46634000/141814685-9d37d8af-ad43-40e2-94f7-62d33a45c1db.mp4