### PR TITLE
Restore `quick-comment-edit` on Discussions

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -15,7 +15,7 @@ function addQuickEditButton(commentForm: Element): void {
 	}
 
 	commentBody
-		.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+		.querySelector('.timeline-comment-actions details.position-relative')! // The dropdown
 		.before(
 			<button
 				type="button"


### PR DESCRIPTION
## Test URLs

- A discussion where you posted some comments
- [Issue conversation](https://github.com/refined-github/sandbox/issues/3)
- [PR conversation](https://github.com/refined-github/sandbox/pull/10)

## Screenshot

https://user-images.githubusercontent.com/46634000/163672370-8f9bab81-003a-40d6-b062-fcff911f921a.mp4

Note: the weird layout of the editor toolbar is a GitHub bug