### PR TITLE
Use emoji in `unfinished-comments`

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -29,7 +29,7 @@ function updateDocumentTitle(): void {
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
-		document.title = '(Draft comment) ' + document.title;
+		document.title = '✏️ (unsent) ' + document.title;
 	} else if (documentTitle) {
 		document.title = documentTitle;
 		documentTitle = undefined;

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -29,7 +29,7 @@ function updateDocumentTitle(): void {
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
-		document.title = '✏️ (unsent) ' + document.title;
+		document.title = '✏️ (draft) ' + document.title;
 	} else if (documentTitle) {
 		document.title = documentTitle;
 		documentTitle = undefined;

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -29,7 +29,7 @@ function updateDocumentTitle(): void {
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
-		document.title = '✏️ (draft) ' + document.title;
+		document.title = '✏️ Draft - ' + document.title;
 	} else if (documentTitle) {
 		document.title = documentTitle;
 		documentTitle = undefined;


### PR DESCRIPTION
I feel that the text isn't visible enough. The only concern is OSes where emojis aren't available. 🤷‍♂️ 😬 

## Test URLs

This PR, type a comment

## Before

<img width="352" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/144763458-2b8b4102-a957-401e-923a-932513e26bf0.png">

## After

<img width="335" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/144763455-ff974ebc-be09-455c-a355-e8e972032690.png">
