### PR TITLE
Ensure that Refined GitHub preserves existing shortcuts

### DIFF
--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -2,13 +2,11 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {addHotkey} from '../github-helpers';
 import addQuickSubmit from './submission-via-ctrl-enter-everywhere';
 
 function init(): void {
-	const createReleaseButton = select('a[href$="/releases/new"]:not([data-hotkey])');
-	if (createReleaseButton) {
-		createReleaseButton.dataset.hotkey = 'c';
-	}
+	addHotkey(select('a[href$="/releases/new"]:not([data-hotkey])'), 'c');
 }
 
 void features.add(import.meta.url, {

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -6,7 +6,7 @@ import {addHotkey} from '../github-helpers';
 import addQuickSubmit from './submission-via-ctrl-enter-everywhere';
 
 function init(): void {
-	addHotkey(select('a[href$="/releases/new"]:not([data-hotkey])'), 'c');
+	addHotkey(select('a[href$="/releases/new"]'), 'c');
 }
 
 void features.add(import.meta.url, {

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -2,6 +2,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {addHotkey} from '../github-helpers';
 
 const nextPageButtonSelectors = [
 	'a.next_page', // Issue/PR list, Search
@@ -20,15 +21,8 @@ const previousPageButtonSelectors = [
 ];
 
 function init(): void {
-	const createNextPageButton = select(nextPageButtonSelectors);
-	if (createNextPageButton) {
-		createNextPageButton.dataset.hotkey = 'ArrowRight';
-	}
-
-	const createPreviousPageButton = select(previousPageButtonSelectors);
-	if (createPreviousPageButton) {
-		createPreviousPageButton.dataset.hotkey = 'ArrowLeft';
-	}
+	addHotkey(select(nextPageButtonSelectors), 'ArrowRight');
+	addHotkey(select(previousPageButtonSelectors), 'ArrowLeft');
 }
 
 void features.add(import.meta.url, {

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -2,22 +2,21 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {addHotkey} from '../github-helpers';
 
 function init(): void {
-	const tabs = select.all('#partial-discussion-header + .tabnav .tabnav-tab');
+	const tabs = select.all('#partial-discussion-header + .tabnav a.tabnav-tab');
 	const lastTab = tabs.length - 1;
 	const selectedIndex = tabs.findIndex(tab => tab.classList.contains('selected'));
 
 	for (const [index, tab] of tabs.entries()) {
-		const keys = [`g ${index + 1}`];
+		addHotkey(tab, `g ${index + 1}`);
 
 		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {
-			keys.push('g ArrowLeft');
+			addHotkey(tab, 'g ArrowLeft');
 		} else if (index === selectedIndex + 1 || (selectedIndex === lastTab && index === 0)) {
-			keys.push('g ArrowRight');
+			addHotkey(tab, 'g ArrowRight');
 		}
-
-		tab.dataset.hotkey = keys.join(',');
 	}
 }
 

--- a/source/github-helpers/index.test.ts
+++ b/source/github-helpers/index.test.ts
@@ -6,6 +6,7 @@ import {
 	compareNames,
 	getLatestVersionTag,
 	shouldFeatureRun,
+	addHotkey,
 } from '.';
 
 test('getConversationNumber', t => {
@@ -166,3 +167,17 @@ test('shouldFeatureRun', t => {
 		exclude: yesNo,
 	}), 'If any `exclude` is true, then it should not run, regardless of `asLongAs` and `include`');
 });
+
+const testAddHotkey = test.macro((t, existing: string | undefined, added: string, final: string) => {
+	const link = document.createElement('a');
+	if (existing) {
+		link.setAttribute('data-hotkey', existing);
+	}
+
+	addHotkey(link, added);
+	t.is(link.dataset.hotkey, final);
+});
+
+test('addHotkey if one is specified', testAddHotkey, 'b', 'shift+a', 'b,shift+a');
+test('addHotkey if the same is already specified', testAddHotkey, 'shift+a', 'shift+a', 'shift+a');
+test('addHotkey when none are specified', testAddHotkey, undefined, 'shift+a', 'shift+a');

--- a/source/github-helpers/index.test.ts
+++ b/source/github-helpers/index.test.ts
@@ -178,6 +178,6 @@ const testAddHotkey = test.macro((t, existing: string | undefined, added: string
 	t.is(link.dataset.hotkey, final);
 });
 
-test('addHotkey if one is specified', testAddHotkey, 'b', 'shift+a', 'b,shift+a');
-test('addHotkey if the same is already specified', testAddHotkey, 'shift+a', 'shift+a', 'shift+a');
-test('addHotkey when none are specified', testAddHotkey, undefined, 'shift+a', 'shift+a');
+test('addHotkey if one is specified', testAddHotkey, 'T-REX', 'CHICKEN', 'T-REX,CHICKEN');
+test('addHotkey if the same is already specified', testAddHotkey, 'CHICKEN', 'CHICKEN', 'CHICKEN');
+test('addHotkey when none are specified', testAddHotkey, undefined, 'CHICKEN', 'CHICKEN');

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -164,3 +164,12 @@ export function shouldFeatureRun({
 }): boolean {
 	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c());
 }
+
+/** Safely a hotkey to an element, preserving any existing ones and avoiding duplicates */
+export const addHotkey = (button: HTMLAnchorElement | HTMLButtonElement | undefined, hotkey: string): void => {
+	if (button) {
+		const hotkeys = new Set(button.dataset.hotkey?.split(','));
+		hotkeys.add(hotkey);
+		button.dataset.hotkey = [...hotkeys].join(',');
+	}
+};

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -165,7 +165,7 @@ export function shouldFeatureRun({
 	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c());
 }
 
-/** Safely a hotkey to an element, preserving any existing ones and avoiding duplicates */
+/** Safely add a hotkey to an element, preserving any existing ones and avoiding duplicates */
 export const addHotkey = (button: HTMLAnchorElement | HTMLButtonElement | undefined, hotkey: string): void => {
 	if (button) {
 		const hotkeys = new Set(button.dataset.hotkey?.split(','));


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5555


## Test


1. Go to [`1bb5e36` (#5422)](https://github.com/refined-github/refined-github/pull/5422/commits/1bb5e36ce3734a045c5e4aaeeba6e0d29d381789)
2. Maybe reload the page
3. Press N; it works
4. Press N again; gone


