### PR TITLE
Fix `unfinished-comments` on new issue templates

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -1,20 +1,32 @@
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
 let documentTitle: string | undefined;
+let submitting: number | undefined;
 
 function hasDraftComments(): boolean {
 	// `[disabled]` excludes the PR description field that `wait-for-build` disables while it waits
 	// `[id^="convert-to-issue-body"]` excludes the hidden pre-filled textareas created when opening the dropdown menu of review comments
 	return select.all('textarea:not([disabled], [id^="convert-to-issue-body"])').some(textarea =>
-		textarea.value !== textarea.textContent // Exclude comments being edited but not yet changed (and empty comment fields)
-		&& !select.exists('.btn-primary[disabled]', textarea.form!), // Exclude forms being submitted
+		textarea.value !== textarea.textContent, // Exclude comments being edited but not yet changed (and empty comment fields)
 	);
 }
 
+function disableOnSubmit(): void {
+	clearTimeout(submitting);
+	submitting = window.setTimeout(() => {
+		submitting = undefined;
+	}, 2000);
+}
+
 function updateDocumentTitle(): void {
+	if (submitting) {
+		return;
+	}
+
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
 		document.title = '(Draft comment) ' + document.title;
@@ -26,6 +38,7 @@ function updateDocumentTitle(): void {
 
 function init(): void {
 	document.addEventListener('visibilitychange', updateDocumentTitle);
+	delegate(document, 'form', 'submit', disableOnSubmit, {capture: true});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fixes #4737 

## Test URLs

 * [New issue template](https://github.com/refined-github/refined-github/issues/new?assignees=&labels=bug&template=1_bug_report.yml)
 * This page (for regular comments)

## Screenshot

Demo showing correct behavior when submitting a comment then quickly changing tab:

https://user-images.githubusercontent.com/46634000/143896128-8b9899b9-d442-4faf-a2f8-62bb47068c55.mp4