### PR TITLE
Meta: Automatically label commits in releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+changelog:
+  exclude:
+    labels:
+      - meta
+  categories:
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: New
+      labels:
+        - enhancement
+    - title: Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Untested 

Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

Mentioned in

- https://github.com/refined-github/refined-github/issues/4008#issuecomment-942723376