### PR TITLE
`dim-bots` when not hovering

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -38,6 +38,7 @@ ALL the following rules define the non-focused state
 	opacity: 20%;
 	margin-bottom: -1.6em;
 	visibility: hidden;
+	/* Delay visibility transition for a slightly shorter time than --rgh-dim-bots-delay, to make the animation smoother */
 	transition-delay: 0s, var(--rgh-dim-bots-delay), 9.9s;
 }
 

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -8,7 +8,7 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 }
 
 .rgh-dim-bots--after-hover {
-	--rgh-dim-bots-delay: 60s; /* #5158 */
+	--rgh-dim-bots-delay: 10s; /* #5158 */
 }
 
 .rgh-dim-bot:not(.rgh-tagged) .mb-1,
@@ -20,7 +20,7 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 	/* Delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items. */
 	transition: 0.1s;
 	transition-delay: 0.3s;
-	transition-property: opacity, margin-bottom;
+	transition-property: opacity, margin-bottom, visibility;
 }
 
 /*
@@ -30,19 +30,20 @@ ALL the following rules define the non-focused state
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus, .Details--on) .mb-1, /* Commit titles, dim */
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus) .Box-row--drag-hide { /* PR row, dim */
 	opacity: 20%;
-	transition-delay: var(--rgh-dim-bots-delay);
+	transition-delay: 0s;
 }
 
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus, .Details--on) .mb-1 ~ .d-flex,
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus, .Details--on) > .d-md-block {
-	opacity: 0%;
+	opacity: 20%;
 	margin-bottom: -1.6em;
-	transition-delay: var(--rgh-dim-bots-delay);
+	visibility: hidden;
+	transition-delay: 0s, var(--rgh-dim-bots-delay), 9.9s;
 }
 
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus) .labels, /* PR labels */
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus) .text-small:is(.color-text-secondary, .color-fg-muted) /* PR meta */ {
-	opacity: 0%;
 	margin-bottom: -2em;
-	transition-delay: var(--rgh-dim-bots-delay);
+	visibility: hidden;
+	transition-delay: 0s, var(--rgh-dim-bots-delay), 9.9s;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

I managed to restored dimming while avoid ["adding a whole other block to add this intermediary state"](https://github.com/refined-github/refined-github/pull/5198#issuecomment-993381037):

https://user-images.githubusercontent.com/44045911/148685609-08232449-f5d8-4ad2-baff-031de031adfd.mov

Also changed restore delay to 10s which should keep the best of both worlds: practical but long enough.

## Test URLs

https://github.com/renovatebot/renovate/commits/main

## Screenshot

(Note the delay is intentionally shorter in the video for demo purpose)

https://user-images.githubusercontent.com/44045911/148685609-08232449-f5d8-4ad2-baff-031de031adfd.mov