### PR TITLE
Meta: Replace `deinit` option with `init` return value

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -17,11 +17,11 @@ Suggestions and pull requests are highly encouraged! Have a look at the [open is
 
 The simplest usage of `feature.add` is the following. This will be run instantly on all page-loads:
 
-```js
+```ts
 import * as pageDetect from 'github-url-detection';
 import features from '.';
 
-function init() {
+function init(): void {
 	console.log('✨');
 }
 

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -62,15 +62,15 @@ function onAltClick(event: delegate.Event<MouseEvent, HTMLInputElement>): void {
 	});
 }
 
-function init(): void {
+function init(): VoidFunction {
 	// `mousedown` required to avoid mouse selection on shift-click
 	delegate(document, '.js-reviewed-toggle', 'mousedown', batchToggle);
 	delegate(document, '.js-toggle-user-reviewed-file-form', 'submit', remember);
 	delegate(document, '.js-reviewed-toggle', 'click', onAltClick);
-}
 
-function deinit(): void {
-	previousFile = undefined;
+	return () => {
+		previousFile = undefined;
+	};
 }
 
 void features.add(import.meta.url, {
@@ -80,5 +80,4 @@ void features.add(import.meta.url, {
 	],
 	deduplicate: 'has-rgh-inner',
 	init,
-	deinit,
 });

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -11,12 +11,12 @@ const handler = ({key, target}: KeyboardEvent): void => {
 	}
 };
 
-function init(): void {
+function init(): VoidFunction {
 	window.addEventListener('keyup', handler);
-}
 
-function deinit(): void {
-	window.removeEventListener('keyup', handler);
+	return () => {
+		window.removeEventListener('keyup', handler);
+	};
 }
 
 void features.add(import.meta.url, {
@@ -31,5 +31,4 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	deduplicate: false,
 	init,
-	deinit,
 });

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -8,8 +8,6 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import {onDiffFileLoad} from '../github-events/on-fragment-load';
 
-const deinit: VoidFunction[] = [];
-
 async function loadDeferred(jumpList: Element): Promise<void> {
 	// This event will trigger the loading, but if run too early, GitHub might not have attached the listener yet, so we try multiple times.
 	const retrier = setInterval(() => {
@@ -19,7 +17,7 @@ async function loadDeferred(jumpList: Element): Promise<void> {
 	clearInterval(retrier);
 }
 
-async function init(): Promise<void | false> {
+async function init(): Promise<VoidFunction> {
 	const fileList = await elementReady([
 		'.toc-select details-menu[src*="/show_toc?"]', // `isPR`
 		'.toc-diff-stats + .content', // `isSingleCommit` and `isCompare`
@@ -54,7 +52,8 @@ async function init(): Promise<void | false> {
 			);
 		},
 	});
-	deinit.push(observer.abort);
+
+	return observer.abort;
 }
 
 void features.add(import.meta.url, {
@@ -69,7 +68,6 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',
 	init,
-	deinit,
 }, {
 	include: [
 		pageDetect.isCompare,

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -8,8 +8,6 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import loadDetailsMenu from '../github-helpers/load-details-menu';
 
-const deinit: VoidFunction[] = [];
-
 async function onButtonClick({delegateTarget: button}: delegate.Event): Promise<void> {
 	button
 		.closest('.js-comment')!
@@ -31,13 +29,14 @@ function addDeleteButton(cancelButton: Element): void {
 	);
 }
 
-function init(): void {
+function init(): VoidFunction[] {
 	const listener = delegate(document, '.rgh-review-comment-delete-button', 'click', onButtonClick);
 	const editButtonListener = delegate(document, '.rgh-quick-comment-edit-button', 'click', onEditButtonClick);
 	const observer = observe('.review-comment > .unminimized-comment form:not(.js-single-suggested-change-form) .js-comment-cancel-button:not(.rgh-delete-button-added)', {
 		add: addDeleteButton,
 	});
-	deinit.push(listener.destroy, editButtonListener.destroy, observer.abort);
+
+	return [listener.destroy, editButtonListener.destroy, observer.abort];
 }
 
 void features.add(import.meta.url, {
@@ -48,5 +47,4 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',
 	init,
-	deinit,
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -85,26 +85,25 @@ async function addReleasesTab(): Promise<false | void> {
 	);
 }
 
-const deinit: VoidFunction[] = [];
-
-async function highlightReleasesTab(): Promise<void> {
+function highlightReleasesTab(): VoidFunction {
 	const selectorObserver = observe('.UnderlineNav-item.selected:not(.rgh-releases-tab)', {
 		add(selectedTab) {
 			unhighlightTab(selectedTab);
 			selectorObserver.abort();
 		},
 	});
-	deinit.push(selectorObserver.abort);
 	highlightTab(select('.rgh-releases-tab')!);
+
+	return selectorObserver.abort;
 }
 
-async function init(): Promise<void | false> {
+async function init(): Promise<VoidFunction | void> {
 	if (!select.exists('.rgh-releases-tab')) {
 		await addReleasesTab();
 	}
 
 	if (pageDetect.isReleasesOrTags()) {
-		await highlightReleasesTab();
+		return highlightReleasesTab();
 	}
 }
 
@@ -118,5 +117,4 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	deduplicate: false,
 	init,
-	deinit,
 });

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -156,8 +156,7 @@ function closeDropdown(): void {
 	select('.rgh-select-notifications')?.removeAttribute('open');
 }
 
-const deinit: VoidFunction[] = [];
-function init(): void {
+function init(): VoidFunction {
 	const selectObserver = observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
 		add(selectAllCheckbox) {
 			selectAllCheckbox.classList.add('rgh-select-notifications-added');
@@ -166,10 +165,11 @@ function init(): void {
 				.after(createDropdown());
 		},
 	});
-	deinit.push(selectObserver.abort);
 
 	// Close the dropdown when one of the toolbar buttons is clicked
 	delegate(document, '.js-notifications-mark-selected-actions > *, .rgh-open-selected-button', 'click', closeDropdown);
+
+	return selectObserver.abort;
 }
 
 void features.add(import.meta.url, {
@@ -183,5 +183,4 @@ void features.add(import.meta.url, {
 		() => select.exists('img[src$="notifications/inbox-zero.svg"]'), // Notifications page may be empty
 	],
 	init,
-	deinit,
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -6,8 +6,6 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-const deinit: VoidFunction[] = [];
-
 // The first selector in the parentheses is for the repo root, the second one for conversation pages
 const sidebarSelector = '.Layout-sidebar :is(.BorderGrid, #partial-discussion-sidebar)';
 
@@ -19,7 +17,7 @@ function updateStickiness(): void {
 
 const onResize = debounce(updateStickiness, {wait: 100});
 
-function init(): void {
+function init(): VoidFunction {
 	const resizeObserver = new ResizeObserver(onResize);
 	const selectObserver = observe(sidebarSelector, {
 		add(sidebar) {
@@ -27,11 +25,12 @@ function init(): void {
 		},
 	});
 	window.addEventListener('resize', onResize);
-	deinit.push(() => {
+
+	return () => {
 		selectObserver.abort();
 		resizeObserver.disconnect();
 		window.removeEventListener('resize', onResize);
-	});
+	};
 }
 
 void features.add(import.meta.url, {
@@ -44,5 +43,4 @@ void features.add(import.meta.url, {
 	],
 	deduplicate: 'has-rgh-inner',
 	init,
-	deinit,
 });

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -81,7 +81,7 @@ function onBeforeunload(event: BeforeUnloadEvent): void {
 	}
 }
 
-function init(): void {
+function init(): VoidFunction {
 	// Watch for new commits and their statuses
 	prCiStatus.addEventListener(showCheckboxIfNecessary);
 
@@ -97,10 +97,10 @@ function init(): void {
 
 	// Warn user if it's not yet submitted.
 	window.addEventListener('beforeunload', onBeforeunload);
-}
 
-function deinit(): void {
-	window.removeEventListener('beforeunload', onBeforeunload);
+	return () => {
+		window.removeEventListener('beforeunload', onBeforeunload);
+	};
 }
 
 void features.add(import.meta.url, {
@@ -113,5 +113,4 @@ void features.add(import.meta.url, {
 	],
 	deduplicate: 'has-rgh-inner',
 	init,
-	deinit,
 });


### PR DESCRIPTION
Implements the second checkbox from https://github.com/refined-github/refined-github/issues/4008#issuecomment-812885528.

## Test URLs

* `batch-mark-files-as-viewed`: this PR's files
* `copy-on-y`: e.g. https://github.com/refined-github/refined-github/blob/081adcdabbd22d5d59721a1aceffed81fb322c5f/source/features/index.tsx
* `highlight-deleted-and-added-files-in-diffs`: https://github.com/sindresorhus/refined-github/pull/3062/files
* `quick-review-comment-deletion`: this PR's discussion thread or this PR's files
* `releases-tab`: basically all repo pages
* `select-notifications`: https://github.com/notifications
* `sticky-sidebar`: this PR or this repo's homepage
* `wait-for-build`: this PR
