### PR TITLE
Fix left padding of `quick-comment-edit` button

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -14,19 +14,13 @@ function addQuickEditButton(commentForm: Element): void {
 		return;
 	}
 
-	const buttonClasses = [
-		'timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button',
-		pageDetect.isIssue() ? 'pl-0' : '', // Compensate whitespace node in issue comments header https://github.com/refined-github/refined-github/pull/5580#discussion_r845354681
-		pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : '',
-	].join(' ');
-
 	commentBody
 		.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
 		.before(
 			<button
 				type="button"
 				role="menuitem"
-				className={buttonClasses}
+				className={'timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button' + (pageDetect.isDiscussion() ? ' js-discussions-comment-edit-button' : '')}
 				aria-label="Edit comment"
 			>
 				<PencilIcon/>


### PR DESCRIPTION
## Test URLs

- [Issue conversation](https://togithub.com/refined-github/sandbox/issues/3)
- [PR conversation](https://github.com/refined-github/sandbox/pull/4)

## Screenshot

**Before**

![image](https://user-images.githubusercontent.com/46634000/163139253-195c53f9-c731-4f7e-b339-4c12e33afa02.png)

**After**

![image](https://user-images.githubusercontent.com/46634000/163139058-71065eff-0ff7-40dc-9a15-3cb946efa9cc.png)

Note to self: it's probably better not to overcompensate for small GitHub mishaps like that.