### PR TITLE
Fix broken "Details" links in PR checks due to `bypass-checks`

### DIFF
--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -15,9 +15,16 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	}
 
 	const {details_url: detailsUrl} = await api.v3(`check-runs/${runId}`);
-	if (detailsUrl && !detailsUrl.startsWith('https://github.com/') && new URL(detailsUrl).pathname !== '/') { // Ignore links to GitHub repos or static product pages #3938
-		detailsLink.href = detailsUrl;
+	if (!detailsUrl) {
+		return;
 	}
+
+	const {pathname, search: queryString} = new URL(detailsUrl);
+	if (detailsUrl.startsWith('https://github.com/') || (pathname === '/' && queryString === '')) { // Ignore links to GitHub repos or static product pages #3938
+		return;
+	}
+
+	detailsLink.href = detailsUrl;
 }
 
 function init(): void {

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -5,6 +5,13 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import * as api from '../github-helpers/api';
 
+const uselessDetailsLinks = new Set([
+	'https://codecov.io', // https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1088
+	'https://github.com/jusx/mergeable', // https://github.com/mergeability/mergeable/pull/519
+	'https://github.com/marketplace/wip', // https://github.com/InsightSoftwareConsortium/ITK/pull/2881
+	'https://github.com/apps/kwrobot-v1',
+]);
+
 async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	const runId = pageDetect.isActionJobRun(detailsLink)
 		? detailsLink.pathname.split('/').pop() // https://github.com/xojs/xo/runs/1104625522
@@ -15,6 +22,10 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	}
 
 	const directLink = await api.v3(`check-runs/${runId}`);
+	if (uselessDetailsLinks.has(directLink.details_url)) { // #3938
+		return;
+	}
+
 	detailsLink.href = directLink.details_url;
 }
 

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -5,13 +5,6 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import * as api from '../github-helpers/api';
 
-const uselessDetailsLinks = new Set([
-	'https://codecov.io', // https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1088
-	'https://github.com/jusx/mergeable', // https://github.com/mergeability/mergeable/pull/519
-	'https://github.com/marketplace/wip', // https://github.com/InsightSoftwareConsortium/ITK/pull/2881
-	'https://github.com/apps/kwrobot-v1',
-]);
-
 async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	const runId = pageDetect.isActionJobRun(detailsLink)
 		? detailsLink.pathname.split('/').pop() // https://github.com/xojs/xo/runs/1104625522
@@ -21,9 +14,9 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 		return;
 	}
 
-	const directLink = await api.v3(`check-runs/${runId}`);
-	if (!uselessDetailsLinks.has(directLink.details_url)) { // #3938
-		detailsLink.href = directLink.details_url;
+	const {details_url: detailsUrl} = await api.v3(`check-runs/${runId}`);
+	if (detailsUrl && !detailsUrl.startsWith('https://github.com/') && new URL(detailsUrl).pathname !== '/') { // Ignore links to GitHub repos or static product pages #3938
+		detailsLink.href = detailsUrl;
 	}
 }
 

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -22,11 +22,9 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	}
 
 	const directLink = await api.v3(`check-runs/${runId}`);
-	if (uselessDetailsLinks.has(directLink.details_url)) { // #3938
-		return;
+	if (!uselessDetailsLinks.has(directLink.details_url)) { // #3938
+		detailsLink.href = directLink.details_url;
 	}
-
-	detailsLink.href = directLink.details_url;
 }
 
 function init(): void {


### PR DESCRIPTION
Fix #3938 

## Test URLs

 * "Details" link should by bypassed
   * https://togithub.com/Kocal/semantic-release-preset/pull/7 (Travis checks)
 * "Details" link should NOT be bypassed
   * https://togithub.com/sindresorhus/eslint-plugin-unicorn/pull/1088#commits-pushed-d34fa26 (commit `f800f82`, "codecov/project")
   * https://togithub.com/mergeability/mergeable/pull/519 ("Mergeable")
   * https://togithub.com/InsightSoftwareConsortium/ITK/pull/2881 ("ghostflow-check-master")

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/142732055-dbab92ad-efcd-4045-83cf-49a92ae624cf.png)