### PR TITLE
Improve `git-checkout-pr` style

### DIFF
--- a/source/features/git-checkout-pr.tsx
+++ b/source/features/git-checkout-pr.tsx
@@ -35,8 +35,7 @@ function checkoutOption(remote?: string, remoteType?: 'HTTPS' | 'SSH'): JSX.Elem
 	const [nameWithOwner, headBranch] = select('.head-ref')!.title.split(':');
 	const [owner] = nameWithOwner.split('/');
 	return (
-		<div className="markdown-body">
-			{remote && <p className="color-text-secondary color-fg-muted text-small my-1">{remoteType}</p>}
+		<div hidden={remoteType && remoteType !== 'HTTPS'} className="markdown-body" role="tabpanel">
 			<div className="snippet-clipboard-content position-relative">
 				<div className="zeroclipboard-container position-absolute right-0 top-0">
 					<clipboard-copy
@@ -52,13 +51,34 @@ function checkoutOption(remote?: string, remoteType?: 'HTTPS' | 'SSH'): JSX.Elem
 						<CheckIcon className="js-clipboard-check-icon color-text-success color-fg-success d-none m-2"/>
 					</clipboard-copy>
 				</div>
-				<pre id={`rgh-checkout-pr-${remoteType!}`}>
+				<pre id={`rgh-checkout-pr-${remoteType!}`} className="mb-2 rgh-linkified-code">
 					<code>
 						{remote && `git remote add ${remote} ${connectionType[remoteType!]}${nameWithOwner}.git\n`}
 						git fetch {remote ?? 'origin'} {headBranch}{'\n'}
 						git switch {remote && `--track ${owner}/`}{headBranch}
 					</code>
 				</pre>
+			</div>
+		</div>
+	);
+}
+
+function getTabList(tabs: string[], selected = tabs[0]): JSX.Element {
+	return (
+		<div className="UnderlineNav my-2 box-shadow-none">
+			<div className="UnderlineNav-body" role="tablist">
+				{tabs.map(tab => (
+					<button
+						type="button"
+						role="tab"
+						className="UnderlineNav-item lh-default f6 py-0 px-0 mr-2 position-relative"
+						// Style won't apply if using the boolean directly
+						aria-selected={tab === selected ? 'true' : 'false'}
+						tabIndex={tab === selected ? 0 : -1}
+					>
+						{tab}
+					</button>
+				))}
 			</div>
 		</div>
 	);
@@ -78,13 +98,16 @@ async function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): Pr
 				Checkout with Git
 			</span>
 			<div className="mt-2 pl-5">
-				<p className="color-text-secondary color-fg-muted text-small">
-					Run in your project repository{remoteName && ', pick either one'}
+				<tab-container>
+					{remoteName ? [
+						getTabList(['HTTPS', 'SSH']),
+						checkoutOption(remoteName, 'HTTPS'),
+						checkoutOption(remoteName, 'SSH'),
+					] : checkoutOption()}
+				</tab-container>
+				<p className="mb-0 f6 color-text-secondary color-fg-muted">
+					Run in your project repository{remoteName && ', pick either one'}.
 				</p>
-				{remoteName ? [
-					checkoutOption(remoteName, 'HTTPS'),
-					checkoutOption(remoteName, 'SSH'),
-				] : checkoutOption()}
 			</div>
 		</li>,
 	);

--- a/source/features/git-checkout-pr.tsx
+++ b/source/features/git-checkout-pr.tsx
@@ -51,7 +51,7 @@ function checkoutOption(remote?: string, remoteType?: 'HTTPS' | 'SSH'): JSX.Elem
 						<CheckIcon className="js-clipboard-check-icon color-text-success color-fg-success d-none m-2"/>
 					</clipboard-copy>
 				</div>
-				<pre id={`rgh-checkout-pr-${remoteType!}`} className="mb-2 rgh-linkified-code">
+				<pre id={`rgh-checkout-pr-${remoteType!}`} className="mb-2 rgh-linkified-code">{/* `.rgh-linkified-code` is intentionally added to avoid parsing */}
 					<code>
 						{remote && `git remote add ${remote} ${connectionType[remoteType!]}${nameWithOwner}.git\n`}
 						git fetch {remote ?? 'origin'} {headBranch}{'\n'}

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -45,6 +45,7 @@ declare namespace JSX {
 		'include-fragment': IntrinsicElements.div & {src?: string};
 		'label': IntrinsicElements.label & {for?: string};
 		'relative-time': IntrinsicElements.div & {datetime: string};
+		'tab-container': IntrinsicElements.div;
 		'time-ago': IntrinsicElements.div & {datetime: string; format?: string};
 	}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

When `git-checkout-pr` adds two code blocks, the dropdown becomes ugly long. This PR adopts to a style inspired by the native clone dropdown:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/44045911/153457664-3ce17804-83e2-488a-9807-a64bb1c6b7d2.png">

This does not affect how it displays when only one code block is added.

## Test URLs

https://github.com//fish-shell/fish-shell/pull/8712

## Screenshot

<table>
<tr>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/153457535-a036b38f-e4da-46f6-b340-0b3fa72420f9.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/153457555-025bf791-4bbe-42d8-9ed0-b8d66a62ef00.png">