### PR TITLE
Meta: Add link to TSX file when looking at CSS feature 

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -49,6 +49,11 @@ async function init(): Promise<void | false> {
 					<div dangerouslySetInnerHTML={{__html: feature.description}} className="text-bold"/>
 					<div className="no-wrap">
 						<a href={conversationsUrl.href} data-pjax="#repo-content-pjax-container">Conversations</a>
+						{
+							location.pathname.endsWith('css')
+								? <> • <a href={location.pathname.replace('.css', '.tsx')} data-pjax="#repo-content-pjax-container">See JavaScript</a></>
+								: undefined
+						}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION


## Test URLs

- Yes: https://github.com/refined-github/refined-github/blob/main/source/features/show-names.css
- No (CSS only): https://github.com/refined-github/refined-github/blob/main/source/features/clean-commit-form.css

## Screenshot





<table>
<tr>
	<td><img width="509" alt="Screen Shot 20" src="https://user-images.githubusercontent.com/1402241/169679051-fb9344a2-5636-4fa4-a7f4-8aeb6593f447.png">
<td>🔗➡️
	<td><img width="512" alt="Screen Shot 21" src="https://user-images.githubusercontent.com/1402241/169679047-d65a2862-290a-43d9-baac-22eb32cc6463.png">

</table>

