### PR TITLE
Meta: Change `web-ext` start page to RGH organization dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 			"firefoxProfile": "./test/web-ext-profile",
 			"chromiumProfile": "./test/web-ext-profile",
 			"startUrl": [
-				"https://github.com/refined-github/refined-github/issues"
+				"https://github.com/orgs/refined-github/dashboard"
 			]
 		}
 	}


### PR DESCRIPTION
I think it gives a better overview of the current state of the repo. Thumb down if you don't want to change.