### PR TITLE
Drop reactions spacing fix

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -45,11 +45,6 @@
 	flex-wrap: wrap;
 }
 
-/* Restore margin between reactions on PRs and releases #5287 */
-:is(#discussion_bucket.pull-request-tab-content, [data-test-selector='release-card']) .social-reaction-summary-item:not(:first-child) {
-	margin-left: 8px !important;
-}
-
 /* Fix spacing of diff icon in commit diff stats #5429 */
 #toc .toc-diff-stats .octicon-file-diff {
 	margin-right: 4px !important;


### PR DESCRIPTION
Seems like GitHub fixed the issue of the missing spacing between reactions, so now our fix is adding superfluous space.

## Test URLs

- [Issue body](https://togithub.com/refined-github/refined-github/issues/5459)
- [PR body](https://togithub.com/refined-github/refined-github/pull/5457)
- [Review thread comment](https://togithub.com/refined-github/refined-github/pull/5458#discussion_r819645385)
- [Release](https://github.com/refined-github/refined-github/releases/tag/22.1.18)

## Screenshot

**Before**
![before](https://user-images.githubusercontent.com/46634000/156834625-f41a84ea-edfe-4040-9ca8-b6ad384371c9.png)

**After**
![after](https://user-images.githubusercontent.com/46634000/156834624-31153791-262d-4044-8322-7950f038e175.png)