### PR TITLE
Restyle two tag-related features

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -34,16 +34,13 @@ async function init(): Promise<void> {
 
 		discussionHeader.parentElement!.append(
 			' • ',
-			<TagIcon className="mx-1 color-text-secondary color-fg-muted"/>,
-			<span className="commit-ref">
-				<a
-					href={buildRepoURL('releases/tag', tagName)}
-					className="no-underline"
-					title={`${tagName} was the first Git tag to include this PR`}
-				>
-					{tagName}
-				</a>
-			</span>,
+			<a
+				href={buildRepoURL('releases/tag', tagName)}
+				className="Link--muted"
+				title={`${tagName} was the first Git tag to include this PR`}
+			>
+				<TagIcon/> {tagName}
+			</a>,
 		);
 	}
 }

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -34,12 +34,14 @@ async function init(): Promise<void> {
 
 		discussionHeader.parentElement!.append(
 			' • ',
+			<TagIcon/>,
+			' ',
 			<a
 				href={buildRepoURL('releases/tag', tagName)}
 				className="Link--muted markdown-title"
 				title={`${tagName} was the first Git tag to include this PR`}
 			>
-				<TagIcon/> <code>{tagName}</code>
+				<code>{tagName}</code>
 			</a>,
 		);
 	}

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -36,10 +36,10 @@ async function init(): Promise<void> {
 			' • ',
 			<a
 				href={buildRepoURL('releases/tag', tagName)}
-				className="Link--muted"
+				className="Link--muted markdown-title"
 				title={`${tagName} was the first Git tag to include this PR`}
 			>
-				<TagIcon/> {tagName}
+				<TagIcon/> <code>{tagName}</code>
 			</a>,
 		);
 	}

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -142,7 +142,7 @@ async function init(): Promise<void | false> {
 						className="Link--muted ml-2"
 						href={buildRepoURL('releases/tag', tag)}
 					>
-						<TagIcon/> {tag}
+						<TagIcon/> <code>{tag}</code>
 					</a>
 				)),
 			);

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -137,16 +137,14 @@ async function init(): Promise<void | false> {
 			commitsWithNoTags.push(targetCommit);
 		} else if (targetTags.length > 0) {
 			select('.flex-auto .d-flex.mt-1', commit)!.append(
-				<div className="ml-2">
-					<TagIcon/>
-					<span className="ml-1">{targetTags.map((tags, i) => (
-						<span className="commit-ref lh-condensed d-inline py-1">
-							<a className="no-underline" href={buildRepoURL('releases/tag', tags)}>{tags}</a>
-							{(i + 1) === targetTags.length ? '' : ', '}
-						</span>
-					))}
-					</span>
-				</div>,
+				...targetTags.map(tag => (
+					<a
+						className="Link--muted ml-2"
+						href={buildRepoURL('releases/tag', tag)}
+					>
+						<TagIcon/> {tag}
+					</a>
+				)),
 			);
 			commit.classList.add('rgh-tagged');
 		}

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -137,14 +137,20 @@ async function init(): Promise<void | false> {
 			commitsWithNoTags.push(targetCommit);
 		} else if (targetTags.length > 0) {
 			select('.flex-auto .d-flex.mt-1', commit)!.append(
-				...targetTags.map(tag => (
-					<a
-						className="Link--muted ml-2"
-						href={buildRepoURL('releases/tag', tag)}
-					>
-						<TagIcon/> <code>{tag}</code>
-					</a>
-				)),
+				<span>
+					<TagIcon className="ml-1"/>
+					{...targetTags.map(tag => (
+						<>
+							{' '}
+							<a
+								className="Link--muted"
+								href={buildRepoURL('releases/tag', tag)}
+							>
+								<code>{tag}</code>
+							</a>
+						</>
+					))}
+				</span>,
 			);
 			commit.classList.add('rgh-tagged');
 		}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

First attempt: #5327

I made a mistake last time: the style is referenced from branch names, but tags are not actually branch names. This makes the blue background of branch names (in contrast to the usual gray of `<code>` blocks) less distinctive. The color also makes it appear more prominent than necessary, especially for `tags-on-commits-list`.

So this time I went to take a look at how [release pages](https://github.com/refined-github/refined-github/releases/tag/22.2.13) show the tag, which also shows meta info just like the feature does.

## Screenshot

<table>
<tr>
	<td align="center"><strong>Test URL</strong>
	<td align="center"><strong>Before</strong>
	<td align="center"><strong>After</strong>
<tr>
	<td><a href="https://github.com/refined-github/refined-github/commits/22.1.18"><code>tags-on-commits-list</code></a>
	<td><img src="https://user-images.githubusercontent.com/44045911/150526885-94bf19ab-638a-43f7-92a7-6e2007d6bd88.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/154959375-73d872f1-58df-4260-bddb-f046afc67b4f.png">
<tr>
	<td><a href="https://github.com/preactjs/next-plugin-preact/commits/cf378c33e929efb26b8736c115cff0116e31193d">Multiple <code>tags-on-commits-list</code></a>
	<td><img src="https://user-images.githubusercontent.com/44045911/154959471-c2dbc158-0130-44cd-8c24-5f3d67ea8a22.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/154959400-1a1ba503-57c0-413b-a02b-8a16a6be2fcc.png">
<tr>
	<td><a href="https://github.com//refined-github/refined-github/pull/5305"><code>first-published-tag-for-merged-pr</code></a>
	<td><img src="https://user-images.githubusercontent.com/44045911/150528453-ef65fffd-c8f1-4f0e-942d-06b3588668be.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/154959428-64757dcc-e92b-4fec-8373-072196eb43d9.png">
</table>

## Alternative design

Wrapping the version in `<code>`, which keeps it easily recognizable while being less prominent.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/44045911/154283364-f6c3ea33-0154-426a-b259-87912824b54c.png">
