### PR TITLE
Fix `use-first-commit-message-for-new-prs`

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -12,7 +12,11 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const [prTitle, ...prMessage] = select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title.split(/\n\n/);
+	// TODO [2022-05-01]: Remove GHE code
+	const [prTitle, ...prMessage] = (pageDetect.isEnterprise()
+		? select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title
+		: select('#commits_bucket .js-commits-list-item a.Link--primary')!.innerHTML.replace(/<\/?code>/g, '`')
+	)!.split(/\n\n/);
 
 	textFieldEdit.set(
 		select('.discussion-topic-header input')!,

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -12,9 +12,8 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	// TODO [2022-05-01]: Remove GHE code
 	const [prTitle, ...prMessage] = (pageDetect.isEnterprise()
-		? select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title
+		? select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title // TODO [2022-05-01]: Remove GHE code
 		: select('#commits_bucket .js-commits-list-item a.Link--primary')!.innerHTML.replace(/<\/?code>/g, '`')
 	)!.split(/\n\n/);
 


### PR DESCRIPTION
Fixes #5108 

## Test URLs

https://github.com/refined-github/refined-github/compare/add-multiple-prs-dropdown?expand=1

## Screenshot

<table>
<tr>
	<td>

**Before**
	<td>

**After**
<tr>
	<td>

![screenshot-1638195347](https://user-images.githubusercontent.com/46634000/143883727-673a53ff-5f1d-4f02-affe-b6dcad60cb1c.png)
	<td>

![screenshot-1638195085](https://user-images.githubusercontent.com/46634000/143883721-97f07e11-397d-4ea3-aa26-6ce2f5b6df49.png)
</table>

