### PR TITLE
Fix GitHub bug: PR lists wrap multiple times sometimes

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -55,3 +55,8 @@
 .js-file-header-dropdown .dropdown-menu > .dropdown-divider:last-child {
 	display: none !important;
 }
+
+/* Avoid multi-column wrapping in PR lists on small displays #4405 */
+.js-issue-row .js-navigation-open ~ .text-small:last-child {
+	flex-wrap: wrap;
+}


### PR DESCRIPTION
- Fix https://github.com/refined-github/refined-github/issues/4405

## Test URLs

https://github.com/sindresorhus/refined-github/pulls?q=Drop+support+for+the+old+GitHub+layout+sort%3Aupdated-desc

## Before

<img width="740" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/146532050-fd642f34-fed2-489c-8d95-a2c644aaeea6.png">


## After

<img width="739" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/146532041-2baf530e-5692-4a4f-aa48-14c7c41f518d.png">

