### PR TITLE
Ensure `restore-file` appears after navigating to the Files tab

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -43,6 +43,7 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isGist,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	include: [

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -43,7 +43,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isGist,
 	],
-	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	include: [

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -139,5 +139,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5606

## Test URLs


1. Open any PRs in https://github.com/refined-github/refined-github/pulls
2. Go to Files tab
3. Look for "Restore file"

## Video with before and after

https://user-images.githubusercontent.com/1402241/169457069-b05f0a28-3350-4a19-9f0d-5903808effd9.mov


