### PR TITLE
Disable deduplication mechanism for all CSS features

### DIFF
--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.isConversationList], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [pageDetect.isConversationList]);

--- a/source/features/clean-pinned-issues.tsx
+++ b/source/features/clean-pinned-issues.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.isRepoIssueList], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [pageDetect.isRepoIssueList]);

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);
+void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor], 'has-rgh-inner');

--- a/source/features/dim-visited-conversations.tsx
+++ b/source/features/dim-visited-conversations.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.isConversationList], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [pageDetect.isConversationList]);

--- a/source/features/hide-diff-signs.tsx
+++ b/source/features/hide-diff-signs.tsx
@@ -6,4 +6,4 @@ import features from '.';
 void features.addCssFeature(import.meta.url, [
 	pageDetect.hasCode,
 	pageDetect.isEditingFile,
-], 'has-rgh-inner');
+]);

--- a/source/features/hide-repo-badges.tsx
+++ b/source/features/hide-repo-badges.tsx
@@ -6,4 +6,4 @@ import features from '.';
 void features.addCssFeature(import.meta.url, [
 	pageDetect.isRepo,
 	pageDetect.isUserProfile,
-], 'has-rgh');
+]);

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -276,11 +276,11 @@ const add = async (url: string, ...loaders: FeatureLoader[]): Promise<void> => {
 	}
 };
 
-const addCssFeature = async (url: string, include: BooleanFunction[] | undefined, deduplicate?: false | string): Promise<void> => {
+const addCssFeature = async (url: string, include: BooleanFunction[] | undefined): Promise<void> => {
 	const id = getFeatureID(url);
 	void add(id, {
 		include,
-		deduplicate,
+		deduplicate: false,
 		awaitDomReady: false,
 		init: () => {
 			document.body.classList.add('rgh-' + id);

--- a/source/features/minimize-upload-bar.tsx
+++ b/source/features/minimize-upload-bar.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor], 'has-rgh-inner');
+void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);


### PR DESCRIPTION
## Test URLs

To reproduce the bug:
1. Go to https://github.com/refined-github/refined-github/issues and reload the page
2. Click on a conversation
3. The text editor at the bottom isn't cleaned


https://user-images.githubusercontent.com/46634000/150654034-492a0f79-658f-4d3d-9f45-67196e238a72.mp4


