### PR TITLE
Restore `hide-inactive-deployments`

### DIFF
--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -6,7 +6,7 @@ import onNewComments from '../github-events/on-new-comments';
 
 function init(): void {
 	// Selects all the deployments first so that we can leave the last one on the page
-	const deployments = select.all('.js-socket-channel[data-url$="/pull_requests/events/deployed"]');
+	const deployments = select.all('.js-socket-channel[data-url*="/partials/deployed_event/"]');
 	deployments.pop(); // Don't hide the last deployment, even if it is inactive
 
 	for (const deployment of deployments) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

At some point GitHub updated their url for deployment events, making the `hide-inactive-deployment` feature no longer work. This updates the selector with the new path. Here is a copy of the new deployment html:

```html
<div class="js-socket-channel js-updatable-content" data-channel="nope" data-url="/btkostner/btkostner.io/pull/11/partials/deployed_event/5714613804" data-gid="PR_kwDOAdZchc4vYKrY">
  <div id="event-5714613804" data-view-component="true" class="TimelineItem js-targetable-element">

    <div data-view-component="true" class="TimelineItem-badge"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-rocket">
        <path fill-rule="evenodd"
          d="M14.064 0a8.75 8.75 0 00-6.187 2.563l-.459.458c-.314.314-.616.641-.904.979H3.31a1.75 1.75 0 00-1.49.833L.11 7.607a.75.75 0 00.418 1.11l3.102.954c.037.051.079.1.124.145l2.429 2.428c.046.046.094.088.145.125l.954 3.102a.75.75 0 001.11.418l2.774-1.707a1.75 1.75 0 00.833-1.49V9.485c.338-.288.665-.59.979-.904l.458-.459A8.75 8.75 0 0016 1.936V1.75A1.75 1.75 0 0014.25 0h-.186zM10.5 10.625c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 00.119-.213v-2.066zM3.678 8.116L5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 00-.213.119l-1.2 1.95 1.782.547zm5.26-4.493A7.25 7.25 0 0114.063 1.5h.186a.25.25 0 01.25.25v.186a7.25 7.25 0 01-2.123 5.127l-.459.458a15.21 15.21 0 01-2.499 2.02l-2.317 1.5-2.143-2.143 1.5-2.317a15.25 15.25 0 012.02-2.5l.458-.458h.002zM12 5a1 1 0 11-2 0 1 1 0 012 0zm-8.44 9.56a1.5 1.5 0 10-2.12-2.12c-.734.73-1.047 2.332-1.15 3.003a.23.23 0 00.265.265c.671-.103 2.273-.416 3.005-1.148z">
        </path>
      </svg></div>
    <div data-view-component="true" class="TimelineItem-body"> <a class="d-inline-block" data-test-selector="pr-timeline-events-actor-avatar" data-hovercard-type="user" data-hovercard-url="/users/btkostner/hovercard"
        data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/btkostner"><img class="avatar avatar-user" src="https://avatars.githubusercontent.com/u/3385679?s=40&amp;u=a0fe09e0f7101fa3311b0da4be177534285a1fbf&amp;v=4"
          width="20" height="20" alt="@btkostner"></a>
      <a class="author Link--primary text-bold rgh-fullname" data-test-selector="pr-timeline-events-actor-profile-link" data-hovercard-type="user" data-hovercard-url="/users/btkostner/hovercard" data-octo-click="hovercard-link-click"
        data-octo-dimensions="link_type:self" href="/btkostner">btkostner</a>


      <a target="_blank" class="Link--secondary" data-skip-pjax="true" rel="noopener noreferrer" href="https://github.com/btkostner/btkostner.io/runs/4413557430?check_suite_focus=true">deployed</a>
      to
      <a href="https://btkostner.io/pr/11" data-view-component="true" class="Link--primary text-bold">
        Preview
      </a>


      <a href="#event-5714613804" data-view-component="true" class="Link--secondary">
        <time-ago datetime="2021-12-03T22:04:43Z" data-view-component="true" class="no-wrap" title="Dec 3, 2021, 3:04 PM MST">17 minutes ago</time-ago>
      </a>
      <a class="btn btn-sm btn-outline float-right" target="_blank" rel="noopener noreferrer" href="https://btkostner.io/pr/11">View deployment</a>

    </div>
  </div>
</div>
```

## Test URLs

https://github.com/btkostner/btkostner.io/pull/10
https://github.com/btkostner/btkostner.io/pull/11

## Screenshot

What currently shows:
![image](https://user-images.githubusercontent.com/3385679/144680946-4d86a91e-ddb8-472b-9df4-85645a33e204.png)

What it looks like after this code change:
![image](https://user-images.githubusercontent.com/3385679/144681355-7d628fe3-7e57-482f-897c-63ef68a61eb8.png)
