### PR TITLE
Fix `hide-tips` CSS feature

### DIFF
--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -23,8 +23,9 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	display: none !important;
 }
 
-/* Remove random protip at the bottom of conversations lists */
-.paginate-container + .text-center:last-child {
+/* Remove random protip at the bottom of pages */
+.paginate-container + .text-center:last-child, /* Conversation lists */
+.js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notification list */
 	display: none !important;
 }
 

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -23,8 +23,8 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	display: none !important;
 }
 
-/* Remove random protip at the bottom of the page */
-.protip {
+/* Remove random protip at the bottom of conversations lists */
+.paginate-container + .text-center:last-child {
 	display: none !important;
 }
 

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -23,7 +23,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	display: none !important;
 }
 
-/* Remove random protip at the bottom of pages */
+/* Remove random protip at the bottom of some pages */
 .paginate-container + .text-center:last-child, /* Conversation lists */
 .js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notification list */
 	display: none !important;


### PR DESCRIPTION
## Test URLs

 * [PR list](https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc)
 * [Gobal conversations list](https://github.com/issues?q=is%3Aopen+author%3A%40me+archived%3Afalse+sort%3Aupdated-desc)

## Screenshot

**Before**

![screenshot-1639343654](https://user-images.githubusercontent.com/46634000/145729761-e8768bc4-64ce-4fa5-a116-64e0798b4ac2.png)

**After**

![screenshot-1639343639](https://user-images.githubusercontent.com/46634000/145729759-c67fceb7-d315-4809-b619-f88aa25e7396.png)