### PR TITLE
Dim more PRs opened by bots in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-const commitSelectors = [
+const botNames = [
 	'actions-user',
 	'bors',
 	'ImgBotApp',
@@ -15,16 +15,18 @@ const commitSelectors = [
 	'scala-steward',
 	'snyk-bot',
 	'web-flow',
-].map(bot => `.commit-author[href$="?author=${bot}"]`);
+];
 
-commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic [bot] label
-
+const commitSelectors = botNames.map(bot => `.commit-author[href$="?author=${bot}"]`);
+commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic `[bot]` label in author name
 const commitSelector = commitSelectors.join(',');
 
-const prSelector = [
-	'.opened-by [href*="author%3Aapp%2F"]',
-	'.labels [href$="label%3Abot"]',
-];
+const prSelectors = botNames.map(bot => `.opened-by [title="pull requests opened by ${bot}"]`);
+prSelectors.push(
+	'.opened-by [href*="author%3Aapp%2F"]', // Search query `is:pr+author:app/*`
+	'.labels [href$="label%3Abot"]', // PR tagged with `bot` label
+);
+const prSelector = prSelectors.join(',');
 
 function init(): void {
 	for (const bot of select.all(commitSelector)) {


### PR DESCRIPTION
Dim more bots PRs + refactor a bit and add an explanatory comment on each extra selector

## Test URLs

- [PRs by `renovate` and `dependabot`](https://github.com/mozilla/dispensary/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed)
- [PRs by `dependabot` and `snyk-bot`](https://github.com/cheap-glitch/fretboarder/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed)
- [Commits by `renovate`](https://github.com/renovatebot/renovate/commits/main)
- [Commits by `bors`](https://github.com/rust-lang/rust/commits/master)

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/158578172-5757c6d4-651f-4e9c-8f89-782c7eb94e25.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/158578164-b0870c55-c9db-4881-a7fb-925618abae43.png)