### PR TITLE
Fix `quick-pr-diff-options` on compare pages

### DIFF
--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -112,11 +112,12 @@ function initCommitAndCompare(): false | void {
 	);
 }
 
-const shortcuts: {
+const shortcuts = {
 	'd w': 'Show/hide whitespaces in diffs',
 };
 
 void features.add(import.meta.url, {
+	shortcuts,
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
@@ -124,16 +125,16 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPRFile404,
 	],
-	shortcuts,
 	deduplicate: 'has-rgh-inner',
 	init: initPR,
 }, {
+	shortcuts,
 	include: [
 		pageDetect.isSingleCommit,
 	],
-	shortcuts,
 	init: initCommitAndCompare,
 }, {
+	shortcuts,
 	include: [
 		pageDetect.isCompare,
 	],
@@ -141,6 +142,5 @@ void features.add(import.meta.url, {
 		onDiffFileLoad,
 	],
 	onlyAdditionalListeners: true,
-	shortcuts,
 	init: initCommitAndCompare,
 });

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -112,6 +112,10 @@ function initCommitAndCompare(): false | void {
 	);
 }
 
+const shortcuts: {
+	'd w': 'Show/hide whitespaces in diffs',
+};
+
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRFiles,
@@ -120,18 +124,14 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPRFile404,
 	],
-	shortcuts: {
-		'd w': 'Show/hide whitespaces in diffs',
-	},
+	shortcuts,
 	deduplicate: 'has-rgh-inner',
 	init: initPR,
 }, {
 	include: [
 		pageDetect.isSingleCommit,
 	],
-	shortcuts: {
-		'd w': 'Show/hide whitespaces in diffs',
-	},
+	shortcuts,
 	init: initCommitAndCompare,
 }, {
 	include: [
@@ -141,8 +141,6 @@ void features.add(import.meta.url, {
 		onDiffFileLoad,
 	],
 	onlyAdditionalListeners: true,
-	shortcuts: {
-		'd w': 'Show/hide whitespaces in diffs',
-	},
+	shortcuts,
 	init: initCommitAndCompare,
 });

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -4,6 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import {BookIcon, CheckIcon, DiffIcon, DiffModifiedIcon} from '@primer/octicons-react';
 
 import features from '.';
+import {onDiffFileLoad} from '../github-events/on-fragment-load';
 
 function makeLink(type: string, icon: Element, selected: boolean): JSX.Element {
 	const url = new URL(location.href);
@@ -127,8 +128,19 @@ void features.add(import.meta.url, {
 }, {
 	include: [
 		pageDetect.isSingleCommit,
+	],
+	shortcuts: {
+		'd w': 'Show/hide whitespaces in diffs',
+	},
+	init: initCommitAndCompare,
+}, {
+	include: [
 		pageDetect.isCompare,
 	],
+	additionalListeners: [
+		onDiffFileLoad,
+	],
+	onlyAdditionalListeners: true,
 	shortcuts: {
 		'd w': 'Show/hide whitespaces in diffs',
 	},


### PR DESCRIPTION
## Test URLs

https://github.com/refined-github/refined-github/compare/add-multiple-prs-dropdown

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/143942411-b7fb4221-7c19-4a4c-8313-cb6a18201466.png)