### PR TITLE
Reduce `mark-private-orgs` cache validity

### DIFF
--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -15,7 +15,8 @@ const getPublicOrganizationsNames = cache.function(async (username: string): Pro
 	const response = await api.v3(`/users/${username}/orgs`);
 	return response.map((organization: AnyObject) => organization.login);
 }, {
-	maxAge: {days: 10},
+	maxAge: {hours: 6},
+	staleWhileRevalidate: {days: 10},
 	cacheKey: ([username]) => 'public-organizations:' + username,
 });
 


### PR DESCRIPTION
I was a bit surprised to see an org still marked as private on my profile a week after I set it to public. Apparently this was missed by https://github.com/refined-github/refined-github/issues/3302. One day seems reasonable.

Also it would be nice to have a way to manually invalidate the cache for a given feature.