### PR TITLE
Fix spacing of diff icon in commit diff stats

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -49,3 +49,8 @@
 :is(#discussion_bucket.pull-request-tab-content, [data-test-selector='release-card']) .social-reaction-summary-item:not(:first-child) {
 	margin-left: 8px !important;
 }
+
+/* Fix spacing of diff icon in commit diff stats */
+#toc .toc-diff-stats .octicon-file-diff {
+	margin-right: 4px !important;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -50,7 +50,7 @@
 	margin-left: 8px !important;
 }
 
-/* Fix spacing of diff icon in commit diff stats */
+/* Fix spacing of diff icon in commit diff stats #5429 */
 #toc .toc-diff-stats .octicon-file-diff {
 	margin-right: 4px !important;
 }


### PR DESCRIPTION
## Test URLs

https://togithub.com/refined-github/refined-github/commit/2b532270a189169835017493b9b6ff2c44d566b3

## Screenshot

<table>
<tr>
	<th>Before
	<td>

![before](https://user-images.githubusercontent.com/46634000/155018607-225d5d65-e1bb-4b88-b41e-05c2c0469c87.png)
<tr>
	<th>After
	<td>

![after](https://user-images.githubusercontent.com/46634000/155018604-ab6b412a-522f-49a4-877f-3904ecbbee73.png)
</table>