### PR TITLE
Refactor `list-prs-for-file`

### DIFF
--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -112,7 +112,7 @@ async function getCurrentPath(): Promise<string> {
 	return element!.getAttribute('value')!;
 }
 
-function getPrsForCurrentPath(): Promise<number[]> {
+async function getPrsForCurrentPath(): Promise<number[]> {
 	const [path, prsByFile] = await Promise.all([
 		getCurrentPath(),
 		getPrsByFile(),

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -53,7 +53,6 @@ function getSingleButton(prNumber: number): HTMLElement {
 		<a
 			href={getPRUrl(prNumber)}
 			className="btn btn-sm flex-self-center"
-			data-pjax="#js-repo-pjax-container"
 		>
 			<GitPullRequestIcon className="v-align-middle"/>
 			<span className="v-align-middle"> #{prNumber}</span>
@@ -154,6 +153,7 @@ async function init(): Promise<void> {
 	const link = getSingleButton(prNumber);
 	link.classList.add('tooltipped', 'tooltipped-ne');
 	link.setAttribute('aria-label', `This file is touched by PR #${prNumber}`);
+	link.dataset.pjax = '#js-repo-pjax-container';
 	await addAfterBranchSelector(link);
 }
 

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -104,9 +104,14 @@ const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> 
 	cacheKey: () => 'files-with-prs:' + getRepo()!.nameWithOwner,
 });
 
-async function init(): Promise<void> {
+async function getCurrentPath(): Promise<string> {
 	// `[aria-label="Copy path"]` on blob page, `#blob-edit-path` on edit page
-	const path = (await elementReady('[aria-label="Copy path"], #blob-edit-path'))!.getAttribute('value')!;
+	const element = await elementReady('[aria-label="Copy path"], #blob-edit-path');
+	return element!.getAttribute('value')!;
+}
+
+async function init(): Promise<void> {
+	const path = await getCurrentPath();
 	let {[path]: prs} = await getPrsByFile();
 
 	if (!prs) {

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -160,6 +160,7 @@ async function initEditing(): Promise<void> {
 							<span className="ml-2 BtnGroup">
 								{prs.map(pr => {
 									const button = getSingleButton(pr) as unknown as HTMLAnchorElement;
+									button.classList.add('BtnGroup-item');
 
 									// Only Chrome supports Scroll To Text Fragment
 									// https://caniuse.com/url-scroll-to-text-fragment

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -112,7 +112,7 @@ async function getCurrentPath(): Promise<string> {
 	return element!.getAttribute('value')!;
 }
 
-async function getPrsForCurrentPath(): Promise<number[]> {
+function getPrsForCurrentPath(): Promise<number[]> {
 	const [path, prsByFile] = await Promise.all([
 		getCurrentPath(),
 		getPrsByFile(),

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -107,8 +107,8 @@ const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> 
 });
 
 async function init(): Promise<void> {
-	// `clipboard-copy` on blob page, `#blob-edit-path` on edit page
-	path = (await elementReady('clipboard-copy, #blob-edit-path'))!.getAttribute('value')!;
+	// `[aria-label="Copy path"]` on blob page, `#blob-edit-path` on edit page
+	path = (await elementReady('[aria-label="Copy path"], #blob-edit-path'))!.getAttribute('value')!;
 	let {[path]: prs} = await getPrsByFile();
 
 	if (!prs) {

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -112,16 +112,13 @@ async function getCurrentPath(): Promise<string> {
 	return element!.getAttribute('value')!;
 }
 
-function getPrsForCurrentPath(): Promise<number[]> {
+async function init(): Promise<void> {
 	const [path, prsByFile] = await Promise.all([
 		getCurrentPath(),
 		getPrsByFile(),
 	]);
-	return prsByFile[path];
-}
+	const prs = prsByFile[path];
 
-async function init(): Promise<void> {
-	const prs = await getPrsForCurrentPath();
 	if (!prs) {
 		return;
 	}
@@ -138,7 +135,11 @@ async function init(): Promise<void> {
 }
 
 async function initEditing(): Promise<void> {
-	let prs = await getPrsForCurrentPath();
+	const [path, prsByFile] = await Promise.all([
+		getCurrentPath(),
+		getPrsByFile(),
+	]);
+	let prs = prsByFile[path];
 
 	if (!prs) {
 		return;

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -112,13 +112,16 @@ async function getCurrentPath(): Promise<string> {
 	return element!.getAttribute('value')!;
 }
 
-async function init(): Promise<void> {
+function getPrsForCurrentPath(): Promise<number[]> {
 	const [path, prsByFile] = await Promise.all([
 		getCurrentPath(),
 		getPrsByFile(),
 	]);
-	const prs = prsByFile[path];
+	return prsByFile[path];
+}
 
+async function init(): Promise<void> {
+	const prs = await getPrsForCurrentPath();
 	if (!prs) {
 		return;
 	}
@@ -135,11 +138,7 @@ async function init(): Promise<void> {
 }
 
 async function initEditing(): Promise<void> {
-	const [path, prsByFile] = await Promise.all([
-		getCurrentPath(),
-		getPrsByFile(),
-	]);
-	let prs = prsByFile[path];
+	let prs = await getPrsForCurrentPath();
 
 	if (!prs) {
 		return;

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -154,16 +154,15 @@ async function init(): Promise<void> {
 		return;
 	}
 
-	if (prs.length > 1) {
-		await addAfterBranchSelector(getDropdown(prs));
-		return;
+	const button = prs.length === 1 ? getSingleButton(prNumber) : getDropdown(prs);
+
+	if (prs.length === 1) {
+		button.classList.add('tooltipped', 'tooltipped-ne');
+		button.setAttribute('aria-label', `This file is touched by PR #${prNumber}`);
+		button.dataset.pjax = '#js-repo-pjax-container';
 	}
 
-	const link = getSingleButton(prNumber);
-	link.classList.add('tooltipped', 'tooltipped-ne');
-	link.setAttribute('aria-label', `This file is touched by PR #${prNumber}`);
-	link.dataset.pjax = '#js-repo-pjax-container';
-	await addAfterBranchSelector(link);
+	await addAfterBranchSelector(button);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -15,6 +15,10 @@ function getPRUrl(prNumber: number): string {
 	return buildRepoURL('pull', prNumber, 'files');
 }
 
+function getHovercardUrl(prNumber: number): string {
+	return buildRepoURL('pull', prNumber, 'hovercard');
+}
+
 function getDropdown(prs: number[]): HTMLElement {
 	// Markup copied from https://primer.style/css/components/dropdown
 	return (
@@ -30,17 +34,14 @@ function getDropdown(prs: number[]): HTMLElement {
 					File touched by PRs
 				</div>
 				{prs.map(prNumber => (
-					<li
-						className="issue-link js-issue-link tooltipped tooltipped-e"
-						data-error-text="Failed to load PR title"
-						data-permission-text="PR title is private"
-						data-url={buildRepoURL('issues', prNumber)}
-						data-id={`rgh-pr-${prNumber}`}
+					<a
+						className="dropdown-item"
+						href={getPRUrl(prNumber)}
+						data-pjax="#js-repo-pjax-container"
+						data-hovercard-url={getHovercardUrl(prNumber)}
 					>
-						<a className="dropdown-item" href={getPRUrl(prNumber)} data-pjax="#js-repo-pjax-container">
-							#{prNumber}
-						</a>
-					</li>
+						#{prNumber}
+					</a>
 				))}
 			</ul>
 		</details>
@@ -52,6 +53,7 @@ function getSingleButton(prNumber: number): HTMLElement {
 		<a
 			href={getPRUrl(prNumber)}
 			className="btn btn-sm flex-self-center"
+			data-hovercard-url={getHovercardUrl(prNumber)}
 		>
 			<GitPullRequestIcon className="v-align-middle"/>
 			<span className="v-align-middle"> #{prNumber}</span>
@@ -123,8 +125,6 @@ async function init(): Promise<void> {
 	const button = prs.length === 1 ? getSingleButton(prNumber) : getDropdown(prs);
 
 	if (prs.length === 1) {
-		button.classList.add('tooltipped', 'tooltipped-ne');
-		button.setAttribute('aria-label', `This file is touched by PR #${prNumber}`);
 		button.dataset.pjax = '#js-repo-pjax-container';
 	}
 

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -22,14 +22,14 @@ function getHovercardUrl(prNumber: number): string {
 function getDropdown(prs: number[]): HTMLElement {
 	// Markup copied from https://primer.style/css/components/dropdown
 	return (
-		<details className="dropdown details-reset details-overlay d-inline-block flex-self-center">
-			<summary aria-haspopup="true" className="btn btn-sm">
+		<details className="dropdown details-reset details-overlay flex-self-center">
+			<summary className="btn btn-sm">
 				<GitPullRequestIcon className="v-align-middle"/>
 				<span className="v-align-middle"> {prs.length} </span>
 				<div className="dropdown-caret"/>
 			</summary>
 
-			<ul className="dropdown-menu dropdown-menu-se">
+			<details-menu className="dropdown-menu dropdown-menu-sw">
 				<div className="dropdown-header">
 					File touched by PRs
 				</div>
@@ -43,7 +43,7 @@ function getDropdown(prs: number[]): HTMLElement {
 						#{prNumber}
 					</a>
 				))}
-			</ul>
+			</details-menu>
 		</details>
 	);
 }

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -113,8 +113,11 @@ async function getCurrentPath(): Promise<string> {
 }
 
 async function init(): Promise<void> {
-	const path = await getCurrentPath();
-	const {[path]: prs} = await getPrsByFile();
+	const [path, prsByFile] = await Promise.all([
+		getCurrentPath(),
+		getPrsByFile(),
+	]);
+	const prs = prsByFile[path];
 
 	if (!prs) {
 		return;
@@ -132,8 +135,11 @@ async function init(): Promise<void> {
 }
 
 async function initEditing(): Promise<void> {
-	const path = await getCurrentPath();
-	let {[path]: prs} = await getPrsByFile();
+	const [path, prsByFile] = await Promise.all([
+		getCurrentPath(),
+		getPrsByFile(),
+	]);
+	let prs = prsByFile[path];
 
 	if (!prs) {
 		return;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

You are suggested to review each individual commit.

- "Improvement: use more specific path selector": the `clipboard-copy` selector is too generic
- "Fix: don't add PJAX buttons on `isEditingFile`": or else you may get duplicate editors:

  <img width="565" alt="1" src="https://user-images.githubusercontent.com/44045911/149632585-4dad5fe6-ca5b-4d91-b314-5c270b68348f.png">

- "Improvement: only append Text Fragment on `isEditingFile` and Chrome": only Chrome supports it now, and it doesn't work with PJAX which resets hash. Also solve https://github.com/refined-github/refined-github/pull/4739#discussion_r700517498
- Refactor commits: separate different logic on `isSingleFile` and `isEditingFile`
- "Fix: add back `.BtnGroup-item` class": this is initially broken by #4619 then some PRs from me 😅
- "Improvement: add hovercards": see #5052

## Test URLs

https://github.com/refined-github/refined-github/edit/lint/source/features/index.tsx

## Screenshot

For "Fix: add back .BtnGroup-item class":

<table>
<tr>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><img width="611" alt="Screen Shot 2022-01-16 at 01 05 11" src="https://user-images.githubusercontent.com/44045911/149632511-a6ac4493-4d79-47a9-b8b8-ae0d08529c86.png">
	<td><img width="601" alt="Screen Shot 2022-01-16 at 01 39 02" src="https://user-images.githubusercontent.com/44045911/149632509-746cd3ea-cd98-4cc6-9df6-0c051bb80f79.png">
</table>