### PR TITLE
Show error toast when `quick-label-removal` fails

### DIFF
--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -18,9 +18,8 @@ async function removeLabelButtonClickHandler(event: delegate.Event<MouseEvent, H
 	event.preventDefault();
 
 	const removeLabelButton = event.delegateTarget;
-	removeLabelButton.disabled = true;
-
 	const label = removeLabelButton.closest('a')!;
+
 	label.hidden = true;
 	try {
 		await api.v3(`issues/${getConversationNumber()!}/labels/${removeLabelButton.dataset.name!}`, {
@@ -28,7 +27,6 @@ async function removeLabelButtonClickHandler(event: delegate.Event<MouseEvent, H
 		});
 	} catch (error: unknown) {
 		void showToast(error as Error);
-		removeLabelButton.disabled = false;
 		removeLabelButton.blur();
 		label.hidden = false;
 		return;

--- a/source/github-helpers/toast.tsx
+++ b/source/github-helpers/toast.tsx
@@ -12,14 +12,14 @@ export function ToastSpinner(): JSX.Element {
 }
 
 type ProgressCallback = (message: string) => void;
-type Task<T> = (progress?: ProgressCallback) => Promise<T>;
-export default async function showToast<TaskOrError extends Task<any> | Error>(
-	task: TaskOrError,
+type Task = (progress?: ProgressCallback) => Promise<unknown>;
+export default async function showToast(
+	task: Task | Error,
 	{
 		message = 'Bulk actions currently being processed.',
 		doneMessage = 'Bulk action processing complete.',
 	} = {},
-): Promise<[TaskOrError] extends [Task<infer R>] ? R : void> {
+): Promise<void> {
 	const iconWrapper = <span className="Toast-icon"><ToastSpinner/></span>;
 	const messageWrapper = <span className="Toast-content">{message}</span>;
 	const toast = (
@@ -44,11 +44,11 @@ export default async function showToast<TaskOrError extends Task<any> | Error>(
 			throw task;
 		}
 
-		const result = await task(updateToast);
+		await task(updateToast);
 		toast.classList.replace('Toast--loading', 'Toast--success');
 		updateToast(doneMessage);
 		iconWrapper.firstChild!.replaceWith(<CheckIcon/>);
-		return result;
+		return;
 	} catch (error: unknown) {
 		toast.classList.replace('Toast--loading', 'Toast--error');
 		updateToast(error instanceof Error ? error.message : 'Unknown Error');

--- a/source/github-helpers/toast.tsx
+++ b/source/github-helpers/toast.tsx
@@ -48,7 +48,6 @@ export default async function showToast(
 		toast.classList.replace('Toast--loading', 'Toast--success');
 		updateToast(doneMessage);
 		iconWrapper.firstChild!.replaceWith(<CheckIcon/>);
-		return;
 	} catch (error: unknown) {
 		toast.classList.replace('Toast--loading', 'Toast--error');
 		updateToast(error instanceof Error ? error.message : 'Unknown Error');


### PR DESCRIPTION
Fixes #4828 

## Test URLs

Revoke your API token and try to remove a label on this page.

## Screenshot

https://user-images.githubusercontent.com/46634000/144035109-e9dc3fc6-d729-48b7-bae6-621cf4630cbb.mp4