### PR TITLE
Fix repo tab menu overflow due to `releases-tab` and `bugs-tab`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -124,6 +124,9 @@ async function addBugsTab(): Promise<void | false> {
 		issuesTab.after(bugsTab);
 	}
 
+	// Trigger a reflow to push the right-most tab into the overflow dropdown
+	window.dispatchEvent(new Event('resize'));
+
 	// Update bugs count
 	try {
 		const bugCount = await countPromise;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -76,6 +76,9 @@ async function addReleasesTab(): Promise<false | void> {
 	// This re-triggers the overflow listener forcing it to also hide this tab if necessary #3347
 	repoNavigationBar.replaceWith(repoNavigationBar);
 
+	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
+	window.dispatchEvent(new Event('resize'));
+
 	appendBefore(
 		select('.js-responsive-underlinenav .dropdown-menu ul')!,
 		'.dropdown-divider', // Won't exist if `more-dropdown` is disabled


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/4254
- Replaces and closes https://github.com/refined-github/refined-github/pull/5333


## Repro

1. Resize the window to have it just barely hide the Releases tab2. 
2. Empty the cache (makes the `bugs-tab` appear later)3. 
3. Refresh the page

## Demo

Shows that triggering a fake `resize` event makes the tab disappear

https://user-images.githubusercontent.com/1402241/158060307-b299c3ce-9bba-4150-b242-5fe6517d054b.mov


