### PR TITLE
Remove `avoid-accidental-submissions` message on the second submission

### DIFF
--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -18,11 +18,14 @@ function onKeyDown(event: delegate.Event<KeyboardEvent, HTMLInputElement>): void
 		|| event.ctrlKey
 		|| event.metaKey
 		|| event.isComposing // #4323
-		|| select.exists([
-			'.suggester', // GitHub’s autocomplete dropdown
-			'.rgh-avoid-accidental-submissions',
-		], form)
+		|| select.exists('.suggester', form)
 	) {
+		return;
+	}
+
+	const previousSubmission = select('.rgh-avoid-accidental-submissions', form);
+	if (previousSubmission) {
+		previousSubmission.remove();
 		return;
 	}
 

--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -18,14 +18,11 @@ function onKeyDown(event: delegate.Event<KeyboardEvent, HTMLInputElement>): void
 		|| event.ctrlKey
 		|| event.metaKey
 		|| event.isComposing // #4323
-		|| select.exists('.suggester', form)
+		|| select.exists([
+			'.suggester', // GitHub’s autocomplete dropdown
+			'.rgh-avoid-accidental-submissions',
+		], form)
 	) {
-		return;
-	}
-
-	const previousSubmission = select('.rgh-avoid-accidental-submissions', form);
-	if (previousSubmission) {
-		previousSubmission.remove();
 		return;
 	}
 

--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -46,6 +46,11 @@ function onKeyDown(event: delegate.Event<KeyboardEvent, HTMLInputElement>): void
 	event.preventDefault();
 }
 
+function onSubmission(): void {
+	// Hide message when the submission goes through
+	select('.rgh-avoid-accidental-submissions', form)?.remove();
+}
+
 const inputElements = [
 	'form.new_issue input#issue_title',
 	'input#pull_request_title',
@@ -54,7 +59,10 @@ const inputElements = [
 ];
 
 function init(): Deinit {
-	return delegate(document, inputElements.join(','), 'keydown', onKeyDown);
+	return [
+		delegate(document, inputElements.join(','), 'keydown', onKeyDown),
+		delegate(document, ['TODO'].join(','), 'submit', onSubmission),
+	];
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
The message stays visible even while the submission is going through. This will hide the message on the second `enter`

## Test URLs

wip

## Screenshot

