### PR TITLE
Fix handling of slashed branches in some commits list features

### DIFF
--- a/source/features/list-prs-for-branch.tsx
+++ b/source/features/list-prs-for-branch.tsx
@@ -1,9 +1,9 @@
 import React from 'dom-chef';
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import getDefaultBranch from '../github-helpers/get-default-branch';
+import {getCurrentCommittish} from '../github-helpers';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';
 import {getPullRequestsAssociatedWithBranch, stateIcon} from './show-associated-branch-prs-on-fork';
 
@@ -15,21 +15,9 @@ const stateColorMap = {
 	DRAFT: '',
 };
 
-// TODO remove this after #4196 is fixed
-function getCurrentBranch(): string {
-	const feedLink = select.last('link[type="application/atom+xml"]')!;
-	return new URL(feedLink.href)
-		.pathname
-		.split('/')
-		.slice(4) // Drops the initial /user/repo/route/ part
-		.join('/')
-		.replace(/\.atom$/, '');
-}
-
 async function init(): Promise<void | false> {
-	const currentBranch = getCurrentBranch();
-
-	if (/^[\da-f]{40}$/.test(currentBranch) || await getDefaultBranch() === currentBranch) {
+	const currentBranch = getCurrentCommittish();
+	if (!currentBranch || /^[\da-f]{40}$/.test(currentBranch) || await getDefaultBranch() === currentBranch) {
 		return false;
 	}
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -29,6 +29,20 @@ export const getCurrentCommittish = (pathname = location.pathname, title = docum
 		return;
 	}
 
+	// Handle slashed branches in commits pages
+	if (type === 'commits') {
+		const branchAndFilepath = pathname.split('/').slice(4).join('/');
+
+		// List of all commits of current branch (no filename)
+		if (title.startsWith('Commits · ')) {
+			return branchAndFilepath;
+		}
+
+		// List of commits touching a particular file ("History")
+		const filepath = /^History for ([^ ]+) - /.exec(title)![1];
+		return branchAndFilepath.slice(0, branchAndFilepath.lastIndexOf('/' + filepath));
+	}
+
 	const parsedTitle = titleWithCommittish.exec(title);
 	if (parsedTitle) {
 		return parsedTitle.groups!.branch;

--- a/test/get-current-committish.ts
+++ b/test/get-current-committish.ts
@@ -83,7 +83,11 @@ test('getCurrentCommittish', t => {
 	t.is(getCurrentCommittish(
 		'/typescript-eslint/typescript-eslint/commits/chore/lerna-4/docs/getting-started/README.md',
 		'History for docs/getting-started/README.md - typescript-eslint/typescript-eslint',
-	), 'chore'); // Wrong, but
+	), 'chore/lerna-4');
+	t.is(getCurrentCommittish(
+		'/yakov116/TestR/commits/this/branch/has/many/slashes',
+		'Commits · yakov116/TestR',
+	), 'this/branch/has/many/slashes');
 
 	// Single commit
 	t.is(getCurrentCommittish(


### PR DESCRIPTION
Fixes #4492
Fixes #4196

## Test URLs

 * [Branch commits list](https://togithub.com/refined-github/sandbox/commits/branch/with/slashes)
 * [Renamed file history](https://togithub.com/refined-github/sandbox/commits/branch/with/slashes/renamed.md)

## Screenshot

`follow-file-renames`

![image](https://user-images.githubusercontent.com/46634000/146674229-52e9b8f3-c16e-4926-af60-2e9d85026526.png)

`list-prs-for-branch`

![image](https://user-images.githubusercontent.com/46634000/146674386-c739fff0-7af2-4946-882c-28c846873839.png)