### PR TITLE
Fix `comments-time-machine-links` on first conversation comment

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -111,7 +111,8 @@ function init(): void {
 	for (const menu of commentPopupMenus) {
 		menu.classList.add('rgh-time-machine-links');
 		// The timestamp of main review comments isn't in their header but in the timeline event above #5423
-		const timestamp = menu.closest('.js-comment:not([id^="pullrequestreview-"]), .js-timeline-item')!
+		const timestamp = menu
+			.closest('.js-comment:not([id^="pullrequestreview-"]), .js-timeline-item')!
 			.querySelector('relative-time')!
 			.attributes.datetime.value;
 		addInlineLinks(menu, timestamp);

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -110,7 +110,10 @@ function init(): void {
 	const commentPopupMenus = select.all('.js-reaction-popover-container ~ details:last-child:not(.rgh-time-machine-links)');
 	for (const menu of commentPopupMenus) {
 		menu.classList.add('rgh-time-machine-links');
-		const timestamp = menu.closest('.js-comment:not(.timeline-comment-group), .js-timeline-item')!.querySelector('relative-time')!.attributes.datetime.value;
+		// The timestamp of main review comments isn't in their header but in the timeline event above #5423
+		const timestamp = menu.closest('.js-comment:not([id^="pullrequestreview-"]), .js-timeline-item')!
+			.querySelector('relative-time')!
+			.attributes.datetime.value;
 		addInlineLinks(menu, timestamp);
 		addDropdownLink(menu, timestamp);
 	}

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -107,7 +107,7 @@ function addDropdownLink(menu: HTMLElement, timestamp: string): void {
 }
 
 function init(): void {
-	const commentPopupMenus = select.all('.js-reaction-popover-container ~ details:last-child:not(.rgh-time-machine-links)');
+	const commentPopupMenus = select.all('.timeline-comment-actions > details:last-child:not(.rgh-time-machine-links)');
 	for (const menu of commentPopupMenus) {
 		menu.classList.add('rgh-time-machine-links');
 		// The timestamp of main review comments isn't in their header but in the timeline event above #5423

--- a/source/github-events/on-new-comments.ts
+++ b/source/github-events/on-new-comments.ts
@@ -7,6 +7,8 @@ const delegates = new Set<delegate.Subscription>();
 const observer = new MutationObserver(run);
 
 function run(): void {
+	console.log(new Date().toLocaleString().split(',').pop()!.trim());
+
 	// Run all callbacks without letting an error stop the loop and without silencing it
 	// eslint-disable-next-line unicorn/no-array-for-each
 	handlers.forEach(async callback => {

--- a/source/github-events/on-new-comments.ts
+++ b/source/github-events/on-new-comments.ts
@@ -7,8 +7,6 @@ const delegates = new Set<delegate.Subscription>();
 const observer = new MutationObserver(run);
 
 function run(): void {
-	console.log(new Date().toLocaleString().split(',').pop()!.trim());
-
 	// Run all callbacks without letting an error stop the loop and without silencing it
 	// eslint-disable-next-line unicorn/no-array-for-each
 	handlers.forEach(async callback => {


### PR DESCRIPTION
`comments-time-machine-links` broke on issue/PR bodies (the first comment of the conversation):

```text
❌ comments-time-machine-links 22.2.13 → TypeError: menu.closest(...) is null
	init moz-extension://6ffeab5e-837d-450e-9fa5-fe3ec6a7ee9f/build/refined-github.js:6345
	runFeature moz-extension://6ffeab5e-837d-450e-9fa5-fe3ec6a7ee9f/build/refined-github.js:3045
```

This PR also fixes the feature for minimized comments inside review threads.

## Test URLs

https://togithub.com/refined-github/refined-github/pull/5422

It should work on:
- first comment (PR body)
- regular comments
- "main" review comments
- review thread comments
- review comments in minimized thread
- minimized review thread comments

## Screenshot

Conversation body (i.e. first comment):
![image](https://user-images.githubusercontent.com/46634000/154857166-488a171e-89bf-4107-ba90-cd0122d272b7.png)

Minimized comment in review thread:
![image](https://user-images.githubusercontent.com/46634000/154857788-a9fd4579-0143-4598-85da-92ced3023387.png)