### PR TITLE
Refactor `quick-repo-deletion`

### DIFF
--- a/source/features/quick-repo-deletion.css
+++ b/source/features/quick-repo-deletion.css
@@ -9,3 +9,68 @@
 	opacity: 30%;
 	z-index: 91; /* Higher than sticky readme header and `sticky-sidebar` #4192 */
 }
+
+.rgh-quick-repo-deletion:not([open]) .btn::after {
+	content: 'Delete';
+}
+
+.rgh-quick-repo-deletion[open] .btn {
+	animation: 6s step-end forwards rgh-quick-repo-deletion-scale;
+}
+
+.rgh-quick-repo-deletion[open] .btn::after {
+	animation: 6s step-end forwards rgh-quick-repo-deletion-countdown;
+	content: '';
+}
+
+@keyframes rgh-quick-repo-deletion-scale {
+	0% {
+		transform: scale(1.2);
+	}
+
+	20% {
+		transform: scale(1.5);
+	}
+
+	40% {
+		transform: scale(1.8);
+	}
+
+	60% {
+		transform: scale(2.1);
+	}
+
+	80% {
+		transform: scale(2.4);
+	}
+
+	100% {
+		transform: scale(2.4);
+	}
+}
+
+@keyframes rgh-quick-repo-deletion-countdown {
+	0% {
+		content: 'Deleting in 5 seconds. Cancel?';
+	}
+
+	20% {
+		content: 'Deleting in 4 seconds. Cancel?';
+	}
+
+	40% {
+		content: 'Deleting in 3 seconds. Cancel?';
+	}
+
+	60% {
+		content: 'Deleting in 2 seconds. Cancel?';
+	}
+
+	80% {
+		content: 'Deleting in 1 second. Cancel?';
+	}
+
+	100% {
+		content: 'Deleting…';
+	}
+}

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -62,8 +62,8 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 
 	// Add a global click listener to avoid potential future issues with z-index
 	document.addEventListener('click', abortHandler, {once: true});
-	// Abort on keypress
-	document.addEventListener('keypress', abortHandler, {once: true});
+	// Abort on keydown
+	document.addEventListener('keydown', abortHandler, {once: true});
 
 	void verifyScopesWhileWaiting(abortController);
 
@@ -72,7 +72,7 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 	} catch {}
 
 	document.removeEventListener('click', abortHandler);
-	document.removeEventListener('keypress', abortHandler);
+	document.removeEventListener('keydown', abortHandler);
 
 	return !abortController.signal.aborted;
 }

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -120,7 +120,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 	}
 }
 
