### PR TITLE
Apply `rgh-linkify-features` to all RGH repos

### DIFF
--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -6,7 +6,7 @@ import {wrap} from '../helpers/dom-utils';
 import features from '.';
 import featureLink from '../helpers/feature-link';
 import {getNewFeatureName} from '../options-storage';
-import {isRefinedGitHubRepo} from '../github-helpers';
+import {isAnyRefinedGitHubRepo} from '../github-helpers';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 function linkifyFeature(possibleFeature: HTMLElement): void {
@@ -57,7 +57,7 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	asLongAs: [
-		isRefinedGitHubRepo,
+		isAnyRefinedGitHubRepo,
 	],
 	include: [
 		pageDetect.hasComments,
@@ -70,7 +70,7 @@ void features.add(import.meta.url, {
 	init,
 }, {
 	asLongAs: [
-		isRefinedGitHubRepo,
+		isAnyRefinedGitHubRepo,
 	],
 	include: [
 		pageDetect.isPR,

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -148,6 +148,10 @@ export function isRefinedGitHubRepo(): boolean {
 	return location.pathname.startsWith('/refined-github/refined-github');
 }
 
+export function isAnyRefinedGitHubRepo(): boolean {
+	return /^\/refined-github\/.+/.test(location.pathname);
+}
+
 export function shouldFeatureRun({
 	/** Every condition must be true */
 	asLongAs = [() => true],


### PR DESCRIPTION
## Test URLs

It should linkify the feature in the title on this page:
- https://github.com/refined-github/sandbox/pull/14

## Screenshot

<img width="434" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/169455650-212987c4-955a-40a1-ba20-2c2c8706dcc0.png">

