### PR TITLE
Restore `expand-all-hidden-comments` feature

### DIFF
--- a/source/features/expand-all-hidden-comments.tsx
+++ b/source/features/expand-all-hidden-comments.tsx
@@ -14,7 +14,7 @@ async function handleAltClick({altKey, delegateTarget}: delegate.Event<MouseEven
 
 	let paginationButton: HTMLButtonElement | undefined = delegateTarget;
 	let wrapper: Element = paginationButton.form!.parentElement!;
-	const isExpandingMainThread = !wrapper.classList.contains('TimelineItem-body');
+	const isExpandingMainThread = wrapper.id === 'js-progressive-timeline-item-container';
 
 	while (paginationButton) {
 		// eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Fixes #4921 

## Test URLs

1. Go to https://togithub.com/lensapp/lens/pull/3910 and scroll down to the "131 hidden items / Load more" button.
2. Alt-click it. Every comment in the main thread should load.
3. Scroll down until you see a review thread with a "44 hidden comments" button.
4. Alt-click it. Every review comment in the thread should load.

## Screenshot

https://user-images.githubusercontent.com/46634000/168293483-7931ccdb-f632-4e9e-8882-f8b08538dc48.mp4