### PR TITLE
Meta: Don't call init function directly in additional listeners

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -57,7 +57,7 @@ function cleanSection(selector: string): boolean {
 	return true;
 }
 
-async function clean(): Promise<void> {
+async function init(): Promise<void> {
 	if (select.exists('.rgh-clean-sidebar')) {
 		return;
 	}
@@ -117,10 +117,10 @@ void features.add(import.meta.url, {
 		pageDetect.isConversation,
 	],
 	additionalListeners: [
-		() => {
-			void onReplacedElement('#partial-discussion-sidebar', clean);
+		runFeature => {
+			void onReplacedElement('#partial-discussion-sidebar', runFeature);
 		},
 	],
 	deduplicate: 'has-rgh-inner',
-	init: clean,
+	init,
 });

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -49,8 +49,8 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 	],
 	additionalListeners: [
-		() => {
-			void onReplacedElement('#partial-discussion-sidebar', addSidebarReviewButton);
+		runFeature => {
+			void onReplacedElement('#partial-discussion-sidebar', runFeature);
 		},
 	],
 	awaitDomReady: false,


### PR DESCRIPTION
I may be wrong with this, but additional listeners should probably not call the init function directly.

Instead, they should use the `runFeature` wrapper that is passed to them, so that any potential errors are correctly caught and logged.