### PR TITLE
Fix and extend `safer-destructive-actions` on Discussions

### DIFF
--- a/source/features/safer-destructive-actions.css
+++ b/source/features/safer-destructive-actions.css
@@ -1,18 +1,18 @@
 /* Move "close issue" and "cancel" buttons on authoring comments to the left */
 
 /* ...in issue comment form */
-#partial-new-comment-form-actions > .d-flex {
+#issuecomment-new #partial-new-comment-form-actions > .d-flex {
 	justify-content: space-between !important;
 }
 
 /* ...in comment edit form */
 div.previewable-edit .previewable-comment-form .form-actions {
 	margin-left: 10px;
-	float: none;
+	float: none !important;
 }
 
 .previewable-edit .previewable-comment-form .form-actions .btn.js-comment-cancel-button {
-	float: left;
+	float: left !important;
 }
 
 /* ...in inline comment form */


### PR DESCRIPTION
## Test URLs

https://togithub.com/github/feedback/discussions/13399

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/163672834-5f3d4861-6dcf-4f2d-953e-42277431b93a.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/163672832-8e16dc24-2b9c-4abf-987e-107a3a5d0909.png)