### PR TITLE
Fix branch dropdown position in `clean-conversation-headers`

### DIFF
--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -46,3 +46,8 @@
 .gh-header.issue .rgh-clean-conversation-headers relative-time {
 	display: none;
 }
+
+/* Fixes vertical alignment of base branch dropdown */
+.rgh-clean-conversation-headers .commit-ref-dropdown {
+	margin-top: -2px !important;
+}

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -47,7 +47,7 @@
 	display: none;
 }
 
-/* Fixes vertical alignment of base branch dropdown */
+/* Fixes vertical alignment of base branch dropdown #5598 */
 .rgh-clean-conversation-headers .commit-ref-dropdown {
 	margin-top: -2px !important;
 }

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -39,11 +39,17 @@ async function cleanPrHeader(): Promise<void | false> {
 	}
 
 	const base = select('.commit-ref', byline)!;
-	const baseBranch = base.title.split(':')[1];
+	const baseBranchDropdown = select('.commit-ref-dropdown', byline);
 
 	// Shows on PRs: main [←] feature
-	base.nextElementSibling!.replaceChildren(<ArrowLeftIcon className="v-align-middle mx-1"/>);
+	const arrowIcon = <ArrowLeftIcon className="v-align-middle mx-1"/>;
+	if (baseBranchDropdown) {
+		baseBranchDropdown.after(<span>{arrowIcon}</span>); // #5598
+	} else {
+		base.nextElementSibling!.replaceChildren();
+	}
 
+	const baseBranch = base.title.split(':')[1];
 	const wasDefaultBranch = pageDetect.isClosedPR() && baseBranch === 'master';
 	const isDefaultBranch = baseBranch === await getDefaultBranch();
 	if (!isDefaultBranch && !wasDefaultBranch) {


### PR DESCRIPTION
Fixes the placement of the arrow icon, relative to the base branch dropdown that appears when editing the title of an open PR.

## Test URLs

- [Open PR you can edit](https://github.com/refined-github/sandbox/pull/4)
- [Open PR you can't edit](https://togithub.com/microsoft/TypeScript/pull/39930)

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/163671780-839e3600-1996-47b5-ac8d-5b5c1b3dfa07.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/163671776-7992f567-cbb4-43cf-adfa-4673b4150dd5.png)