### PR TITLE
Properly hide new starring dropdown in `clean-dashboard`

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -83,8 +83,8 @@
 }
 
 /* Hide star button */
-.rgh-clean-dashboard .dashboard .flex-items-baseline :is([value='Star'], [value='Unstar']) {
-	display: none;
+.rgh-clean-dashboard .dashboard .starring-container {
+	display: none !important;
 }
 
 /* Restore right margin for repo descriptions #5024 */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5182



## Test URLs



https://github.com/

## Before

<img width="709" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/146528604-e5cb565a-5443-4218-8b70-3f249a33c3d6.png">

## After

<img width="705" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/146528590-c4f4e14e-bbf9-4894-8317-d9c3371d7989.png">

