### PR TITLE
`deprioritize-marketplace-link` to footer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,7 +379,7 @@ Thanks for contributing! 🦋🙌
 - [](# "useful-not-found-page") 🔥 [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
 - [](# "selection-in-new-tab") [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/refined-github/refined-github/issues/1110)
 - [](# "close-out-of-view-modals") [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
-- [](# "deprioritize-marketplace-link") Moves the "Marketplace" link from the black header bar to the profile dropdown.
+- [](# "deprioritize-marketplace-link") Moves the "Marketplace" link from the header to the footer.
 - [](# "parse-backticks") [Renders `` `text in backticks` `` in issue titles, commit titles and more places.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "pagination-hotkey") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -1,30 +1,28 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import onetime from 'onetime';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onProfileDropdownLoad from '../github-events/on-profile-dropdown-load';
 
 async function init(): Promise<void> {
-	const marketplaceLink = await elementReady('.Header-link[href="/marketplace"]', {waitForChildren: false});
-	if (marketplaceLink) { // On GHE it can be disabled #3725
-		// The link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
-		marketplaceLink.closest('.border-top, .mr-3')!.remove();
-
-		await onProfileDropdownLoad();
-		select.last('.header-nav-current-user ~ .dropdown-divider')!.before(
-			<div className="dropdown-divider"/>,
-			<a role="menuitem" className="dropdown-item" href="/marketplace">Marketplace</a>,
-		);
+	const marketplaceLink = select('.Header-link[href="/marketplace"]');
+	// On GHE it can be disabled #3725
+	if (!marketplaceLink) {
+		return;
 	}
+
+	// The link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
+	marketplaceLink.closest('.border-top, .mr-3')!.remove();
+	select.last('footer ul')!.append(
+		<li className="ml-3 ml-lg-0">
+			<a href="/marketplace">Marketplace</a>
+		</li>,
+	);
 }
 
 void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isGist,
 	],
-	awaitDomReady: false,
-	init: onetime(init),
+	init,
 });

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -15,14 +15,18 @@ async function init(): Promise<void> {
 
 	const link = <a href="/marketplace">Marketplace</a>;
 	const item = <li>{link}</li>;
+	const footers = [elementReady('.footer[role="contentinfo"] ul:last-of-type')]; // Native
 
 	if (pageDetect.isDashboard()) {
 		link.classList.add('Link--secondary');
+		footers.push(elementReady('[aria-label="Explore"] .footer ul:last-of-type')); // Added by `infinite-scroll`
 	} else {
 		item.classList.add('ml-3', 'ml-lg-0');
 	}
 
-	(await elementReady('.footer ul:last-of-type'))!.append(item);
+	for await (const footer of footers) {
+		footer?.append(item.cloneNode(true));
+	}
 }
 
 void features.add(import.meta.url, {

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -13,11 +13,17 @@ async function init(): Promise<void> {
 
 	// The link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
 	marketplaceLink.closest('.border-top, .mr-3')!.remove();
-	select.last('footer ul')!.append(
-		<li className="ml-3 ml-lg-0">
-			<a href="/marketplace">Marketplace</a>
-		</li>,
-	);
+
+	const link = <a href="/marketplace">Marketplace</a>;
+	const item = <li>{link}</li>;
+
+	if (pageDetect.isDashboard()) {
+		link.classList.add('Link--secondary');
+	} else {
+		item.classList.add('ml-3', 'ml-lg-0');
+	}
+
+	select.last('.footer ul')!.append(item);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -11,8 +11,7 @@ async function init(): Promise<void> {
 		return;
 	}
 
-	// The link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
-	marketplaceLink.closest('.border-top, .mr-3')!.remove();
+	marketplaceLink.remove();
 
 	const link = <a href="/marketplace">Marketplace</a>;
 	const item = <li>{link}</li>;

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -1,11 +1,11 @@
 import React from 'dom-chef';
-import select from 'select-dom';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
 async function init(): Promise<void> {
-	const marketplaceLink = select('.Header-link[href="/marketplace"]');
+	const marketplaceLink = await elementReady('.Header-link[href="/marketplace"]', {waitForChildren: false});
 	// On GHE it can be disabled #3725
 	if (!marketplaceLink) {
 		return;
@@ -22,12 +22,13 @@ async function init(): Promise<void> {
 		item.classList.add('ml-3', 'ml-lg-0');
 	}
 
-	select.last('.footer ul')!.append(item);
+	(await elementReady('.footer ul:last-of-type'))!.append(item);
 }
 
 void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isGist,
 	],
+	awaitDomReady: false,
 	init,
 });


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Extracted from #5113

I never get his feature, since I use dropdown _way more_ than the header. The extra link suddenly appears in the dropdown, which looks like this feature is making it more noticable. Not to mention the link feels out of place in the dropdown (where should we put it?)

So I just find another nice place to put it: the footer. It's always on the bottom right corner for convenience. 

~~The only problem is that `infinite-scroll` effectively makes it inaccessible, however that's another issue.~~  Fixed by moving the footer to the right.

## Test URLs

- https://github.com/
- Here

## Screenshot

On dashboard:

![image](https://user-images.githubusercontent.com/44045911/143930718-5823e2f2-6bba-4183-841b-699791c351e7.png)

On other pages:

![image](https://user-images.githubusercontent.com/44045911/143930724-bece916a-2685-476d-a99a-a0788ac67ace.png)
