### PR TITLE
Add keyboard shortcuts for `conversation-activity-filter`

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -160,7 +160,7 @@ const minorFixesIssuePages = new Set([
 ]);
 
 function runShortcuts({key, target}: KeyboardEvent): void {
-	if (isEditable(target) || key !== 'h') {
+	if (key !== 'h' || isEditable(target)) {
 		return;
 	}
 

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -171,6 +171,7 @@ function runShortcuts(event: KeyboardEvent): void {
 	} else {
 		currentSetting = 'default';
 	}
+
 	applyCurrentSetting();
 }
 
@@ -187,6 +188,7 @@ async function init(): Promise<void> {
 		currentSetting = 'hideEventsAndCollapsedComments';
 		applyCurrentSetting();
 	}
+
 	document.body.addEventListener('keypress', runShortcuts);
 }
 

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -9,6 +9,7 @@ import {CheckIcon, EyeClosedIcon, EyeIcon} from '@primer/octicons-react';
 import features from '.';
 import onNewComments from '../github-events/on-new-comments';
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
+import {isEditable} from '../helpers/dom-utils';
 import {removeClassFromAll, wrap} from '../helpers/dom-utils';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
@@ -159,6 +160,21 @@ const minorFixesIssuePages = new Set([
 	getRghIssueUrl(4008),
 ]);
 
+function runShortcuts(event: KeyboardEvent): void {
+	if (isEditable(event.target)) {
+		return;
+	}
+
+	if (event.key === 'h' && currentSetting !== 'hideEventsAndCollapsedComments') {
+		currentSetting = 'hideEventsAndCollapsedComments';
+	} else if(event.key === 'f' && currentSetting !== 'hideEvents'){
+		currentSetting = 'hideEvents';
+	} else{
+		currentSetting = 'default';
+	}
+	applyCurrentSetting();
+}
+
 async function init(): Promise<void> {
 	// Reset dropdowns state #4997
 	currentSetting = 'default';
@@ -172,6 +188,7 @@ async function init(): Promise<void> {
 		currentSetting = 'hideEventsAndCollapsedComments';
 		applyCurrentSetting();
 	}
+	document.body.addEventListener('keypress', runShortcuts);
 }
 
 void features.add(import.meta.url, {
@@ -181,6 +198,10 @@ void features.add(import.meta.url, {
 	additionalListeners: [
 		onConversationHeaderUpdate,
 	],
+	shortcuts: {
+		h: 'Hide/show events and collapsed comments',
+		f: 'Hide/show events'
+	},
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',
 	init,

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -159,20 +159,18 @@ const minorFixesIssuePages = new Set([
 	getRghIssueUrl(4008),
 ]);
 
-function runShortcuts(event: KeyboardEvent): void {
-	if (isEditable(event.target)) {
+function runShortcuts({key, target}: KeyboardEvent): void {
+	if (isEditable(target)) {
 		return;
 	}
 
-	if (event.key === 'h' && currentSetting !== 'hideEventsAndCollapsedComments') {
-		currentSetting = 'hideEventsAndCollapsedComments';
-	} else if (event.key === 'f' && currentSetting !== 'hideEvents') {
-		currentSetting = 'hideEvents';
-	} else {
-		currentSetting = 'default';
+	if (key === 'h') {
+		currentSetting = currentSetting === 'hideEventsAndCollapsedComments' ? 'default' : 'hideEventsAndCollapsedComments';
+		applyCurrentSetting();
+	} else if (key === 'f') {
+		currentSetting = currentSetting === 'hideEvents' ? 'default' : 'hideEvents';
+		applyCurrentSetting();
 	}
-
-	applyCurrentSetting();
 }
 
 async function init(): Promise<void> {
@@ -200,8 +198,8 @@ void features.add(import.meta.url, {
 		onConversationHeaderUpdate,
 	],
 	shortcuts: {
-		h: 'Hide/show events and collapsed comments',
-		f: 'Hide/show events',
+		h: 'Toggle events and collapsed comments',
+		f: 'Toggle events',
 	},
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -200,7 +200,7 @@ void features.add(import.meta.url, {
 		onConversationHeaderUpdate,
 	],
 	shortcuts: {
-		h: 'Hide events or/and collapsed comments',
+		h: 'Cycle between conversation activity filters',
 	},
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -9,8 +9,7 @@ import {CheckIcon, EyeClosedIcon, EyeIcon} from '@primer/octicons-react';
 import features from '.';
 import onNewComments from '../github-events/on-new-comments';
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
-import {isEditable} from '../helpers/dom-utils';
-import {removeClassFromAll, wrap} from '../helpers/dom-utils';
+import {removeClassFromAll, wrap, isEditable} from '../helpers/dom-utils';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 const states = {
@@ -167,9 +166,9 @@ function runShortcuts(event: KeyboardEvent): void {
 
 	if (event.key === 'h' && currentSetting !== 'hideEventsAndCollapsedComments') {
 		currentSetting = 'hideEventsAndCollapsedComments';
-	} else if(event.key === 'f' && currentSetting !== 'hideEvents'){
+	} else if (event.key === 'f' && currentSetting !== 'hideEvents') {
 		currentSetting = 'hideEvents';
-	} else{
+	} else {
 		currentSetting = 'default';
 	}
 	applyCurrentSetting();
@@ -200,7 +199,7 @@ void features.add(import.meta.url, {
 	],
 	shortcuts: {
 		h: 'Hide/show events and collapsed comments',
-		f: 'Hide/show events'
+		f: 'Hide/show events',
 	},
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -160,17 +160,19 @@ const minorFixesIssuePages = new Set([
 ]);
 
 function runShortcuts({key, target}: KeyboardEvent): void {
-	if (isEditable(target)) {
+	if (isEditable(target) || key !== 'h') {
 		return;
 	}
 
-	if (key === 'h') {
-		currentSetting = currentSetting === 'hideEventsAndCollapsedComments' ? 'default' : 'hideEventsAndCollapsedComments';
-		applyCurrentSetting();
-	} else if (key === 'f') {
-		currentSetting = currentSetting === 'hideEvents' ? 'default' : 'hideEvents';
-		applyCurrentSetting();
+	if (currentSetting === 'default') {
+		currentSetting = 'hideEvents';
+	} else if (currentSetting === 'hideEvents') {
+		currentSetting = 'hideEventsAndCollapsedComments';
+	} else {
+		currentSetting = 'default';
 	}
+
+	applyCurrentSetting();
 }
 
 async function init(): Promise<void> {
@@ -198,8 +200,7 @@ void features.add(import.meta.url, {
 		onConversationHeaderUpdate,
 	],
 	shortcuts: {
-		h: 'Toggle events and collapsed comments',
-		f: 'Toggle events',
+		h: 'Hide events or/and collapsed comments',
 	},
 	awaitDomReady: false,
 	deduplicate: 'has-rgh-inner',


### PR DESCRIPTION
Closes #5379

Add new shortcuts  into the `conversation-activity-filter` feature:

- One `h` press: hide events
- Two `h` presses: hide everything
- Three `h`  presses: show everything
- Repeat

## Test URLs
https://github.com/refined-github/refined-github/pull/4029

## Screenshot
<img width="632" alt="109589540-15a73d00-7ad0-11eb-9d4c-d31e403435f0" src="https://user-images.githubusercontent.com/472927/154731791-afe712d6-a749-4c58-b1fb-f0fae401b453.png">

Keyboard shortcuts
<img width="786" alt="Screenshot 2022-02-18 at 20 03 07" src="https://user-images.githubusercontent.com/472927/154745997-9c40681d-a53d-4f63-8d83-52f17e00f222.png">
