### PR TITLE
Add feature `pr-merge-commit-reviewers`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -309,6 +309,7 @@ Thanks for contributing! 🦋🙌
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
 - [](# "quick-review") [Adds a review button to the PR sidebar, automatically focuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
 - [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif)
+- [](# "pr-merge-commit-reviewers") [Adds reviewers who have approved the PR to the default merge commit description.](https://user-images.githubusercontent.com/9374207/152912033-231286ea-96aa-4178-804e-04f9e5cbe154.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/pr-merge-commit-reviewers.tsx
+++ b/source/features/pr-merge-commit-reviewers.tsx
@@ -1,0 +1,46 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
+
+function init(): void {
+	const messageField = select('textarea#merge_message_field')!;
+
+	if (messageField.value.includes('Approved by')) {
+		return;
+	}
+
+	const reviewers = select.all('span.reviewers-status-icon');
+	const message = ['Approved by:'];
+
+	for (const reviewer of reviewers) {
+		if (!reviewer.hasAttribute('aria-label')) {
+			continue;
+		}
+
+		const label = reviewer.getAttribute('aria-label');
+		if (label!.includes('approved these changes')) {
+			const name = label!.split(' ')[0];
+			message.push(name);
+		}
+	}
+
+	if (messageField.value.length > 0) {
+		messageField.value += '\n';
+	}
+
+	messageField.value += message.join(' ');
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRConversation,
+	],
+	additionalListeners: [
+		onPrMergePanelOpen,
+	],
+	onlyAdditionalListeners: true,
+	deduplicate: 'has-rgh-inner',
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -214,3 +214,4 @@ import './features/hide-repo-badges';
 import './features/same-branch-author-commits';
 import './features/prevent-pr-merge-panel-opening';
 import './features/dim-visited-conversations';
+import './features/pr-merge-commit-reviewers';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
This feature doesn't have an existing issue. It's just something that I want to use. It affects the pull request page, specifically the merge panel on that page. I tested the changes on a private GitHub enterprise instance.

## Test URL
https://github.com/ForrestH/HTMLClock/pull/1

## Screenshot
![](https://user-images.githubusercontent.com/9374207/152912033-231286ea-96aa-4178-804e-04f9e5cbe154.png)

