### PR TITLE
Toggle `<details>` in issues/PRs with `toggle-everything-with-alt`

### DIFF
--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -21,6 +21,11 @@ const collapseSelector = '.js-file .js-collapse-diff';
 
 const commitMessageSelector = '.TimelineItem .ellipsis-expander';
 
+function markdownCommentSelector(clickedItem: HTMLElement): string {
+	const id = clickedItem.closest('.TimelineItem-body[id]')!.id
+	return `#${id} .markdown-body details > summary`;
+}
+
 function init(): void {
 	// Collapsed comments in PR conversations and files
 	delegate(document, '.minimized-comment details summary', 'click', clickAll(minimizedCommentsSelector));
@@ -37,6 +42,9 @@ function init(): void {
 
 	// Commit message buttons in commit lists and PR conversations
 	delegate(document, commitMessageSelector, 'click', clickAll(commitMessageSelector));
+
+	// <details> elements in issue/PR comment Markdown content
+	delegate(document, '.TimelineItem-body[id] .markdown-body details > summary', 'click', clickAll(markdownCommentSelector));
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Closes #5430.

## Test URLs

* Issue description: https://github.com/yakov116/TestR/issues/34
* Issue comment: https://github.com/yakov116/TestR/issues/34#issuecomment-1057957916
* PR description: [OpenLightingProject/open-fixture-library#2455](https://togithub.com/OpenLightingProject/open-fixture-library/pull/2455)
* PR comment: [OpenLightingProject/open-fixture-library#2453 (comment)](https://togithub.com/OpenLightingProject/open-fixture-library/pull/2453#issuecomment-1055672394)

## Test steps

1. <kbd>alt</kbd>-click any of the collapsed section's summaries, then all `<details>` in that comment expand
2. <kbd>alt</kbd>-click again, then all `<details>` in that comment collapse