### PR TITLE
Disable `wait-for-checks` when PR requires admin privileges

### DIFF
--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -142,6 +142,11 @@ function watchForNewCommits(): void {
 }
 
 function onPrMergePanelHandler(): void {
+	// Disable the feature if the PR requires administrator privileges https://github.com/refined-github/refined-github/issues/1771#issuecomment-1092415019
+	if (select.exists('input.js-admin-merge-override[type="checkbox"]')) {
+		return;
+	}
+
 	showCheckboxIfNecessary();
 	watchForNewCommits();
 }


### PR DESCRIPTION
Fixes #1771 

## Test URLs

A PR requiring admin privileges on a repo where you're an admin

## Screenshot

![2022-04-17_15-54](https://user-images.githubusercontent.com/46634000/163717580-694d8256-aa18-48e6-b27f-d2c4a7933990.png)