### PR TITLE
Fix misalignment of header buttons on Gist and during page load

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -91,9 +91,8 @@
 		margin: 0;
 	}
 
-	/* The complex selector avoids the jumps during page load caused by the inconsistent DOM structure of each widget */
-	.pagehead-actions .BtnGroup,
-	.pagehead-actions :not(.BtnGroup, .BtnGroup-parent) > .btn {
+	.pagehead-actions > li > * {
 		margin: 8px 8px 0 0 !important;
+		display: block; /* Inline elements don't treat margins the same way, which causes a jump during the page load */
 	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -91,7 +91,9 @@
 		margin: 0;
 	}
 
-	.pagehead-actions > li > * {
+	/* The complex selector avoids the jumps during page load caused by the inconsistent DOM structure of each widget */
+	.pagehead-actions .BtnGroup,
+	.pagehead-actions :not(.BtnGroup, .BtnGroup-parent) > .btn {
 		margin: 8px 8px 0 0 !important;
 	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -92,6 +92,6 @@
 	}
 
 	.pagehead-actions > li > * {
-		margin: 8px 8px 0 0;
+		margin: 8px 8px 0 0 !important;
 	}
 }


### PR DESCRIPTION
Makes the (un)subscribe button appear correctly for gists.

---

1. Does this PR close/fix an existing issue?

Closes #5663 

2. What pages does this PR affect? Include some REAL URLs where you tested the code

Gist pages, ex. https://gist.github.com/ajmeese7/1eb7178a9cc7284e8627316b475e03dd

3. If applicable, add demonstrative screenshots or gifs

Before:

![before fix](https://user-images.githubusercontent.com/17814535/171059746-94297a9a-d2f7-4df2-ad60-044075ac084a.png)

After:

![after fix](https://user-images.githubusercontent.com/17814535/171059815-517997ff-4a78-431e-b2b0-bf93bb3fd50e.png)
