### PR TITLE
Fix branch handling on commit list without a branch

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -72,7 +72,7 @@ function addDropdownLink(menu: HTMLElement, timestamp: string): void {
 }
 
 async function showTimeMachineBar(): Promise<void | false> {
-	const url = new URL(location.href); // This can't be replaced with `GitHubURL` because `getCurrentBranch` throws on 404s
+	const url = new URL(location.href); // This can't be replaced with `GitHubURL` because `getCurrentCommittish` throws on 404s
 	const date = url.searchParams.get('rgh-link-date')!;
 
 	// Drop parameter from current page after using it

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -30,8 +30,9 @@ const getDefaultBranch = cache.function(async function (repository?: pageDetect.
 			}
 		}
 
-		if (pageDetect.utils.getRepositoryInfo()!.path === 'commits') {
-			return getCurrentBranchFromFeed();
+		const defaultBranch = getCurrentBranchFromFeed();
+		if (defaultBranch) {
+			return defaultBranch;
 		}
 
 		if (!pageDetect.isForkedRepo()) {

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import * as api from './api';
-import {getRepo} from '.';
+import {getRepo, getCurrentBranchFromFeed} from '.';
 
 // This regex should match all of these combinations:
 // "This branch is even with master."
@@ -12,16 +12,6 @@ import {getRepo} from '.';
 // "This branch is 1 commit ahead of master."
 // "This branch is 1 commit ahead, 27 commits behind master."
 const branchInfoRegex = /([^ ]+)\.$/;
-
-export function getCurrentBranchFromFeed(): string {
-	const feedLink = select('link[type="application/atom+xml"]')!;
-	return new URL(feedLink.href)
-		.pathname
-		.split('/')
-		.slice(4) // Drops the initial /user/repo/route/ part
-		.join('/')
-		.replace(/\.atom$/, '');
-}
 
 const getDefaultBranch = cache.function(async function (repository?: pageDetect.RepositoryInfo): Promise<string> {
 	if (arguments.length === 0) {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -16,10 +16,10 @@ export const getConversationNumber = (): string | undefined => {
 	return undefined;
 };
 
-export function getCurrentBranchFromFeed(): string {
+export function getCurrentBranchFromFeed(): string | void {
 	// Not `isRepoCommitList` because this works exclusively on the default branch
 	if (pageDetect.utils.getRepositoryInfo()!.path !== 'commits') {
-		return '';
+		return;
 	}
 
 	const feedLink = select('link[type="application/atom+xml"]')!;
@@ -47,7 +47,7 @@ export const getCurrentCommittish = (pathname = location.pathname, title = docum
 	// Handle slashed branches in commits pages
 	if (type === 'commits') {
 		if (!unslashedCommittish) {
-			return getCurrentBranchFromFeed();
+			return getCurrentBranchFromFeed()!;
 		}
 
 		const branchAndFilepath = pathname.split('/').slice(4).join('/');

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -17,6 +17,11 @@ export const getConversationNumber = (): string | undefined => {
 };
 
 export function getCurrentBranchFromFeed(): string {
+	// Not `isRepoCommitList` because this works exclusively on the default branch
+	if (pageDetect.utils.getRepositoryInfo()!.path !== 'commits') {
+		return '';
+	}
+
 	const feedLink = select('link[type="application/atom+xml"]')!;
 	return new URL(feedLink.href)
 		.pathname

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -18,7 +18,7 @@ export const getConversationNumber = (): string | undefined => {
 
 export function getCurrentBranchFromFeed(): string | void {
 	// Not `isRepoCommitList` because this works exclusively on the default branch
-	if (pageDetect.utils.getRepositoryInfo()!.path !== 'commits') {
+	if (getRepo()!.path !== 'commits') {
 		return;
 	}
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -4,8 +4,6 @@ import elementReady from 'element-ready';
 import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection';
 
-import {getCurrentBranchFromFeed} from './get-default-branch';
-
 // This never changes, so it can be cached here
 export const getUsername = onetime(pageDetect.utils.getUsername);
 export const {getRepositoryInfo: getRepo, getCleanPathname} = pageDetect.utils;
@@ -17,6 +15,16 @@ export const getConversationNumber = (): string | undefined => {
 
 	return undefined;
 };
+
+export function getCurrentBranchFromFeed(): string {
+	const feedLink = select('link[type="application/atom+xml"]')!;
+	return new URL(feedLink.href)
+		.pathname
+		.split('/')
+		.slice(4) // Drops the initial /user/repo/route/ part
+		.join('/')
+		.replace(/\.atom$/, '');
+}
 
 const typesWithCommittish = new Set(['tree', 'blob', 'blame', 'edit', 'commit', 'commits', 'compare']);
 const titleWithCommittish = / at (?<branch>[.\w-/]+)( · [\w-]+\/[\w-]+)?$/i;

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -3,6 +3,7 @@ import onetime from 'onetime';
 import elementReady from 'element-ready';
 import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection';
+
 import {getCurrentBranchFromFeed} from './get-default-branch';
 
 // This never changes, so it can be cached here

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -3,6 +3,7 @@ import onetime from 'onetime';
 import elementReady from 'element-ready';
 import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection';
+import {getCurrentBranchFromFeed} from './get-default-branch';
 
 // This never changes, so it can be cached here
 export const getUsername = onetime(pageDetect.utils.getUsername);
@@ -31,6 +32,10 @@ export const getCurrentCommittish = (pathname = location.pathname, title = docum
 
 	// Handle slashed branches in commits pages
 	if (type === 'commits') {
+		if (!unslashedCommittish) {
+			return getCurrentBranchFromFeed();
+		}
+
 		const branchAndFilepath = pathname.split('/').slice(4).join('/');
 
 		// List of all commits of current branch (no filename)


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

This PR actually comes in 3 parts:

1. `getDefaultBranch()` seems to always fallback to using API as the following code fails due to DOM not ready

   https://github.com/refined-github/refined-github/blob/a665157c410da81e9fdd83dcad945cd7085fafa4/source/github-helpers/get-default-branch.ts#L25-L30

   This PR fixes it with `elementReady()`.

2. The above method may return a truncated branch name.
   This PR uses a better method. Fix #5240.

3. `getDefaultBranch()` and `getCurrentCommittish()` doesn't work on commit list without a branch, namely `/repo/user/commits` page.
   This PR fixes it by restoring and using `getCurrentBranchFromFeed()` (renamed), which parses the current branch from the feed link. Reasons to do so:
   - I'm aware of #5211, but this is safe since we only do it on commit lists which always has a predictable feed link.
   - Using DOM is better than calling API.
   - The trick used in 1. does not suit `getCurrentCommittish()` since the latter is a synchronous function.

## Test URLs

1. This can only be tested after you added some indicators whether `getDefaultBranch()` uses API or not (e.g. `console.log()`). After that, test it on:

   - https://github.com/refined-github/refined-github
   - https://github.com/refined-github/refined-github/commits

2. With 1. tested, visit https://github.com/gamemaker1/test, then check if `default-branch-button` appears on https://github.com/gamemaker1/test/tree/very-very-long-long-long-long-branch-name or not.
3. Check if `default-branch-button` appears on https://github.com/refined-github/refined-github/commits.

## Screenshot

