### PR TITLE
Fix `latest-tag-button` on branch ahead by more than 20 commits

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -88,7 +88,7 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 });
 
 async function init(): Promise<false | void> {
-	const {latestTag, aheadBy = 0} = await getRepoPublishState();
+	const {latestTag, aheadBy} = await getRepoPublishState();
 	if (!latestTag) {
 		return false;
 	}
@@ -118,7 +118,7 @@ async function init(): Promise<false | void> {
 	const defaultBranch = await getDefaultBranch();
 	const onLatestTag = currentBranch === latestTag;
 	const onDefaultBranch = !currentBranch || currentBranch === defaultBranch; // `getCurrentCommittish` returns `undefined` when at the repo root on the default branch #5446
-	const isAhead = aheadBy > 0;
+	const isAhead = aheadBy === undefined || aheadBy > 0;
 
 	if (onLatestTag || (onDefaultBranch && !isAhead)) {
 		link.setAttribute('aria-label', 'You’re on the latest version');
@@ -131,7 +131,7 @@ async function init(): Promise<false | void> {
 		link.setAttribute(
 			'aria-label',
 			isAhead
-				? `${defaultBranch} is ${pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest version`
+				? `${defaultBranch} is ${aheadBy === undefined ? 'more than 20 commits' : pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest version`
 				: `The HEAD of ${defaultBranch} isn’t tagged`,
 		);
 

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -15,7 +15,7 @@ import {buildRepoURL, getCurrentCommittish, getLatestVersionTag, getRepo} from '
 
 interface RepoPublishState {
 	latestTag: string | false;
-	aheadBy?: number;
+	aheadBy: number;
 }
 
 interface Tags {
@@ -27,6 +27,8 @@ interface Tags {
 		};
 	};
 }
+
+const undeterminableAheadBy = Number.MAX_SAFE_INTEGER; // For when the branch is ahead by more than 20 commits #5505
 
 const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> => {
 	const {repository} = await api.v4(`
@@ -64,6 +66,7 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 	if (repository.refs.nodes.length === 0) {
 		return {
 			latestTag: false,
+			aheadBy: 0,
 		};
 	}
 
@@ -76,11 +79,10 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 	const latestTagOid = tags.get(latestTag)!;
 	const aheadBy = repository.defaultBranchRef.target.history.nodes.findIndex((node: AnyObject) => node.oid === latestTagOid);
 
-	if (aheadBy < 0) {
-		return {latestTag};
-	}
-
-	return {latestTag, aheadBy};
+	return {
+		latestTag,
+		aheadBy: aheadBy === -1 ? undeterminableAheadBy : aheadBy,
+	};
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 2},
@@ -118,7 +120,7 @@ async function init(): Promise<false | void> {
 	const defaultBranch = await getDefaultBranch();
 	const onLatestTag = currentBranch === latestTag;
 	const onDefaultBranch = !currentBranch || currentBranch === defaultBranch; // `getCurrentCommittish` returns `undefined` when at the repo root on the default branch #5446
-	const isAhead = aheadBy === undefined || aheadBy > 0;
+	const isAhead = aheadBy > 0;
 
 	if (onLatestTag || (onDefaultBranch && !isAhead)) {
 		link.setAttribute('aria-label', 'You’re on the latest version');
@@ -131,7 +133,7 @@ async function init(): Promise<false | void> {
 		link.setAttribute(
 			'aria-label',
 			isAhead
-				? `${defaultBranch} is ${aheadBy === undefined ? 'more than 20 commits' : pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest version`
+				? `${defaultBranch} is ${aheadBy === undeterminableAheadBy ? 'more than 20 commits' : pluralize(aheadBy, '1 commit', '$$ commits')} ahead of the latest version`
 				: `The HEAD of ${defaultBranch} isn’t tagged`,
 		);
 

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -129,7 +129,7 @@ async function init(): Promise<false | void> {
 	}
 
 	if (pageDetect.isRepoHome() || onDefaultBranch) {
-		link.append(<sup> +{aheadBy}</sup>);
+		link.append(<sup> {aheadBy === undeterminableAheadBy ? '*' : `+${aheadBy}`}</sup>);
 		link.setAttribute(
 			'aria-label',
 			isAhead


### PR DESCRIPTION
Fixes #5504 
Follow-up of #5462

## Test URLs

- [Latest tag](https://github.com/refined-github/refined-github/tree/22.3.3)
- [Default branch, tagged](https://github.com/kas-elvirov/gloc)
- [Default branch, not tagged](https://github.com/refined-github/github-url-detection)
- [Default branch, not tagged (20+ commits ahead)](https://github.com/refined-github/refined-github)
- [Other branches](https://github.com/refined-github/refined-github/tree/hotfix)

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/158328382-ba60c5df-220e-42fa-bbb2-af64bc1c5ce2.png)