### PR TITLE
Fix `tags-dropdown` layout

### DIFF
--- a/source/features/tags-dropdown.css
+++ b/source/features/tags-dropdown.css
@@ -10,7 +10,19 @@
 	max-width: 300px;
 }
 
-/* Space out buttons on Releases page */
-.subnav > .float-right {
-	margin-left: 20px;
+/* Limit dropdown height */
+:root .rgh-tags-dropdown .SelectMenu-list {
+	max-height: 300px !important;
+}
+
+/* Fix layout breakage on smaller screens */
+@media (min-width: 544px) and (max-width: 566px) {
+	nav[aria-label='Releases and Tags navigation buttons'] {
+		flex-basis: auto !important;
+		flex-shrink: 0 !important;
+	}
+
+	nav[aria-label='Releases and Tags navigation buttons'] + .d-flex > .flex-sm-self-end {
+		align-self: flex-start !important;
+	}
 }

--- a/source/features/tags-dropdown.css
+++ b/source/features/tags-dropdown.css
@@ -12,7 +12,7 @@
 
 /* Limit dropdown height */
 :root .rgh-tags-dropdown .SelectMenu-list {
-	max-height: 300px !important;
+	max-height: 330px !important;
 }
 
 /* Fix layout breakage on smaller screens */

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -47,11 +47,13 @@ function init(): void {
 	if (pageDetect.isEnterprise() || pageDetect.isTags()) {
 		select('.subnav')!.append(tagsDropdown);
 	} else {
-		select('.subnav-search-input')!.closest('.d-flex')!.before(
-			<div className={pageDetect.isTags() ? 'ml-2' : 'mb-2 mr-2'}>
+		const searchBarWrapper = select('input[aria-label="Find a release"]')!.closest('div')!;
+		searchBarWrapper.prepend(
+			<div className="mr-2 mr-md-0 ml-md-2">
 				{tagsDropdown}
 			</div>,
 		);
+		searchBarWrapper.classList.add('d-flex');
 	}
 
 	// https://github.com/github/remote-input-element#events


### PR DESCRIPTION
Follow-up of https://github.com/refined-github/refined-github/pull/5399#discussion_r804887489

## Test URLs

- [Releases](https://github.com/refined-github/refined-github/releases)
- [Tags](https://github.com/refined-github/refined-github/tags)

## Screenshots

**Before (~550px wide)**

![before](https://user-images.githubusercontent.com/46634000/153644287-897680a0-66de-4c04-91df-dd394e129f72.png)

**After**

_Desktop_

![image](https://user-images.githubusercontent.com/46634000/153720087-42b5dee0-a248-4e77-87de-ca4b0d6e27ca.png)

_Mobile_

https://user-images.githubusercontent.com/46634000/153719068-abc6e8ce-77ef-42df-a88e-683c7dbbe902.mp4