### PR TITLE
Drop `unwrap-unnecessary-dropdowns` on action run page

### DIFF
--- a/source/features/unwrap-unnecessary-dropdowns.tsx
+++ b/source/features/unwrap-unnecessary-dropdowns.tsx
@@ -35,39 +35,10 @@ async function unwrapNotifications(): Promise<void | false> {
 	button.textContent = `Group by ${button.textContent!.toLowerCase()}`;
 }
 
-async function unwrapActionRun(): Promise<void | false> {
-	const desiredForm = await elementReady('.js-check-suite-rerequest-form', {waitForChildren: false});
-	if (!desiredForm) {
-		return false;
-	}
-
-	const availableOptions = desiredForm
-		.closest('.dropdown-menu')!
-		.querySelectorAll('li > *'); // GitHub left an empty `li` in there 😒
-	if (availableOptions.length > 1) {
-		throw new Error('GitHub added items to the dropdown. This feature is obsolete.');
-	}
-
-	// Fix button’s style
-	const button = select('button', desiredForm)!;
-	button.className = 'btn';
-	button.prepend(select('.octicon-sync')!);
-
-	// Replace dropdown
-	const dropdown = desiredForm.closest('details')!;
-	replaceDropdownInPlace(dropdown, desiredForm);
-}
-
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isNotifications,
 	],
 	awaitDomReady: false,
 	init: unwrapNotifications,
-}, {
-	include: [
-		pageDetect.isActionRun,
-	],
-	awaitDomReady: false,
-	init: unwrapActionRun,
 });


### PR DESCRIPTION
```text
❌ unwrap-unnecessary-dropdowns 0.0.0 → Error: GitHub added items to the dropdown. This feature is obsolete.
    unwrapActionRun moz-extension://c2ad1c81-15a9-47dc-844b-f4235a6885c1/build/refined-github.js:15227
```

## Test URLs

https://github.com/refined-github/refined-github/actions/runs/1857951266

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/154454358-c6cd00f3-d28e-426c-92c1-bb8704a18c35.png)