### PR TITLE
Fix linkified `use-first-commit-message-for-new-prs`

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -6,6 +6,23 @@ import * as textFieldEdit from 'text-field-edit';
 import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
+// TODO [2022-05-01]: Drop GHE code and merge function back in init
+function getFirstCommitMessage(): string[] {
+	if (pageDetect.isEnterprise()) {
+		return select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title.split('\n\n');
+	}
+
+	// Linkified commit summaries are split into several adjacent links #5382
+	const commitSummary = select.all('#commits_bucket .js-commits-list-item:first-child .js-details-container > p > a')
+		.map(commitTitleLink => commitTitleLink.innerHTML)
+		.join('')
+		.replace(/<\/?code>/g, '`');
+
+	const commitDescription = select('#commits_bucket .js-commits-list-item pre')?.textContent ?? '';
+
+	return [commitSummary, commitDescription];
+}
+
 async function init(): Promise<void | false> {
 	const commitCountIcon = await elementReady('div.Box.mb-3 .octicon-git-commit');
 	const commitCount = commitCountIcon?.nextElementSibling;
@@ -13,18 +30,14 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const [prTitle, ...prMessage] = (pageDetect.isEnterprise()
-		? select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title // TODO [2022-05-01]: Remove GHE code
-		: select('#commits_bucket .js-commits-list-item a.Link--primary')!.innerHTML.replace(/<\/?code>/g, '`')
-	)!.split(/\n\n/);
-
+	const [prTitle, ...prBody] = getFirstCommitMessage();
 	textFieldEdit.set(
 		select('.discussion-topic-header input')!,
 		prTitle,
 	);
 	textFieldEdit.insert(
 		select('#new_pull_request textarea[aria-label="Comment body"]')!,
-		prMessage.join('\n\n'),
+		prBody.join('\n\n'),
 	);
 }
 

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -13,12 +13,12 @@ function getFirstCommitMessage(): string[] {
 	}
 
 	// Linkified commit summaries are split into several adjacent links #5382
-	const commitSummary = select.all('#commits_bucket .js-commits-list-item:first-child .js-details-container > p > a')
+	const commitSummary = select.all('.js-commits-list-item:first-child .js-details-container > p > a')
 		.map(commitTitleLink => commitTitleLink.innerHTML)
 		.join('')
 		.replace(/<\/?code>/g, '`');
 
-	const commitDescription = select('#commits_bucket .js-commits-list-item pre')?.textContent ?? '';
+	const commitDescription = select('.js-commits-list-item pre')?.textContent ?? '';
 
 	return [commitSummary, commitDescription];
 }

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -12,13 +12,14 @@ function getFirstCommitMessage(): string[] {
 		return select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title.split('\n\n');
 	}
 
+	const commitSummaryWrapper = select('.js-commits-list-item a.Link--primary')!.parentElement!;
+	const commitDescription = select('.js-commits-list-item pre')?.textContent ?? '';
+
 	// Linkified commit summaries are split into several adjacent links #5382
-	const commitSummary = select.all('.js-commits-list-item:first-child .js-details-container > p > a')
+	const commitSummary = select.all(':scope > a', commitSummaryWrapper)
 		.map(commitTitleLink => commitTitleLink.innerHTML)
 		.join('')
 		.replace(/<\/?code>/g, '`');
-
-	const commitDescription = select('.js-commits-list-item pre')?.textContent ?? '';
 
 	return [commitSummary, commitDescription];
 }


### PR DESCRIPTION
Fixes #5382 

Also restores using the commit description as the PR body.

## Test URLs

- https://togithub.com/refined-github/sandbox/compare/first-commit-msg?expand=1
- https://togithub.com/BNFC/bnfc/compare/master...176-source-position?expand=1
- https://togithub.com/refined-github/refined-github/compare/add-multiple-prs-dropdown?expand=1

## Screenshot

With the following commits:

![image](https://user-images.githubusercontent.com/46634000/153720713-d12e7af4-21f5-4f53-8579-2e0e052d5f1a.png)

**Before**

![before-pr-message](https://user-images.githubusercontent.com/46634000/153720687-067324c9-172a-4c4f-8812-868c6a839b96.png)

**After**

![after-pr-message](https://user-images.githubusercontent.com/46634000/153720686-78a09f55-9ef7-4661-95ff-d6d3c14ab3de.png)