### PR TITLE
Meta: Fix indentation of stack trace in issue links

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -70,7 +70,11 @@ const logError = (url: string, error: unknown): void => {
 	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
 	newIssueUrl.searchParams.set('title', `\`${id}\`: ${message}`);
 	newIssueUrl.searchParams.set('example_url', location.href);
-	newIssueUrl.searchParams.set('description', ['```', (error instanceof Error ? error.stack! : String(error)).trim(), '```'].join('\n'));
+	newIssueUrl.searchParams.set('description', [
+		'```',
+		String(error instanceof Error ? error.stack! : error).trim(),
+		'```'
+	].join('\n'));
 
 	console.group('Open an issue');
 	console.log(newIssueUrl.href);

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -70,11 +70,7 @@ const logError = (url: string, error: unknown): void => {
 	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
 	newIssueUrl.searchParams.set('title', `\`${id}\`: ${message}`);
 	newIssueUrl.searchParams.set('example_url', location.href);
-	newIssueUrl.searchParams.set('description', stripIndent(`
-		\`\`\`
-		${error instanceof Error ? error.stack! : String(error)}
-		\`\`\`
-	`));
+	newIssueUrl.searchParams.set('description', ['```', (error instanceof Error ? error.stack! : String(error)).trim(), '```'].join('\n'));
 
 	console.group('Open an issue');
 	console.log(newIssueUrl.href);

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -73,7 +73,7 @@ const logError = (url: string, error: unknown): void => {
 	newIssueUrl.searchParams.set('description', [
 		'```',
 		String(error instanceof Error ? error.stack! : error).trim(),
-		'```'
+		'```',
 	].join('\n'));
 
 	console.group('Open an issue');


### PR DESCRIPTION
Fixes #5173 

## Test URLs

[Example of a created link](https://github.com/refined-github/refined-github/issues/new?labels=bug&template=1_bug_report.yml&title=%60forked-to%60%3A+forkCounter+is+undefined&example_url=https%3A%2F%2Fgithub.com%2Frefined-github%2Frefined-github%2Fpulls%3Fq%3Dis%253Apr%2Bis%253Aopen%2Bsort%253Aupdated-desc&description=%60%60%60%0AupdateUI%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A6743%3A5%0Aasync*init%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A6780%3A11%0Aasync*runFeature%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A7973%3A17%0AsetupPageLoad%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A7991%3A11%0Aadd%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A8049%3A12%0Aasync*.%2Fsource%2Ffeatures%2Fforked-to.tsx%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A6789%3A48%0A__webpack_require__%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A25907%3A42%0A%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A26080%3A98%0A%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A26375%3A3%0A%40moz-extension%3A%2F%2Fc2ad1c81-15a9-47dc-844b-f4235a6885c1%2Fbuild%2Frefined-github.js%3A26377%3A12%0A%60%60%60)


## Screenshot

![image](https://user-images.githubusercontent.com/46634000/146173954-b382a60e-9b67-4052-9fdd-28cd5fc01f78.png)