### PR TITLE
Fix: `stop-pjax-loading-with-esc` stopped working

### DIFF
--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -40,13 +40,9 @@ function pjaxErrorHandler(event: CustomEvent): void {
 	}
 }
 
-function init(): Deinit {
+function init(): void {
 	progressLoader = select('.progress-pjax-loader')!;
 	window.addEventListener('keydown', keydownHandler);
-
-	return () => {
-		window.removeEventListener('keydown', keydownHandler);
-	};
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fixes #5561 :man_facepalming: :man_facepalming: 

## Test URLs

1. Click on a repo tab
2. Quick! Press <kbd>Esc</kbd>!
3. Voilà

## Screenshot

https://user-images.githubusercontent.com/46634000/161933513-449c86eb-9ef6-4233-912a-a5181d8e7f3b.mp4