### PR TITLE
Refactor `shorten-links` code

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -15,12 +15,6 @@ function init(): void {
 			}
 		},
 	});
-
-	for (const link of document.querySelectorAll('.comment-body a[href*="/tree/"]')) {
-		if (!isLinkInCode(link)) {
-			applyToLink(link, location.href);
-		}
-	}
 }
 
 function isLinkInCode(link: HTMLAnchorElement): boolean {

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -10,16 +10,24 @@ function init(): void {
 	observe(`a[href]:not(.${linkifiedURLClass})`, {
 		constructor: HTMLAnchorElement,
 		add(link) {
-			// Don't shorten links in code or code suggestions (but shorten them in review comments)
-			// Code explanation: Exclude links if the closest element found is not `.comment-body`
-			// https://github.com/refined-github/refined-github/pull/4759#discussion_r702460890
-			if (link.closest('.blob-code, .comment-body, .js-suggested-changes-blob')?.matches('.blob-code, .js-suggested-changes-blob')) {
-				return;
+			if (!isLinkInCode(link)) {
+				applyToLink(link, location.href);
 			}
-
-			applyToLink(link, location.href);
 		},
 	});
+
+	for (const link of document.querySelectorAll('.comment-body a[href*="/tree/"]')) {
+		if (!isLinkInCode(link)) {
+			applyToLink(link, location.href);
+		}
+	}
+}
+
+function isLinkInCode(link: HTMLAnchorElement): boolean {
+	// Don't shorten links in code or code suggestions (but shorten them in review comments)
+	// Code explanation: Exclude links if the closest element found is not `.comment-body`
+	// https://github.com/refined-github/refined-github/pull/4759#discussion_r702460890
+	return Boolean(link.closest('.blob-code, .comment-body, .js-suggested-changes-blob')?.matches('.blob-code'));
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
This pull request fixes tree links that do not shorten unless in preview mode. The solution is to call the `applyToLink` function on page load as well as on DOM changes.

I am not certain about removing the `.js-suggested-changes-blob` selector so it's entirely possible this breaks other things.

## Test URLs
https://github.com/refined-github/refined-github/pull/4759
https://github.com/dnicolson/x/issues/1

## Screenshot
Before:
![bad (1)](https://user-images.githubusercontent.com/2276355/156841128-2a4dc3c9-9df5-4220-8b84-5a68d0530ae6.gif)

After:
![good (1)](https://user-images.githubusercontent.com/2276355/156841132-2f336d61-b64f-4371-aa26-01218015294e.gif)
