### PR TITLE
Make `toggle-files-button` unforgettable

### DIFF
--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -9,7 +9,8 @@
 	display: none !important;
 }
 
-.rgh-files-hidden #files ~ .Details {
+.rgh-files-hidden #files ~ .Details,
+.repository-content:not(.rgh-files-hidden) .rgh-files-hidden-notice {
 	display: none;
 }
 

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -9,8 +9,7 @@
 	display: none !important;
 }
 
-.rgh-files-hidden #files ~ .Details,
-.repository-content:not(.rgh-files-hidden) .rgh-files-hidden-notice {
+.rgh-files-hidden #files ~ .Details {
 	display: none;
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -44,8 +44,12 @@ async function init(): Promise<Deinit[]> {
 	if (await cache.get<boolean>(cacheKey)) {
 		repoContent.classList.add('rgh-files-hidden');
 		select('#files')!.after(
-			<div className="py-1 text-right text-small rgh-files-hidden-notice" style={{paddingRight: '19px'}}>
-				Files hidden <ArrowUpIcon className="v-align-middle"/>
+			// 19px align this icon with the <UnfoldIcon/> above it
+			<div
+				className="py-1 text-right text-small color-fg-muted rgh-files-hidden-notice"
+				style={{paddingRight: '19px'}}
+			>
+				The file list was collapsed via Refined GitHub <ArrowUpIcon className="v-align-middle"/>
 			</div>,
 		);
 	}

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -43,10 +43,10 @@ async function init(): Promise<Deinit[]> {
 
 	if (await cache.get<boolean>(cacheKey)) {
 		repoContent.classList.add('rgh-files-hidden');
-		select('#files')!.after(
+		select('.Box', repoContent)!.after(
 			// 19px align this icon with the <UnfoldIcon/> above it
 			<div
-				className="py-1 text-right text-small color-fg-muted rgh-files-hidden-notice"
+				className="mb-3 mt-n3 py-1 text-right text-small color-fg-subtle rgh-files-hidden-notice"
 				style={{paddingRight: '19px'}}
 			>
 				The file list was collapsed via Refined GitHub <ArrowUpIcon className="v-align-middle"/>

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -33,10 +33,14 @@ function addButton(): void {
 async function toggleHandler(): Promise<void> {
 	const isHidden = select('.repository-content')!.classList.toggle('rgh-files-hidden');
 	await (isHidden ? cache.set(cacheKey, true) : cache.delete(cacheKey));
+
+	// Remove notice after the first click
+	select('.rgh-files-hidden-notice')?.remove();
 }
 
 async function init(): Promise<Deinit[]> {
 	const repoContent = (await elementReady('.repository-content'))!;
+
 	if (await cache.get<boolean>(cacheKey)) {
 		repoContent.classList.add('rgh-files-hidden');
 		select('#files')!.after(
@@ -48,7 +52,7 @@ async function init(): Promise<Deinit[]> {
 
 	return [
 		observeElement(repoContent, addButton),
-		delegate(document, '.rgh-toggle-files', 'click', toggleHandler),
+		delegate(document, '.rgh-toggle-files, .rgh-files-hidden-notice', 'click', toggleHandler),
 	];
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -43,6 +43,8 @@ async function init(): Promise<Deinit[]> {
 
 	if (await cache.get<boolean>(cacheKey)) {
 		repoContent.classList.add('rgh-files-hidden');
+
+		// Add notice so the user knows that the list was collapsed #5524
 		select('.Box', repoContent)!.after(
 			// 19px align this icon with the <UnfoldIcon/> above it
 			<div

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
-import {FoldIcon, UnfoldIcon} from '@primer/octicons-react';
+import {FoldIcon, UnfoldIcon, ArrowUpIcon} from '@primer/octicons-react';
 
 import features from '.';
 import observeElement from '../helpers/simplified-element-observer';
@@ -39,6 +39,11 @@ async function init(): Promise<Deinit[]> {
 	const repoContent = (await elementReady('.repository-content'))!;
 	if (await cache.get<boolean>(cacheKey)) {
 		repoContent.classList.add('rgh-files-hidden');
+		select('#files')!.after(
+			<div className="py-1 text-right text-small rgh-files-hidden-notice" style={{paddingRight: '19px'}}>
+				Files hidden <ArrowUpIcon className="v-align-middle"/>
+			</div>,
+		);
 	}
 
 	return [


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5524
- Fixes https://github.com/refined-github/refined-github/issues/4402

cc @sideshowbarker because this issue was reported in https://github.com/refined-github/refined-github/issues/4402

## Test URLs

1. Go to https://github.com/refined-github/refined-github
2. Hide files
3. Refresh the page

## Screenshot

<img width="184" alt="Screen Shot 23" src="https://user-images.githubusercontent.com/1402241/169680163-ad6bf8dd-c745-4ebd-ab8b-b7ecbdf2104d.png">

## Video

- The notice only appears when the list is hidden automatically so the user doesn't forget about it
- The notice is gone after the first interaction
- The notice is only clickable because the user might click it, but we don't want to actually show a hand because they should prefer clicking the actual button instead

https://user-images.githubusercontent.com/1402241/169680332-6b02c852-be43-44b9-a01a-a7c634aa7e02.mov


