### PR TITLE
Enable `hide-diff-signs` on file edition pages

### DIFF
--- a/source/features/hide-diff-signs.tsx
+++ b/source/features/hide-diff-signs.tsx
@@ -3,4 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.hasCode], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [
+	pageDetect.hasCode,
+	() => pageDetect.isEditingFile() && !location.href.endsWith('.md'),
+], 'has-rgh-inner');

--- a/source/features/hide-diff-signs.tsx
+++ b/source/features/hide-diff-signs.tsx
@@ -5,5 +5,5 @@ import features from '.';
 
 void features.addCssFeature(import.meta.url, [
 	pageDetect.hasCode,
-	() => pageDetect.isEditingFile() && !location.href.endsWith('.md'),
+	pageDetect.isEditingFile,
 ], 'has-rgh-inner');


### PR DESCRIPTION
## Test URLs

 * [Edit file](https://togithub.com/refined-github/refined-github/edit/main/source/features/index.tsx)
 * [Edit PR file](https://togithub.com/refined-github/refined-github/edit/enable-hide-diff-on-edit/source/features/hide-diff-signs.tsx?pr=%2Frefined-github%2Frefined-github%2Fpull%2F5229)

## Screenshot

**Before**

![screenshot-1640000005](https://user-images.githubusercontent.com/46634000/146761393-9388e1be-078f-4f66-bd61-9bac5f7c4fa8.png)

**After**

![screenshot-1639999930](https://user-images.githubusercontent.com/46634000/146761390-9c83fca8-b207-470c-b14a-5b048b4443cd.png)