### PR TITLE
Fix duplication in `comment-on-draft-pr-indicator`

### DIFF
--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -5,6 +5,7 @@ import features from '.';
 import onReplacedElement from '../helpers/on-replaced-element';
 
 function addIndicator(button: HTMLElement): void {
+	button.classList.add('rgh-draft-pr-indicator');
 	const preposition = button.textContent!.includes('Add') ? ' to ' : ' on ';
 	button.textContent += preposition + 'draft PR';
 }
@@ -21,7 +22,7 @@ function init(): void {
 
 	if (pageDetect.isPRConversation()) {
 		// The button is part of a .js-updatable-content partial
-		void onReplacedElement('#partial-new-comment-form-actions .btn-primary', addIndicator, {runCallbackOnStart: true});
+		void onReplacedElement('#partial-new-comment-form-actions .btn-primary:not(.rgh-draft-pr-indicator)', addIndicator, {runCallbackOnStart: true});
 	}
 }
 


### PR DESCRIPTION
Fix #5191 

## Test URLs

 1. Go to https://togithub.com/refined-github/sandbox/pull/7
 2. Click on the "Open issue" link in the sidebar
 3. Go back
 4. The text in the comment button should not be duplicated

## Screenshot

https://user-images.githubusercontent.com/46634000/145685950-4ab3e8d2-b7d8-469d-a742-af8b2058cf8b.mp4