### PR TITLE
Fix `bugs-tab` where the emoji contains a dash

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|:[\w_-]+:\s?bug)$/i;
+const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|(:[\w_-]+:|\p{Emoji})\s?bug)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|(:[\w_-]+:|\p{Emoji})\s?bug)$/iu;
+const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|:\w+:bug)$/i;
+const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|:[\w_-]+:bug)$/i;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|:[\w_-]+:bug)$/i;
+const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|:[\w_-]+:\s?bug)$/i;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));


### PR DESCRIPTION
Fixes #5068


## Test URLs
https://github.com/zdharma-continuum/zinit

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/142773697-749387ee-d0c0-4a98-be67-2b8f796ebc3a.png)
