### PR TITLE
Fix spacing of icons in repo header buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,18 @@
 			"selector-class-pattern": null,
 			"selector-id-pattern": null,
 			"selector-max-universal": null
-		}
+		},
+		"overrides": [
+			{
+				"files": [
+					"source/refined-github.css",
+					"source/features/github-bugs.css"
+				],
+				"rules": {
+					"no-descending-specificity": null
+				}
+			}
+		]
 	},
 	"ava": {
 		"timeout": "30s",

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -72,3 +72,8 @@
 #partial-discussion-sidebar .js-collab-form .status-indicator .octicon {
 	vertical-align: baseline !important;
 }
+
+/* Fix spacing of repo header button icons */
+.pagehead-actions :is(.btn, summary) .octicon {
+	margin-right: 4px !important;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -73,7 +73,7 @@
 	vertical-align: baseline !important;
 }
 
-/* Fix spacing of repo header button icons */
+/* Fix spacing of repo header button icons #5620 */
 .pagehead-actions :is(.btn, summary) .octicon {
 	margin-right: 4px !important;
 }


### PR DESCRIPTION
## Test URLs

Any repo page.

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/166957571-61c1013b-5c53-4c85-969d-9134f077d951.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/166957597-df47f372-1fac-4e5a-8ca1-0b6a123b896a.png)