### PR TITLE
Improve `tags-on-commits-list` and `first-published-tag-for-merged-pr` style

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -35,13 +35,15 @@ async function init(): Promise<void> {
 		discussionHeader.parentElement!.append(
 			' • ',
 			<TagIcon className="mx-1 color-text-secondary color-fg-muted"/>,
-			<a
-				href={buildRepoURL('releases/tag', tagName)}
-				className="commit-ref"
-				title={`${tagName} was the first Git tag to include this PR`}
-			>
-				{tagName}
-			</a>,
+			<span className="commit-ref">
+				<a
+					href={buildRepoURL('releases/tag', tagName)}
+					className="no-underline"
+					title={`${tagName} was the first Git tag to include this PR`}
+				>
+					{tagName}
+				</a>
+			</span>,
 		);
 	}
 }

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -140,10 +140,10 @@ async function init(): Promise<void | false> {
 				<div className="ml-2">
 					<TagIcon/>
 					<span className="ml-1">{targetTags.map((tags, i) => (
-						<>
-							<a href={buildRepoURL('releases/tag', tags)}>{tags}</a>
+						<span className="commit-ref lh-condensed d-inline py-1">
+							<a className="no-underline" href={buildRepoURL('releases/tag', tags)}>{tags}</a>
 							{(i + 1) === targetTags.length ? '' : ', '}
-						</>
+						</span>
 					))}
 					</span>
 				</div>,


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Adopt to GitHub's commit ref style, as seen on PRs headers.

## Test URLs

- `tags-on-commits-list`: https://github.com/refined-github/refined-github/commits/22.1.18
- `first-published-tag-for-merged-pr`: https://togithub.com/refined-github/refined-github/pull/5305

## Screenshot

<table>
<tr>
	<td align="center"><strong>Feature</strong>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><code>tags-on-commits-list</code>
	<td><img src="https://user-images.githubusercontent.com/44045911/150526862-46e027ef-dd23-4649-8deb-c03334de50e5.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/150526885-94bf19ab-638a-43f7-92a7-6e2007d6bd88.png">
<tr>
	<td><code>first-published-tag-for-merged-pr</code>
	<td><img src="https://user-images.githubusercontent.com/44045911/150528437-83c2f2e2-fde3-42f7-8d7a-94db7864982f.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/150528453-ef65fffd-c8f1-4f0e-942d-06b3588668be.png">
</table>