### PR TITLE
Ensure all features appears after navigating to the "Files" tab

### DIFF
--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -66,6 +66,7 @@ void features.add(import.meta.url, {
 		// If you're viewing changes from partial commits, ensure you're on the latest one.
 		() => select.exists('.js-commits-filtered') && !select.exists('[aria-label="You are viewing the latest commit"]'),
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	asLongAs: [

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -42,7 +42,14 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isGist,
+		pageDetect.isPRFiles,
 	],
+	init,
+}, {
+	include: [
+		pageDetect.isPRFiles,
+	],
+	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	include: [


### PR DESCRIPTION
Follow-up of https://togithub.com/refined-github/refined-github/pull/5641

## Test URLs

1. Go to https://togithub.com/refined-github/refined-github/pull/5658
2. Reload the page and click on the "Files" tab
3. The link should be clickable (`linkify-code`) & the URLs in the file dropdown should point to the branch (`enable-file-links-in-compare-view`)