### PR TITLE
Add filters for deployment requests and failed runs in `select-notifications`

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -14,7 +14,9 @@ import {
 	GitPullRequestDraftIcon,
 	GitPullRequestIcon,
 	IssueOpenedIcon,
+	RocketIcon,
 	XCircleIcon,
+	XIcon,
 } from '@primer/octicons-react';
 
 import features from '.';
@@ -22,10 +24,12 @@ import features from '.';
 const filters = {
 	'Pull requests': ':is(.octicon-git-pull-request, .octicon-git-pull-request-closed, .octicon-git-pull-request-draft, .octicon-git-merge)',
 	Issues: ':is(.octicon-issue-opened, .octicon-issue-closed)',
-	Open: ':is(.octicon-issue-opened, .octicon-git-pull-request)',
+	Deployments: ':is(.octicon-rocket, .octicon-x)',
+	Open: ':is(.octicon-issue-opened, .octicon-git-pull-request, .octicon-rocket)',
 	Closed: ':is(.octicon-issue-closed, .octicon-git-pull-request-closed)',
 	Draft: '.octicon-git-pull-request-draft',
 	Merged: '.octicon-git-merge',
+	'Run failed': '.octicon-x',
 	Read: '.notification-read',
 	Unread: '.notification-unread',
 };
@@ -84,10 +88,12 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 	const icons: {[Key in Filter]: JSX.Element} = {
 		'Pull requests': <GitPullRequestIcon className="color-text-secondary color-fg-muted"/>,
 		Issues: <IssueOpenedIcon className="color-text-secondary color-fg-muted"/>,
+		Deployments: <RocketIcon className="color-text-ling color-fg-muted"/>,
 		Open: <CheckCircleIcon className="color-text-success color-fg-success"/>,
 		Closed: <XCircleIcon className="color-text-danger color-fg-danger"/>,
 		Draft: <GitPullRequestDraftIcon className="color-text-tertiary color-fg-subtle"/>,
 		Merged: <GitMergeIcon className="color-fg-done"/>,
+		'Run failed': <XIcon className="color-fg-danger"/>,
 		Read: <DotIcon className="color-text-link color-fg-accent"/>,
 		Unread: <DotFillIcon className="color-text-link color-fg-accent"/>,
 	};
@@ -142,8 +148,8 @@ const createDropdown = onetime(() => (
 		>
 			<div className="SelectMenu-modal">
 				<form id="rgh-select-notifications-form">
-					{createDropdownList('Type', ['Pull requests', 'Issues'])}
-					{createDropdownList('Status', ['Open', 'Closed', 'Merged', 'Draft'])}
+					{createDropdownList('Type', ['Pull requests', 'Issues', 'Deployments'])}
+					{createDropdownList('Status', ['Open', 'Closed', 'Merged', 'Draft', 'Run failed'])}
 					{createDropdownList('Read', ['Read', 'Unread'])}
 				</form>
 			</div>


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Added a filter for GH Actions deployment notifications.
- New type `Deployments` added.
- New status `Run failed` added.

Deployment review requests can be filtered with type `Deployments` and status `Open`.
Failed deployments can be filtered with type `Deployments` and status `Run failed`.

## Test URLs
[github.com/notifications](https://github.com/notifications)

## Screenshot
![image](https://user-images.githubusercontent.com/24573585/160610037-ffffe32b-0ec8-48b6-8446-d5c368c538ef.png)

![image](https://user-images.githubusercontent.com/24573585/160611497-4486e70f-9867-42fe-bd76-f126b19017bc.png)

