### PR TITLE
Update `repo-age` and `clean-repo-sidebar` spacing

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -12,14 +12,6 @@ async function hideReadmeLink(): Promise<void> {
 	link?.parentElement!.setAttribute('hidden', 'true');
 }
 
-async function cleanLicenseText(): Promise<void> {
-	// Remove whitespace in license link to fix alignment of icons https://github.com/refined-github/refined-github/pull/3974#issuecomment-780213892
-	const licenseLink = await elementReady('.repository-content .octicon-law');
-	if (licenseLink) {
-		licenseLink.nextSibling!.textContent = licenseLink.nextSibling!.textContent!.trim();
-	}
-}
-
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
@@ -84,7 +76,6 @@ async function init(): Promise<void> {
 
 	await Promise.all([
 		hideReadmeLink(),
-		cleanLicenseText(),
 		cleanReleases(),
 		hideEmptyPackages(),
 		hideLanguageHeader(),

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -6,10 +6,10 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-async function removeReadmeLink(): Promise<void> {
+async function hideReadmeLink(): Promise<void> {
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
 	const link = await elementReady('.Link--muted[href="#readme"]');
-	link?.parentElement!.remove();
+	link?.parentElement!.setAttribute('hidden', 'true');
 }
 
 async function cleanLicenseText(): Promise<void> {
@@ -61,26 +61,35 @@ async function hideEmptyPackages(): Promise<void> {
 	}
 }
 
-async function init(): Promise<void> {
-	document.body.classList.add('rgh-clean-repo-sidebar');
-
-	void removeReadmeLink();
-	void cleanLicenseText();
-	void cleanReleases();
-	void hideEmptyPackages();
-
+async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
-	// Hide empty meta if it’s not editable by the current user
-	if (!pageDetect.canUserEditRepo()) {
-		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
-	}
-
-	// Hide "Language" header
 	const lastSidebarHeader = select('.repository-content .BorderGrid-row:last-of-type h2');
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
+}
+
+// Hide empty meta if it’s not editable by the current user
+async function hideEmptyMeta(): Promise<void> {
+	await domLoaded;
+
+	if (!pageDetect.canUserEditRepo()) {
+		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
+	}
+}
+
+async function init(): Promise<void> {
+	document.body.classList.add('rgh-clean-repo-sidebar');
+
+	await Promise.all([
+		hideReadmeLink(),
+		cleanLicenseText(),
+		cleanReleases(),
+		hideEmptyPackages(),
+		hideLanguageHeader(),
+		hideEmptyMeta(),
+	]);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -108,14 +108,14 @@ async function init(): Promise<void> {
 	// About a day old or less ?
 	const age = Date.now() - birthday.getTime() < 10e7
 		? fresh[Math.floor(Math.random() * fresh.length)]
-		: `${value} ${unit} old`;
+		: <><strong>{value}</strong> {unit} old</>;
 
 	const sidebarAboutSection = await elementReady('.repository-content .BorderGrid-cell');
 	sidebarAboutSection!.append(
 		<h3 className="sr-only">Repository age</h3>,
 		<div className="mt-2">
 			<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>
-				<RepoIcon className="mr-2"/>{age}
+				<RepoIcon className="mr-2"/> {age}
 			</a>
 		</div>,
 	);

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -113,7 +113,7 @@ async function init(): Promise<void> {
 	const sidebarAboutSection = await elementReady('.repository-content .BorderGrid-cell');
 	sidebarAboutSection!.append(
 		<h3 className="sr-only">Repository age</h3>,
-		<div className="mt-3">
+		<div className="mt-2">
 			<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 				<RepoIcon className="mr-2"/>{age}
 			</a>


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5179

## Test URLs

https://github.com/fregante/webext-tools
https://github.com/refined-github/refined-github
https://github.com/rust-lang/rust

## Native

<table>
<tr>
	<th>Native
	<th>Before
	<th>After
<tr  valign=top>
	<td>
<img width="332" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/145778584-cbc3948e-a791-4f91-8be6-81823edb0521.png">
	<td><img width="322" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/145778658-c15cf17a-c37f-4b7f-ab42-f81eda8fb27e.png">
	<td><img width="322" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/145778646-40a05cc6-d296-40ad-887d-59c7060ce909.png">
</table>



