### PR TITLE
Fix `reactions-avatars` size

### DIFF
--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -2,6 +2,7 @@
 	--size: 16px;
 	margin-left: calc(var(--size) * 0.3); /* Move away from count */
 	margin-right: calc(var(--size) * -0.5);
+	height: var(--size);
 }
 
 :root .rgh-reactions-avatar:last-of-type {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5204

This is happening because they added a CSS rule that targets `span`s in that button, which we're using.

## Test URLs

https://togithub.com/xojs/xo/issues/261

## Screenshot

<img width="278" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/146147802-90b946a2-43a6-4469-b1ca-e1f408111992.png">

