### PR TITLE
Make `edit-readme` wait for DOM ready

### DIFF
--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -1,7 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import {PencilIcon} from '@primer/octicons-react';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -11,7 +10,7 @@ import isArchivedRepo from '../helpers/is-archived-repo';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 
 async function init(): Promise<void | false> {
-	const readmeHeader = await elementReady('#readme :is(.Box-header, .js-sticky)');
+	const readmeHeader = select('#readme :is(.Box-header, .js-sticky)');
 
 	// The button already exists on repos you can push to
 	if (!readmeHeader || select.exists('[aria-label="Edit this file"]', readmeHeader)) {
@@ -48,7 +47,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		isArchivedRepo,
 	],
-	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',
 	init,
 });


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix https://github.com/refined-github/refined-github/pull/5355#issuecomment-1041170072
Reverts #3510

So here comes a reminder: `isArchivedRepo` cannot coexist with `awaitDomReady`
It makes sense as `isArchivedRepo` is primarily dealing with features related to editing or changing stuff, which you don't hurry to do even if the DOM is not ready.

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

