### PR TITLE
Meta: Correctly display "token missing" errors in `bugs-tab`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -131,7 +131,7 @@ async function addBugsTab(): Promise<void | false> {
 		bugsCounter.title = bugCount > 999 ? String(bugCount) : '';
 	} catch (error: unknown) {
 		bugsCounter.remove();
-		features.log.error(import.meta.url, error);
+		throw error; // Likely an API call error that will be handled by the init
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5181

## Test URLs

https://github.com/refined-github/refined-github but without a token stored

## Screenshot

Not yet tested
