### PR TITLE
Allow using videos as screenshots

### DIFF
--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -36,7 +36,7 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 	return {
 		id: simpleId as FeatureID,
 		description: parseMarkdown(linkLessMarkdownDescription),
-		screenshot: urls.find(url => /\.(png|gif)$/i.test(url)),
+		screenshot: urls.find(url => /\.(png|gif|jpg|mp4|mov)$/i.test(url)),
 	};
 }
 

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -36,7 +36,7 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 	return {
 		id: simpleId as FeatureID,
 		description: parseMarkdown(linkLessMarkdownDescription),
-		screenshot: urls.find(url => /\.(png|gif|jpg|mp4|mov)$/i.test(url)),
+		screenshot: urls.find(url => /\.(png|gif|jpg|mp4|mov)$/.test(url)),
 	};
 }
 

--- a/readme.md
+++ b/readme.md
@@ -229,7 +229,7 @@ Thanks for contributing! 🦋🙌
 
 ### Reading comments
 
-- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.png)
 - [](# "comments-time-machine-links") Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
 - [](# "show-names") [Adds the real name of users by their usernames.](https://user-images.githubusercontent.com/1402241/62075835-5f82ce00-b270-11e9-91eb-4680b70cb3cb.png)
 - [](# "shorten-links") [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
@@ -315,7 +315,7 @@ Thanks for contributing! 🦋🙌
 - [](# "patch-diff-links") [Adds links to `.patch` and `.diff` files in commits.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [](# "more-file-links") [Adds links to view the raw version, the blame and the history of files in PRs and commits.](https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png)
 - [](# "one-click-diff-options") [Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: <kbd>d</kbd> <kbd>w</kbd>.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
-- [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
+- [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.png)
 - [](# "hide-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
 - [](# "suggest-commit-title-limit") [Suggests limiting commit titles to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 - [](# "tags-on-commits-list") [Displays the corresponding tags next to commits.](https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png)

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -122,7 +122,9 @@ function buildFeatureCheckbox({id, description, screenshot}: FeatureMeta): HTMLE
 				)}
 				{descriptionElement}
 				{screenshot && (
-					<img hidden data-src={screenshot} className="screenshot"/>
+					screenshot.endsWith('.mp4') || screenshot.endsWith('.mov')
+						? <video hidden controls data-src={screenshot} className="screenshot"/>
+						: <img hidden data-src={screenshot} className="screenshot"/>
 				)}
 			</div>
 		</div>
@@ -165,8 +167,8 @@ function summaryHandler(event: delegate.Event<MouseEvent>): void {
 	const toggle = feature.querySelector('input.screenshot-toggle')!;
 	toggle.checked = !toggle.checked;
 
-	// Lazy-load image
-	const screenshot = feature.querySelector('img.screenshot')!;
+	// Lazy-load image/video
+	const screenshot = feature.querySelector<HTMLImageElement | HTMLVideoElement>('.screenshot')!;
 	screenshot.src = screenshot.dataset.src!;
 }
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Both a bug fix and an enhancement.

- Bug fix: the readme parser doesn't include `jpg` in the screenshot regex, resulting in many screenshots being unavailable in the options window.
- Enhancement: [`.mp4` and `.mov` videos are now supported](https://github.blog/2021-05-13-video-uploads-available-github/) in the options window. In fact, `select-notifications` already uses a video as the screenshot.

```
$ rg --only-matching --replace '$1' 'user-images.+\.(\w+)\)$' readme.md | sort -u
gif
jpg
mp4
png
```

## Test URLs

chrome://extensions/?options=balgliakcbamepammkbcjdepogihccmj

## Screenshot

![image](https://user-images.githubusercontent.com/44045911/148571595-2a9e555f-f9a2-4646-9fe3-b820a9a9bf1d.png)
