### PR TITLE
Clean up and stick sidebar footer in `infinite-scroll`

### DIFF
--- a/source/features/infinite-scroll.css
+++ b/source/features/infinite-scroll.css
@@ -1,6 +1,6 @@
 aside[aria-label='Explore'] > .footer {
 	position: sticky !important;
-	top: 20px;
+	top: 24px;
 }
 
 aside[aria-label='Explore'] > .footer > :first-child {

--- a/source/features/infinite-scroll.css
+++ b/source/features/infinite-scroll.css
@@ -1,0 +1,8 @@
+aside[aria-label='Explore'] > .footer {
+	position: sticky !important;
+	top: 20px;
+}
+
+aside[aria-label='Explore'] > .footer > :first-child {
+	display: none !important;
+}

--- a/source/features/infinite-scroll.css
+++ b/source/features/infinite-scroll.css
@@ -2,7 +2,3 @@ aside[aria-label='Explore'] > .footer {
 	position: sticky !important;
 	top: 24px;
 }
-
-aside[aria-label='Explore'] > .footer > :first-child {
-	display: none !important;
-}

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -37,9 +37,8 @@ function init(): void {
 	});
 
 	// Use cloneNode to keep the original ones for responsive layout
-	const feedFooter = select('.news > .f6')!.cloneNode(true);
+	const feedLink = select('.news a.f6')!.cloneNode(true);
 	const footer = select('.footer > .d-flex')!.cloneNode(true);
-	footer.classList.add('mt-3');
 
 	for (const child of footer.children) {
 		child.classList.remove('pl-lg-4', 'col-xl-3');
@@ -47,7 +46,9 @@ function init(): void {
 
 	select('[aria-label="Explore"]')!.append(
 		<div className="footer">
-			{feedFooter}
+			<div>
+				{feedLink}
+			</div>
 			{footer}
 		</div>,
 	);

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -1,3 +1,4 @@
+import './infinite-scroll.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';


### PR DESCRIPTION
This PR:
 - cleans up the footer in the sidebar (the notice & subscription link are still available in the original footer at the bottom of the page)
 - makes the footer sticks at the top when the feed is scrolled

## Test URLs

https://github.com

## Screenshot

<table>
<tr>
	<th>Before</th>
	<th>After</th>
</tr>
<tr>
	<td align="top">
		<img src="https://user-images.githubusercontent.com/46634000/150097041-b83a3ae2-d441-428e-bd3b-48353e9c8faa.png">
	</td>
	<td valign="top">
		<img src="https://user-images.githubusercontent.com/46634000/150097066-e35c91c2-f946-4ede-91e7-801526a6ad1b.png">
	</td>
</tr>
</table>