### PR TITLE
Fix top alignment of PR sidebar in `clean-conversation-sidebar`

### DIFF
--- a/source/features/clean-conversation-sidebar.css
+++ b/source/features/clean-conversation-sidebar.css
@@ -4,8 +4,8 @@
 }
 
 /* Align sidebar to the top */
-.discussion-sidebar-item.rgh-clean-sidebar:first-child {
-	padding-top: 0;
+.rgh-clean-sidebar .discussion-sidebar-item:first-child {
+	padding-top: 0 !important;
 }
 
 /* Move message under the `Unsubscribe` button above the button */


### PR DESCRIPTION
## Test URLs

- [Issue conversation](https://togithub.com/refined-github/sandbox/issues/3)
- [PR conversation](https://togithub.com/refined-github/sandbox/pull/4)

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/157217143-dbd9d84f-077c-4bf7-831c-062870d589de.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/157217134-a9c665fa-f88a-46b7-81f3-3675478978d4.png)