### PR TITLE
Fix position and duplication of `quick-comment-edit` button

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ Thanks for contributing! 🦋🙌
 - [](# "tab-to-indent") 🔥 [Enables <kbd>tab</kbd> and <kbd>shift</kbd> <kbd>tab</kbd> for indentation in comment fields.](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)
 - [](# "collapsible-content-button") [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
-- [](# "quick-comment-edit") [Lets you edit any comment with one click instead of having to open a dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
+- [](# "quick-comment-edit") [Lets you edit any comment with one click instead of having to open a dropdown.](https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png)
 - [](# "comment-fields-keyboard-shortcuts") [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/refined-github/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
 - [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif) `[` `` ` `` `'` `"` `*` `~` `_`
 - [](# "minimize-upload-bar") [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/17612510/99140148-205dd380-2693-11eb-9a61-9c228f8f9e36.png)

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -8,10 +8,8 @@ import features from '.';
 import isArchivedRepo from '../helpers/is-archived-repo';
 
 function addQuickEditButton(commentForm: Element): void {
-	commentForm.classList.add('rgh-edit-comment');
-
-	const comment = commentForm.closest('.js-comment')!;
-	if (select.exists('.rgh-quick-comment-edit-button', comment)) { // #5572
+	// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
+	if (select.exists('.rgh-quick-comment-edit-button', commentForm)) {
 		return;
 	}
 
@@ -21,7 +19,8 @@ function addQuickEditButton(commentForm: Element): void {
 		pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : '',
 	].join(' ');
 
-	comment
+	commentForm
+		.closest('.js-comment')!
 		.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
 		.before(
 			<button
@@ -53,7 +52,7 @@ function init(): Deinit {
 	// If true then the resulting selector will match all comments, otherwise it will only match those made by you
 	const preSelector = canEditEveryComment() ? '' : '.current-user';
 	// Find editable comments first, then traverse to the correct position
-	return observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
+	return observe(preSelector + '.js-comment.unminimized-comment .js-comment-update', {
 		add: addQuickEditButton,
 	});
 }

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -26,7 +26,6 @@ function addQuickEditButton(commentForm: Element): void {
 		</button>
 	);
 
-	// Need a child combinator because the reaction picker on PR comments is also a <details> #5558
 	const dropdown = comment.querySelector('.timeline-comment-actions > details:last-child')!;
 	if (pageDetect.isIssue()) {
 		dropdown.previousSibling!.replaceWith(button); // Replace whitespace node in issue comments header

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -8,8 +8,9 @@ import features from '.';
 import isArchivedRepo from '../helpers/is-archived-repo';
 
 function addQuickEditButton(commentForm: Element): void {
+	const commentBody = commentForm.closest('.js-comment')!;
 	// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
-	if (select.exists('.rgh-quick-comment-edit-button', commentForm)) {
+	if (select.exists('.rgh-quick-comment-edit-button', commentBody)) {
 		return;
 	}
 
@@ -19,8 +20,7 @@ function addQuickEditButton(commentForm: Element): void {
 		pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : '',
 	].join(' ');
 
-	commentForm
-		.closest('.js-comment')!
+	commentBody
 		.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
 		.before(
 			<button

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -15,23 +15,24 @@ function addQuickEditButton(commentForm: Element): void {
 		return;
 	}
 
-	const button = (
-		<button
-			type="button"
-			role="menuitem"
-			className={`timeline-comment-action btn-link js-comment-edit-button ${pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : ''} rgh-quick-comment-edit-button`}
-			aria-label="Edit comment"
-		>
-			<PencilIcon/>
-		</button>
-	);
+	const buttonClasses = [
+		'timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button',
+		pageDetect.isIssue() ? 'pl-0' : '', // Compensate whitespace node in issue comments header https://github.com/refined-github/refined-github/pull/5580#discussion_r845354681
+		pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : '',
+	].join(' ');
 
-	const dropdown = comment.querySelector('.timeline-comment-actions > details:last-child')!;
-	if (pageDetect.isIssue()) {
-		dropdown.previousSibling!.replaceWith(button); // Replace whitespace node in issue comments header
-	} else {
-		dropdown.before(button);
-	}
+	comment
+		.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+		.before(
+			<button
+				type="button"
+				role="menuitem"
+				className={buttonClasses}
+				aria-label="Edit comment"
+			>
+				<PencilIcon/>
+			</button>,
+		);
 }
 
 function canEditEveryComment(): boolean {


### PR DESCRIPTION
Fixes #5558 
Fixes #5572 

## Test URLs

Add, edit and delete regular & review comments in conversations

- [Issue conversation](https://togithub.com/refined-github/sandbox/issues/3)
- [PR conversation](https://togithub.com/refined-github/sandbox/pull/10)

## Screenshot

![quick-comment-edit](https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png)