### PR TITLE
Fix `latest-tag-button` at repo home on tagged default branch

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -117,7 +117,8 @@ async function init(): Promise<false | void> {
 
 	const defaultBranch = await getDefaultBranch();
 
-	if (currentBranch === latestTag || (currentBranch === defaultBranch && aheadBy === 0)) {
+	// `getCurrentCommittish` returns `undefined` when at the repo root on the default branch #5446
+	if (currentBranch === latestTag || ((!currentBranch || currentBranch === defaultBranch) && aheadBy === 0)) {
 		link.setAttribute('aria-label', 'You’re on the latest version');
 		link.classList.add('disabled', 'tooltipped', 'tooltipped-ne');
 		return;


### PR DESCRIPTION
Fixes #5446 

## Test URLs

- [Latest tag](https://github.com/refined-github/refined-github/tree/22.3.3)
- [Default branch, tagged](https://github.com/kas-elvirov/gloc)
- [Default branch, not tagged](https://github.com/refined-github/github-url-detection)
- [Other branches](https://github.com/refined-github/refined-github/tree/hotfix)

## Screenshot

**Before**
![before](https://user-images.githubusercontent.com/46634000/156833015-49ec38df-0c97-4d8b-bd93-2594205990e9.png)

**After**
![after](https://user-images.githubusercontent.com/46634000/156833012-445d73ce-689f-451b-a6cc-d8fc7100d228.png)