### PR TITLE
fix: make `hide-watch-and-fork-count` feature disableable

### DIFF
--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,3 +1,6 @@
-.pagehead-actions :is(#repo-network-counter, #repo-notifications-counter) {
+.rgh-hide-watch-and-fork-count .pagehead-actions :is(
+#repo-network-counter,
+#repo-notifications-counter
+) {
 	display: none;
 }

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -1,0 +1,6 @@
+import './hide-watch-and-fork-count.css';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+void features.addCssFeature(import.meta.url, [pageDetect.isRepo]);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -18,7 +18,6 @@ import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
 import './features/align-repository-header.css';
 import './features/night-not-found.css';
-import './features/hide-watch-and-fork-count.css';
 import './features/clean-commit-form.css';
 import './features/sticky-file-header.css';
 
@@ -30,6 +29,7 @@ import './features/align-issue-labels';
 import './features/clean-pinned-issues';
 import './features/clean-dashboard';
 import './features/hide-noisy-newsfeed-events';
+import './features/hide-watch-and-fork-count';
 import './features/minimize-upload-bar';
 import './features/hide-diff-signs';
 import './features/hide-repo-badges';


### PR DESCRIPTION
really don't feel like [pasting in the custom css](https://github.com/refined-github/refined-github/pull/5197#issuecomment-993390710) in each of my accounts in different browsers & laptops..
would really appreciate if we could keep this feature disableable.

partly reverts pr: https://github.com/refined-github/refined-github/pull/5197
or commit: 7551cccbd72ba5fdca3a4a5635c31df488b451ad

