### PR TITLE
Meta: Fix warnings for todo comments

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -8,18 +8,16 @@
 		"__filebasename"
 	],
 	"rules": {
+		"no-alert": "off",
+		"no-warning-comments": "off",
+		"unicorn/expiring-todo-comments": ["warn", {
+			"allowWarningComments": false
+		}],
 		"@typescript-eslint/naming-convention": "off",
 		"@typescript-eslint/no-unsafe-assignment": "off",
 		"@typescript-eslint/no-unsafe-member-access": "off",
 		"@typescript-eslint/no-unsafe-return": "off",
 		"@typescript-eslint/no-unsafe-call": "off",
-
-		"import/no-cycle": "off",
-		"import/no-unassigned-import": "off",
-		"import/extensions": "off",
-		"no-alert": "off",
-		"react/jsx-key": "off",
-		"node/prefer-global/process": "off",
 		"@typescript-eslint/consistent-type-definitions": "error",
 		"@typescript-eslint/explicit-function-return-type": [
 			"error",
@@ -27,6 +25,11 @@
 				"allowExpressions": true
 			}
 		],
+		"node/prefer-global/process": "off",
+		"import/no-cycle": "off",
+		"import/no-unassigned-import": "off",
+		"import/extensions": "off",
+		"import/prefer-default-export": "error",
 		"import/order": [
 			"error",
 			{
@@ -39,7 +42,7 @@
 				"newlines-between": "always-and-inside-groups"
 			}
 		],
-		"import/prefer-default-export": "error",
+		"react/jsx-key": "off",
 		"react/function-component-definition": [
 			"error",
 			{


### PR DESCRIPTION
This PR:
- sorts the local rules list by plugin
- disable `no-warning-comments`
- sets `unicorn/expiring-todo-comments` to produce a warning on todo comments with no condition

Output of `npx xo` before:

```
  source/options-storage.ts:55:1
  ⚠   55:1   Unexpected todo comment: TODO [2022-05-01]: Remove obsolete color....  no-warning-comments

  source/github-helpers/index.ts:78:3
  ⚠   78:3   Unexpected todo comment: TODO: Can TypeScript take care of this?....   no-warning-comments

  source/github-helpers/pr-ci-status.ts:11:47
  ⚠   11:47  Unexpected todo comment: TODO [2022-05-01]: GHE.                       no-warning-comments

  source/features/ci-link.tsx:12:71
  ⚠   12:71  Unexpected todo comment: TODO[2022-04-29]: GHE #4294.                  no-warning-comments

  source/features/highest-rated-comment.tsx:70:76
  ⚠   70:76  Unexpected todo comment: TODO: Drop generic once TypeScript sorts....  no-warning-comments

  source/features/one-click-diff-options.tsx:79:54
  ⚠   79:54  Unexpected todo comment: TODO [2022-05-01]: Remove GHE code.           no-warning-comments

  source/features/pagination-hotkey.tsx:39:2
  ⚠   39:2   Unexpected todo comment: TODO: enable for isDiscussionList after....   no-warning-comments

  source/features/quick-repo-deletion.tsx:132:3
  ⚠  132:3   Unexpected todo comment: TODO [2022-06-01]: Remove....                 no-warning-comments

  source/features/scheduled-and-manual-workflow-indicators.tsx:64:2
  ⚠   64:2   Unexpected todo comment: TODO [2022-05-01]: Remove....                 no-warning-comments

  source/features/use-first-commit-message-for-new-prs.tsx:9:1
  ⚠    9:1   Unexpected todo comment: TODO [2022-05-01]: Drop GHE code and....      no-warning-comments

  source/features/useful-forks.tsx:11:2
  ⚠   11:2   Unexpected todo comment: TODO [2022-06-01]: Remove....                 no-warning-comments

  11 warnings
```

and after:

```
  source/github-helpers/index.ts:78:3
  ⚠  78:3   Unexpected todo comment without any conditions: TODO: Can TypeScript take care of this?....   unicorn/expiring-todo-comments

  source/features/highest-rated-comment.tsx:70:76
  ⚠  70:76  Unexpected todo comment without any conditions: TODO: Drop generic once TypeScript sorts....  unicorn/expiring-todo-comments

  source/features/pagination-hotkey.tsx:39:2
  ⚠  39:2   Unexpected todo comment without any conditions: TODO: enable for isDiscussionList after....   unicorn/expiring-todo-comments

  3 warnings
```