### PR TITLE
Lint and extend `hide-tips.css`

### DIFF
--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -24,8 +24,10 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 }
 
 /* Remove random protip at the bottom of some pages */
+.protip, /* Conversations */
+.js-notifications-list-protip, /* "Save" and "Done" notification lists */
 .paginate-container + .text-center:last-child, /* Conversation lists */
-.js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notification list */
+.js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notifications inbox */
 	display: none !important;
 }
 

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -5,8 +5,3 @@
 .js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notifications inbox */
 	display: none !important;
 }
-
-/* Remove Marketplace marketing box on PRs */
-.js-marketplace-callout-container {
-	display: none !important;
-}

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,8 +1,3 @@
-/* Remove "Continuous integration has not been set up" message on PRs */
-.branch-action-item.marketplace-product-callout {
-	display: none;
-}
-
 /* Remove "pro tip!" box on profile page (appears when name isn't set) */
 .new-user-avatar-cta {
 	display: none !important;

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -2,6 +2,6 @@
 .protip, /* Conversations */
 .js-notifications-list-protip, /* "Save" and "Done" notification lists */
 .paginate-container + .text-center:last-child, /* Conversation lists */
-.js-notifications-container .js-navigation-container + .flex-items-center:last-child { /* Notifications inbox */
+.js-notifications-container :is(.octicon-light-bulb, .octicon-light-bulb + div) { /* Notifications inbox */
 	display: none !important;
 }

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,8 +1,3 @@
-/* Remove the "helpful" banner on the issue tracker listing */
-.repository-content .mb-4.js-notice {
-	display: none !important;
-}
-
 /* Remove the "helpful" popover on the repo label page */
 .labels-list .TutorialPopover {
 	display: none !important;

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,8 +1,3 @@
-/* Remove "pro tip!" box on profile page (appears when name isn't set) */
-.new-user-avatar-cta {
-	display: none !important;
-}
-
 /* Remove random protip at the bottom of some pages */
 .protip, /* Conversations */
 .js-notifications-list-protip, /* "Save" and "Done" notification lists */

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,8 +1,3 @@
-/* Remove the "Styling with Markdown is supported" link when a PR comment is in edit mode */
-a.tabnav-extra[href$='mastering-markdown/'] {
-	display: none !important;
-}
-
 /* Remove the "helpful" banner on the issue tracker listing */
 .repository-content .mb-4.js-notice {
 	display: none !important;

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,8 +1,3 @@
-/* Remove the "helpful" popover on the repo label page */
-.labels-list .TutorialPopover {
-	display: none !important;
-}
-
 /* Remove "Continuous integration has not been set up" message on PRs */
 .branch-action-item.marketplace-product-callout {
 	display: none;


### PR DESCRIPTION
This PR:
- restores hiding protips at the bottom of conversation pages (removed in #5196)
- hides protip at the bottom of "Saved" and "Done" notifications list

## Test URLs

- this page
- https://github.com/notifications/beta?query=is%3Adone

## Screenshots

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![before](https://user-images.githubusercontent.com/46634000/150312692-b4709227-614d-4cc9-bd81-10de16bbd68d.png)
	<td>

![after](https://user-images.githubusercontent.com/46634000/150312706-581024d2-d63c-47e0-a7ef-4d013ca5b9c4.png)
<tr>
	<td>

![before-02](https://user-images.githubusercontent.com/46634000/150312722-863620c2-a76f-4d15-8109-b1b7e12706e1.png)
	<td>

![after-02](https://user-images.githubusercontent.com/46634000/150312743-02a11bbd-f9de-4a9e-b6aa-24ae7e8f277f.png)
</table>