### PR TITLE
Add link to the upstream repo after `quick-repo-deletion`

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -4,12 +4,13 @@ import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import {TrashIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
+import {getForkedRepo, getRepo} from '../github-helpers';
 import pluralize from '../helpers/pluralize';
 import addNotice from '../github-widgets/notice-bar';
 import {getCacheKey} from './forked-to';
@@ -96,12 +97,13 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 			method: 'DELETE',
 			json: false,
 		});
+		const forkSource = '/' + getForkedRepo()!;
 		const restoreURL = pageDetect.isOrganizationRepo()
 			? `/organizations/${owner}/settings/deleted_repositories`
 			: '/settings/deleted_repositories';
 		const otherForksURL = `/${owner}?tab=repositories&type=fork`;
 		addNotice(
-			<span>Repository {nameWithOwner} deleted. You might be able to <a href={restoreURL}>restore it</a> or see <a href={otherForksURL}>your other forks.</a></span>,
+			<><TrashIcon/> <span>Repository <strong>{nameWithOwner}</strong> deleted. <a href={restoreURL}>Restore it</a>, <a href={forkSource}>visit the source repo</a>, or see <a href={otherForksURL}>your other forks.</a></span></>,
 			{action: false},
 		);
 		select('.application-main')!.remove();


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5369


## Test URLs

Gotta delete one of your own forks

## Screenshot
![Screen Shot 19](https://user-images.githubusercontent.com/1402241/169678812-4ebe2cff-b7a4-422d-a9f8-69774867f951.png)

