### PR TITLE
Fix page getting stuck when leaving PR conversation

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onElementRemoval from '../helpers/on-element-removal';
-import onReplacedElement from '../helpers/on-replaced-element';
+import onDiscussionSidebarUpdate from '../github-events/on-discussion-sidebar-update';
 
 const canEditSidebar = onetime((): boolean => select.exists('.discussion-sidebar-item [data-hotkey="l"]'));
 
@@ -117,9 +117,7 @@ void features.add(import.meta.url, {
 		pageDetect.isConversation,
 	],
 	additionalListeners: [
-		runFeature => {
-			void onReplacedElement('#partial-discussion-sidebar', runFeature);
-		},
+		onDiscussionSidebarUpdate,
 	],
 	deduplicate: 'has-rgh-inner',
 	init,

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -13,7 +13,7 @@ import optionsStorage, {RGHOptions} from '../options-storage';
 import {getLocalHotfixesAsOptions, getStyleHotfixes, updateHotfixes, updateStyleHotfixes} from '../helpers/hotfix';
 
 type BooleanFunction = () => boolean;
-type CallerFunction = (callback: VoidFunction, signal: AbortSignal) => void;
+export type CallerFunction = (callback: VoidFunction, signal: AbortSignal) => void;
 type FeatureInitResult = false | void | VoidFunction | VoidFunction[];
 type FeatureInit = () => Promisable<FeatureInitResult>;
 

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onReplacedElement from '../helpers/on-replaced-element';
+import onDiscussionSidebarUpdate from '../github-events/on-discussion-sidebar-update';
 
 async function addSidebarReviewButton(): Promise<void | false> {
 	const reviewFormUrl = new URL(location.href);
@@ -49,9 +49,7 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 	],
 	additionalListeners: [
-		(runFeature, signal) => {
-			void onReplacedElement('#partial-discussion-sidebar', runFeature, {signal});
-		},
+		onDiscussionSidebarUpdate,
 	],
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/github-events/on-discussion-sidebar-update.ts
+++ b/source/github-events/on-discussion-sidebar-update.ts
@@ -1,0 +1,8 @@
+import onReplacedElement from '../helpers/on-replaced-element';
+import type {CallerFunction} from '../features';
+
+const onDiscussionSidebarUpdate: CallerFunction = (runFeature, signal) => {
+	void onReplacedElement('#partial-discussion-sidebar', runFeature, {signal});
+};
+
+export default onDiscussionSidebarUpdate;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix https://github.com/refined-github/refined-github/pull/5238#issuecomment-1018551405

The problem is `clean-conversation-sidebar` doesn't get updated along with `quick-review`, resulting in looping `while` in `onReplacedElement`.

## Test URLs

From here, visit any PJAXed page

## Screenshot

N/A
