### PR TITLE
Change `hide-repo-badges` into a feature that can be disabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ Thanks for contributing! 🦋🙌
 - [](# "quick-repo-deletion") [Lets you delete your repos in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
+- [](# "hide-repo-badges") [Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards.](TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ Thanks for contributing! 🦋🙌
 - [](# "quick-repo-deletion") [Lets you delete your repos in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
-- [](# "hide-repo-badges") [Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards.](TODO)
+- [](# "hide-repo-badges") [Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards.](https://user-images.githubusercontent.com/46634000/148645393-d3fa4ca9-6df4-4bb2-b810-7d73cc057772.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/hide-repo-badges.css
+++ b/source/features/hide-repo-badges.css
@@ -1,0 +1,3 @@
+.rgh-hide-repo-badges :is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
+	display: none !important;
+}

--- a/source/features/hide-repo-badges.tsx
+++ b/source/features/hide-repo-badges.tsx
@@ -1,0 +1,9 @@
+import './hide-repo-badges.css';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+void features.addCssFeature(import.meta.url, [
+	pageDetect.isRepo,
+	pageDetect.isUserProfile,
+], 'has-rgh');

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -165,8 +165,3 @@ pr-branches
 	width: calc(72ch + 26px);
 	max-width: 100%;
 }
-
-/* Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards #4767 */
-:is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
-	display: none !important;
-}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -209,3 +209,4 @@ import './features/comment-on-draft-pr-indicator';
 import './features/select-notifications';
 import './features/clean-repo-tabs';
 import './features/rgh-welcome-issue';
+import './features/hide-repo-badges';


### PR DESCRIPTION
Fixes #5268 

## Test URLs

 * https://togithub.com/refined-github/refined-github
 * https://togithub.com/fregante

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/148645381-b4f23b2d-aae4-476a-af74-208b1ddd7fbc.png)

**Feature screenshot**

![hide-repo-badges](https://user-images.githubusercontent.com/46634000/148645393-d3fa4ca9-6df4-4bb2-b810-7d73cc057772.png)