### PR TITLE
Improve `clean-footer` support for custom Enterprise footers

### DIFF
--- a/source/features/clean-footer.css
+++ b/source/features/clean-footer.css
@@ -1,19 +1,17 @@
-.footer > div:not([data-test-selector]) {
+.footer > div:nth-last-child(2) ul {
 	transition: opacity 0.2s ease;
+	margin: auto;
 }
 
-.footer:not(:hover) > div:not([data-test-selector]) {
+.footer:not(:hover) > div:nth-last-child(2) ul {
 	opacity: 30%;
 }
 
-.footer > div:not([data-test-selector]) > ul:first-of-type li:first-of-type { /* The `© 2022 GitHub, Inc.` text */
+/* The `© 2022 GitHub, Inc.` text */
+.footer > div:nth-last-child(2) ul:first-child {
 	display: none !important;
 }
 
-.footer > div:not([data-test-selector]) .footer-octicon {
-	display: none !important;
-}
-
-.footer > div:not([data-test-selector]) li :is(a, .btn-link) {
+.footer > div:nth-last-child(2) a {
 	color: var(--color-text-disabled, #666);
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5292

## Test URLs

- Any GitHub page
- Any GitHub Enterprise page with a custom footer

## Screenshot

<img width="1280" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/150271030-7d7fd41a-9b9d-4927-935b-3c459834b6ef.png">

<img width="1014" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/150271022-daa1e344-b518-4966-9d73-b8b499d1883e.png">

