### PR TITLE
Hide badges in repo headers and pinned repo cards

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -5,8 +5,3 @@
 .rgh-ci-link summary .octicon {
 	vertical-align: 0;
 }
-
-/* Adds space between `ci-link` and "Private" label, if present */
-.rgh-ci-link .Label + .commit-build-statuses {
-	margin-left: 8px;
-}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -166,7 +166,7 @@ pr-branches
 	max-width: 100%;
 }
 
-/* Hide repo badges ("Public", "Template", etc.) on repo pages and pinned repo cards #4767 */
+/* Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards #4767 */
 :is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
 	display: none !important;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -165,3 +165,9 @@ pr-branches
 	width: calc(72ch + 26px);
 	max-width: 100%;
 }
+
+/* Hide all repo badges ("Public", "Template", etc.) #4767 */
+:is(#repository-container-header h1, .pinned-item-list-item-content) .Label,
+a[itemprop='name codeRepository'] ~ .Label {
+	display: none !important;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -166,8 +166,7 @@ pr-branches
 	max-width: 100%;
 }
 
-/* Hide all repo badges ("Public", "Template", etc.) #4767 */
-:is(#repository-container-header h1, .pinned-item-list-item-content) .Label,
-a[itemprop='name codeRepository'] ~ .Label {
+/* Hide repo badges ("Public", "Template", etc.) on repo pages and pinned repo cards #4767 */
+:is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
 	display: none !important;
 }


### PR DESCRIPTION
Resolves #4767 

## Test URLs

 * [Repo home](https://github.com/refined-github/refined-github)
 * [User pinned repos](https://github.com/fregante)
 * [User repo list](https://github.com/fregante?tab=repositories)
 * [Organization pinned repos & repo list](https://github.com/refined-github?type=source)

## Screenshot

<table>
<tr>
	<td>
	<td>Before
	<td>After
<tr>
	<td>Repo title
	<td>

![screenshot-1638202650](https://user-images.githubusercontent.com/46634000/143906895-09475aaf-d5c9-45ab-a8a8-e9476bde9fcb.png)
	<td>

![screenshot-1638202662](https://user-images.githubusercontent.com/46634000/143906897-cb255f5a-5ff9-4bc4-bb6e-8028decba7ea.png)
<tr>
	<td>Pinned repos
	<td>

![screenshot-1638202618](https://user-images.githubusercontent.com/46634000/143906891-3415a98d-20d5-4e20-9360-d84a9756c3df.png)
	<td>

![screenshot-1638202551](https://user-images.githubusercontent.com/46634000/143906875-b375794e-307b-479e-b401-b74d4b3dad82.png)
</table>

<!--
<tr>
	<td>Repo list
	<td>

![screenshot-1638202600](https://user-images.githubusercontent.com/46634000/143906885-0472851c-4005-421f-b8c0-e422fd9acaad.png)
	<td>

![screenshot-1638202573](https://user-images.githubusercontent.com/46634000/143906879-699bcddf-a8cd-487d-a0aa-fd72de2020f9.png)
-->