### PR TITLE
Meta: Rearrange category order in releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,12 +4,12 @@ changelog:
     labels:
       - meta
   categories:
-    - title: Bugfixes
-      labels:
-        - bug
     - title: New
       labels:
         - enhancement
     - title: Changes
       labels:
         - "*"
+    - title: Bugfixes
+      labels:
+        - bug


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

*(This is a follow-up of PR #5175 )*  .
Currently the categories order in Releases is: `Bugfixes` → `New` → `Changes` .
My suggested minor change in release.yml is to make it: `New` → `Changes` → `Bugfixes` .

I believe `New` entries should be listed first, followed by `Changes` and `Bugfixes` to be in the end.

## Test URLs

https://github.com/refined-github/refined-github/releases/tag/22.2.22

## Screenshot

<details>
<summary>Before:</summary>

![2022-02-24_003827](https://user-images.githubusercontent.com/723651/155421501-5b3142c9-7098-4ee9-962d-1447408a91f1.jpg)
</details>

<details>
<summary>After:</summary>


![2022-02-24_003945](https://user-images.githubusercontent.com/723651/155421528-620a1ae4-0ead-4753-8e5e-84185bc1b832.jpg)
</details>