### PR TITLE
Add `easy-toggle-commit-messages` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,7 +326,7 @@ Thanks for contributing! 🦋🙌
 - [](# "highlight-deleted-and-added-files-in-diffs") [Indicates with an icon whether files in commits and pull requests being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
 - [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
 - [](# "same-branch-author-commits") [Preserves current branch and path when viewing all commits by an author.](https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png)
-- [](# "easy-toggle-commit-messages") [Enables toggling commit messages by clicking on the commit box.](TODO)
+- [](# "easy-toggle-commit-messages") [Enables toggling commit messages by clicking on the commit box.](https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,7 @@ Thanks for contributing! 🦋🙌
 - [](# "highlight-deleted-and-added-files-in-diffs") [Indicates with an icon whether files in commits and pull requests being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
 - [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
 - [](# "same-branch-author-commits") [Preserves current branch and path when viewing all commits by an author.](https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png)
+- [](# "easy-toggle-commit-messages") [Enables toggling commit messages by clicking on the commit box.](TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -8,7 +8,7 @@ function toggleCommitMessage(event: MouseEvent): void {
 	const commitBox = elementClicked.closest('.js-commits-list-item')!;
 
 	// The clicked element is not a button or a link
-	if (elementClicked === commitBox || elementClicked.matches('div, p, pre')) {
+	if (!elementClicked.closest('a, button')) {
 		select('.ellipsis-expander', commitBox)!
 			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
 	}

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -1,0 +1,28 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function toggleCommitMessage(event: MouseEvent): void {
+	const elementClicked = event.target as HTMLElement;
+	const commitBox = elementClicked.closest('.js-commits-list-item')!;
+
+	// The clicked element is not a button or a link
+	if (elementClicked === commitBox || elementClicked.matches('div, p, pre')) {
+		select('.ellipsis-expander', commitBox)!
+			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
+	}
+}
+
+async function init(): Promise<void> {
+	document.body.addEventListener('click', toggleCommitMessage);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isCommitList,
+	],
+	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
+	init,
+});

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -9,10 +9,7 @@ function toggleCommitMessage(event: delegate.Event<MouseEvent>): void {
 	// The clicked element is not a button, a link or a popup ("Verified" badge, CI details, etc.)
 	if (!elementClicked.closest('a, button, clipboard-copy, details')) {
 		select('.ellipsis-expander', event.delegateTarget)?.dispatchEvent(
-			new MouseEvent('click', {
-				bubbles: true,
-				altKey: event.altKey,
-			}),
+			new MouseEvent('click', {bubbles: true, altKey: event.altKey}),
 		);
 	}
 }

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -1,21 +1,20 @@
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function toggleCommitMessage(event: MouseEvent): void {
+function toggleCommitMessage(event: delegate.Event<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
-	const commitBox = elementClicked.closest('.js-commits-list-item')!;
-
 	// The clicked element is not a button or a link
 	if (!elementClicked.closest('a, button, clipboard-copy')) {
-		select('.ellipsis-expander', commitBox)!
+		select('.ellipsis-expander', event.delegateTarget)!
 			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
 	}
 }
 
 async function init(): Promise<void> {
-	document.body.addEventListener('click', toggleCommitMessage);
+	delegate(document, '.js-commits-list-item', 'click', toggleCommitMessage);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -6,8 +6,8 @@ import features from '.';
 
 function toggleCommitMessage(event: delegate.Event<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
-	// The clicked element is not a button or a link
-	if (!elementClicked.closest('a, button, clipboard-copy')) {
+	// The clicked element is not a button, a link or a popup ("Verified" badge, CI details, etc.)
+	if (!elementClicked.closest('a, button, clipboard-copy, details')) {
 		select('.ellipsis-expander', event.delegateTarget)?.dispatchEvent(
 			new MouseEvent('click', {
 				bubbles: true,

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -8,7 +8,7 @@ function toggleCommitMessage(event: MouseEvent): void {
 	const commitBox = elementClicked.closest('.js-commits-list-item')!;
 
 	// The clicked element is not a button or a link
-	if (!elementClicked.closest('a, button')) {
+	if (!elementClicked.closest('a, button, clipboard-copy')) {
 		select('.ellipsis-expander', commitBox)!
 			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
 	}

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -21,6 +21,7 @@ async function init(): Promise<void> {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isCommitList,
+		pageDetect.isCompare,
 	],
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -8,8 +8,12 @@ function toggleCommitMessage(event: delegate.Event<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
 	// The clicked element is not a button or a link
 	if (!elementClicked.closest('a, button, clipboard-copy')) {
-		select('.ellipsis-expander', event.delegateTarget)!
-			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
+		select('.ellipsis-expander', event.delegateTarget)?.dispatchEvent(
+			new MouseEvent('click', {
+				bubbles: true,
+				altKey: event.altKey,
+			}),
+		);
 	}
 }
 

--- a/source/features/easy-toggle-files.tsx
+++ b/source/features/easy-toggle-files.tsx
@@ -1,11 +1,12 @@
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function toggleFile(event: MouseEvent): void {
+function toggleFile(event: delegate.Event<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
-	const headerBar = elementClicked.closest('.file-header')!;
+	const headerBar = event.delegateTarget;
 
 	// The clicked element is either the bar itself or one of its 2 children
 	if (elementClicked === headerBar || elementClicked.parentElement === headerBar) {
@@ -15,7 +16,7 @@ function toggleFile(event: MouseEvent): void {
 }
 
 async function init(): Promise<void> {
-	document.body.addEventListener('click', toggleFile);
+	delegate(document, '.file-header', 'click', toggleFile);
 }
 
 void features.add(import.meta.url, {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -213,3 +213,4 @@ import './features/hide-repo-badges';
 import './features/same-branch-author-commits';
 import './features/prevent-pr-merge-panel-opening';
 import './features/dim-visited-conversations';
+import './features/easy-toggle-commit-messages';


### PR DESCRIPTION
Resolves #5341 

## Test URLs

- [Repo commit list](https://github.com/torvalds/linux/commits/master)
- [PR commit list](https://togithub.com/refined-github/refined-github/pull/5324/commits)
- [Compare page](https://github.com/torvalds/linux/compare/v5.17-rc1...master)

## Screenshot

![easy-toggle-commit-messages](https://user-images.githubusercontent.com/46634000/151691917-bf1ed002-05e9-4488-9ce7-e06a36eba1ad.gif)