### PR TITLE
Meta: Avoid unnecessary calls in diff load listeners

### DIFF
--- a/source/github-events/on-fragment-load.ts
+++ b/source/github-events/on-fragment-load.ts
@@ -16,7 +16,7 @@ function createFragmentLoadListener(fragmentSelector: string, callback: EventLis
 const diffFileFragmentsSelector = [
 	'include-fragment.diff-progressive-loader', // Incremental file loader on scroll
 	'include-fragment.js-diff-entry-loader', // File diff loader on clicking "Load Diff"
-	'#files_bucket include-fragment', // Diff on compare pages
+	'#files_bucket:not(.pull-request-tab-content) include-fragment', // Diff on compare pages
 ].join(',');
 
 export function onDiffFileLoad(callback: EventListener): delegate.Subscription {


### PR DESCRIPTION
Fixes bug introduced by #5094 

## Test URLs

 * `show-whitespace`: https://github.com/refined-github/refined-github/pull/5109/files
 * `highlight-deleted-and-added-files-in-diffs`: [kidonng/xuann.wang@`576490d6a60a52601fbc33f31d5d9afcc3840bde...34b0d598eae7633d64f1ecbeb927254e74737905`#diff-05ed1c7f99](https://github.com/kidonng/xuann.wang/compare/576490d6a60a52601fbc33f31d5d9afcc3840bde...34b0d598eae7633d64f1ecbeb927254e74737905#diff-05ed1c7f99e45b485708115502a1e0f28c8547e9a9a29c1b8664f79103cf7873)

## Screenshot

n/a