### PR TITLE
Don't hide custom enterprise footer in `clean-footer.css`

### DIFF
--- a/source/features/clean-footer.css
+++ b/source/features/clean-footer.css
@@ -1,20 +1,19 @@
-.footer {
+.footer > div:not([data-test-selector]) {
 	transition: opacity 0.2s ease;
 }
 
-.footer:not(:hover) {
+.footer:not(:hover) > div:not([data-test-selector]) {
 	opacity: 30%;
 }
 
-.footer > div > ul:first-of-type li:first-of-type { /* The `© 2017 GitHub, Inc.` text */
-	display: none;
-}
-
-.footer-octicon {
+.footer > div:not([data-test-selector]) > ul:first-of-type li:first-of-type { /* The `© 2022 GitHub, Inc.` text */
 	display: none !important;
 }
 
-.footer li a,
-.footer li .btn-link {
+.footer > div:not([data-test-selector]) .footer-octicon {
+	display: none !important;
+}
+
+.footer > div:not([data-test-selector]) li :is(a, .btn-link) {
 	color: var(--color-text-disabled, #666);
 }


### PR DESCRIPTION
Resolves #5292 

Also fixes the hiding of the "GitHub inc." text.

## Test URLs
n/a

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/149299604-1971e361-17ee-450e-b61a-afbf8a793146.png)

**After**

![image](https://user-images.githubusercontent.com/46634000/149300715-8b77bea2-c06e-4f49-83e3-45f1988154c3.png)