### PR TITLE
Add `type/bug` and `kind/bug` to list of supported labels in `bugs-tab`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|type\/bug|kind:bug|kind\/bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(bug|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type:bug|kind:bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(bug|confirmed-bug|type:bug|type\/bug|kind:bug|kind\/bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

This PR adds the `type/bug` and `kind/bug` labels to the list of supported labels for the `bugs-tab` feature. The `kind/bug` label format is currently used by Prisma in all of their repositories.

## Test URLs

https://github.com/prisma/prisma

## Screenshot

![image](https://user-images.githubusercontent.com/23125036/168393038-c2d71ca8-7f14-4ec0-b3fb-a65044dfaa1f.png)

