### PR TITLE
Show message during API call

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 			"firefoxProfile": "./test/web-ext-profile",
 			"chromiumProfile": "./test/web-ext-profile",
 			"startUrl": [
-				"github.com"
+				"https://github.com/refined-github/refined-github"
 			]
 		}
 	}

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -6,17 +6,15 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import LoadingIcon from '../github-helpers/icon-loading';
+import showToast from '../github-helpers/toast';
 
 const editReleaseButtonSelector = [
 	'.BtnGroup a[href*="releases/edit"]', // Before "Releases UI refresh" #4902
 	'.Box-btn-octicon[aria-label="Edit"]',
 ].join(',');
 
-async function convertToDraft({delegateTarget: draftButton}: delegate.Event): Promise<void> {
-	try {
-		draftButton.append(<LoadingIcon className="ml-2 v-align-text-bottom" width={16}/>);
-
+async function convertToDraft(): Promise<void> {
+	await showToast(async () => {
 		const tagName = location.pathname.split('/').pop()!;
 		const release = await api.v3(`releases/tags/${tagName}`);
 		await api.v3(release.url, {
@@ -27,10 +25,10 @@ async function convertToDraft({delegateTarget: draftButton}: delegate.Event): Pr
 		});
 
 		select(editReleaseButtonSelector)!.click(); // Visit "Edit release" page
-	} catch (error: unknown) {
-		draftButton.textContent = 'Error. Check console or retry';
-		features.log.error(import.meta.url, error);
-	}
+	}, {
+		message: 'Converting to draft',
+		doneMessage: 'Converting to draft',
+	});
 }
 
 async function init(): Promise<void | false> {

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -9,8 +9,8 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getConversationNumber} from '../github-helpers';
 import showToast from '../github-helpers/toast';
+import {getConversationNumber} from '../github-helpers';
 
 const canNotEditLabels = onetime((): boolean => !select.exists('.label-select-menu .octicon-gear'));
 

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -10,6 +10,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import * as api from '../github-helpers/api';
 import {getConversationNumber} from '../github-helpers';
+import showToast from '../github-helpers/toast';
 
 const canNotEditLabels = onetime((): boolean => !select.exists('.label-select-menu .octicon-gear'));
 
@@ -19,8 +20,10 @@ async function removeLabelButtonClickHandler(event: delegate.Event<MouseEvent, H
 	const removeLabelButton = event.delegateTarget;
 
 	removeLabelButton.disabled = true;
-	await api.v3(`issues/${getConversationNumber()!}/labels/${removeLabelButton.dataset.name!}`, {
-		method: 'DELETE',
+	const endpoint = `issues/${getConversationNumber()!}/labels/${removeLabelButton.dataset.name!}`;
+	await showToast(async () => api.v3(endpoint, {method: 'DELETE'}), {
+		message: 'Removing label',
+		doneMessage: 'Label removed',
 	});
 
 	removeLabelButton.closest('a')!.remove();


### PR DESCRIPTION

- Fixes https://github.com/refined-github/refined-github/issues/4828
- Replaces https://github.com/refined-github/refined-github/pull/4946

## Details

I looked at all the features that used a v3 call with custom `method`. Many of them already handle errors inline or have an inline loading icon. Only some of them could be replaced to show a toast only when the action was not successful. Even here it's kind of a stretch.


https://user-images.githubusercontent.com/1402241/143673554-bc38445c-06fa-488f-ae6e-68679fc8ebc0.mov



## Test URLs

- any PR or issue with labels. Or this PR

## Future

- [ ] Adjust `showToast` to also accept a raw error: `showToast(new Error('Something’s up'))`
- [ ] Drop mentions of "bulk action" in showToast’s defaults

## Rejected

I tried converting `convert-release-to-draft` but it makes less sense than before. 


https://user-images.githubusercontent.com/1402241/143673445-77dbd45e-9f14-4c15-b296-a60ed8569a7b.mov