### PR TITLE
Prevent `patch-diff-links` from being AJAXed

### DIFF
--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -12,7 +12,7 @@ function init(): void {
 	}
 
 	select('.commit-meta > :last-child')!.append(
-		<span className="sha-block patch-diff-links">
+		<span className="sha-block">
 			<a data-skip-pjax href={`${commitUrl}.patch`} className="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }
 			<a data-skip-pjax href={`${commitUrl}.diff`} className="sha">diff</a>

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -13,9 +13,9 @@ function init(): void {
 
 	select('.commit-meta > :last-child')!.append(
 		<span className="sha-block patch-diff-links">
-			<a href={`${commitUrl}.patch`} className="sha">patch</a>
+			<a data-skip-pjax href={`${commitUrl}.patch`} className="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }
-			<a href={`${commitUrl}.diff`} className="sha">diff</a>
+			<a data-skip-pjax href={`${commitUrl}.diff`} className="sha">diff</a>
 		</span>,
 	);
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

PJAX should never enable on these links, yet it does on PR commits page.

## Test URLs

https://github.com//refined-github/refined-github/pull/5238/commits/ebf3f1da71aea11782b8586501ec92fbb002316d

## Screenshot

N/A