### PR TITLE
Fix `release-download-count` feature

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -51,9 +51,9 @@ async function init(): Promise<void | false> {
 		const name = select('.Box svg.octicon-tag ~ span')!.textContent!.trim();
 		releases.set(name, select('.Box-footer')!);
 	} else {
-		for (const release of select.all('.js-release-expandable')) {
+		for (const release of select.all('[data-test-selector="release-card"] > .Box')) {
 			if (!select.exists('.octicon-package', release)) {
-				return;
+				continue;
 			}
 
 			// Get the tag name from the heading link


### PR DESCRIPTION
Fixes #5147 

## Test URLs

 * [Release list](https://github.com/AudioBand/AudioBand/releases)
 * [Single release](https://github.com/AudioBand/AudioBand/releases/tag/v1.0.3)
 * [Release list (with several artifact per release)](https://github.com/fish-shell/fish-shell/releases)

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/144709837-81173523-3303-4a1a-8d1f-e5b4c9951ff9.png)