### PR TITLE
Reliability fixes for `fork-source-link-same-view`

### DIFF
--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -11,17 +11,13 @@ const isFilePath = (): boolean => pageDetect.isSingleFile()
 	|| (pageDetect.isRepoTree())
 	|| pageDetect.hasFileEditor();
 
-function updateHeaderLink(url: string): void {
-	select<HTMLAnchorElement>(`[data-hovercard-url="/${getForkedRepo()!}/hovercard"]`)!.href = url;
-}
-
-async function init(): Promise<void | false> {
+async function getEquivalentURL(): Promise<string> {
 	const forkedRepository = getRepo(getForkedRepo())!;
+	const defaultUrl = '/' + forkedRepository.nameWithOwner;
 
 	if (pageDetect.isConversation() || pageDetect.isRepoRoot()) {
 		// We must reset the link because the header is outside the ajaxed area
-		updateHeaderLink('/' + forkedRepository.nameWithOwner);
-		return false;
+		return defaultUrl;
 	}
 
 	const sameViewUrl = new GitHubURL(location.href).assign({
@@ -32,11 +28,15 @@ async function init(): Promise<void | false> {
 	if (isFilePath()) {
 		sameViewUrl.branch = await getDefaultBranch(forkedRepository);
 		if (!await doesFileExist(sameViewUrl)) {
-			return false;
+			return 	defaultUrl;
 		}
 	}
 
-	updateHeaderLink(sameViewUrl.href);
+	return (sameViewUrl.href);
+}
+
+async function init(): Promise<void> {
+	select<HTMLAnchorElement>(`[data-hovercard-url="/${getForkedRepo()!}/hovercard"]`)!.href = await getEquivalentURL();
 }
 
 void features.add(import.meta.url, {

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -36,6 +36,7 @@ async function getEquivalentURL(): Promise<string> {
 }
 
 async function init(): Promise<void> {
+	// The link must always be updated/reset. This pattern ensures that the link is always updated and never fails through some conditions.
 	select<HTMLAnchorElement>(`[data-hovercard-url="/${getForkedRepo()!}/hovercard"]`)!.href = await getEquivalentURL();
 }
 
@@ -43,7 +44,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isForkedRepo,
 	],
-	// We can't use `exclude` because the header is outside the ajaxed area
+	// We can't use `exclude` because the header is outside the ajaxed area so it must be manually reset even when the feature doesn't apply there
 	deduplicate: false,
 	init,
 });

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -8,7 +8,7 @@ import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getRepo, getForkedRepo} from '../github-helpers';
 
 const isFilePath = (): boolean => pageDetect.isSingleFile()
-	|| (pageDetect.isRepoTree())
+	|| pageDetect.isRepoTree()
 	|| pageDetect.hasFileEditor();
 
 async function getEquivalentURL(): Promise<string> {
@@ -28,11 +28,11 @@ async function getEquivalentURL(): Promise<string> {
 	if (isFilePath()) {
 		sameViewUrl.branch = await getDefaultBranch(forkedRepository);
 		if (!await doesFileExist(sameViewUrl)) {
-			return 	defaultUrl;
+			return defaultUrl;
 		}
 	}
 
-	return (sameViewUrl.href);
+	return sameViewUrl.href;
 }
 
 async function init(): Promise<void> {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5479
- Follows #5351 

## Test

1. Visit https://github.com/humphd/browser-extension-template/tree/update-deps/.github
2. Link must point to https://github.com/fregante/browser-extension-template/tree/main/.github
3. Click "Code" tab
4. Link must be reset to https://github.com/fregante/browser-extension-template
5. Click "Pull requests" tab
6. Link must include URL parameters https://github.com/humphd/browser-extension-template/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc
7. Go back in history to verify everything is still correct