### PR TITLE
Include but skip inert URL segments in `useful-not-found-page`

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -76,16 +76,11 @@ async function showMissingPart(): Promise<void> {
 
 	for (const [i, part] of pathParts.entries()) {
 		// Exclude parts that don't exist as standalones
-		if (i === 0 && part === 'orgs') {
-			continue;
-		}
-
-		if (i === 2 && ['tree', 'blob', 'edit'].includes(part)) {
-			continue;
-		}
-
-		if (i === pathParts.length - 1) {
-			// The last part of the URL is a known 404
+		if (
+			(i === 0 && part === 'orgs')
+			|| (i === 2 && ['tree', 'blob', 'edit'].includes(part))
+			|| i === pathParts.length - 1 // The last part is a known 404
+		) {
 			breadcrumbs.push(getStrikeThrough(part));
 		} else {
 			const pathname = '/' + pathParts.slice(0, i + 1).join('/');


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5483


## Test URLs

https://github.com/orgs/date-fns/teams/i18n-id

## Before
<img width="398" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/158056083-10c6a38b-5903-44f9-b1b0-7f6171a69042.png">

## After
<img width="361" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/158056081-ee2a6772-ace3-46ec-9542-d21dbf07abe8.png">

