### PR TITLE
Fix GitHub bug: Avoid excessive repo title wrap

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -92,6 +92,6 @@
 	}
 
 	.pagehead-actions > li > * {
-		margin: 0 8px 8px 0;
+		margin: 8px 8px 0 0;
 	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -79,17 +79,19 @@
 }
 
 /* Avoid excessive repo title wrap by deprioritizing the repo header actions #5398 */
-:root .pagehead-actions {
-	flex-shrink: 3 !important;
-	display: inline-flex !important;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-}
+@media (min-width: 768px) { /* Match .d-md-inline-flex */
+	:root .pagehead-actions {
+		flex-shrink: 3 !important;
+		display: inline-flex !important;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+	}
 
-:root .pagehead-actions > li {
-	margin: 0;
-}
+	:root .pagehead-actions > li {
+		margin: 0;
+	}
 
-.pagehead-actions > li > * {
-	margin: 0 8px 8px 0;
+	.pagehead-actions > li > * {
+		margin: 0 8px 8px 0;
+	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -77,3 +77,16 @@
 .pagehead-actions :is(.btn, summary) .octicon {
 	margin-right: 4px !important;
 }
+
+/* Avoid excessive repo title wrap by deprioritizing the repo header actions #5398 */
+:root .pagehead-actions {
+	flex-shrink: 3 !important;
+}
+
+:root .pagehead-actions > li {
+	margin: 0;
+}
+
+.pagehead-actions > li > * {
+	margin: 0 8px 8px 0;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -81,6 +81,10 @@
 /* Avoid excessive repo title wrap by deprioritizing the repo header actions #5398 */
 :root .pagehead-actions {
 	flex-shrink: 3 !important;
+
+	display: inline-flex !important;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 :root .pagehead-actions > li {

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -81,7 +81,6 @@
 /* Avoid excessive repo title wrap by deprioritizing the repo header actions #5398 */
 :root .pagehead-actions {
 	flex-shrink: 3 !important;
-
 	display: inline-flex !important;
 	flex-wrap: wrap;
 	justify-content: flex-end;


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5398
Replaces #5622


## Test URLs

https://github.com/refined-github/refined-github
https://github.com/fregante/webext-dynamic-content-scripts

## Before
<img width="752" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/167237279-005084ea-50f2-4ca3-9b31-0ca4a1f90446.png">

## After

<img width="758" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/167237274-5a74987a-2b47-41f0-8658-0ccb3fa0c8ff.png">



---

Unfortunately the parent’s flexbox is still pretty bad at sharing the space, but it's unlikely that we can do much about it: Once flexbox has to wrap something, it will drop space **from both**: 1/4 from the title and 3/4 from the actions. This can cause both sides to wrap internally even even the sum of the available space is available from at least one more piece from either side:

<img width="764" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/167237175-f02517d8-6a50-4cab-b102-5aeae60e3115.png">
