### PR TITLE
Exclude explicitly linked comments in `hide-low-quality-comments`

### DIFF
--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -37,7 +37,11 @@ function init(): void {
 		lowQualityCount++;
 	}
 
-	for (const commentText of select.all('.comment-body > p:only-child')) {
+	const notLinkedCommentSelector = window.location.hash.startsWith('#issuecomment-')
+		? `.timeline-comment-group:not(${window.location.hash}) .comment-body > p:only-child`
+		: '.comment-body > p:only-child';
+
+	for (const commentText of select.all(notLinkedCommentSelector)) {
 		if (!isLowQualityComment(commentText.textContent!)) {
 			continue;
 		}

--- a/test/is-low-quality-comment.ts
+++ b/test/is-low-quality-comment.ts
@@ -25,4 +25,5 @@ test('isLowQualityComment', t => {
 	t.false(isLowQualityComment('Same here. <some useful information>'));
 	t.false(isLowQualityComment('Same here, please update, thanks'));
 	t.false(isLowQualityComment('Same here! Please update, thank you.'));
+	t.false(isLowQualityComment('[here](https://www.example.com)'));
 });


### PR DESCRIPTION
Resolves #5334 

## Test URLs

- [All 41 useless comments should be hidden](https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/167)
- [Linked comment should be visible (40 hidden comments)](https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issuecomment-821212185)

## Screenshots

![image](https://user-images.githubusercontent.com/46634000/152177605-debc2999-9004-4fb0-8c0e-b024a6e360fb.png)

---

![image](https://user-images.githubusercontent.com/46634000/152177706-1c8ece6e-ff07-4800-a558-aceef41a4fd9.png)