### PR TITLE
Fix error reporting in Safari

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -52,18 +52,12 @@ const logError = (url: string, error: unknown): void => {
 	const message = error instanceof Error ? error.message : String(error);
 
 	if (message.includes('token')) {
-		console.log(`ℹ️ ${id} →`, message);
+		console.log('ℹ️', id, '→', message);
 		return;
 	}
 
-	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
-	console.group('❌', id, version, pageDetect.isEnterprise() ? 'GHE →' : '→', error);
-
 	const searchIssueUrl = new URL('https://github.com/refined-github/refined-github/issues');
 	searchIssueUrl.searchParams.set('q', `is:issue is:open sort:updated-desc ${message}`);
-	console.group('Search issue');
-	console.log(searchIssueUrl.href);
-	console.groupEnd();
 
 	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
 	newIssueUrl.searchParams.set('labels', 'bug');
@@ -76,10 +70,11 @@ const logError = (url: string, error: unknown): void => {
 		'```',
 	].join('\n'));
 
-	console.group('Open an issue');
-	console.log(newIssueUrl.href);
-	console.groupEnd();
-
+	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
+	console.group(`❌ ${id}`); // Safari supports only one parameter
+	console.log('📕', version, pageDetect.isEnterprise() ? 'GHE →' : '→', error)
+	console.log('🔍 Search issue', searchIssueUrl.href);
+	console.log('🚨 Report issue', newIssueUrl.href);
 	console.groupEnd();
 };
 

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -72,7 +72,7 @@ const logError = (url: string, error: unknown): void => {
 
 	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
 	console.group(`❌ ${id}`); // Safari supports only one parameter
-	console.log('📕', version, pageDetect.isEnterprise() ? 'GHE →' : '→', error)
+	console.log('📕', version, pageDetect.isEnterprise() ? 'GHE →' : '→', error);
 	console.log('🔍 Search issue', searchIssueUrl.href);
 	console.log('🚨 Report issue', newIssueUrl.href);
 	console.groupEnd();

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -72,7 +72,7 @@ const logError = (url: string, error: unknown): void => {
 
 	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
 	console.group(`❌ ${id}`); // Safari supports only one parameter
-	console.log('📕', version, pageDetect.isEnterprise() ? 'GHE →' : '→', error);
+	console.log(`📕 ${version} ${pageDetect.isEnterprise() ? 'GHE →' : '→'}`, error); // One parameter improves Safari formatting
 	console.log('🔍 Search issue', searchIssueUrl.href);
 	console.log('🚨 Report issue', newIssueUrl.href);
 	console.groupEnd();


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5174

## Test URL

https://github.com/MatthewL246/hello-world/edit/main/CONTRIBUTING.md

(error was reported in https://github.com/refined-github/refined-github/issues/4194)

## Chrome

<img width="504" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/158048569-dfe4f199-5ce0-492f-95a6-e888087d02c2.png">


## Safari

<img width="731" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/158048571-c620e480-2f42-484b-9edc-8e8967fa3f55.png">

## Safari after clicking the first line

<img width="589" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/158048577-f4354610-c565-462f-b904-318fbf0e1556.png">

