### PR TITLE
Disable `align-repository-header` on small screens

### DIFF
--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,14 +1,10 @@
-/* Align repo header to the content, just on the left side */
-body:not(.full-width, .enterprise) main > .hide-full-screen > * {
-	padding-left: calc(50% - 1280px / 2) !important;
-}
-
-/* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
-body:not(.full-width, .enterprise) main > .hide-full-screen > * > * {
-	margin-left: 16px !important;
-}
-
 @media (min-width: 768px) {
+	/* Align repo header to the content, just on the left side */
+	body:not(.full-width, .enterprise) main > .hide-full-screen > * {
+		padding-left: calc(50% - 1280px / 2) !important;
+	}
+
+	/* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
 	body:not(.full-width, .enterprise) main > .hide-full-screen > * > * {
 		margin-left: 24px !important;
 	}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Because it doesn't need to work there.

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<table>
<tr>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/153726296-f213ce38-9d4e-42c7-9e7b-b48a16873fe8.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/153726299-2e3371d7-4be3-4cd3-9392-57f0dbf863f1.png">