### PR TITLE
Fix custom CSS injection order via `contentScripts.register`

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -63,3 +63,27 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 	await cache.delete('hotfixes');
 	await cache.delete('style-hotfixes');
 });
+
+let customCssRegistration: browser.contentScripts.RegisteredContentScript;
+async function setCustomStyleSheet(css: string): Promise<void> {
+	customCssRegistration = await browser.contentScripts.register({
+		matches: [
+			'https://github.com/*',
+			'https://gist.github.com/*',
+		],
+		css: [
+			{
+				code: css,
+			},
+		],
+	});
+}
+
+browser.storage.onChanged.addListener(async (changes, areaName) => {
+	if (areaName === 'sync' && 'customCSS' in changes) {
+		await customCssRegistration?.unregister();
+		if (changes.customCSS.newValue.trim()) {
+			await setCustomStyleSheet(changes.customCSS.newValue.trim());
+		}
+	}
+});

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -98,11 +98,10 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 		bisectFeatures(),
 	]);
 
-	if (hotfixCSS.length > 0 || options.customCSS.trim().length > 0) {
+	if (hotfixCSS.length > 0) {
 		await waitFor(() => document.head);
 		document.head.append(
 			<style>{hotfixCSS}</style>,
-			<style>{options.customCSS}</style>,
 		);
 	}
 


### PR DESCRIPTION
Just an attempt at fixing https://github.com/refined-github/refined-github/issues/4731

Unfortunately this lacks support for GHE, which is a little complex.

Also obviously missing the `setCustomStyleSheet` on load, but I'm probably going to abandon this