### PR TITLE
Meta: Automatically generate release notes again /2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,16 @@ jobs:
       - uses: fregante/daily-version-action@v1
         name: Create tag if necessary
         id: daily-version
+      - if: steps.daily-version.outputs.created
+        name: Create release
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.request(`POST /repos/${{ github.repository }}/releases`, {
+              tag_name: "${{ steps.daily-version.outputs.version }}",
+              generate_release_notes: true
+            });
 
   Submit:
     needs: Version


### PR DESCRIPTION
Follow-up to #5223, this time with the correct step name (see https://github.com/refined-github/refined-github/pull/5223#issuecomment-1000299508).

~This is still untested.~ Tested now: https://github.com/refined-github/refined-github/pull/5243#issuecomment-1003366051