### PR TITLE
Restore `align-issue-labels`

### DIFF
--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -4,7 +4,7 @@
 	flex-wrap: wrap;
 }
 
-.rgh-align-issue-labels .js-issue-row .labels {
+.rgh-align-issue-labels .js-issue-row .lh-default.d-block.d-md-inline { /* Labels */
 	order: 1;
 }
 


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/5532

They dropped the `labels` class.

Heads up: `dim-bots` is also affected but it's not as high priority



## Test URLs

https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

https://github.com/orden-gg/fireball/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

## Screenshot


<img width="580" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/159403083-5ce41adb-fd34-430e-b11c-6103196458c6.png">
