### PR TITLE
Fix selector in `wait-for-build`

### DIFF
--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -6,7 +6,8 @@ type CommitStatus = false | typeof SUCCESS | typeof FAILURE | typeof PENDING | t
 type StatusListener = (status: CommitStatus) => void;
 
 // `.TimelineItem--condensed` excludes unrelated references. See `deemphasize-unrelated-commit-references` feature
-const commitSelector = '.js-commit-group .TimelineItem--condensed';
+// TODO [2022-05-01]: Remove `.js-commit-group` (GHE)
+const commitSelector = ':is(.js-commit-group, [data-test-selector="pr-timeline-commits-list"]) .TimelineItem--condensed';
 
 function getLastCommitReference(): string | null {
 	return select.last(`${commitSelector} code`)!.textContent;


### PR DESCRIPTION
`wait-for-build` is broken:
```
❌ wait-for-build 0.0.0 → TypeError: select_dom__WEBPACK_IMPORTED_MODULE_0__.default.last(...) is undefined
    getLastCommitReference moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:16955
    addEventListener moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:16989
    init moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:15816
    runFeature moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:8021
    setupPageLoad moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:8039
    add moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:8094
    add moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:8095
    tsx moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:15827
    __webpack_require__ moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:25516
    <anonymous> moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:25641
    <anonymous> moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:25988
    <anonymous> moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:25990
refined-github.js:7944:11
```

## Test URLs

This page

## Screenshot

![screenshot-1637515146](https://user-images.githubusercontent.com/46634000/142772462-78fec920-1df6-42e4-a75f-8c825c355227.png)