### PR TITLE
Fix styles of `table-input` and `collapsible-content-button`

### DIFF
--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -39,7 +39,7 @@ function addButtons(): void {
 	for (const anchor of select.all('md-ref:not(.rgh-collapsible-content-btn-added)')) {
 		anchor.classList.add('rgh-collapsible-content-btn-added');
 		anchor.after(
-			<button type="button" className="toolbar-item tooltipped tooltipped-sw rgh-collapsible-content-btn" aria-label="Add collapsible content">
+			<button type="button" className="toolbar-item btn-octicon p-2 p-md-1 tooltipped tooltipped-sw rgh-collapsible-content-btn" aria-label="Add collapsible content">
 				<FoldDownIcon/>
 			</button>,
 		);

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -2,7 +2,7 @@
 	width: auto;
 	padding: 3px;
 	z-index: 99;
-	display: grid;
+	display: grid !important;
 	grid-template: repeat(5, 20px) / repeat(5, 20px);
 }
 

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -38,9 +38,9 @@ function addButtons(): void {
 	for (const anchor of select.all('md-task-list:not(.rgh-table-input-added)')) {
 		anchor.classList.add('rgh-table-input-added');
 		anchor.after(
-			<details className="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right hx_rsm">
+			<details className="details-reset details-overlay flex-auto toolbar-item btn-octicon mx-1 select-menu select-menu-modal-right hx_rsm">
 				<summary
-					className="text-center menu-target py-2 p-md-1 hx_rsm-trigger mx-1"
+					className="text-center menu-target p-2 p-md-1 hx_rsm-trigger"
 					role="button"
 					aria-label="Add a table"
 					aria-haspopup="menu"


### PR DESCRIPTION
Fixes #5392 

## Test URLs

Any page with a comment form

## Screenshots

<table>
<tr>
	<th>

Before
	<th>

After
<tr>
	<td>

![before](https://user-images.githubusercontent.com/46634000/153488291-1f4ff1f0-f892-427b-bf67-e169dac61fe5.png)
	<td>

![after](https://user-images.githubusercontent.com/46634000/153488299-48d06669-3805-4db6-bd71-124db7139670.png)

<tr>
	<td></td>
	<td>

On mobile:
![after-mobile](https://user-images.githubusercontent.com/46634000/153488384-b994a01a-000d-41b5-92ee-15dbca0c76f3.png)
</table>