### PR TITLE
Improve wrapping of repo header buttons on smaller screens

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -80,13 +80,9 @@
 
 /* Improve wrapping of repo header buttons on smaller screens #5398 */
 @media (min-width: 768px) {
-	#repository-container-header > :first-child > :first-child {
-		flex-shrink: 0 !important;
-	}
-
 	.pagehead-actions {
 		display: flex !important;
-		flex-shrink: 1 !important;
+		flex-shrink: 3 !important;
 		flex-wrap: wrap !important;
 		justify-content: flex-end;
 		gap: 8px;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -80,11 +80,12 @@
 
 /* Improve wrapping of repo header buttons on smaller screens #5398 */
 @media (min-width: 768px) {
-	:root .pagehead-actions { /* https://github.com/refined-github/refined-github/pull/5622#discussion_r867296418 */
+	:root:root .pagehead-actions {
 		display: flex !important;
-		flex-shrink: 3 !important;
+		flex: 1 1 40% !important;
 		flex-wrap: wrap !important;
 		justify-content: flex-end;
+		margin-left: 0 !important;
 		gap: 8px;
 	}
 

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -80,7 +80,7 @@
 
 /* Improve wrapping of repo header buttons on smaller screens #5398 */
 @media (min-width: 768px) {
-	.pagehead-actions {
+	:root .pagehead-actions { /* https://github.com/refined-github/refined-github/pull/5622#discussion_r867296418 */
 		display: flex !important;
 		flex-shrink: 3 !important;
 		flex-wrap: wrap !important;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -77,3 +77,22 @@
 .pagehead-actions :is(.btn, summary) .octicon {
 	margin-right: 4px !important;
 }
+
+/* Improve wrapping of repo header buttons on smaller screens #5398 */
+@media (min-width: 768px) {
+	#repository-container-header > :first-child > :first-child {
+		flex-shrink: 0 !important;
+	}
+
+	.pagehead-actions {
+		display: flex !important;
+		flex-shrink: 1 !important;
+		flex-wrap: wrap !important;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+
+	.pagehead-actions li {
+		margin-right: 0 !important;
+	}
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -179,32 +179,20 @@ pr-branches
 }
 
 /* Improve wrapping of repo header buttons on smaller screens #5398 */
-.pagehead-actions {
-	display: flex !important;
-	flex-wrap: wrap !important;
-	gap: 8px;
-}
-
-.pagehead-actions li {
-	margin-right: 0 !important;
-}
-
-@media (max-width: 768px) {
-	/* Put the buttons under the repo title */
-	#repository-container-header > :first-child {
-		flex-direction: column;
-		gap: 8px;
-	}
-}
-
 @media (min-width: 768px) {
-	/* Force the buttons container to wrap instead of the title */
 	#repository-container-header > :first-child > :first-child {
 		flex-shrink: 0 !important;
 	}
 
 	.pagehead-actions {
+		display: flex !important;
 		flex-shrink: 1 !important;
+		flex-wrap: wrap !important;
 		justify-content: flex-end;
+		gap: 8px;
+	}
+
+	.pagehead-actions li {
+		margin-right: 0 !important;
 	}
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -177,3 +177,34 @@ pr-branches
 	min-height: 4em;
 	height: 4em;
 }
+
+/* Improve wrapping of repo header buttons on smaller screens #5398 */
+.pagehead-actions {
+	display: flex !important;
+	flex-wrap: wrap !important;
+	gap: 8px;
+}
+
+.pagehead-actions li {
+	margin-right: 0 !important;
+}
+
+@media (max-width: 768px) {
+	/* Put the buttons under the repo title */
+	#repository-container-header > :first-child {
+		flex-direction: column;
+		gap: 8px;
+	}
+}
+
+@media (min-width: 768px) {
+	/* Force the buttons container to wrap instead of the title */
+	#repository-container-header > :first-child > :first-child {
+		flex-shrink: 0 !important;
+	}
+
+	.pagehead-actions {
+		flex-shrink: 1 !important;
+		justify-content: flex-end;
+	}
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -177,22 +177,3 @@ pr-branches
 	min-height: 4em;
 	height: 4em;
 }
-
-/* Improve wrapping of repo header buttons on smaller screens #5398 */
-@media (min-width: 768px) {
-	#repository-container-header > :first-child > :first-child {
-		flex-shrink: 0 !important;
-	}
-
-	.pagehead-actions {
-		display: flex !important;
-		flex-shrink: 1 !important;
-		flex-wrap: wrap !important;
-		justify-content: flex-end;
-		gap: 8px;
-	}
-
-	.pagehead-actions li {
-		margin-right: 0 !important;
-	}
-}


### PR DESCRIPTION
Fixes #5398 

## Test URLs

[refined-github/refined-github](https://github.com/refined-github/refined-github)
[fregante/webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts)

## Screenshot

**Before** :-1:

![before](https://user-images.githubusercontent.com/46634000/167182088-82085f2f-b732-4a2e-bac2-70c3c61a95d0.png)

**After** :+1:

![after](https://user-images.githubusercontent.com/46634000/167182078-6c5d332d-d76a-425b-9a3e-b2f506ac936b.png)