### PR TITLE
Fix missing `download-folder-button` on commit tree pages

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -1,20 +1,40 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {getRepo} from '../github-helpers';
 
+function getDropdownItem(downloadUrl: URL): JSX.Element {
+	return (
+		<a className="dropdown-item rgh-download-folder" href={downloadUrl.href}>
+			Download directory
+		</a>
+	);
+}
+
 function init(): void {
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 
-	for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`)) {
-		deleteButton.before(
-			<a className="dropdown-item rgh-download-folder" href={downloadUrl.href}>
-				Download directory
+	const deleteButtons = select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`);
+	if (deleteButtons.length === 0) { // There are no buttons to delete the folder on "commit tree" pages #5335
+		select('a.btn[data-hotkey="t"]')!.after(
+			<a
+				className="btn d-none d-md-block tooltipped tooltipped-nw rgh-download-folder"
+				aria-label="Download directory"
+				href={downloadUrl.href}
+			>
+				<DownloadIcon/>
 			</a>,
 		);
+		select('a.dropdown-item[data-hotkey="t"]')!.after(getDropdownItem(downloadUrl));
+		return;
+	}
+
+	for (const deleteButton of deleteButtons) {
+		deleteButton.before(getDropdownItem(downloadUrl));
 	}
 }
 

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -23,7 +23,7 @@ function init(): void {
 		for (const deleteButton of deleteButtons) {
 			deleteButton.before(getDropdownItem(downloadUrl));
 		}
-		
+
 		return;
 	}
 

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -19,23 +19,24 @@ function init(): void {
 	downloadUrl.searchParams.set('url', location.href);
 
 	const deleteButtons = select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`);
-	if (deleteButtons.length === 0) { // There are no buttons to delete the folder on "commit tree" pages #5335
-		select('a.btn[data-hotkey="t"]')!.after(
-			<a
-				className="btn d-none d-md-block tooltipped tooltipped-nw rgh-download-folder"
-				aria-label="Download directory"
-				href={downloadUrl.href}
-			>
-				<DownloadIcon/>
-			</a>,
-		);
-		select('a.dropdown-item[data-hotkey="t"]')!.after(getDropdownItem(downloadUrl));
+	if (deleteButtons.length > 0) { // There are no buttons to delete the folder on "commit tree" pages #5335
+		for (const deleteButton of deleteButtons) {
+			deleteButton.before(getDropdownItem(downloadUrl));
+		}
+		
 		return;
 	}
 
-	for (const deleteButton of deleteButtons) {
-		deleteButton.before(getDropdownItem(downloadUrl));
-	}
+	select('a.dropdown-item[data-hotkey="t"]')!.after(getDropdownItem(downloadUrl));
+	select('a.btn[data-hotkey="t"]')!.after(
+		<a
+			className="btn d-none d-md-block tooltipped tooltipped-nw rgh-download-folder"
+			aria-label="Download directory"
+			href={downloadUrl.href}
+		>
+			<DownloadIcon/>
+		</a>,
+	);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5335

## Test URLs
https://github.com/dotnet/runtime/tree/09ff1acdad2e7789908b5db9bb89896144c13042/src/libraries/Microsoft.VisualBasic.Core

## Screenshot

![01](https://user-images.githubusercontent.com/46634000/151665051-a43c9897-1aaf-459b-8af1-9882a4eacf15.png)
![02](https://user-images.githubusercontent.com/46634000/151665052-51e427b8-5a20-497b-9a11-d68190aab170.png)