### PR TITLE
Fix alignment of "Allow edits by maintainers" checkbox

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -59,3 +59,17 @@
 :root .blob-code-marker::before {
 	top: 0;
 }
+
+/* Fix alignment of "Allow edits by maintainers" checkbox label and icons */
+#partial-discussion-sidebar .discussion-sidebar-item:last-child > .d-inline-flex {
+	align-items: center !important;
+}
+
+#partial-discussion-sidebar .js-collab-option input,
+#partial-discussion-sidebar .js-collab-form + details summary {
+	margin-top: 0 !important;
+}
+
+#partial-discussion-sidebar .js-collab-form .status-indicator .octicon {
+	vertical-align: baseline !important;
+}


### PR DESCRIPTION
## Test URLs

A PR you opened from a fork

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/158367006-5b53d039-277d-4aa4-9a5d-b939ff1b1657.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/158367038-532de586-db32-4c0c-98f1-587d40006f25.png)

![with-icon](https://user-images.githubusercontent.com/46634000/158367113-0189dd24-77a4-4848-a40f-cd147a7b2df8.png)