### PR TITLE
Fix `suggest-commit-title-limit` 1-character-short width

### DIFF
--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -3,7 +3,11 @@
 #commit-summary-input {
 	box-sizing: content-box; /* Exclude padding/border from `width`; No need to mess with `calc` */
 	width: 72ch;
-	max-width: intrinsic; /* Like 100%, except it works with content-box */
+
+	/* Like 100%, except it works with content-box and it feels like -webkit-1999 */
+	max-width: -webkit-available;
+	max-width: -moz-available;
+	max-width: intrinsic;
 }
 
 :is(#commit-summary-input, #merge_title_field).rgh-title-over-limit {

--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -5,7 +5,7 @@
 	width: 72ch;
 
 	/* Like 100%, except it works with content-box and it feels like -webkit-1999 */
-	max-width: -webkit-available;
+	max-width: -webkit-fill-available;
 	max-width: -moz-available;
 	max-width: intrinsic;
 }

--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -1,3 +1,11 @@
+/* Limit width of commit title to 72 characters */
+#merge_title_field,
+#commit-summary-input {
+	box-sizing: content-box; /* Exclude padding/border from `width`; No need to mess with `calc` */
+	width: 72ch;
+	max-width: intrinsic; /* Like 100%, except it works with content-box */
+}
+
 :is(#commit-summary-input, #merge_title_field).rgh-title-over-limit {
 	border-color: var(--rgh-red);
 	background-color: rgb(203 36 49 / 3%);

--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -5,9 +5,11 @@
 	width: 72ch;
 
 	/* Like 100%, except it works with content-box and it feels like -webkit-1999 */
+	/* stylelint-disable */
 	max-width: -webkit-fill-available;
 	max-width: -moz-available;
 	max-width: intrinsic;
+	/* stylelint-enable */
 }
 
 :is(#commit-summary-input, #merge_title_field).rgh-title-over-limit {
@@ -18,3 +20,13 @@
 :is(#commit-summary-input, #merge_title_field).rgh-title-over-limit:focus {
 	box-shadow: inset 0 1px 2px rgb(35 27 27 / 7.5%), 0 0 0 0.2em rgb(203 36 49 / 30%);
 }
+
+/*
+
+## Test URLs
+
+- File edit: https://github.com/refined-github/refined-github/edit/fix-commit-title-limit/source/refined-github.css
+- Workflow edit: https://github.com/refined-github/refined-github/edit/fix-commit-title-limit/.github/workflows/features.yml
+- Any mergeable PR
+
+*/

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -54,3 +54,5 @@ void features.add(import.meta.url, {
 - https://github.com/refined-github/sandbox/pull/8
 - Any editable file
 - https://github.com/refined-github/refined-github/edit/main/readme.md
+
+*/

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -39,3 +39,18 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init: validateInput,
 });
+
+/*
+
+# Test data
+
+## Commit title
+
+123456789 123456789 123456789 123456789 123456789 123456789 123456789 123
+
+## URLs
+
+- Any mergeable PR
+- https://github.com/refined-github/sandbox/pull/8
+- Any editable file
+- https://github.com/refined-github/refined-github/edit/main/readme.md

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -6,7 +6,6 @@
 }
 
 /* Make tab indented code more readable on GitHub and Gist */
-:root, /* GHE, drop in February 2022 */
 .comment-body [data-tab-size='8'] { /* User setting is ignored in comments #4833 */
 	--tab-size: 4;
 }
@@ -147,14 +146,6 @@ pr-branches
 /* Remove the underline on PR filename copy button hover #4871 */
 .file-header .file-info clipboard-copy {
 	display: inline-block;
-}
-
-/* Limit width of commit title to 72 characters */
-#merge_title_field,
-#commit-summary-input {
-	/* 12px for the padding and 1px for the border https://user-images.githubusercontent.com/46634000/136789268-442caa39-33bc-4af3-8fb2-9cf6db722127.png */
-	width: calc(72ch + 26px);
-	max-width: 100%;
 }
 
 /* Ensure all buttons in the repo file navigation header are aligned in the center rather than to the top */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/3998

Untested, except via dev tools in Safari. I should also test it when editing files


## Test URLs

- This PR
- https://github.com/refined-github/refined-github/edit/fix-commit-title-limit/source/refined-github.css

## Screenshot

![gif](https://user-images.githubusercontent.com/1402241/169017348-58631357-223d-46c5-b5f5-36ad9a469603.gif)


