### PR TITLE
Fix GitHub Safari bug: Horizontal scrollbars on Action logs

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -49,3 +49,8 @@
 #toc .toc-diff-stats .octicon-file-diff {
 	margin-right: 4px !important;
 }
+
+/* Avoid horizontal scrollbars on Action logs in Safari #5152 */
+:root .CheckStep-line .CheckStep-line-content {
+	overflow: hidden;
+}


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5152

## Test URL: 

https://github.com/pixiebrix/pixiebrix-extension/runs/5523238774?check_suite_focus=true

## Before

<img width="891" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/158048790-d78877da-dfad-447c-be58-c58f6a0d8dd8.png">

## After

<img width="898" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/158048794-d8afa1c7-929a-4a3b-9006-29fa19ec4533.png">

