### PR TITLE
Move footer to right side when enabling `infinite-scroll`

### DIFF
--- a/source/features/clean-footer.css
+++ b/source/features/clean-footer.css
@@ -1,12 +1,12 @@
-body > .footer {
+.footer {
 	transition: opacity 0.2s ease;
 }
 
-body > .footer:not(:hover) {
+.footer:not(:hover) {
 	opacity: 30%;
 }
 
-body > .footer > div > ul:first-of-type li:first-of-type { /* The `© 2017 GitHub, Inc.` text */
+.footer > div > ul:first-of-type li:first-of-type { /* The `© 2017 GitHub, Inc.` text */
 	display: none;
 }
 
@@ -14,7 +14,7 @@ body > .footer > div > ul:first-of-type li:first-of-type { /* The `© 2017 GitHu
 	display: none !important;
 }
 
-body > .footer li a,
-body > .footer li .btn-link {
+.footer li a,
+.footer li .btn-link {
 	color: var(--color-text-disabled, #666);
 }

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -33,6 +33,17 @@ function init(): void {
 			inView.observe(button);
 		},
 	});
+
+	// Use cloneNode to keep the original ones for responsive layout
+	const feedFooter = select('.news > .f6')!.cloneNode(true);
+	const footer = select('.footer > .d-flex')!.cloneNode(true);
+	footer.classList.add('mt-3');
+
+	for (const child of footer.children) {
+		child.classList.remove('pl-lg-4', 'col-xl-3');
+	}
+
+	select('[aria-label="Explore"]')!.append(feedFooter, footer);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -48,7 +48,7 @@ function init(): void {
 		<div className="footer">
 			{feedFooter}
 			{footer}
-		</div>
+		</div>,
 	);
 }
 

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -1,3 +1,4 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
 import debounce from 'debounce-fn';
@@ -43,7 +44,12 @@ function init(): void {
 		child.classList.remove('pl-lg-4', 'col-xl-3');
 	}
 
-	select('[aria-label="Explore"]')!.append(feedFooter, footer);
+	select('[aria-label="Explore"]')!.append(
+		<div className="footer">
+			{feedFooter}
+			{footer}
+		</div>
+	);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

As mentioned in #5126, `infinite-scroll` effectively makes footer inaccessible, not only affecting that PR but also making us lose access to lots of useful links.

## Test URLs

https://github.com/

## Screenshot

<details>

![image](https://user-images.githubusercontent.com/44045911/143937759-78842be7-1552-4789-ac03-402520762f85.png)

(Similiar to Twitter sidebar:)

![image](https://user-images.githubusercontent.com/44045911/143938767-2a909c0a-13fe-4423-9595-f5d2380bd503.png)

</details


