### PR TITLE
Avoid some console errors when attempting to edit files on non-own repos

### DIFF
--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -61,6 +61,9 @@ void features.add(import.meta.url, {
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation,
 	],
+	exclude: [
+		pageDetect.isBlank,
+	],
 	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -155,7 +155,12 @@ async function initEditing(): Promise<void> {
 
 	const [prNumber] = prs; // First one or only one
 
-	(await elementReady('.file'))!.after(
+	const file = await elementReady('.file');
+	if (!file && pageDetect.isBlank()) {
+		return false;
+	}
+
+	file!.after(
 		<div className="form-warning p-3 mb-3 mx-lg-3">
 			{
 				prs.length === 1

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -134,7 +134,7 @@ async function init(): Promise<void> {
 	await addAfterBranchSelector(button);
 }
 
-async function initEditing(): Promise<void> {
+async function initEditing(): Promise<false | void> {
 	const [path, prsByFile] = await Promise.all([
 		getCurrentPath(),
 		getPrsByFile(),

--- a/source/features/submission-via-ctrl-enter-everywhere.tsx
+++ b/source/features/submission-via-ctrl-enter-everywhere.tsx
@@ -18,5 +18,8 @@ void features.add(import.meta.url, {
 		pageDetect.isNewRelease,
 		pageDetect.isEditingRelease,
 	],
+	exclude: [
+		pageDetect.isBlank,
+	],
 	init: addQuickSubmit,
 });


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/4194

The ideal, global solution continues to be https://github.com/refined-github/refined-github/issues/4008#issuecomment-822942520

## Test URLs

- https://github.com/MatthewL246/hello-world/edit/main/CONTRIBUTING.md

## Screenshot


This is a blank slate and this excludes it.

<img width="703" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/169014344-141a60e3-8197-4400-97d0-c4f4850a6615.png">

