### PR TITLE
Drop `hide-tips` feature

### DIFF
--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -1,7 +1,0 @@
-/* Remove random protip at the bottom of some pages */
-.protip, /* Conversations */
-.js-notifications-list-protip, /* "Save" and "Done" notification lists */
-.paginate-container + .text-center:last-child, /* Conversation lists */
-.js-notifications-container :is(.octicon-light-bulb, .octicon-light-bulb + div) { /* Notifications inbox */
-	display: none !important;
-}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -8,7 +8,6 @@ import './features/safer-destructive-actions.css';
 import './features/clean-mergeability-box.css';
 import './features/clean-footer.css';
 import './features/pr-approvals-count.css';
-import './features/hide-tips.css';
 import './features/clean-conversations.css';
 import './features/sticky-conversation-list-toolbar.css';
 import './features/always-show-branch-delete-buttons.css';


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/4574

I don’t think it's worth hiding these tips. GitHub’s interface is way more complex than when this feature was added, so hiding "all tips" to save space is a uphill battle that does not help new (and old) GitHub users.