### PR TITLE
Exclude low quality comments from `highest-rated-comment`

### DIFF
--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -8,6 +8,9 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import isLowQualityComment from '../helpers/is-low-quality-comment';
 
+// eslint-disable-next-line import/prefer-default-export
+export const singleParagraphCommentSelector = '.comment-body > p:only-child';
+
 async function unhide(event: delegate.Event): Promise<void> {
 	for (const comment of select.all('.rgh-hidden-comment')) {
 		comment.hidden = false;
@@ -37,10 +40,9 @@ function init(): void | Deinit {
 		lowQualityCount++;
 	}
 
-	const commentSelector = '.comment-body > p:only-child';
-	const linkedComment = location.hash.startsWith('#issuecomment-') ? select(`${location.hash} ${commentSelector}`) : undefined;
+	const linkedComment = location.hash.startsWith('#issuecomment-') ? select(`${location.hash} ${singleParagraphCommentSelector}`) : undefined;
 
-	for (const commentText of select.all(commentSelector)) {
+	for (const commentText of select.all(singleParagraphCommentSelector)) {
 		// Exclude explicitely linked comments #5363
 		if (commentText === linkedComment) {
 			continue;

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -7,6 +7,8 @@ import {ArrowDownIcon, CheckCircleFillIcon} from '@primer/octicons-react';
 
 import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
+import isLowQualityComment from '../helpers/is-low-quality-comment';
+import {singleParagraphCommentSelector} from './hide-low-quality-comments';
 
 // `.js-timeline-item` gets the nearest comment excluding the very first comment (OP post)
 const commentSelector = '.js-timeline-item';
@@ -92,6 +94,11 @@ function selectSum(selector: string, container: HTMLElement): number {
 function init(): false | void {
 	const bestComment = getBestComment();
 	if (!bestComment) {
+		return false;
+	}
+
+	const commentText = select(singleParagraphCommentSelector, bestComment)?.textContent;
+	if (commentText && isLowQualityComment(commentText)) { // #5567
 		return false;
 	}
 


### PR DESCRIPTION
Resolves #5567 

## Test URLs

- Control URL: https://togithub.com/vercel/swr/issues/93
- No comment should be highlighted here: https://togithub.com/facebook/jest/issues/5311

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/161938785-63b961df-6063-419f-b6bd-9c7fc053834f.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/161938783-742c8129-006d-4720-8edc-10c657cb42ec.png)