### PR TITLE
Fix Code of conduct link hiding in `clean-repo-sidebar`

### DIFF
--- a/source/features/clean-conversation-sidebar.css
+++ b/source/features/clean-conversation-sidebar.css
@@ -25,8 +25,3 @@ form.thread-subscribe-form { /* `form` excludes the header */
 .thread-subscription-status .reason {
 	margin: 0 0 10px !important;
 }
-
-/* Hide links that are hideable via CSS */
-.rgh-clean-sidebar-done .Layout-sidebar .Link--muted[href$='/code-of-conduct.md' i] {
-	display: none;
-}

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -62,8 +62,6 @@ async function clean(): Promise<void> {
 		return;
 	}
 
-	document.body.classList.add('rgh-clean-sidebar-done');
-
 	select('#partial-discussion-sidebar')!.classList.add('rgh-clean-sidebar');
 
 	// Assignees

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -12,3 +12,11 @@
 .rgh-clean-repo-sidebar ul.flex-wrap + .mt-3 {
 	display: none;
 }
+
+/* Hide Code of conduct links */
+.rgh-clean-repo-sidebar .Layout-sidebar .Link--muted:is(
+	[href$='/code-of-conduct.md' i],
+	[href$='/code_of_conduct.md' i]
+ ) {
+	display: none;
+}

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -15,8 +15,8 @@
 
 /* Hide Code of conduct links */
 .rgh-clean-repo-sidebar .Layout-sidebar .Link--muted:is(
-	[href$='/code-of-conduct.md' i],
-	[href$='/code_of_conduct.md' i]
- ) {
+[href$='/code-of-conduct.md' i],
+[href$='/code_of_conduct.md' i]
+) {
 	display: none;
 }

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -19,13 +19,6 @@ async function cleanLicenseText(): Promise<void> {
 	}
 }
 
-async function cleanCodeOfConductText(): Promise<void> {
-	const codeOfConductLink = await elementReady('.Layout-sidebar .octicon-checklist');
-	if (codeOfConductLink) {
-		codeOfConductLink.nextSibling!.textContent = codeOfConductLink.nextSibling!.textContent!.trim();
-	}
-}
-
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
@@ -72,7 +65,6 @@ async function init(): Promise<void> {
 
 	void removeReadmeLink();
 	void cleanLicenseText();
-	void cleanCodeOfConductText();
 	void cleanReleases();
 	void hideEmptyPackages();
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -19,6 +19,13 @@ async function cleanLicenseText(): Promise<void> {
 	}
 }
 
+async function cleanCodeOfConductText(): Promise<void> {
+	const codeOfConductLink = await elementReady('.Layout-sidebar .octicon-checklist');
+	if (codeOfConductLink) {
+		codeOfConductLink.nextSibling!.textContent = codeOfConductLink.nextSibling!.textContent!.trim();
+	}
+}
+
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
@@ -65,6 +72,7 @@ async function init(): Promise<void> {
 
 	void removeReadmeLink();
 	void cleanLicenseText();
+	void cleanCodeOfConductText();
 	void cleanReleases();
 	void hideEmptyPackages();
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Back story time. I remember seeing #5098 a while ago, and just now I was at https://github.com/fish-shell/fish-shell/ and noticed that link is still there.

I literally updated the browser extension moments ago (I use the store version when not developing it), what could go wrong? Then I noticed #5133 and after taking a closer look, I notice that fish-shell's link is `CODE_OF_CONDUCT.md` (underscore-separated) instead of `code-of-conduct.md` (dash-separated).

Then I fired up the dev env and updated the selectors, nothing happened. I went to check the original testing link (got) and nothing happened either.

Taking a _closer_ look again I noticed [the wrong feature are changed in #5133](https://github.com/refined-github/refined-github/pull/5133#discussion_r761085007). So that's it.


## Test URLs

- `code-of-conduct.md`: https://github.com/sindresorhus/got
- `CODE_OF_CONDUCT.md`: https://github.com/fish-shell/fish-shell/

## Screenshot

Before:
![image](https://user-images.githubusercontent.com/44045911/144431918-344210ad-6b51-430a-b8e5-70bcdccd53ba.png)


![image](https://user-images.githubusercontent.com/44045911/144431894-d01cce72-61a8-4bdd-92c2-02c22f8ed2e6.png)

After:
![image](https://user-images.githubusercontent.com/44045911/144431947-179b2a1a-48b1-4d72-bf88-96f7cdd42ef4.png)


![image](https://user-images.githubusercontent.com/44045911/144431930-965d558e-f269-44eb-b4c5-8b25dbb21811.png)
