### PR TITLE
Clear `forked-to` cache after `quick-repo-deletion`

### DIFF
--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -12,6 +12,7 @@ import GitHubURL from '../github-helpers/github-url';
 import {getUsername, getForkedRepo, getRepo} from '../github-helpers';
 
 const getForkSourceRepo = (): string => getForkedRepo() ?? getRepo()!.nameWithOwner;
+// eslint-disable-next-line import/prefer-default-export
 export const getCacheKey = (): string => `forked-to:${getForkSourceRepo()}@${getUsername()!}`;
 
 const updateCache = cache.function(async (): Promise<string[] | undefined> => {

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -12,7 +12,7 @@ import GitHubURL from '../github-helpers/github-url';
 import {getUsername, getForkedRepo, getRepo} from '../github-helpers';
 
 const getForkSourceRepo = (): string => getForkedRepo() ?? getRepo()!.nameWithOwner;
-const getCacheKey = (): string => `forked-to:${getForkSourceRepo()}@${getUsername()!}`;
+export const getCacheKey = (): string => `forked-to:${getForkSourceRepo()}@${getUsername()!}`;
 
 const updateCache = cache.function(async (): Promise<string[] | undefined> => {
 	const document = await fetchDom(`/${getForkSourceRepo()}/fork?fragment=1`);

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -1,6 +1,7 @@
 import './quick-repo-deletion.css';
 import delay from 'delay';
 import React from 'dom-chef';
+import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import delegate from 'delegate-it';
 import elementReady from 'element-ready';
@@ -11,6 +12,7 @@ import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 import pluralize from '../helpers/pluralize';
 import addNotice from '../github-widgets/notice-bar';
+import {getCacheKey} from './forked-to';
 import looseParseInt from '../helpers/loose-parse-int';
 import parseBackticks from '../github-helpers/parse-backticks';
 
@@ -103,6 +105,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 			{action: false},
 		);
 		select('.application-main')!.remove();
+		await cache.delete(getCacheKey())
 		if (document.hidden) {
 			// Try closing the tab if in the background. Could fail, so we still update the UI above
 			void browser.runtime.sendMessage({closeTab: true});

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -105,7 +105,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 			{action: false},
 		);
 		select('.application-main')!.remove();
-		await cache.delete(getCacheKey())
+		await cache.delete(getCacheKey());
 		if (document.hidden) {
 			// Try closing the tab if in the background. Could fail, so we still update the UI above
 			void browser.runtime.sendMessage({closeTab: true});


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

I usually try not to correlate features together, but this is a convenient and harmless improvement we can do.

## Test URLs

1. Fork https://github.com/octocat/Spoon-Knife
2. Visit your fork
3. Delete the fork using `quick-repo-deletion`
4. Return to https://github.com/octocat/Spoon-Knife, `forked-to` should not be present

## Screenshot

N/A