### PR TITLE
Fix `useful-forks` and `quick-repo-deletion` selectors

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -126,7 +126,8 @@ async function init(): Promise<void | false> {
 		!await elementReady('nav [data-content="Settings"]')
 
 		// Only if the repository hasn't been starred
-		|| looseParseInt(select('.starring-container .social-count')) > 0
+		// TODO [2022-06-01]: Remove `.social-count` (GHE)
+		|| looseParseInt(select('.starring-container :is(.Counter, .social-count)')) > 0
 	) {
 		return false;
 	}

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -8,7 +8,8 @@ import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';
 
 async function init(): Promise<void | false> {
-	const forkCount = await elementReady('.social-count[href$="/network/members"]');
+	// TODO [2022-06-01]: Remove `.social-count` (GHE)
+	const forkCount = await elementReady('#repo-network-counter, .social-count[href$="/network/members"]');
 	if (looseParseInt(forkCount) === 0) {
 		return false;
 	}


### PR DESCRIPTION
Fixes #5225 

## Test URLs

https://github.com/refined-github/refined-github/network

## Screenshot

`useful-forks`

![screenshot-1639853824](https://user-images.githubusercontent.com/46634000/146652844-697d8c50-4e17-48c8-91d8-f353841c9013.png)

`quick-repo-deletion`

![screenshot-1639853778](https://user-images.githubusercontent.com/46634000/146652842-d7c2b969-538e-4ad3-86cd-4c2b4d7c72d0.png)

![screenshot-1639853755](https://user-images.githubusercontent.com/46634000/146652839-1b0ac811-94ce-4cd0-bd75-b239390164e1.png)