### PR TITLE
Fix subscription button position on Gist

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -92,6 +92,6 @@
 	}
 
 	.pagehead-actions > li > * {
-		margin: 8px 8px 0 0;
+		margin: 8px 8px 0 0 !important;
 	}
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Introduced in #5623

RGH's selector is less specific than GitHub's `.gisthead .pagehead-actions .thread-subscription-status`.

## Test URLs

https://gist.github.com/kidonng/1f70b2e3de50b519483f6c79dd3d82e2

## Screenshot

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="432" alt="image" src="https://user-images.githubusercontent.com/44045911/171444002-d44fcbee-d484-4a45-bd70-c42864e0d802.png">
	<td><img width="437" alt="image" src="https://user-images.githubusercontent.com/44045911/171444058-b9c4ab62-176b-43e7-b653-e926c1e5bef9.png">
</table>

---

P.S. apologize for suddenly disappearing for the last two months, I'm going to be busy for real life for another month. Will try to pick up the work I left when I (really) come back.