-async function init(): Promise<void | false> {
+async function init(): Promise<VoidFunction | false> {
 	if (
 		// Only if the user can delete the repository
 		!await elementReady('nav [data-content="Settings"]')
@@ -149,6 +149,12 @@ async function init(): Promise<void | false> {
 	);
 
 	delegate(document, '.rgh-quick-repo-deletion[open]', 'toggle', handleToggle, true);
+
+	return async () => {
+		// Wait for PJAX to restore DOM
+		await delay(0);
+		select('details.rgh-quick-repo-deletion')!.open = false;
+	};
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -4,13 +4,13 @@ import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import {TrashIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
-import pluralize from '../helpers/pluralize';
 import addNotice from '../github-widgets/notice-bar';
 import {getCacheKey} from './forked-to';
 import looseParseInt from '../helpers/loose-parse-int';
@@ -68,18 +68,9 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 
 	void verifyScopesWhileWaiting(abortController);
 
-	let secondsLeft = 5;
-	const button = select('.btn', buttonContainer)!;
 	try {
-		do {
-			button.style.transform = `scale(${1.2 - ((secondsLeft - 5) / 3)})`; // Dividend is zoom speed
-			button.textContent = `Deleting repo in ${pluralize(secondsLeft, '$$ second')}. Cancel?`;
-			await delay(1000, {signal: abortController.signal}); // eslint-disable-line no-await-in-loop
-		} while (--secondsLeft);
-	} catch {
-		button.textContent = 'Delete fork';
-		button.style.transform = '';
-	}
+		await delay(5000, {signal: abortController.signal});
+	} catch {}
 
 	return !abortController.signal.aborted;
 }
@@ -89,7 +80,6 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 		return;
 	}
 
-	select('.btn', buttonContainer)!.textContent = 'Deleting repo…';
 	try {
 		const {nameWithOwner, owner} = getRepo()!;
 		await api.v3('/repos/' + nameWithOwner, {
@@ -140,10 +130,12 @@ async function init(): Promise<void | false> {
 	// (Ab)use the details element as state and an accessible "click-anywhere-to-cancel" utility
 	select('.pagehead-actions')!.prepend(
 		<li>
-			<details className="details-reset details-overlay select-menu rgh-quick-repo-deletion">
-				<summary aria-haspopup="menu" role="button">
+			<details className="details-reset details-overlay rgh-quick-repo-deletion">
+				<summary role="button">
 					{/* This extra element is needed to keep the button above the <summary>’s lightbox */}
-					<span className="btn btn-sm btn-danger">Delete fork</span>
+					<span className="btn btn-sm btn-danger">
+						<TrashIcon className="v-align-text-top mr-2"/>
+					</span>
 				</summary>
 			</details>
 		</li>,

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -59,18 +59,25 @@ async function verifyScopesWhileWaiting(abortController: AbortController): Promi
 
 async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boolean> {
 	const abortController = new AbortController();
-	// Add a global click listener to avoid potential future issues with z-index
-	document.addEventListener('click', event => {
+	const abortHandler = (event: Event): void => {
 		event.preventDefault();
 		abortController.abort();
 		buttonContainer.open = false;
-	}, {once: true});
+	};
+
+	// Add a global click listener to avoid potential future issues with z-index
+	document.addEventListener('click', abortHandler, {once: true});
+	// Abort on keypress
+	document.addEventListener('keypress', abortHandler, {once: true});
 
 	void verifyScopesWhileWaiting(abortController);
 
 	try {
 		await delay(5000, {signal: abortController.signal});
 	} catch {}
+
+	document.removeEventListener('click', abortHandler);
+	document.removeEventListener('keypress', abortHandler);
 
 	return !abortController.signal.aborted;
 }

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -23,13 +23,8 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 		'.rgh-open-prs-of-forks', // PRs opened in the source repo
 	]);
 
-	if (hasContent && !confirm('This repo has open issues/PRs, are you sure you want to delete everything?')) {
+	if (hasContent && !confirm('This repository has open issues or pull requests, are you absolutely sure?')) {
 		// Close the <details> element again
-		event.delegateTarget.open = false;
-		return;
-	}
-
-	if (!pageDetect.isForkedRepo() && !confirm('⚠️ This action cannot be undone. This will permanently delete the repository, wiki, issues, comments, packages, secrets, workflow runs, and remove all collaborator associations.')) {
 		event.delegateTarget.open = false;
 		return;
 	}

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -71,7 +71,7 @@ async function initHeadHint(): Promise<void | false> {
 		return false;
 	}
 
-	select(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`)!.after(
+	select('#repository-container-header .text-small [data-hovercard-type="repository"]')!.after(
 		// The class is used by `quick-fork-deletion`
 		<> with <a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a></>,
 	);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

- Adjust the button style to be more consistent with others
- Rewrite animation with pure CSS since it's cooler and no more need to handle exceptions

  It looks the almost the same except for some minor text changes

- Previously the catch-all click listener will prevent your first click after deletion, now the listener will be removed properly
- Also add a listener to abort deletion on "any" keypress (actually doesn't work with many keys like `Esc`, `S` or `Space` due to other listeners)
- Properly deinit

  For example, pressing `t` to search files while the deletion countdown is activate, then go back, the button is no longer in a weird state

## Test URLs

Visit your forks at `https://github.com/<username>?tab=repositories&q=&type=fork`

## Screenshot

<table>
<tr>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/44045911/154348698-f493433a-4bcc-4854-bf07-59490f1b5aa2.png">
	<td><img src="https://user-images.githubusercontent.com/44045911/154348761-99bc0424-17e7-4a89-aea9-713093069cda.png">
</table>

https://user-images.githubusercontent.com/44045911/154350458-aa729b29-4ff9-49d5-afbb-5c4373eafe16.mov


