### PR TITLE
Fix default branch getter

### DIFF
--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -30,8 +30,6 @@ const getDefaultBranch = cache.function(async function (repository?: pageDetect.
 					? branchSelector.textContent!.trim()
 					: branchSelector.title;
 			}
-
-			console.error(`Could not find the branch selector. Calling API to get the default branch of ${repository.nameWithOwner}.`);
 		}
 
 		const defaultBranch = getCurrentBranchFromFeed();

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -25,7 +25,6 @@ const getDefaultBranch = cache.function(async function (repository?: pageDetect.
 	if (arguments.length === 0 || JSON.stringify(repository) === JSON.stringify(getRepo())) {
 		if (pageDetect.isRepoHome()) {
 			const branchSelector = await elementReady('[data-hotkey="w"]');
-
 			if (branchSelector) {
 				return branchSelector.title === 'Switch branches or tags'
 					? branchSelector.textContent!.trim()

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -24,10 +24,17 @@ const getDefaultBranch = cache.function(async function (repository?: pageDetect.
 
 	if (arguments.length === 0 || JSON.stringify(repository) === JSON.stringify(getRepo())) {
 		if (pageDetect.isRepoHome()) {
-			const currentBranch = await elementReady('[data-hotkey="w"]');
-			if (currentBranch) { // If missing, it'll default to the API call
-				return currentBranch.title;
+			const branchSelector = await elementReady('[data-hotkey="w"]');
+
+			if (branchSelector) {
+				if (branchSelector.title === 'Switch branches or tags') {
+					return branchSelector.textContent!.trim();
+				} else {
+					return branchSelector.title;
+				}
 			}
+
+			console.error(`Could not find the branch selector. Calling API to get the default branch of ${repository.nameWithOwner}.`);
 		}
 
 		const defaultBranch = getCurrentBranchFromFeed();

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -27,11 +27,9 @@ const getDefaultBranch = cache.function(async function (repository?: pageDetect.
 			const branchSelector = await elementReady('[data-hotkey="w"]');
 
 			if (branchSelector) {
-				if (branchSelector.title === 'Switch branches or tags') {
-					return branchSelector.textContent!.trim();
-				} else {
-					return branchSelector.title;
-				}
+				return branchSelector.title === 'Switch branches or tags'
+					? branchSelector.textContent!.trim()
+					: branchSelector.title;
 			}
 
 			console.error(`Could not find the branch selector. Calling API to get the default branch of ${repository.nameWithOwner}.`);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

It seems that the branch selector's `title` will only include the full branch name **only** when the displayed branch name is truncated. Otherwise, it becomes "Switch branches or tags". This causes the default branch getter to return a wrong result most of the time.

When making #5246 I may have forgotten to clear extension cache on https://github.com/refined-github/refined-github, so somehow I didn't notice this.

This PR also addresses https://github.com/refined-github/refined-github/pull/5246#discussion_r781721667.

## Test URLs

1. Clear extension cache
2. Go to https://github.com/refined-github/refined-github
3. Click "<number> commits"
4. The `default-branch-button` should not be there

## Screenshot

<table>
<tr>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/149357803-a1d475ab-ec61-4d7a-9e23-4f196e6e14a1.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/149357836-e115b477-5c8c-4965-a8bf-269174e30aae.png">
</table>