### PR TITLE
Hide trailing separator in PR and commit files dropdown

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -51,3 +51,8 @@
 #all_commit_comments .timeline-comment-wrapper {
 	max-width: 780px; /* This is the limit applied on the comment thread by `.comment-holder` */
 }
+
+/* Hide trailing separator in PR/commit file diff dropdown */
+.js-file-header-dropdown .dropdown-menu > .dropdown-divider:last-child {
+	display: none !important;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -170,8 +170,3 @@ pr-branches
 :is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
 	display: none !important;
 }
-
-/* Hide trailing separator in PR/commit file diff dropdown */
-.js-file-header-dropdown .dropdown-menu > .dropdown-divider:last-child {
-	display: none !important;
-}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -170,3 +170,8 @@ pr-branches
 :is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
 	display: none !important;
 }
+
+/* Hide trailing separator in PR/commit file diff dropdown */
+.js-file-header-dropdown .dropdown-menu > .dropdown-divider:last-child {
+	display: none !important;
+}


### PR DESCRIPTION
## Test URLs

 * [PR file](https://togithub.com/refined-github/refined-github/pull/5151/files)
 * [Commit file](https://togithub.com/refined-github/refined-github/commit/fd89b5a69999aa08ba9add6240c33ac5624e6ac8)

## Screenshot

**Before**

![screenshot-1638872748](https://user-images.githubusercontent.com/46634000/145012292-ded734c5-7aa8-4dbf-8d8e-73af892fb485.png)

**After**

![screenshot-1638872703](https://user-images.githubusercontent.com/46634000/145012288-68b7ad04-4817-4ff1-922d-1db5e2cdd3ff.png)