### PR TITLE
Fix `clean-repo-sidebar` hiding some readme links

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -9,13 +9,13 @@
 }
 
 /* Hide "Readme" link made unnecessary by `toggle-files-button` #3580 */
-.rgh-clean-repo-sidebar [href$='#readme'] {
+.rgh-clean-repo-sidebar .Layout-sidebar [href$='#readme'] {
 	display: none;
 }
 
 /* Hide "Releases" header */
 @media (min-width: 768px) {
-	.rgh-clean-repo-sidebar h2 [href$='/releases'] {
+	.rgh-clean-repo-sidebar .Layout-sidebar h2 [href$='/releases'] {
 		display: none;
 	}
 }

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,10 +1,10 @@
 /* Hide "About" header */
-.rgh-clean-repo-sidebar .BorderGrid-row:first-child h2 {
+.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-row:first-child h2 {
 	display: none;
 }
 
 /* Align the top of the repo root sidebar with the main page content */
-.rgh-clean-repo-sidebar .BorderGrid-row:first-child h2 + p.f4 {
+.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-row:first-child h2 + p.f4 {
 	margin-top: 0 !important;
 }
 
@@ -25,7 +25,7 @@
  * Hide "Learn more about GitHub Sponsors" link
  * Hide "+ 123 contributors" link
  */
-.rgh-clean-repo-sidebar .BorderGrid-cell > .mt-3 {
+.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-cell > .mt-3 {
 	display: none;
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 async function cleanReleases(): Promise<void> {
-	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
+	const sidebarReleases = await elementReady('.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
 		return;
 	}
@@ -36,7 +36,7 @@ async function cleanReleases(): Promise<void> {
 }
 
 async function hideEmptyPackages(): Promise<void> {
-	const packagesCounter = await elementReady('.BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false})!;
+	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false})!;
 	if (packagesCounter && packagesCounter.textContent === '0') {
 		packagesCounter.closest('.BorderGrid-row')!.hidden = true;
 	}
@@ -45,7 +45,7 @@ async function hideEmptyPackages(): Promise<void> {
 async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
-	const lastSidebarHeader = select('.repository-content .BorderGrid-row:last-of-type h2');
+	const lastSidebarHeader = select('.Layout-sidebar .BorderGrid-row:last-of-type h2');
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
@@ -56,7 +56,7 @@ async function hideEmptyMeta(): Promise<void> {
 	await domLoaded;
 
 	if (!pageDetect.canUserEditRepo()) {
-		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
+		select('.Layout-sidebar .BorderGrid-cell > .text-italic')?.remove();
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5410

## Test URLs

https://github.com/panva/jose

## Screenshot

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![before](https://user-images.githubusercontent.com/46634000/154056852-9df1758c-13b5-4b3e-9100-cf045f87a4e8.png)
	<td>

![after](https://user-images.githubusercontent.com/46634000/154056868-1464985c-38b9-4721-9079-fc63ddf00433.png)
</table>