### PR TITLE
Restore `hide-watch-and-fork-count`

### DIFF
--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,25 +1,6 @@
-/* The Watchers count visible (and clickable) when the dropdown is open */
-/* This isn't possible for the Forks count because of an incompatible DOM structure and #2368 */
-.rgh-hide-watch-and-fork-count details:not([open]) .btn[data-ga-click^='Repository, click Watch'] {
-	border-radius: 6px !important; /* Matches GitHub's default */
-}
-
-.rgh-hide-watch-and-fork-count details:not([open]) ~ .social-count[href$='/watchers'] {
+.rgh-hide-watch-and-fork-count :is(
+#repo-network-counter,
+#repo-notifications-counter
+) {
 	display: none;
-}
-
-@media (max-width: 1000px) {
-	.rgh-hide-watch-and-fork-count:not(.rgh-forked-to) .btn:is([title^='Fork your own'], [aria-label^='Fork your own'], [aria-label^='Cannot fork']) {
-		border-radius: 6px !important; /* Matches GitHub's default */
-	}
-
-	.rgh-hide-watch-and-fork-count .social-count[href$='/network/members'] {
-		display: none;
-	}
-}
-
-/* Bring the Watcher counts above the lightbox to make it clickable */
-.rgh-hide-watch-and-fork-count details[open] ~ .social-count[href$='/watchers'] {
-	position: relative;
-	z-index: 100;
 }

--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,6 +1,3 @@
-.rgh-hide-watch-and-fork-count :is(
-#repo-network-counter,
-#repo-notifications-counter
-) {
+.pagehead-actions :is(#repo-network-counter, #repo-notifications-counter) {
 	display: none;
 }

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -1,6 +1,0 @@
-import './hide-watch-and-fork-count.css';
-import * as pageDetect from 'github-url-detection';
-
-import features from '.';
-
-void features.addCssFeature(import.meta.url, [pageDetect.isRepo]);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -20,6 +20,7 @@ import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';
 import './features/night-not-found.css';
 import './features/hide-empty-profile-status.css';
+import './features/hide-watch-and-fork-count.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.
@@ -30,7 +31,6 @@ import './features/clean-pinned-issues';
 import './features/clean-dashboard';
 import './features/hide-low-quality-comments';
 import './features/hide-noisy-newsfeed-events';
-import './features/hide-watch-and-fork-count';
 import './features/minimize-upload-bar';
 import './features/hide-diff-signs';
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5161

I had hotfixed this in https://github.com/refined-github/refined-github/commit/88c3effcdf64cea8bf5dbdbf3084dce75af9cfb5

The old logic no longer applies, the links are now accessible in the sidebar: https://github.com/refined-github/refined-github/issues/5179

I'd argue we don't even need to keep this disableable since it's so simple and there's no loss of information (it appears in the sidebar), but maybe that's harder to sell since it's been possible to disable it already. Thoughts? Should we make it a CSS-only feature?

## Test URLs

- This page
- https://github.com/refined-github/shorten-repo-url


## Screenshot

<img width="385" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/145773517-e4d093fe-ce95-47e0-bdc5-5a6080eb28e0.png">

