### PR TITLE
Fix duplicated "Merged" filter in global conversation list

### DIFF
--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -66,9 +66,15 @@ async function init(): Promise<void | false> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isConversationList,
+		pageDetect.isRepoConversationList,
 	],
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',
+	init,
+}, {
+	include: [
+		pageDetect.isGlobalConversationList,
+	],
+	awaitDomReady: false,
 	init,
 });


### PR DESCRIPTION
Fixes #4870 

## Test URLs

 * https://github.com/pulls?q=is%3Aopen+is%3Apr+author%3A%40me+archived%3Afalse+sort%3Aupdated-desc
 * https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

Click on the "Merged" filter, then go back and forward in history. The extra filter should not be duplicated.

## Screenshot

https://user-images.githubusercontent.com/46634000/149303068-ed6b1b76-363b-4c99-ab9a-e0c110db0132.mp4