### PR TITLE
Drop `dim-visited-conversations` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,7 +266,6 @@ Thanks for contributing! 🦋🙌
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif)
 - [](# "esc-to-cancel") [Adds a shortcut to cancel editing a conversation title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
 - [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
-- [](# "dim-visited-conversations") [Dims the title of visited conversations.](https://user-images.githubusercontent.com/1402241/152119410-0d90e11e-66e6-4938-b839-861e9e186f33.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/dim-visited-conversations.css
+++ b/source/features/dim-visited-conversations.css
@@ -1,3 +1,0 @@
-.rgh-dim-visited-conversations .js-issue-row .h4:visited:not(:hover) {
-	color: var(--color-fg-muted) !important;
-}

--- a/source/features/dim-visited-conversations.tsx
+++ b/source/features/dim-visited-conversations.tsx
@@ -1,6 +1,0 @@
-import './dim-visited-conversations.css';
-import * as pageDetect from 'github-url-detection';
-
-import features from '.';
-
-void features.addCssFeature(import.meta.url, [pageDetect.isConversationList]);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -32,7 +32,6 @@ import './features/clean-dashboard';
 import './features/hide-noisy-newsfeed-events';
 import './features/minimize-upload-bar';
 import './features/hide-diff-signs';
-import './features/dim-visited-conversations';
 import './features/hide-repo-badges';
 import './features/clean-rich-text-editor';
 


### PR DESCRIPTION
On repos you visit often, this just leads to links having lower contrast.


- See https://github.com/refined-github/refined-github/pull/1206#issuecomment-386051034

Being 3 lines of CSS, it can be added to one’s own CSS field

## Before

<img width="649" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/159521246-52156990-0cc4-40b5-908b-3e50b15dc14a.png">



