### PR TITLE
Fix `reactions-avatars` on releases and review comments

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -21,8 +21,7 @@ interface Participant {
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
 	// Reaction buttons on releases and review comments have the list of people in their `title` attribute instead of `aria-label` #5150
-	const buttonTitle = button.getAttribute('title')!;
-	const users = (buttonTitle.length > 0 ? buttonTitle : button.getAttribute('aria-label')!)
+	const users = (button.getAttribute('title')! || button.getAttribute('aria-label')!)
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -21,7 +21,7 @@ interface Participant {
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
 	const currentUser = getUsername();
-	const users = button.getAttribute('aria-label')!
+	const users = (pageDetect.isReleasesOrTags() ? button.getAttribute('title') : button.getAttribute('aria-label'))!
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')
@@ -56,8 +56,8 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 	const avatarLimit = arbitraryAvatarLimit - (commentReactions.children.length * approximateHeaderLength);
 
 	const participantByReaction = select
-		.all(':scope > button[aria-label$="emoji"]', commentReactions)
-		.map(button => getParticipants(button));
+		.all(':scope > button:is([aria-label$="emoji"], [title$="emoji"])', commentReactions) // `aria-label` is for PR/issue comments, `title` for releases
+		.map(button => getParticipants(button as HTMLButtonElement));
 	const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
 	for (const {button, username, imageUrl} of flatParticipants) {

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -56,7 +56,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 	const avatarLimit = arbitraryAvatarLimit - (commentReactions.children.length * approximateHeaderLength);
 
 	const participantByReaction = select
-		.all(':scope > button:is([aria-label$="emoji"], [title$="emoji"])', commentReactions) // `aria-label` is for PR/issue comments, `title` for releases
+		.all(':scope > button.social-reaction-summary-item', commentReactions) // `aria-label` is for PR/issue comments, `title` for releases
 		.map(button => getParticipants(button as HTMLButtonElement));
 	const flatParticipants = flatZip(participantByReaction, avatarLimit);
 

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -21,7 +21,7 @@ interface Participant {
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
 	const currentUser = getUsername();
-	const users = (pageDetect.isReleasesOrTags() ? button.getAttribute('title') : button.getAttribute('aria-label'))!
+	const users = pageDetect.isReleasesOrTags() ? button.getAttribute('title')! : button.getAttribute('aria-label')!
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -20,13 +20,15 @@ interface Participant {
 }
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
-	const currentUser = getUsername();
-	const users = pageDetect.isReleasesOrTags() ? button.getAttribute('title')! : button.getAttribute('aria-label')!
+	// Reaction buttons on releases and review comments have the list of people in their `title` attribute instead of `aria-label` #5150
+	const buttonTitle = button.getAttribute('title')!;
+	const users = (buttonTitle.length > 0 ? buttonTitle : button.getAttribute('aria-label')!)
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')
 		.split(', ');
 
+	const currentUser = getUsername();
 	const participants = [];
 	for (const username of users) {
 		if (username === currentUser) {
@@ -56,8 +58,8 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 	const avatarLimit = arbitraryAvatarLimit - (commentReactions.children.length * approximateHeaderLength);
 
 	const participantByReaction = select
-		.all(':scope > button.social-reaction-summary-item', commentReactions) // `aria-label` is for PR/issue comments, `title` for releases
-		.map(button => getParticipants(button as HTMLButtonElement));
+		.all(':scope > button.social-reaction-summary-item', commentReactions)
+		.map(button => getParticipants(button));
 	const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
 	for (const {button, username, imageUrl} of flatParticipants) {


### PR DESCRIPTION
Fixes #5190 

## Test URLs

 * [Release list](https://github.com/refined-github/refined-github/releases)
 * [Single release](https://github.com/refined-github/refined-github/releases/tag/21.11.23)
 * [Issue with reactions](https://togithub.com/refined-github/refined-github/issues/2673)

## Screenshot

**Before**

![screenshot-1638622978](https://user-images.githubusercontent.com/46634000/144710466-f6c373f9-a49b-40d9-b6c1-3e90c466e5f7.png)

**After**

![screenshot-1638622876](https://user-images.githubusercontent.com/46634000/144710465-2b0ddb1a-3f01-457c-aae5-6832995ec565.png)