### PR TITLE
Don't override the PR title and body provided via URL parameters

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -25,6 +25,7 @@ function getFirstCommitMessage(): string[] {
 }
 
 async function init(): Promise<void | false> {
+	const requestedContent = new URL(location.href).searchParams;
 	const commitCountIcon = await elementReady('div.Box.mb-3 .octicon-git-commit');
 	const commitCount = commitCountIcon?.nextElementSibling;
 	if (!commitCount || looseParseInt(commitCount) < 2 || !select.exists('#new_pull_request')) {
@@ -32,14 +33,19 @@ async function init(): Promise<void | false> {
 	}
 
 	const [prTitle, ...prBody] = getFirstCommitMessage();
-	textFieldEdit.set(
-		select('.discussion-topic-header input')!,
-		prTitle,
-	);
-	textFieldEdit.insert(
-		select('#new_pull_request textarea[aria-label="Comment body"]')!,
-		prBody.join('\n\n'),
-	);
+	if (!requestedContent.has('pull_request[title]')) {
+		textFieldEdit.set(
+			select('.discussion-topic-header input')!,
+			prTitle,
+		);
+	}
+
+	if (!requestedContent.has('pull_request[body]')) {
+		textFieldEdit.insert(
+			select('#new_pull_request textarea[aria-label="Comment body"]')!,
+			prBody.join('\n\n'),
+		);
+	}
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5477

## Test

https://github.com/refined-github/refined-github/compare/main...add-multiple-prs-dropdown?expand=1&pull_request%5Bbody%5D=bar&pull_request%5Btitle%5D=foo


## Screenshot

<img width="705" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/158055356-59ba9ec7-63ff-4d8b-b486-f0f63171669f.png">
