### PR TITLE
Fix `ci-link` on Discussions and get from page if present

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -5,3 +5,10 @@
 .rgh-ci-link summary .octicon {
 	vertical-align: 0;
 }
+
+/* Fix orientation of details dropdown when cloned from the repo homepage or the commit list */
+.rgh-ci-link .commit-build-statuses .dropdown-menu {
+	top: 50% !important;
+	left: 100% !important;
+	margin-left: 8px !important;
+}

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -33,20 +33,16 @@ async function getCiDetails(): Promise<HTMLElement | undefined> {
 	return ciDetails;
 }
 
-function appendCiDetailsToRepoTitle(ciDetails: HTMLElement): void {
-	// Append to title (aware of forks and private repos)
-	const repoNameHeader = select('[itemprop="name"]')!.parentElement!;
-	repoNameHeader.append(ciDetails);
-	repoNameHeader.classList.add('rgh-ci-link');
-}
-
 async function init(): Promise<false | void> {
 	const ciDetails = await getCiDetails();
 	if (!ciDetails) {
 		return false;
 	}
 
-	appendCiDetailsToRepoTitle(ciDetails);
+	// Append to repo title (aware of forks and private repos)
+	const repoNameHeader = select('[itemprop="name"]')!.parentElement!;
+	repoNameHeader.append(ciDetails);
+	repoNameHeader.classList.add('rgh-ci-link');
 }
 
 void features.add(import.meta.url, {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -2,12 +2,11 @@ import './ci-link.css';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
-import getDefaultBranch from '../github-helpers/get-default-branch';
-import {getCurrentCommittish} from '../github-helpers';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
-import {buildRepoURL} from '../github-helpers';
+import getDefaultBranch from '../github-helpers/get-default-branch';
+import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 
 async function getIcon(): Promise<HTMLElement | void> {
 	// Look for the CI icon in the latest 2 days of commits #2990
@@ -19,7 +18,7 @@ async function getIcon(): Promise<HTMLElement | void> {
 	if (pageDetect.isRepoHome()) {
 		const icon = await elementReady('.file-navigation + .Box .commit-build-statuses', {
 			stopOnDomReady: false,
-			timeout: 10000,
+			timeout: 10_000,
 		});
 
 		if (icon) {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -19,11 +19,16 @@ async function getCiDetails(): Promise<HTMLElement | undefined> {
 			'.file-navigation + .Box .commit-build-statuses', // Select the CI details if they're already loaded
 			'.file-navigation + .Box .js-details-container include-fragment[src*="/rollup?"]', // Otherwise select the include-fragment
 		].join(','));
-		return ciDetails!.cloneNode(true);
+		if (ciDetails) {
+			return ciDetails.cloneNode(true);
+		}
 	}
 
 	if (pageDetect.isRepoCommitList() && getCurrentCommittish() === await getDefaultBranch()) {
-		return select(ciDetailsSelector)!.cloneNode(true);
+		const ciDetails = select(ciDetailsSelector);
+		if (ciDetails) {
+			return ciDetails.cloneNode(true);
+		}
 	}
 
 	const dom = await fetchDom(buildRepoURL('commits'));

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -29,7 +29,7 @@ async function getIcon(): Promise<HTMLElement | void> {
 
 	if (pageDetect.isRepoCommitList() && getCurrentCommittish() === await getDefaultBranch()) {
 		const icon = await elementReady(iconSelector);
-		return icon!.cloneNode(true)
+		return icon!.cloneNode(true);
 	}
 
 	return fetchDom(buildRepoURL('commits'), iconSelector);

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -31,7 +31,14 @@ async function getIcon(): Promise<HTMLElement | void> {
 		return icon!.cloneNode(true);
 	}
 
-	return fetchDom(buildRepoURL('commits'), iconSelector);
+	const dom = await fetchDom(buildRepoURL('commits'));
+
+	if (pageDetect.isDiscussion() || pageDetect.isDiscussionList()) {
+		const style = select('link[href*="/assets/github-"]', dom)!;
+		document.head.append(style);
+	}
+
+	return select<HTMLElement>(iconSelector, dom);
 }
 
 async function init(): Promise<false | void> {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -38,6 +38,7 @@ async function getIcon(): Promise<HTMLElement | void> {
 		document.head.append(style);
 	}
 
+	// eslint-disable-next-line no-unnecessary-type-arguments -- Rule doesn't respect overloads
 	return select<HTMLElement>(iconSelector, dom);
 }
 

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -15,8 +15,11 @@ const ciDetailsSelector = [
 
 async function getCiDetails(): Promise<HTMLElement | undefined> {
 	if (pageDetect.isRepoHome()) {
-		// Clone the CI details if they're already loaded, otherwise clone the include-fragment
-		return select('.file-navigation + .Box :is(.commit-build-statuses, .js-details-container include-fragment[src*="/rollup?"])')!.cloneNode(true);
+		const ciDetails = select([
+			'.file-navigation + .Box .commit-build-statuses', // Select the CI details if they're already loaded
+			'.file-navigation + .Box .js-details-container include-fragment[src*="/rollup?"]', // Otherwise select the include-fragment
+		].join(','));
+		return ciDetails!.cloneNode(true);
 	}
 
 	if (pageDetect.isRepoCommitList() && getCurrentCommittish() === await getDefaultBranch()) {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -51,10 +51,7 @@ function initRepoHome(): void | false {
 		return false;
 	}
 
-	const clonedDetails = ciDetails.cloneNode(true);
-	// Fix the dropdown orientation
-	select('.dropdown-menu', clonedDetails)!.classList.replace('dropdown-menu-sw', 'dropdown-menu-se');
-	appendCiDetailsToRepoTitle(clonedDetails);
+	appendCiDetailsToRepoTitle(ciDetails.cloneNode(true));
 }
 
 void features.add(import.meta.url, {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -51,7 +51,10 @@ function initRepoHome(): void | false {
 		return false;
 	}
 
-	appendIconToRepoHeader(icon.cloneNode(true));
+	const clonedIcon = icon.cloneNode(true);
+	// Fix the dropdown orientation
+	select('.dropdown-menu', clonedIcon)!.classList.replace('dropdown-menu-sw', 'dropdown-menu-se');
+	appendIconToRepoHeader(clonedIcon);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -50,7 +50,6 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	exclude: [
-		// PageDetect.isRepoHome,
 		pageDetect.isEmptyRepo,
 	],
 	awaitDomReady: false,

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -1,49 +1,43 @@
 import './ci-link.css';
 import select from 'select-dom';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
+import {onCiIconLoad} from '../github-events/on-fragment-load';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 
+// Look for the CI icon in the latest 2 days of commits #2990
+const iconSelector = [
+	'.TimelineItem--condensed:nth-of-type(-n+2) .commit-build-statuses', // TODO[2022-04-29]: GHE #4294
+	'.TimelineItem--condensed:nth-of-type(-n+2) batch-deferred-content[data-url$="checks-statuses-rollups"]',
+].join(',');
+
 async function getIcon(): Promise<HTMLElement | void> {
-	// Look for the CI icon in the latest 2 days of commits #2990
-	const iconSelector = [
-		'.TimelineItem--condensed:nth-of-type(-n+2) .commit-build-statuses', // TODO[2022-04-29]: GHE #4294
-		'.TimelineItem--condensed:nth-of-type(-n+2) batch-deferred-content[data-url$="checks-statuses-rollups"]',
-	].join(',');
-
-	if (pageDetect.isRepoHome()) {
-		const icon = await elementReady('.file-navigation + .Box .commit-build-statuses', {
-			stopOnDomReady: false,
-			timeout: 10_000,
-		});
-
-		if (icon) {
-			return icon.cloneNode(true);
-		}
-	}
-
 	if (pageDetect.isRepoCommitList() && getCurrentCommittish() === await getDefaultBranch()) {
-		const icon = await elementReady(iconSelector);
-		return icon!.cloneNode(true);
+		return select(iconSelector)!.cloneNode(true);
 	}
 
 	const dom = await fetchDom(buildRepoURL('commits'));
 	const icon = select(iconSelector, dom);
-
 	if (!icon) {
 		return;
 	}
 
 	if (pageDetect.isDiscussion() || pageDetect.isDiscussionList()) {
 		const style = select('link[href*="/assets/github-"]', dom)!;
-		document.head.append(style);
+		document.head.append(style); // #5283
 	}
 
 	return icon;
+}
+
+function appendIconToRepoHeader(icon: HTMLElement): void {
+	// Append to title (aware of forks and private repos)
+	const repoNameHeader = select('[itemprop="name"]')!.parentElement!;
+	repoNameHeader.append(icon);
+	repoNameHeader.classList.add('rgh-ci-link');
 }
 
 async function init(): Promise<false | void> {
@@ -52,10 +46,16 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
-	// Append to title (aware of forks and private repos)
-	const repoNameHeader = select('[itemprop="name"]')!.parentElement!;
-	repoNameHeader.append(icon);
-	repoNameHeader.classList.add('rgh-ci-link');
+	appendIconToRepoHeader(icon);
+}
+
+function initRepoHome(): void | false {
+	const icon = select('.file-navigation + .Box .commit-build-statuses');
+	if (!icon) {
+		return false;
+	}
+
+	appendIconToRepoHeader(icon.cloneNode(true));
 }
 
 void features.add(import.meta.url, {
@@ -63,8 +63,22 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	exclude: [
+		pageDetect.isRepoHome,
 		pageDetect.isEmptyRepo,
 	],
 	awaitDomReady: false,
 	init,
+}, {
+	include: [
+		pageDetect.isRepoHome,
+	],
+	exclude: [
+		pageDetect.isEmptyRepo,
+	],
+	additionalListeners: [
+		onCiIconLoad,
+	],
+	awaitDomReady: false,
+	onlyAdditionalListeners: true,
+	init: initRepoHome,
 });

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -38,7 +38,7 @@ async function getIcon(): Promise<HTMLElement | void> {
 		document.head.append(style);
 	}
 
-	// eslint-disable-next-line no-unnecessary-type-arguments -- Rule doesn't respect overloads
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- Rule doesn't respect overloads
 	return select<HTMLElement>(iconSelector, dom);
 }
 

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -32,14 +32,18 @@ async function getIcon(): Promise<HTMLElement | void> {
 	}
 
 	const dom = await fetchDom(buildRepoURL('commits'));
+	const icon = select(iconSelector, dom);
+
+	if (!icon) {
+		return;
+	}
 
 	if (pageDetect.isDiscussion() || pageDetect.isDiscussionList()) {
 		const style = select('link[href*="/assets/github-"]', dom)!;
 		document.head.append(style);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- Rule doesn't respect overloads
-	return select<HTMLElement>(iconSelector, dom);
+	return icon;
 }
 
 async function init(): Promise<false | void> {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -14,18 +14,14 @@ const iconSelector = [
 	'.TimelineItem--condensed:nth-of-type(-n+2) batch-deferred-content[data-url$="checks-statuses-rollups"]',
 ].join(',');
 
-async function getIcon(): Promise<HTMLElement | void> {
+async function getIcon(): Promise<HTMLElement | undefined> {
 	if (pageDetect.isRepoCommitList() && getCurrentCommittish() === await getDefaultBranch()) {
 		return select(iconSelector)!.cloneNode(true);
 	}
 
 	const dom = await fetchDom(buildRepoURL('commits'));
 	const icon = select(iconSelector, dom);
-	if (!icon) {
-		return;
-	}
-
-	if (pageDetect.isDiscussion() || pageDetect.isDiscussionList()) {
+	if (icon && (pageDetect.isDiscussion() || pageDetect.isDiscussionList())) {
 		const style = select('link[href*="/assets/github-"]', dom)!;
 		document.head.append(style); // #5283
 	}

--- a/source/github-events/on-fragment-load.ts
+++ b/source/github-events/on-fragment-load.ts
@@ -27,6 +27,6 @@ export function onCommentEdit(callback: EventListener): delegate.Subscription {
 	return createFragmentLoadListener('.js-comment-edit-form-deferred-include-fragment', callback);
 }
 
-export function onCiIconLoad(callback: EventListener): delegate.Subscription {
+export function onRepoHomeCiDetailsLoad(callback: EventListener): delegate.Subscription {
 	return createFragmentLoadListener('.file-navigation + .Box .js-details-container include-fragment[src*="/rollup?"]', callback);
 }

--- a/source/github-events/on-fragment-load.ts
+++ b/source/github-events/on-fragment-load.ts
@@ -26,3 +26,7 @@ export function onDiffFileLoad(callback: EventListener): delegate.Subscription {
 export function onCommentEdit(callback: EventListener): delegate.Subscription {
 	return createFragmentLoadListener('.js-comment-edit-form-deferred-include-fragment', callback);
 }
+
+export function onCiIconLoad(callback: EventListener): delegate.Subscription {
+	return createFragmentLoadListener('.file-navigation + .Box .js-details-container include-fragment[src*="/rollup?"]', callback);
+}

--- a/source/github-events/on-fragment-load.ts
+++ b/source/github-events/on-fragment-load.ts
@@ -26,7 +26,3 @@ export function onDiffFileLoad(callback: EventListener): delegate.Subscription {
 export function onCommentEdit(callback: EventListener): delegate.Subscription {
 	return createFragmentLoadListener('.js-comment-edit-form-deferred-include-fragment', callback);
 }
-
-export function onRepoHomeCiDetailsLoad(callback: EventListener): delegate.Subscription {
-	return createFragmentLoadListener('.file-navigation + .Box .js-details-container include-fragment[src*="/rollup?"]', callback);
-}


### PR DESCRIPTION
This and #5246 both reduce requests when opening a new repo.
Fixes #5283 

## Test URLs

- `isRepoHome`: https://github.com/refined-github/refined-github
- `isRepoCommitList`
  - https://github.com/refined-github/refined-github/commits/main
  - https://github.com/refined-github/refined-github/commits (after #5246 gets merged)
- Fallback: https://github.com/refined-github/refined-github/issues
- Discussions: https://github.com/cli/cli/discussions (reload the page to see the bug)

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/150669500-cf1842cf-9d50-4f8a-b90d-df47b6cc31f0.png)