### PR TITLE
Restore `forked-to` feature

### DIFF
--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -47,14 +47,13 @@ async function updateUI(forks: string[]): Promise<void> {
 	}
 
 	document.body.classList.add('rgh-forked-to');
+	const forkContainer = select('.pagehead-actions > li > div.float-left')!;
 	const forkCounter = select('#repo-network-counter');
 	const forkBoxContents = forkCounter!.parentElement!;
 	const forkBox = forkBoxContents.parentElement!;
-	const forkContainer = forkBox.parentElement!;
 
-	forkBoxContents.className += ' rounded-left-2 border-right-0 BtnGroup-item';
-	forkBox.className += ' details-reset details-overlay details-overlay-dark';
-	forkContainer.className += ' d-flex';
+	forkBoxContents.classList.add('rounded-left-2', 'border-right-0', 'BtnGroup-item');
+	forkContainer.classList.add('d-flex');
 
 	if (forks.length === 1) {
 		forkBox.after(

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -46,9 +46,8 @@ async function updateUI(forks: string[]): Promise<void> {
 	}
 
 	document.body.classList.add('rgh-forked-to');
-	const forkContainer = select('.pagehead-actions > li > div.float-left')!;
-	const forkCounter = select('#repo-network-counter');
-	const forkBoxContents = forkCounter!.parentElement!;
+	const forkContainer = select('.pagehead-actions .octicon-repo-forked')!.closest('.float-left')!;
+	const forkBoxContents = select('#repo-network-counter')!.parentElement!;
 	const forkBox = forkBoxContents.parentElement!;
 
 	forkBoxContents.classList.add('rounded-left-2', 'border-right-0', 'BtnGroup-item');

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -47,22 +47,30 @@ async function updateUI(forks: string[]): Promise<void> {
 	}
 
 	document.body.classList.add('rgh-forked-to');
-	const forkCounter = await elementReady('.social-count[href$="/network/members"]', {waitForChildren: false});
+	const forkCounter = select('#repo-network-counter');
+	const forkBoxContents = forkCounter!.parentElement!;
+	const forkBox = forkBoxContents.parentElement!;
+	const forkContainer = forkBox.parentElement!;
+
+	forkBoxContents.className += ' rounded-left-2 border-right-0 BtnGroup-item';
+	forkBox.className += ' details-reset details-overlay details-overlay-dark';
+	forkContainer.className += ' d-flex';
+
 	if (forks.length === 1) {
-		forkCounter!.before(
+		forkBox.after(
 			<a
 				href={createLink(forks[0])}
-				className="btn btn-sm float-left rgh-forked-button rgh-forked-link"
+				className="btn btn-sm rounded-right-2 rgh-forked-button rgh-forked-link"
 				title={`Open your fork at ${forks[0]}`}
 			>
 				<LinkExternalIcon/>
 			</a>,
 		);
 	} else {
-		forkCounter!.before(
-			<details className="details-reset details-overlay select-menu float-left">
+		forkBox.after(
+			<details className="details-reset details-overlay select-menu float-right">
 				<summary
-					className="select-menu-button float-left btn btn-sm btn-with-count rgh-forked-button"
+					className="select-menu-button btn btn-sm btn-with-count rounded-right-2 rgh-forked-button"
 					aria-haspopup="menu"
 					title="Open any of your forks"/>
 				<details-menu
@@ -107,7 +115,7 @@ async function init(): Promise<void | false> {
 	}
 
 	// This feature only applies to users that have multiple organizations, because that makes a fork picker modal appear when clicking on "Fork"
-	const hasOrganizations = await elementReady('details-dialog[src*="/fork"] include-fragment');
+	const hasOrganizations = await elementReady('details-dialog[src*="/fork"]');
 
 	// Only fetch/update forks when we see a fork (on the current page or in the cache).
 	// This avoids having to `updateCache` for every single repo you visit.

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -2,6 +2,7 @@ import './forked-to.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {CheckIcon, LinkExternalIcon, RepoForkedIcon} from '@primer/octicons-react';
 
@@ -46,8 +47,8 @@ async function updateUI(forks: string[]): Promise<void> {
 	}
 
 	document.body.classList.add('rgh-forked-to');
-	const forkContainer = select('.pagehead-actions .octicon-repo-forked')!.closest('.float-left')!;
-	const forkBoxContents = select('#repo-network-counter')!.parentElement!;
+	const forkContainer = (await elementReady('.pagehead-actions .octicon-repo-forked'))!.closest('.float-left')!;
+	const forkBoxContents = (await elementReady('#repo-network-counter'))!.parentElement!;
 	const forkBox = forkBoxContents.parentElement!;
 
 	forkBoxContents.classList.add('rounded-left-2', 'border-right-0', 'BtnGroup-item');
@@ -112,7 +113,7 @@ async function init(): Promise<void | false> {
 	}
 
 	// This feature only applies to users that have multiple organizations, because that makes a fork picker modal appear when clicking on "Fork"
-	const hasOrganizations = select('details-dialog[src*="/fork"]');
+	const hasOrganizations = await elementReady('details-dialog[src*="/fork"]');
 
 	// Only fetch/update forks when we see a fork (on the current page or in the cache).
 	// This avoids having to `updateCache` for every single repo you visit.

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -2,7 +2,6 @@ import './forked-to.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {CheckIcon, LinkExternalIcon, RepoForkedIcon} from '@primer/octicons-react';
 
@@ -114,7 +113,7 @@ async function init(): Promise<void | false> {
 	}
 
 	// This feature only applies to users that have multiple organizations, because that makes a fork picker modal appear when clicking on "Fork"
-	const hasOrganizations = await elementReady('details-dialog[src*="/fork"]');
+	const hasOrganizations = select('details-dialog[src*="/fork"]');
 
 	// Only fetch/update forks when we see a fork (on the current page or in the cache).
 	// This avoids having to `updateCache` for every single repo you visit.

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -46,13 +46,13 @@ async function updateUI(forks: string[]): Promise<void> {
 		return;
 	}
 
-	document.body.classList.add('rgh-forked-to');
-	const forkContainer = (await elementReady('.pagehead-actions .octicon-repo-forked'))!.closest('.float-left')!;
 	const forkBoxContents = (await elementReady('#repo-network-counter'))!.parentElement!;
+	const forkContainer = select('.pagehead-actions .octicon-repo-forked')!.closest('.float-left')!;
 	const forkBox = forkBoxContents.parentElement!;
 
-	forkBoxContents.classList.add('rounded-left-2', 'border-right-0', 'BtnGroup-item');
+	document.body.classList.add('rgh-forked-to');
 	forkContainer.classList.add('d-flex');
+	forkBoxContents.classList.add('rounded-left-2', 'border-right-0', 'BtnGroup-item');
 
 	if (forks.length === 1) {
 		forkBox.after(

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -46,7 +46,7 @@ async function updateUI(forks: string[]): Promise<void> {
 		return;
 	}
 
-	const forkBoxContents = (await elementReady('#repo-network-counter'))!.parentElement!;
+	const forkBoxContents = (await elementReady('#repo-network-counter', {waitForChildren: false}))!.parentElement!;
 	const forkContainer = select('.pagehead-actions .octicon-repo-forked')!.closest('.float-left')!;
 	const forkBox = forkBoxContents.parentElement!;
 
@@ -113,7 +113,7 @@ async function init(): Promise<void | false> {
 	}
 
 	// This feature only applies to users that have multiple organizations, because that makes a fork picker modal appear when clicking on "Fork"
-	const hasOrganizations = await elementReady('details-dialog[src*="/fork"]');
+	const hasOrganizations = await elementReady('details-dialog[src*="/fork"]', {waitForChildren: false});
 
 	// Only fetch/update forks when we see a fork (on the current page or in the cache).
 	// This avoids having to `updateCache` for every single repo you visit.


### PR DESCRIPTION
## What does this PR change?

> As the title says

| When  | Screenshot |
| ---  | --- |
| Before | ![no `forked-to` button](https://user-images.githubusercontent.com/34235681/145825515-0a9df8ce-d0d4-4a58-b7b6-691138d7904d.png) |
| After (only one fork) | ![only one fork](https://user-images.githubusercontent.com/34235681/145825633-79eec672-b2ee-4c54-9267-685b9570a8f0.png) |
| After (two or more forks) | ![two or more forks](https://user-images.githubusercontent.com/34235681/145825755-c70dd001-7fae-4cc6-8f82-4f1d896d20cc.png) |

I couldn't live without that feature for barely even a week XD



