### PR TITLE
Don't link to first comment in `highest-rated-comment`

### DIFF
--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -62,9 +62,11 @@ function highlightBestComment(bestComment: Element): void {
 }
 
 function linkBestComment(bestComment: HTMLElement): void {
-	const firstTimelineItem = select('#js-timeline-progressive-loader')!.nextElementSibling!;
+	// Find position of comment in thread
+	const position = select.all(commentSelector).indexOf(bestComment);
+
 	// Only link to it if it doesn't already appear at the top of the conversation
-	if (firstTimelineItem === bestComment) {
+	if (position < 3) {
 		return;
 	}
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -14,13 +14,13 @@ import {singleParagraphCommentSelector} from './hide-low-quality-comments';
 const commentSelector = '.js-timeline-item';
 
 const positiveReactionsSelector = `
-	${commentSelector} [aria-label*="reacted with thumbs up"],
-	${commentSelector} [aria-label*="reacted with hooray"],
-	${commentSelector} [aria-label*="reacted with heart"]
+	${commentSelector} [aria-label="react with thumbs up"],
+	${commentSelector} [aria-label="react with hooray"],
+	${commentSelector} [aria-label="react with heart"]
 `;
 
 const negativeReactionsSelector = `
-	${commentSelector} [aria-label*="reacted with thumbs down"]
+	${commentSelector} [aria-label="react with thumbs down"]
 `;
 
 const getPositiveReactions = mem((comment: HTMLElement): number | void => {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5577
- Restores unwanted change from https://github.com/refined-github/refined-github/pull/5357#discussion_r796514659

The feature seems to be broken? Can't test at all

## Test URLs

- https://togithub.com/vercel/next.js/issues/31054



<table><caption>Both screenshots include a fix that restores the feature altogether</caption>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="519" alt="Screen Shot 16" src="https://user-images.githubusercontent.com/1402241/169487402-dbf0b555-c46d-493a-b232-280472dc5b32.png">
	<td><img width="508" alt="Screen Shot 15" src="https://user-images.githubusercontent.com/1402241/169487412-c36abe89-569f-4cce-aec0-4400da75efcb.png">
</table>



