### PR TITLE
Fix `previous-next-commit-buttons` on condensed commit views

### DIFF
--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -10,9 +10,13 @@ function init(): false | void {
 	}
 
 	const previousNext = originalPreviousNext.cloneNode(true);
-	const files = select('#files')!;
-
-	files.after(previousNext);
+	const condensedVersionWarningBox = select('#files ~ .flash-warn');
+	if (condensedVersionWarningBox) {
+		previousNext.classList.add('mt-3');
+		condensedVersionWarningBox.after(previousNext); // #4503
+	} else {
+		select('#files')!.after(previousNext);
+	}
 }
 
 void features.add(import.meta.url, {

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -12,7 +12,7 @@ function init(): false | void {
 
 	// Wrap the button in a <div> to avoid #4503
 	select('#files')!.after(
-		<div className={'d-flex flex-justify-end' + (select.exists('#files ~ .flash-warn') ? ' mb-3' : '')}>
+		<div className="d-flex flex-justify-end mb-3">
 			{originalPreviousNext.cloneNode(true)}
 		</div>,
 	);

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -1,3 +1,4 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
@@ -9,14 +10,14 @@ function init(): false | void {
 		return false;
 	}
 
-	const previousNext = originalPreviousNext.cloneNode(true);
-	const condensedVersionWarningBox = select('#files ~ .flash-warn');
-	if (condensedVersionWarningBox) {
-		previousNext.classList.add('mt-3');
-		condensedVersionWarningBox.after(previousNext); // #4503
-	} else {
-		select('#files')!.after(previousNext);
-	}
+	// Wrap the button in a <div> to avoid #4503
+	select('#files')!.after(
+		<div className="d-flex flex-justify-end">
+			{originalPreviousNext.cloneNode(true)}
+		</div>,
+	);
+
+	select('#files ~ .flash-warn')?.classList.add('mt-3');
 }
 
 void features.add(import.meta.url, {

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -12,12 +12,10 @@ function init(): false | void {
 
 	// Wrap the button in a <div> to avoid #4503
 	select('#files')!.after(
-		<div className="d-flex flex-justify-end">
+		<div className={'d-flex flex-justify-end' + (select.exists('#files ~ .flash-warn') ? ' mb-3' : '')}>
 			{originalPreviousNext.cloneNode(true)}
 		</div>,
 	);
-
-	select('#files ~ .flash-warn')?.classList.add('mt-3');
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fixes #4503 

## Test URLs

* [Condensed commit](https://togithub.com/refined-github/refined-github/pull/4448/commits/0b8966c918eae11da9fc992368741757088edf08)
* [Regular commit](https://togithub.com/refined-github/refined-github/pull/5113/commits/5b7282afc40b013f5928271fb6740cf70b4e4295)

## Screenshot

**Before**

![image](https://user-images.githubusercontent.com/46634000/144264476-dd1caff5-9d2b-41ad-bc4d-9f630a97852b.png)

**After**

![image](https://user-images.githubusercontent.com/46634000/145017103-58d405ef-1b3f-4b21-b006-b1970078055a.png)