### PR TITLE
Meta: Move small bug report fields higher

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -14,15 +14,9 @@ body:
       options:
         - label: The bug is caused by Refined GitHub. It doesn't happen if I disable the extension.
           required: true
-  - type: checkboxes
+  - type: textarea
     attributes:
-      label: 'Include in this issue:'
-      options:
-        - label: Screenshots/video/gif demonstrating the bug, if it’s visual
-        - label: Console errors, if any
-  - type: input
-    attributes:
-      label: Example URL
+      label: Example URLs
       description: A REAL URL where the bug appears. If it happens on a private repo, find an equivalent public URL, even if it doesn't happen there.
       placeholder: https://github.com/refined-github/refined-github/issues
     validations:
@@ -38,3 +32,9 @@ body:
       description: Describe the issue and how to replicate it
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: 'Include in this issue:'
+      options:
+        - label: Screenshots/video/gif demonstrating the bug, if it’s visual
+        - label: Console errors, if any

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -20,12 +20,6 @@ body:
       options:
         - label: Screenshots/video/gif demonstrating the bug, if it’s visual
         - label: Console errors, if any
-  - type: textarea
-    attributes:
-      label: Description
-      description: Describe the issue and how to replicate it
-    validations:
-      required: true
   - type: input
     attributes:
       label: Example URL
@@ -36,5 +30,11 @@ body:
   - type: input
     attributes:
       label: Browser(s) used
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: Describe the issue and how to replicate it
     validations:
       required: true


### PR DESCRIPTION
I always miss these 2 fields both when looking at an issue and when opening one. I feel that they're fundamental enough to be shown at the top.

Any other suggestions?