### PR TITLE
Hide code of conduct in `clean-conversation-sidebar`

### DIFF
--- a/source/features/clean-conversation-sidebar.css
+++ b/source/features/clean-conversation-sidebar.css
@@ -25,3 +25,8 @@ form.thread-subscribe-form { /* `form` excludes the header */
 .thread-subscription-status .reason {
 	margin: 0 0 10px !important;
 }
+
+/* Hide links that are hideable via CSS */
+.rgh-clean-sidebar-done .Layout-sidebar .Link--muted[href$='/code-of-conduct.md' i] {
+	display: none;
+}

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -58,6 +58,7 @@ function cleanSection(selector: string): boolean {
 }
 
 async function clean(): Promise<void> {
+	document.body.classList.add('rgh-clean-sidebar-done')
 	if (select.exists('.rgh-clean-sidebar')) {
 		return;
 	}

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -19,13 +19,6 @@ async function cleanLicenseText(): Promise<void> {
 	}
 }
 
-async function cleanCodeOfConductText(): Promise<void> {
-	const codeOfConductLink = await elementReady('.Layout-sidebar .octicon-checklist');
-	if (codeOfConductLink) {
-		codeOfConductLink.nextSibling!.textContent = codeOfConductLink.nextSibling!.textContent!.trim();
-	}
-}
-
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
@@ -72,7 +65,6 @@ async function init(): Promise<void> {
 
 	void removeReadmeLink();
 	void cleanLicenseText();
-	void cleanCodeOfConductText();
 	void cleanReleases();
 	void hideEmptyPackages();
 


### PR DESCRIPTION
Replaces https://github.com/refined-github/refined-github/pull/5098