### PR TITLE
Hide "Unpin" button in repo header

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -161,3 +161,8 @@ pr-branches
 .file-navigation.flex-items-start {
 	align-items: center !important;
 }
+
+/* Hide "Unpin" button in repo header https://github.com/refined-github/refined-github/issues/5398#issuecomment-1036112206 */
+.pagehead-actions [data-test-selector='pin-repo-button'] {
+	display: none !important;
+}


### PR DESCRIPTION
https://github.com/refined-github/refined-github/issues/5398#issuecomment-1036112206

## Test URLs

Any page of a repo pinned to your profile

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/153662247-089056cb-a7cd-4202-bf03-c835b256c1eb.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/153662243-6826c561-9211-4854-abbe-2bf17a3641c1.png)