### PR TITLE
Enable `one-key-formatting` on more places

### DIFF
--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -43,6 +43,7 @@ void features.add(import.meta.url, {
 		pageDetect.isGist,
 		pageDetect.isNewFile,
 		pageDetect.isEditingFile,
+		pageDetect.isDeletingFile,
 	],
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -41,6 +41,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 		pageDetect.isGist,
+		pageDetect.isNewFile,
 		pageDetect.isEditingFile,
 	],
 	awaitDomReady: false,

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 
 import features from '.';
-import {onCommentFieldKeydown, onConversationTitleFieldKeydown} from '../github-events/on-field-keydown';
+import {onCommentFieldKeydown, onConversationTitleFieldKeydown, onCommitTitleFieldKeydown} from '../github-events/on-field-keydown';
 
 const formattingCharacters = ['`', '\'', '"', '[', '(', '{', '*', '_', '~', '“', '‘'];
 const matchingCharacters = ['`', '\'', '"', ']', ')', '}', '*', '_', '~', '”', '’'];
@@ -33,6 +33,7 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement |
 function init(): void {
 	onCommentFieldKeydown(eventHandler);
 	onConversationTitleFieldKeydown(eventHandler);
+	onCommitTitleFieldKeydown(eventHandler);
 	delegate(document, 'input[name="commit_title"], input[name="gist[description]"], #saved-reply-title-field', 'keydown', eventHandler);
 }
 
@@ -40,6 +41,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 		pageDetect.isGist,
+		pageDetect.isEditingFile,
 	],
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -26,3 +26,7 @@ export function onCommentFieldKeydown(callback: DelegateFieldEvent): void {
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent): void {
 	onFieldKeydown('#issue_title, #pull_request_title', callback);
 }
+
+export function onCommitTitleFieldKeydown(callback: DelegateFieldEvent): void {
+	onFieldKeydown('#commit-summary-input', callback);
+}

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -20,7 +20,7 @@ function onFieldKeydown(selector: string, callback: DelegateFieldEvent): void {
 }
 
 export function onCommentFieldKeydown(callback: DelegateFieldEvent): void {
-	onFieldKeydown('.js-comment-field, #commit-description-textarea', callback);
+	onFieldKeydown('.js-comment-field, #commit-description-textarea, #merge_message_field', callback);
 }
 
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent): void {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Enable `one-key-formatting` on:

- Commit title with `onCommitTitleFieldKeydown` (new event listener)
- Commit description with `onCommentFieldKeydown` (we just enable it on `isEditingFile` pages)
- Merge commit description with `onCommentFieldKeydown` (new selector)

## Test URLs

- https://github.com/refined-github/refined-github/edit/main/.gitignore
- Here

## Screenshot

https://user-images.githubusercontent.com/44045911/142914589-3c76b599-8c52-457b-bcdb-5e18be0fa7f6.mov



