### PR TITLE
Fix `clean-conversation-sidebar` leaking style

### DIFF
--- a/source/features/clean-conversation-sidebar.css
+++ b/source/features/clean-conversation-sidebar.css
@@ -4,24 +4,20 @@
 }
 
 /* Align sidebar to the top */
-.discussion-sidebar-item:first-child {
+.discussion-sidebar-item.rgh-clean-sidebar:first-child {
 	padding-top: 0;
 }
 
-.sidebar-labels .sidebar-labels-style:first-child {
-	margin-top: 0;
-}
-
 /* Move message under the `Unsubscribe` button above the button */
-.thread-subscription-status {
+.rgh-clean-sidebar .thread-subscription-status {
 	display: flex;
 	flex-direction: column;
 }
 
-form.thread-subscribe-form { /* `form` excludes the header */
+.rgh-clean-sidebar form.thread-subscribe-form { /* `form` excludes the header */
 	order: 1;
 }
 
-.thread-subscription-status .reason {
+.rgh-clean-sidebar .thread-subscription-status .reason {
 	margin: 0 0 10px !important;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Previously the style is leaking and affects `isCommit`.

## Test URLs

https://github.com/refined-github/refined-github/commit/79ef6d8f680ab39c17bb6ec4458b2228769e5fe8#comments

## Screenshot

<table>
<tr>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/151678437-ea676d66-68b5-4270-9739-3406081f05d2.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/151678429-8b13a423-72ef-44c9-8983-76c85c06b619.png">
</table>
