### PR TITLE
Restore monospace font in commit and merge title fields

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -42,6 +42,8 @@
 	font-weight: 600;
 }
 
+#merge_title_field,
+#commit-summary-input, /* Restore monospace font in commit/merge title fields #5188 */
 :is(.new_public_key, .new_gpg_key) textarea { /* Monospace textareas for new SSH/GPG keys #4917 */
 	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace !important;
 }


### PR DESCRIPTION
Fixes #5188 

## Test URLs

 * [Commit title field](https://togithub.com/refined-github/refined-github/edit/main/readme.md)
 * [Open PR merge title field](https://togithub.com/refined-github/sandbox/pull/4)

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/146191977-09b7bf2d-0622-4bb5-912e-d26d02a96f17.png)