### PR TITLE
Restore `clean-dashboard` style

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -21,7 +21,9 @@
 
 /* Add "box" style to each event group */
 /* This exact `>` sequence ensures it works on ajaxed-in events */
-.rgh-clean-dashboard tab-container [role="tabpanel"] [data-repository-hovercards-enabled] >[class] > .body {
+.rgh-clean-dashboard [role='tabpanel'] [data-repository-hovercards-enabled] > [class] > .body,
+
+.rgh-clean-dashboard .news > [data-repository-hovercards-enabled] > [class] > .body {
 	background-color: var(--color-canvas-default);
 	border: 1px solid var(--color-border-muted);
 	border-radius: 4px;
@@ -30,7 +32,7 @@
 }
 
 /* Drop extra border */
-.rgh-clean-dashboard tab-container [role="tabpanel"] .body > .border-bottom {
+.rgh-clean-dashboard .news .body > .border-bottom {
 	border-bottom: none !important;
 }
 

--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -12,19 +12,26 @@
 	display: none;
 }
 
-/* Add background and border Whole list */
-.rgh-clean-dashboard .news > .f4 + div {
-	background-color: var(--rgh-background);
-	border: 1px solid var(--rgh-border-color);
-	border-radius: 6px;
-	margin-top: 8px !important;
-}
-
-/* Drop "box" style for all events */
-.rgh-clean-dashboard .news > .f4 + div .Box {
+/* Drop "box" style from the repos */
+.rgh-clean-dashboard .news .body .Box {
 	padding: 0 !important;
 	border: none;
 	background: none;
+}
+
+/* Add "box" style to each event group */
+/* This exact `>` sequence ensures it works on ajaxed-in events */
+.rgh-clean-dashboard tab-container [role="tabpanel"] [data-repository-hovercards-enabled] >[class] > .body {
+	background-color: var(--color-canvas-default);
+	border: 1px solid var(--color-border-muted);
+	border-radius: 4px;
+	margin-top: 16px !important;
+	box-shadow: var(--color-shadow-medium);
+}
+
+/* Drop extra border */
+.rgh-clean-dashboard tab-container [role="tabpanel"] .body > .border-bottom {
+	border-bottom: none !important;
 }
 
 /* Restore "row"-like spacing for all events */

--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -22,7 +22,7 @@
 /* Add "box" style to each event group */
 /* This exact `>` sequence ensures it works on ajaxed-in events */
 .rgh-clean-dashboard [role='tabpanel'] [data-repository-hovercards-enabled] > [class] > .body,
-
+/* The organization newsfeed doesn't yet support the new style */
 .rgh-clean-dashboard .news > [data-repository-hovercards-enabled] > [class] > .body {
 	background-color: var(--color-canvas-default);
 	border: 1px solid var(--color-border-muted);


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5530

I'm updating the style a bit:

- keep the card styles, but move them to each event group rather than around each repo. I think we had this at some point but maybe it wasn't working
- add some shadows to match the upcoming "For you" style

## Test URLs

- [x] https://github.com/
- [x] https://github.com/orgs/refined-github/dashboard

## Screenshot

<img width="660" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/159398463-5d4a296b-dc9e-4201-862b-dcea7fed9f2d.png">


### Organization newsfeed

<img width="878" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/159399366-296e87ae-17d2-432a-993e-bb95173a7be8.png">



### It matches the native upcoming "For You" style (untouched)

<img width="623" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/159398582-ea7fd4aa-0bb5-44b9-aa5b-d73c5f5a1786.png">

