### PR TITLE
Meta: Fix option saving only in Safari

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -298,11 +298,6 @@ function addEventListeners(): void {
 async function init(): Promise<void> {
 	await generateDom();
 	addEventListeners();
-
-	// Safari’s storage is inexplicably limited #4823
-	if (navigator.userAgent.includes('Safari')) {
-		void cache.clear();
-	}
 }
 
 void init();


### PR DESCRIPTION
Reverts refined-github/refined-github#5166

Perhaps it should be "if UserAgent includes `Safari` but not `Chrome` then it's Safari".