### PR TITLE
Avoid extra scrollbars in `scrollable-code-and-blockquote`

### DIFF
--- a/source/features/scrollable-code-and-blockquote.css
+++ b/source/features/scrollable-code-and-blockquote.css
@@ -1,11 +1,9 @@
-.comment-body :is(blockquote, pre) {
+:root .comment-body :is(blockquote, pre) {
 	position: relative; /* OctoLinker compat: attach the purple balls to the scroll */
 	max-height: 30.5em;
 	overflow-y: auto;
-}
 
-/* A tiny scroll bar appears when the last paragraph contains a `code` or `g-emoji` tag #3012 */
-.comment-body blockquote {
+	/* A tiny scroll bar appears when the last paragraph contains a `code` or `g-emoji` tag #3012 #4597 */
 	padding-bottom: 0.2em;
 }
 

--- a/source/features/scrollable-code-and-blockquote.css
+++ b/source/features/scrollable-code-and-blockquote.css
@@ -7,6 +7,6 @@
 	padding-bottom: 0.2em;
 }
 
-.comment-body :is(details, blockquote) :is(blockquote, pre) {
+:root .comment-body :is(details, blockquote) :is(blockquote, pre) {
 	max-height: none;
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/4597

Our code was just being overridden by GitHub’s


## Test URLs

- https://github.com/refined-github/refined-github/pull/5416#issuecomment-1041546190
- https://github.com/discordjs/discord.js/pull/6162#issuecomment-884157859
- https://github.com/refined-github/refined-github/pull/5506#issuecomment-1067652695


## Before

<img width="545" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/158330004-eff55e01-af3b-452f-a6c7-a7e8dba85eaa.png">

<img width="545" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/158330014-6f2f2b47-1455-439d-9b75-e7495081dd1d.png">


## After


<img width="545" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/158330035-97b7a283-bf8a-4b53-95a9-cf3d886debe7.png">

<img width="545" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/158330044-63178e92-1f23-47bc-bab3-bf751a02b55b.png">

