### PR TITLE
Fix `sort-conversations-by-update-time` feature

### DIFF
--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -18,7 +18,7 @@ function init(): void {
 	const issueLinks = select.all('a:is([href*="/issues"], [href*="/pulls"], [href*="/projects"], [href*="/labels/"]):not([href*="sort%3A"], .issues-reset-query)');
 	for (const link of issueLinks) {
 		if (link.host !== location.host || link.closest('.pagination, .table-list-header-toggle')) {
-			return;
+			continue;
 		}
 
 		// Pick only links to lists, not single issues


### PR DESCRIPTION
Fixes #5584 

## Test URLs

https://github.com/refined-github/refined-github/pulls?q=is%3Apr+sort%3Aupdated-desc+assignee%3Afregante+is%3Aclosed

## Screenshot

![image](https://user-images.githubusercontent.com/46634000/162713514-b896f55e-86b9-4e26-852c-ca3543dd6d71.png)