### PR TITLE
Meta: Make our bug report "Example URLs" field smaller

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -166,3 +166,14 @@ pr-branches
 .pagehead-actions [data-test-selector='pin-repo-button'] {
 	display: none !important;
 }
+
+/* Make our "Example URLs" but report field smaller https://github.com/refined-github/refined-github/issues/5222#issuecomment-1064769358 */
+[action='/refined-github/refined-github/issues'] #issue_form_example_urls {
+	min-height: 4em !important;
+	height: 4em !important;
+}
+
+[action='/refined-github/refined-github/issues'] #issue_form_example_urls + div textarea { /* Also the WYSIWYG editor */
+	min-height: 4em;
+	height: 4em;
+}


### PR DESCRIPTION
- For https://github.com/refined-github/refined-github/issues/5222#issuecomment-1064769358

The code makes it smaller without breaking the autosizer

![gif](https://user-images.githubusercontent.com/1402241/158057891-ef917f8a-dd30-419e-be45-28bf82b44162.gif)

