### PR TITLE
Only disable `latest-tag-button` when actually on the latest tag

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -118,7 +118,7 @@ async function init(): Promise<false | void> {
 	const defaultBranch = await getDefaultBranch();
 
 	if (currentBranch === latestTag || (currentBranch === defaultBranch && aheadBy === 0)) {
-		link.setAttribute('aria-label', 'You’re on the latest tag');
+		link.setAttribute('aria-label', 'You’re on the latest version');
 		link.classList.add('disabled', 'tooltipped', 'tooltipped-ne');
 		return;
 	}
@@ -128,7 +128,7 @@ async function init(): Promise<false | void> {
 		link.setAttribute(
 			'aria-label',
 			aheadBy
-				? `${defaultBranch} is ${pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest tag`
+				? `${defaultBranch} is ${pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest version`
 				: `The HEAD of ${defaultBranch} isn’t tagged`,
 		);
 
@@ -146,7 +146,7 @@ async function init(): Promise<false | void> {
 			groupButtons([link, compareLink]).classList.add('flex-self-center', 'd-flex');
 		}
 	} else {
-		link.setAttribute('aria-label', 'Visit the latest tag');
+		link.setAttribute('aria-label', 'Visit the latest version');
 	}
 
 	link.classList.add('tooltipped', 'tooltipped-ne');

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -115,19 +115,20 @@ async function init(): Promise<false | void> {
 		link.append(' ', <span className="css-truncate-target v-align-middle">{latestTag}</span>);
 	}
 
-	if (currentBranch === latestTag || aheadBy === 0) {
-		link.setAttribute('aria-label', 'You’re on the latest release');
+	const defaultBranch = await getDefaultBranch();
+
+	if (currentBranch === latestTag || (currentBranch === defaultBranch && aheadBy === 0)) {
+		link.setAttribute('aria-label', 'You’re on the latest tag');
 		link.classList.add('disabled', 'tooltipped', 'tooltipped-ne');
 		return;
 	}
 
-	const defaultBranch = await getDefaultBranch();
 	if (pageDetect.isRepoHome() || currentBranch === defaultBranch) {
 		link.append(<sup> +{aheadBy}</sup>);
 		link.setAttribute(
 			'aria-label',
 			aheadBy
-				? `${defaultBranch} is ${pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest release`
+				? `${defaultBranch} is ${pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest tag`
 				: `The HEAD of ${defaultBranch} isn’t tagged`,
 		);
 
@@ -145,7 +146,7 @@ async function init(): Promise<false | void> {
 			groupButtons([link, compareLink]).classList.add('flex-self-center', 'd-flex');
 		}
 	} else {
-		link.setAttribute('aria-label', 'Visit the latest release');
+		link.setAttribute('aria-label', 'Visit the latest tag');
 	}
 
 	link.classList.add('tooltipped', 'tooltipped-ne');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Bug introduced in [`e7f0d3e` (#3199)](https://github.com/refined-github/refined-github/pull/3199/commits/e7f0d3e099edc355aa0f38497cc4ea24e719365f#diff-865e9997a2004e222760004e23714c43b27194f59ec8aae2483c934935ed66b4R110), it only checks if the default branch is not ahead of the latest tag, but doesn't check if you are actually on the default branch.

Also changed the text from "release" to "tag". "Release" is a GitHub term and what we are really working with is Git tags.

## Test URLs

https://github.com/refined-github/refined-github/tree/22.1.18

## Screenshot

<table>
<tr>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/152232563-919b9a5b-e830-4f53-8cab-963a43108934.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/152232555-27ff9735-226f-4ab6-8239-3a3525b38acd.png">