### PR TITLE
Fix `user-profile-follower-badge` feature

### DIFF
--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -21,7 +21,7 @@ const doesUserFollow = cache.function(async (userA: string, userB: string): Prom
 
 async function init(): Promise<void> {
 	if (await doesUserFollow(getCleanPathname(), getUsername()!)) {
-		select('.js-profile-editable-area .octicon-star')!.closest('.mb-3')!.append(
+		select('.js-profile-editable-area [href$="?tab=following"]')!.after(
 			<span className="color-text-secondary color-fg-muted"> · Follows you</span>,
 		);
 	}


### PR DESCRIPTION
Fixes #5186 

## Test URLs

The profile of someones that follows you ( ͡° ͜ʖ ͡°)

## Screenshot

![screenshot-1639342500](https://user-images.githubusercontent.com/46634000/145729304-7467976d-1efd-4428-8f44-442e487aca16.png)