### PR TITLE
Disable `quick-mention` on reviews without a comment

### DIFF
--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -36,8 +36,9 @@ function init(): void {
 	const avatars = select.all(`:is(${[
 		// `:first-child` avoids app badges #2630
 		// The hovercard attribute avoids `highest-rated-comment`
-		// Avatars next to review events aren't wrapped in a <div> #4844
 		'div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child',
+
+		// Avatars next to review events aren't wrapped in a <div> #4844
 		'a.TimelineItem-avatar',
 	].join(',')}):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -33,13 +33,13 @@ function mentionUser({delegateTarget: button}: delegate.Event): void {
 }
 
 function init(): void {
-	// `:first-child` avoids app badges #2630
-	// The hovercard attribute avoids `highest-rated-comment`
-	// Avatars next to review events aren't wrapped in a <div> #4844
 	const avatars = select.all(`:is(${[
+		// `:first-child` avoids app badges #2630
+		// The hovercard attribute avoids `highest-rated-comment`
+		// Avatars next to review events aren't wrapped in a <div> #4844
 		'div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child',
 		'a.TimelineItem-avatar',
-	]}):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
+	].join(',')}):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {
 		const timelineItem = avatar.closest('.TimelineItem')!;
 

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -33,21 +33,12 @@ function mentionUser({delegateTarget: button}: delegate.Event): void {
 }
 
 function init(): void {
-	const avatars = select.all(`:is(${[
-		// `:first-child` avoids app badges #2630
-		// The hovercard attribute avoids `highest-rated-comment`
-		'div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child',
-
-		// Avatars next to review events aren't wrapped in a <div> #4844
-		'a.TimelineItem-avatar',
-	].join(',')}):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
+	// `:first-child` avoids app badges #2630
+	// The hovercard attribute avoids `highest-rated-comment`
+	// Avatars next to review events aren't wrapped in a <div> #4844
+	const avatars = select.all(`:is(div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child, a.TimelineItem-avatar):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {
-		const timelineItem = avatar.closest('.TimelineItem')!;
-
-		if (
-			select.exists('.minimized-comment', timelineItem) // Hidden comments
-			|| !select.exists('.timeline-comment', timelineItem) // Reviews without a comment
-		) {
+		if (avatar.closest('.TimelineItem')!.querySelector('.minimized-comment')) {
 			continue;
 		}
 

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -38,7 +38,12 @@ function init(): void {
 	// Avatars next to review events aren't wrapped in a <div> #4844
 	const avatars = select.all(`:is(div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child, a.TimelineItem-avatar):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {
-		if (avatar.closest('.TimelineItem')!.querySelector('.minimized-comment')) {
+		const timelineItem = avatar.closest('.TimelineItem')!;
+
+		if (
+			timelineItem.querySelector('.minimized-comment') // Hidden comments
+			|| !timelineItem.querySelector('.timeline-comment') // Reviews without a comment
+		) {
 			continue;
 		}
 
@@ -59,11 +64,6 @@ function init(): void {
 				<ReplyIcon/>
 			</button>,
 		);
-
-		const timelineItem = avatar.closest('.js-timeline-item')!;
-		if (timelineItem && !timelineItem.querySelector('.timeline-comment')) {
-			timelineItem.classList.add('mb-2');
-		}
 	}
 
 	delegate(document, 'button.rgh-quick-mention', 'click', mentionUser);

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -44,6 +44,8 @@ function init(): void {
 			select.exists('.minimized-comment', timelineItem) // Hidden comments
 			|| !select.exists('.timeline-comment', timelineItem) // Reviews without a comment
 		) {
+			continue;
+		}
 
 		// Wrap avatars next to review events so the inserted button doesn't break the layout #4844
 		if (avatar.classList.contains('TimelineItem-avatar')) {

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -44,8 +44,8 @@ function init(): void {
 		const timelineItem = avatar.closest('.TimelineItem')!;
 
 		if (
-			timelineItem.querySelector('.minimized-comment') // Hidden comments
-			|| !timelineItem.querySelector('.timeline-comment') // Reviews without a comment
+			select.exists('.minimized-comment', timelineItem) // Hidden comments
+			|| !select.exists('.timeline-comment', timelineItem) // Reviews without a comment
 		) {
 			continue;
 		}

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -36,7 +36,10 @@ function init(): void {
 	// `:first-child` avoids app badges #2630
 	// The hovercard attribute avoids `highest-rated-comment`
 	// Avatars next to review events aren't wrapped in a <div> #4844
-	const avatars = select.all(`:is(div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child, a.TimelineItem-avatar):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
+	const avatars = select.all(`:is(${[
+		'div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child',
+		'a.TimelineItem-avatar',
+	]}):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {
 		const timelineItem = avatar.closest('.TimelineItem')!;
 

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -38,9 +38,12 @@ function init(): void {
 	// Avatars next to review events aren't wrapped in a <div> #4844
 	const avatars = select.all(`:is(div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child, a.TimelineItem-avatar):not([href="/${getUsername()!}"], .rgh-quick-mention)`);
 	for (const avatar of avatars) {
-		if (avatar.closest('.TimelineItem')!.querySelector('.minimized-comment')) {
-			continue;
-		}
+		const timelineItem = avatar.closest('.TimelineItem')!;
+
+		if (
+			select.exists('.minimized-comment', timelineItem) // Hidden comments
+			|| !select.exists('.timeline-comment', timelineItem) // Reviews without a comment
+		) {
 
 		// Wrap avatars next to review events so the inserted button doesn't break the layout #4844
 		if (avatar.classList.contains('TimelineItem-avatar')) {

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -59,6 +59,11 @@ function init(): void {
 				<ReplyIcon/>
 			</button>,
 		);
+
+		const timelineItem = avatar.closest('.js-timeline-item')!;
+		if (timelineItem && !timelineItem.querySelector('.timeline-comment')) {
+			timelineItem.classList.add('mb-2');
+		}
 	}
 
 	delegate(document, 'button.rgh-quick-mention', 'click', mentionUser);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

See screenshots for the issue

Also, as you can see from the screenshot, there is a `z-index` issue happening. However it should not happen again with this patch, but nevertheless I will leave the fix here for completeness:

https://github.com/refined-github/refined-github/blob/2d701217614009c3d8e4e0f20fd0c967b4419a7f/source/features/quick-mention.tsx#L48

Add a `style={{zIndex: 2}}` would be fine


## Test URLs

- Multiple reviews: https://togithub.com/refined-github/refined-github/pull/5105#pullrequestreview-813257530
- Review + comment: https://togithub.com/NixOS/nixpkgs/pull/147010#pullrequestreview-817111882

## Screenshot

Before:
<img width="307" alt="截屏2021-11-29 20 59 02" src="https://user-images.githubusercontent.com/44045911/143873361-caf0e103-92a5-4580-9ed9-7734a4e82d3f.png">

After: 

![image](https://user-images.githubusercontent.com/44045911/144451252-985d3b0c-0e94-48f4-bb66-d413fb4661ef.png)

