### PR TITLE
Add `same-branch-author-commits` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -324,7 +324,7 @@ Thanks for contributing! 🦋🙌
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit a single change.](https://user-images.githubusercontent.com/16872793/77248541-8e3f2180-6c10-11ea-91d4-221ccc0ecebb.png)
 - [](# "highlight-deleted-and-added-files-in-diffs") [Indicates with an icon whether files in commits and pull requests being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
 - [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
-- [](# "same-branch-author-commits") [Enables viewing all commits by an author on the same branch you are viewing.]()
+- [](# "same-branch-author-commits") [Enables viewing all commits by an author on the same branch you are viewing.](https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -323,7 +323,8 @@ Thanks for contributing! 🦋🙌
 - [](# "mark-merge-commits-in-list") [Marks merge commits in commit lists.](https://user-images.githubusercontent.com/16872793/75561016-457eb900-5a14-11ea-95e1-a89e81ee7390.png)
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit a single change.](https://user-images.githubusercontent.com/16872793/77248541-8e3f2180-6c10-11ea-91d4-221ccc0ecebb.png)
 - [](# "highlight-deleted-and-added-files-in-diffs") [Indicates with an icon whether files in commits and pull requests being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
-- [](# "easy-toggle-files") [Toggle file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
+- [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
+- [](# "same-branch-author-commits") [Enables viewing all commits by an author on the same branch you are viewing.]()
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -6,6 +6,7 @@ import features from '.';
 function init(): void | false {
 	for (const author of select.all('#repo-content-pjax-container .js-navigation-container a.commit-author')) {
 		author.pathname = location.pathname;
+		author.dataset.pjax = '#repo-content-pjax-container';
 	}
 }
 

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -3,7 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function init(): void | false  {
+function init(): void | false {
 	for (const author of select.all('#repo-content-pjax-container .js-navigation-container a.commit-author')) {
 		author.pathname = location.pathname;
 	}

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function init(): void | false  {
-	for (const author of select.all('a.commit-author')) {
+	for (const author of select.all('#repo-content-pjax-container .js-navigation-container a.commit-author')) {
 		author.pathname = location.pathname;
 	}
 }

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -1,0 +1,17 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function init(): void | false  {
+	for (const author of select.all('a.commit-author')) {
+		author.pathname = location.pathname;
+	}
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepoCommitList,
+	],
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -210,3 +210,4 @@ import './features/select-notifications';
 import './features/clean-repo-tabs';
 import './features/rgh-welcome-issue';
 import './features/hide-repo-badges';
+import './features/same-branch-author-commits';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

All author names link to `/owner/repo/commits?author=<author>`, that is, the branch is not considered at all. Seems like a GitHub bug, but very easy to fix.

~~The feature can exclude `getRepo()!.path === 'commits'` but there's no need.~~ Now more useful with PJAX!

Note that despite the name is inspired by `same-page-definition-jump`, it can not use `delegate` because the links are actually different.

## Test URLs

https://github.com/refined-github/refined-github/commits/hotfix

## Screenshot

<img width="473" alt="Screen Shot 2022-01-10 at 20 07 55" src="https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png">