### PR TITLE
Don't run Refined GitHub on login pages

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -51,7 +51,7 @@ void features.add(import.meta.url, {
 		pageDetect.isConversationList,
 	],
 	exclude: [
-		pageDetect.isBlank, // Prevent error on empty milestone list #5544
+		pageDetect.isBlank, // Prevent error on empty lists #5544
 	],
 	deduplicate: 'has-rgh-inner',
 	init,

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -45,6 +45,9 @@
 				"https://github.com/*",
 				"https://gist.github.com/*"
 			],
+			"exclude_matches": [
+				"https://*/login/*"
+			],
 			"css": [
 				"refined-github.css"
 			],


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5386

@kidonng @cheap-glitch can you think of any more static URLs that we can exclude this way?

## Test URLs

```
// https://github.com/login <-- nothing runs
// https://github.com/logins <-- works as usual
```

## Screenshot

<img width="397" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/169676386-ec6d5f20-0bb8-4402-aa58-e84a7c818d38.png">


<img width="394" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/169676380-7120b9bc-954c-40f8-ba7d-bbe8ab2f2737.png">


