### PR TITLE
Add `prevent-pr-merge-panel-opening` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -409,6 +409,7 @@ Thanks for contributing! 🦋🙌
 - [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png)
 - [](# "convert-pr-to-draft-improvements") [Moves the "Convert PR to Draft" button to the mergeability box and adds visual feedback to its confirm button.](https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif)
 - [](# "clean-header-search-field") [Clears duplicate queries in the header search field.](https://user-images.githubusercontent.com/1402241/114177338-7c890300-9966-11eb-83a3-a711a76fae99.png)
+- [](# "prevent-pr-merge-panel-opening") Prevents the merge panel from automatically opening on every page load after it’s been opened once.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/prevent-pr-merge-panel-opening.tsx
+++ b/source/features/prevent-pr-merge-panel-opening.tsx
@@ -3,20 +3,17 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-let controller: AbortController;
-
 async function sessionResumeHandler(): Promise<void> {
 	await Promise.resolve(); // The `session:resume` event fires a bit too early
 	const cancelMergeButton = select('.merge-branch-form .js-details-target');
 	if (cancelMergeButton) {
 		cancelMergeButton.click();
-		controller.abort();
+		document.removeEventListener('session:resume', sessionResumeHandler);
 	}
 }
 
 function init(): void {
-	controller = new AbortController();
-	document.addEventListener('session:resume', sessionResumeHandler, {signal: controller.signal});
+	document.addEventListener('session:resume', sessionResumeHandler);
 }
 
 void features.add(import.meta.url, {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -211,3 +211,4 @@ import './features/clean-repo-tabs';
 import './features/rgh-welcome-issue';
 import './features/hide-repo-badges';
 import './features/same-branch-author-commits';
+import './features/prevent-pr-merge-panel-opening';


### PR DESCRIPTION
Resolves #4101 

## Test URLs

https://github.com/refined-github/sandbox/pull/4

Open the merge box and reload the page (or click on a tab and come back) to see the behavior.

## Screenshot

https://user-images.githubusercontent.com/46634000/149317428-338673be-c42a-4895-993e-728a38716c86.mp4