### PR TITLE
Don't apply `shorten-links` to links in code blocks

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -10,14 +10,12 @@ function init(): void {
 	observe(`a[href]:not(.${linkifiedURLClass})`, {
 		constructor: HTMLAnchorElement,
 		add(link) {
-			// Don't shorten links in code or code suggestions (but shorten them in review comments)
-			// Code explanation: Exclude links if the closest element found is not `.comment-body`
+			// Exclude the link if the closest element found is not `.comment-body`
+			// This avoids shortening links in code and code suggestions, but still shortens them in review comments
 			// https://github.com/refined-github/refined-github/pull/4759#discussion_r702460890
-			if (link.closest('.blob-code, .comment-body, .js-suggested-changes-blob')?.matches('.blob-code, .js-suggested-changes-blob')) {
-				return;
+			if (link.closest('pre, .blob-code, .js-suggested-changes-blob, .comment-body')?.classList.contains('comment-body')) {
+				applyToLink(link, location.href);
 			}
-
-			applyToLink(link, location.href);
 		},
 	});
 }

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -5,6 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters';
+import {codeElementsSelectors} from './show-whitespace';
 
 function init(): void {
 	observe(`a[href]:not(.${linkifiedURLClass})`, {
@@ -13,7 +14,7 @@ function init(): void {
 			// Exclude the link if the closest element found is not `.comment-body`
 			// This avoids shortening links in code and code suggestions, but still shortens them in review comments
 			// https://github.com/refined-github/refined-github/pull/4759#discussion_r702460890
-			if (link.closest('pre, .blob-code, .js-suggested-changes-blob, .comment-body')?.classList.contains('comment-body')) {
+			if (link.closest(`${codeElementsSelectors}, .js-suggested-changes-blob, .comment-body`)?.classList.contains('comment-body')) {
 				applyToLink(link, location.href);
 			}
 		},

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -14,7 +14,7 @@ function init(): void {
 			// Exclude the link if the closest element found is not `.comment-body`
 			// This avoids shortening links in code and code suggestions, but still shortens them in review comments
 			// https://github.com/refined-github/refined-github/pull/4759#discussion_r702460890
-			if (link.closest(`${codeElementsSelectors}, .js-suggested-changes-blob, .comment-body`)?.classList.contains('comment-body')) {
+			if (link.closest(`${codeElementsSelectors}, .comment-body`)?.classList.contains('comment-body')) {
 				applyToLink(link, location.href);
 			}
 		},


### PR DESCRIPTION
Fixes #4758 
Follow-up of #4759 

## Test URLs

- [Highlighted and non-highlighted code blocks in comment](https://togithub.com//denosaurs/mod.land/issues/55)
- [Code block in readme](https://togithub.com/oakserver/oak#application-middleware-and-context)
- [Review suggestion](https://togithub.com/refined-github/refined-github/pull/4759#discussion_r738167140)

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/44045911/156889403-de0f23c1-a8fa-4835-ab1b-0223ee59ca74.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/157297562-7781a930-6e14-4425-9539-b62e8cecdee0.png)