### PR TITLE
Hide "New repository" button on organization dashboard

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -82,7 +82,7 @@
 }
 
 /* Remove the "New repository" button in the dashboard sidebar */
-.dashboard-sidebar a[href='/new'] {
+.dashboard-sidebar a.btn[href$='/new'] {
 	display: none;
 }
 


### PR DESCRIPTION
Fixes #5276 

## Test URLs

https://github.com/orgs/refined-github/dashboard

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/148645717-bf0ec74a-c3c8-4aa1-afeb-27686103a4fc.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/148645719-9b7d8b76-bd1f-40e6-8866-680312b38b51.png)