### PR TITLE
Fix: `quick-comment-edit` should only shown on editable discussion comments

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -10,7 +10,7 @@ import features from '.';
 function canEditEveryComment(): boolean {
 	return select.exists([
 		// If you can lock conversations, you have write access
-		'.lock-toggle-link',
+		'.lock-toggle-link > .octicon-lock',
 
 		// Some pages like `isPRFiles` does not have a lock button
 		// These elements only exist if you commented on the page


### PR DESCRIPTION
### Related Issues

Closes #5235 if merged.

### The Problem

GitHub uses the `.lock-toggle-link` class on the `create issue from discussion` button (which is visible to everyone). `quick-comment-edit` use the same class to check if the user can lock the thread. This results in edit buttons appearing on all comments in all discussions.

### The Fix

If a lock button is actually shown, then there is a `.octicon-lock` SVG inside the div with the `.lock-toggle-link` class. This PR modifies the selector to reflect this.

### Example URLs

- https://github.com/PatrickF1/fzf.fish/discussions/190 (not editable) [no comment, not collaborator]
- https://github.com/dabbu-knowledge-platform/cli/discussions/4 (all are editable) [one comment, is collaborator]
- https://github.com/Sunbird-RC/community/discussions/178 (only my comment is editable) [one comment, not collaborator]