### PR TITLE
Fix `hide-repo-badges` feature

### DIFF
--- a/source/features/hide-repo-badges.css
+++ b/source/features/hide-repo-badges.css
@@ -1,3 +1,7 @@
-.rgh-hide-repo-badges :is(#repository-container-header h1, .pinned-item-list-item-content) .Label {
+.rgh-hide-repo-badges :is(
+#repository-container-header h1, /* GHE */
+#repository-container-header h2,
+.pinned-item-list-item-content,
+) .Label {
 	display: none !important;
 }


### PR DESCRIPTION
## Test URLs

Any repo page

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/162594293-6b7f6efa-5d02-42d2-b738-46160381261e.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/162594300-2d66322f-67c9-490f-a1bc-70d65faa01ee.png)