### PR TITLE
Fix `conversation-filters` showing multiple checked marks

### DIFF
--- a/source/features/conversation-filters.tsx
+++ b/source/features/conversation-filters.tsx
@@ -12,12 +12,14 @@ function init(): void {
 	commentsLink.lastChild!.textContent = 'Everything commented by you';
 	commentsLink.removeAttribute('target');
 	new SearchQuery(commentsLink).set('is:open commenter:@me');
+	commentsLink.setAttribute('aria-checked', String(commentsLink.href === location.href)); // #4589
 
 	sourceItem.after(commentsLink);
 
 	// Add "Everything you subscribed to" link
 	const subscriptionsLink = commentsLink.cloneNode(true);
 	subscriptionsLink.lastChild!.textContent = 'Everything you subscribed to';
+	subscriptionsLink.setAttribute('aria-checked', 'false'); // #4589
 
 	const subscriptionsUrl = new URL('https://github.com/notifications/subscriptions');
 	const repositoryId = select('input[name="repository_id"]')!.value;


### PR DESCRIPTION
Fixes #4589 

## Test URLs
```js
// https://github.com/refined-github/refined-github/issues?q=is%3Aopen+mentions%3A%40me
```

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/141990563-fd2fb9b4-bd35-441f-9d76-a5dd0cdc6417.png)