### PR TITLE
Don't `shorten-links` in code blocks in tables in comments

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -19,3 +19,11 @@ void features.add(import.meta.url, {
 	],
 	init: onetime(init),
 });
+
+/*
+
+## Test URLs
+
+https://github.com/refined-github/sandbox/pull/14
+
+*/

--- a/source/github-helpers/dom-formatters.ts
+++ b/source/github-helpers/dom-formatters.ts
@@ -13,6 +13,7 @@ export const codeElementsSelector = [
 	'.blob-code-inner', // Code lines
 	'.highlight > pre', // Highlighted code blocks in comments
 	'.snippet-clipboard-content > pre', // Non-highlighted code blocks in comments
+	'.notranslate', // Non-highlighted code blocks in tables in comments
 ].join(',');
 
 export function shortenLink(link: HTMLAnchorElement): void {


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5630

The interesting part here is that GitHub is specifically parsing **Markdown** tables differently and linkifying URLs within them. Since this does not usually happen with other tables, we've never encountered this bug. 

## Test URLs


- https://github.com/refined-github/sandbox/pull/14

<table>
<tr>
	<th> Native
	<th> Before
	<th> After
<tr>
	<td><img width="320" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/169455067-f38d0d1a-ca25-498f-8c53-2056289b0390.png">
	<td>
<img width="328" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/169455080-e3bc1b13-86f7-4a27-8140-0f19c7e8adb4.png">
	<td><img width="337" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/169454921-3befa8f3-98f6-4a34-ab65-369ff2ac1ef5.png">
</table>
