### PR TITLE
Fix `reactions-avatars` in reviews, releases and discussions

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -65,5 +65,5 @@
 
 /* Restore margin between reactions on releases #5287 */
 [data-test-selector='release-card'] .social-reaction-summary-item:not(:first-child) {
-    margin-left: 8px !important;
+	margin-left: 8px !important;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -64,6 +64,6 @@
 }
 
 /* Restore margin between reactions on releases #5287 */
-[data-test-selector="release-card"] .social-reaction-summary-item:not(:first-child) {
+[data-test-selector='release-card'] .social-reaction-summary-item:not(:first-child) {
     margin-left: 8px !important;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -62,3 +62,8 @@
 .js-issue-row .js-navigation-open ~ .text-small:last-child {
 	flex-wrap: wrap;
 }
+
+/* Restore margin between reactions on releases #5287 */
+[data-test-selector="release-card"] .social-reaction-summary-item:not(:first-child) {
+    margin-left: 8px !important;
+}

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -20,10 +20,10 @@ interface Participant {
 }
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
+	// Reaction buttons on releases and review comments have the list of people in subsequent `<primer-tooltip>` element instead of `aria-label` #5287
 	const tooltip = button.classList.contains('tooltipped')
 		? button.getAttribute('aria-label')!
 		: button.nextElementSibling!.textContent!;
-	// Reaction buttons on releases and review comments have the list of people in their `title` attribute instead of `aria-label` #5150
 	const users = tooltip
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -20,8 +20,11 @@ interface Participant {
 }
 
 function getParticipants(button: HTMLButtonElement): Participant[] {
+	const tooltip = button.classList.contains('tooltipped')
+		? button.getAttribute('aria-label')!
+		: button.nextElementSibling!.textContent!;
 	// Reaction buttons on releases and review comments have the list of people in their `title` attribute instead of `aria-label` #5150
-	const users = (button.getAttribute('title')! || button.getAttribute('aria-label')!)
+	const users = tooltip
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #5275

## Test URLs

- Review threads: https://togithub.com/refined-github/refined-github/pull/5113#discussion_r758597247
- Releases: https://github.com/refined-github/refined-github/releases/tag/21.12.21
- Discussions: https://github.com/sindresorhus/meta/discussions/15#discussioncomment-1934341

## Screenshot

<table>
<tr>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/148698975-12e06e22-d8e7-4455-b0c3-57b01915bef3.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/148698996-366a71f4-045e-445b-9a3b-1ec0c34c34f4.png">
</table>