### PR TITLE
Extend `clean-conversations` to new comment forms

### DIFF
--- a/source/features/clean-conversations.css
+++ b/source/features/clean-conversations.css
@@ -8,7 +8,7 @@
 }
 
 /* Hide arrow on new comment form */
-.timeline-comment--caret::before,
-.timeline-comment--caret::after {
+#issuecomment-new .timeline-comment--caret::before,
+#issuecomment-new .timeline-comment--caret::after {
 	content: none !important;
 }

--- a/source/features/clean-conversations.css
+++ b/source/features/clean-conversations.css
@@ -1,5 +1,5 @@
 /* Remove user avatar from new comment form */
-:is(.review-thread-reply, #issuecomment-new) .avatar {
+:is(.review-thread-reply, .timeline-new-comment) .avatar {
 	display: none;
 }
 
@@ -8,7 +8,7 @@
 }
 
 /* Hide arrow on new comment form */
-#issuecomment-new .timeline-comment--caret::before,
-#issuecomment-new .timeline-comment--caret::after {
+.timeline-new-comment .timeline-comment--caret::before,
+.timeline-new-comment .timeline-comment--caret::after {
 	content: none !important;
 }

--- a/source/features/clean-conversations.css
+++ b/source/features/clean-conversations.css
@@ -1,8 +1,14 @@
-/* Remove user avatar from new comment form on threads */
-.review-thread-reply .avatar {
+/* Remove user avatar from new comment form */
+:is(.review-thread-reply, #issuecomment-new) .avatar {
 	display: none;
 }
 
 .review-thread-reply .review-thread-reply-button {
 	margin-left: 0;
+}
+
+/* Hide arrow on new comment form */
+.timeline-comment--caret::before,
+.timeline-comment--caret::after {
+	content: none !important;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -35,15 +35,6 @@
 	display: none !important;
 }
 
-/* Remove user avatar from new comment form on threads */
-.review-thread-reply .avatar {
-	display: none;
-}
-
-.review-thread-reply .review-thread-reply-button {
-	margin-left: 0;
-}
-
 /* Hide `New pull request button` near file list */
 .file-navigation .new-pull-request-btn {
 	display: none;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Cherry-picked from [`84c9dc1` (#5113)](https://github.com/refined-github/refined-github/pull/5113/commits/84c9dc1f747c144ddf22accfce531e7a00c7fafb)

Mentioned in #1066

## Test URLs

- Conversations: Here
- Discussions: https://github.com/vercel/vercel/discussions/3874
- Commits: https://github.com/refined-github/refined-github/commit/82fb3d62f11838ad4120f510bd90520c57bb12da

## Screenshot

<table>
<tr>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/149635782-951694c8-2da8-4733-90e1-22d3a3b29a87.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/149635788-2c8380cd-128d-46f2-9cdf-37907a25579e.png">
</table>