### PR TITLE
Improve `highest-rated-comment`

### DIFF
--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -15,13 +15,6 @@ a.rgh-highest-rated-comment {
 	border: 2px solid var(--color-success-emphasis) !important;
 }
 
-a.rgh-highest-rated-comment .timeline-comment-header-text {
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
-	max-width: none;
-}
-
 a.rgh-highest-rated-comment .avatar {
 	position: absolute;
 	left: -58px;

--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -24,5 +24,5 @@ a.rgh-highest-rated-comment .timeline-comment-header-text {
 
 a.rgh-highest-rated-comment .avatar {
 	position: absolute;
-	left: -55px;
+	left: -58px;
 }

--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -1,9 +1,10 @@
 .rgh-highest-rated-comment.timeline-comment {
-	border: 2px solid var(--rgh-green);
+	/* Same as GitHub's `.timeline-chosen-answer` */
+	border: 2px solid var(--color-success-emphasis);
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::before {
-	background-color: var(--rgh-green);
+	background-color: var(--color-success-emphasis);
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::after {
@@ -11,7 +12,7 @@
 }
 
 a.rgh-highest-rated-comment {
-	border: 2px solid var(--rgh-green) !important;
+	border: 2px solid var(--color-success-emphasis) !important;
 }
 
 a.rgh-highest-rated-comment .timeline-comment-header-text {

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -75,7 +75,7 @@ function linkBestComment(bestComment: HTMLElement): void {
 			{avatar}
 
 			<h3 className="timeline-comment-header-text f5 color-fg-muted text-normal text-italic">
-				<strong>Highest-rated comment</strong> — {text}
+				<span className="Label mr-2">Highest-rated</span>{text}
 			</h3>
 
 			<div className="color-fg-muted f6 no-wrap">

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -74,7 +74,7 @@ function linkBestComment(bestComment: HTMLElement): void {
 		<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment timeline-comment color-bg-tertiary color-bg-subtle px-2 d-flex flex-items-center">
 			{avatar}
 
-			<h3 className="timeline-comment-header-text f5 color-fg-muted text-normal text-italic">
+			<h3 className="timeline-comment-header-text f5 color-fg-muted text-normal text-italic css-truncate css-truncate-overflow mr-2">
 				<span className="Label mr-2">Highest-rated</span>{text}
 			</h3>
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -72,18 +72,17 @@ function linkBestComment(bestComment: HTMLElement): void {
 	const avatar = select('img.avatar', bestComment)!.cloneNode();
 
 	bestComment.parentElement!.firstElementChild!.after(
-		<div className="timeline-comment-wrapper pl-0 my-0">
-			<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment timeline-comment color-bg-tertiary color-bg-subtle px-2 d-flex flex-items-center">
-				{avatar}
-				<span className="btn btn-sm mr-2">
-					<ArrowDownIcon/>
-				</span>
+		<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment timeline-comment color-bg-tertiary color-bg-subtle px-2 d-flex flex-items-center">
+			{avatar}
 
-				<span className="color-text-secondary color-fg-muted timeline-comment-header-text">
-					Highest-rated comment: <em>{text}</em>
-				</span>
-			</a>
-		</div>,
+			<h3 className="timeline-comment-header-text f5 color-fg-muted text-normal text-italic">
+				<strong>Highest-rated comment</strong> — {text}
+			</h3>
+
+			<div className="color-fg-muted f6 no-wrap">
+				<ArrowDownIcon className="mr-1"/>Jump to comment
+			</div>
+		</a>,
 	);
 }
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -51,7 +51,7 @@ function highlightBestComment(bestComment: Element): void {
 	select('.unminimized-comment', bestComment)!.classList.add('rgh-highest-rated-comment');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span
-			className="d-inline-block color-text-success color-fg-success mr-1 tooltipped tooltipped-n"
+			className="color-text-success color-fg-success tooltipped tooltipped-s"
 			aria-label="This comment has the most positive reactions on this issue."
 		>
 			<CheckCircleFillIcon/>

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -60,10 +60,9 @@ function highlightBestComment(bestComment: Element): void {
 }
 
 function linkBestComment(bestComment: HTMLElement): void {
-	// Find position of comment in thread
-	const position = select.all(commentSelector).indexOf(bestComment);
+	const firstTimelineItem = select('#js-timeline-progressive-loader')!.nextElementSibling!;
 	// Only link to it if it doesn't already appear at the top of the conversation
-	if (position < 3) {
+	if (firstTimelineItem === bestComment) {
 		return;
 	}
 

--- a/source/features/preview-hidden-comments.css
+++ b/source/features/preview-hidden-comments.css
@@ -1,6 +1,0 @@
-/* Truncate hidden comment preview text with ellipsis */
-.rgh-preview-hidden-comments :is(.timeline-comment-header-text, summary h3) {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -30,7 +30,9 @@ function init(): void {
 
 		header.append(
 			<span className="Details-content--open">{select(':scope > .d-inline-block', header) ?? header.firstChild}</span>,
-			<span className="Details-content--closed">{`${upperCaseFirst(reason)} — ${commentText.slice(0, 100)}`}</span>,
+			<span className="Details-content--closed">
+				<strong>{upperCaseFirst(reason)}</strong> — {commentText.slice(0, 100)}
+			</span>,
 		);
 	}
 }

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -1,4 +1,3 @@
-import './preview-hidden-comments.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
@@ -28,6 +27,7 @@ function init(): void {
 			continue;
 		}
 
+		header.classList.add('css-truncate', 'css-truncate-overflow', 'mr-2');
 		header.append(
 			<span className="Details-content--open">{select(':scope > .d-inline-block', header) ?? header.firstChild}</span>,
 			<span className="Details-content--closed">

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -31,7 +31,7 @@ function init(): void {
 		header.append(
 			<span className="Details-content--open">{select(':scope > .d-inline-block', header) ?? header.firstChild}</span>,
 			<span className="Details-content--closed">
-				<strong>{upperCaseFirst(reason)}</strong> — {commentText.slice(0, 100)}
+				<span className="Label mr-2">{upperCaseFirst(reason)}</span>{commentText.slice(0, 100)}
 			</span>,
 		);
 	}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

- Align `highest-rated-comment` style with GitHub
- Redesign `highest-rated-comment` jump to comment button (like hidden comments)

  `preview-hidden-comments` is also changed slightly to align with it

- Always add `highest-rated-comment` link unless the fist timeline item is the best comment

  Previous logic is to check if the first **3** timeline items contain the best comment.

  However chances are the first 3 timeline items could be _many_ events like references, label and assignment changes, etc. (e.g. https://github.com//ytdl-org/youtube-dl/issues/30568, previously the link to highest-rated comment isn't created).

## Changes

<table>
<tr>
	<td><strong>Test URL</strong>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><a href="https://github.com//vercel/swr/issues/93"><code>highest-rated-comment</code> button</a>
	<td><img src="https://user-images.githubusercontent.com/44045911/151883793-77439f39-d8f6-48b5-bac8-f3ba00072377.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/153730184-2370b72a-307b-433b-8ce6-5e6820613722.png">
<tr>
	<td><a href="https://github.com//vercel/swr/issues/93"><code>highest-rated-comment</code> comment</a>
	<td><img src="https://user-images.githubusercontent.com/44045911/151883865-85c9f0d7-e26c-4a22-b572-be302be98b71.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/151883729-c5e28ad1-9829-4064-9137-0771da662b71.png">
<tr>
	<td><a href="https://github.com//refined-github/refined-github/issues/5326#event-5924166637"><code>preview-hidden-comments</code> comment</a>
	<td><img src="https://user-images.githubusercontent.com/44045911/151883149-e6db1630-a8a4-4aa1-b332-e752206c50d4.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/153730161-55c50820-cc62-41c4-b34c-02e725a5d97b.png">
</table>