### PR TITLE
Fix option saving in Safari

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -234,9 +234,6 @@ async function generateDom(): Promise<void> {
 
 	// Update list from saved options
 	await perDomainOptions.syncForm('form');
-	if (navigator.userAgent.includes('Safari')) {
-		void cache.clear();
-	}
 
 	// Decorate list
 	await highlightNewFeatures();
@@ -301,6 +298,11 @@ function addEventListeners(): void {
 async function init(): Promise<void> {
 	await generateDom();
 	addEventListeners();
+
+	// Safari’s storage is inexplicably limited #4823
+	if (navigator.userAgent.includes('Safari')) {
+		void cache.clear();
+	}
 }
 
 void init();

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -234,6 +234,9 @@ async function generateDom(): Promise<void> {
 
 	// Update list from saved options
 	await perDomainOptions.syncForm('form');
+	if (navigator.userAgent.includes('Safari')) {
+		void cache.clear();
+	}
 
 	// Decorate list
 	await highlightNewFeatures();


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/4823

Every time I want to change the options in Safari, I have to manually clear the cache due to this issue. So why not do it automatically?