### PR TITLE
Enable `clean-rich-text-editor` on Gist pages

### DIFF
--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.isRepo]);
+void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);


### PR DESCRIPTION
Fixes #5185 

## Test URLs

https://gist.github.com/junegunn/8b572b8d4b5eddd8b85e5f4d40f17236#new_comment_field

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/146175276-d0e3bcef-2757-4e8c-86f2-6a6ab8576c75.png)