### PR TITLE
Improve `Deinit` type

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -19,7 +19,6 @@
 			"allowWarningComments": false
 		}],
 		"@typescript-eslint/naming-convention": "off",
-		"@typescript-eslint/no-redundant-type-constituents": "off",
 		"@typescript-eslint/no-unsafe-assignment": "off",
 		"@typescript-eslint/no-unsafe-member-access": "off",
 		"@typescript-eslint/no-unsafe-return": "off",

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -66,7 +66,7 @@ function onAltClick(event: delegate.Event<MouseEvent, HTMLInputElement>): void {
 	});
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		// `mousedown` required to avoid mouse selection on shift-click
 		delegate(document, '.js-reviewed-toggle', 'mousedown', batchToggle),

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -46,7 +46,7 @@ function addButtons(): void {
 	}
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	addButtons();
 
 	return [

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -25,7 +25,7 @@ function addConvertToDraftButton(alternativeActions: Element): void {
 	alternativeActions.prepend(convertToDraft);
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		// Immediately close lightbox after click instead of waiting for the ajaxed widget to refresh
 		delegate(document, '.js-convert-to-draft', 'click', closeModal),

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -57,7 +57,7 @@ function pjaxCompleteHandler(): void {
 	}
 }
 
-function init(): Deinit {
+function init(): void {
 	window.addEventListener('pjax:start', pjaxStartHandler);
 	window.addEventListener('pjax:complete', pjaxCompleteHandler);
 }

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -28,7 +28,7 @@ const inView = new IntersectionObserver(([{isIntersecting}]) => {
 	rootMargin: '500px', // https://github.com/refined-github/refined-github/pull/505#issuecomment-309273098
 });
 
-function init(): Deinit[] {
+function init(): Deinit {
 	const selectorObserver = observe('.ajax-pagination-btn', {
 		add(button) {
 			inView.observe(button);

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -46,7 +46,7 @@ function runShortcuts(event: KeyboardEvent): void {
 	}
 }
 
-function init(signal: AbortSignal): Deinit {
+function init(signal: AbortSignal): void {
 	document.body.addEventListener('keypress', runShortcuts, {signal});
 }
 

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -79,7 +79,7 @@ function addOpenAllButton(className: string, text: string): void {
 	);
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	const deinit = [delegate(document, '.rgh-open-selected-button', 'click', openSelectedNotifications)];
 	addOpenAllButton('rgh-open-selected-button', 'Open all selected');
 

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -63,7 +63,7 @@ const updateUI = debounceFn(({delegateTarget: field}: delegate.Event<Event, HTML
 	wait: 300,
 });
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		updateUI.cancel,
 		delegate(document, 'form:is(#new_issue, #new_release) textarea, form.js-new-comment-form textarea, textarea.comment-form-textarea', 'input', updateUI),

--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -74,7 +74,7 @@ function showSubmenu(event: delegate.Event): void {
 	event.preventDefault();
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		// `useCapture` required to be fired before GitHub's handlers
 		delegate(document, '.js-comment-hide-button', 'click', showSubmenu, true),

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -50,7 +50,7 @@ function addRemoveLabelButton(label: HTMLElement): void {
 	);
 }
 
-async function init(): Promise<Deinit[]> {
+async function init(): Promise<Deinit> {
 	await api.expectToken();
 
 	return [

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -29,7 +29,7 @@ function addDeleteButton(cancelButton: Element): void {
 	);
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		delegate(document, '.rgh-review-comment-delete-button', 'click', onButtonClick),
 		delegate(document, '.rgh-quick-comment-edit-button', 'click', onEditButtonClick),

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -105,7 +105,7 @@ function observeCommentReactions(commentReactions: Element): void {
 	viewportObserver.observe(commentReactions);
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	observeReactions();
 
 	return [
@@ -114,7 +114,7 @@ function init(): Deinit[] {
 	];
 }
 
-function discussionInit(): Deinit[] {
+function discussionInit(): Deinit {
 	return [
 		observe(selector, {add: observeCommentReactions}),
 		viewportObserver,

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -126,7 +126,7 @@ function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): void {
 	);
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		// `useCapture` required to be fired before GitHub's handlers
 		delegate(document, '.file-header .js-file-header-dropdown', 'toggle', handleMenuOpening, true),

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -155,7 +155,7 @@ function closeDropdown(): void {
 	select('.rgh-select-notifications')?.removeAttribute('open');
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
 			add(selectAllCheckbox) {

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -73,7 +73,7 @@ function observeWhiteSpace(): void {
 	}
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	observeWhiteSpace();
 
 	return [

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -17,7 +17,7 @@ function updateStickiness(): void {
 
 const onResize = debounce(updateStickiness, {wait: 100});
 
-function init(signal: AbortSignal): Deinit[] {
+function init(signal: AbortSignal): Deinit {
 	document.body.classList.add('rgh-sticky-sidebar-enabled');
 
 	const resizeObserver = new ResizeObserver(onResize);

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -70,7 +70,7 @@ function addButtons(): void {
 	}
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	addButtons();
 
 	return [

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -26,7 +26,7 @@ function markdownCommentSelector(clickedItem: HTMLElement): string {
 	return `#${id} .markdown-body details > summary`;
 }
 
-function init(): Deinit[] {
+function init(): Deinit {
 	return [
 		// Collapsed comments in PR conversations and files
 		delegate(document, '.minimized-comment details summary', 'click', clickAll(minimizedCommentsSelector)),

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -38,7 +38,7 @@ async function toggleHandler(): Promise<void> {
 	select('.rgh-files-hidden-notice')?.remove();
 }
 
-async function init(): Promise<Deinit[]> {
+async function init(): Promise<Deinit> {
 	const repoContent = (await elementReady('.repository-content'))!;
 
 	if (await cache.get<boolean>(cacheKey)) {

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -62,7 +62,7 @@ async function addButton(position: Element): Promise<void> {
 	}
 }
 
-async function init(): Promise<Deinit | false> {
+async function init(): Promise<false | Deinit> {
 	await api.expectToken();
 
 	// "Resolve conflicts" is the native button to update the PR

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -157,7 +157,7 @@ function onBeforeunload(event: BeforeUnloadEvent): void {
 	}
 }
 
-async function init(signal: AbortSignal): Promise<Deinit[]> {
+async function init(signal: AbortSignal): Promise<Deinit> {
 	// Warn user if it's not yet submitted
 	window.addEventListener('beforeunload', onBeforeunload, {signal});
 

--- a/source/github-events/on-new-comments.ts
+++ b/source/github-events/on-new-comments.ts
@@ -35,7 +35,7 @@ function getFragmentLoadHandler(callback: EventListener): delegate.EventHandler 
 	};
 }
 
-function addListeners(): Deinit[] {
+function addListeners(): delegate.Subscription[] {
 	const discussion = select('.js-discussion');
 	if (!discussion || discussionsWithListeners.has(discussion)) {
 		return [];
@@ -59,7 +59,7 @@ function addListeners(): Deinit[] {
 	];
 }
 
-export default function onNewComments(callback: VoidFunction): Deinit[] {
+export default function onNewComments(callback: VoidFunction): Deinit {
 	handlers.add(callback);
 
 	return [

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style */
 
 type AnyObject = Record<string, any>;
-// TODO: Fix this type (there's no such `delegate` global type) and enable the @typescript-eslint/no-redundant-type-constituents rule
-type Deinit = delegate.Subscription | Observer | MutationObserver | ResizeObserver | IntersectionObserver | VoidFunction;
+type DeinitHandle = MutationObserver | ResizeObserver | IntersectionObserver | {destroy: VoidFunction} | {abort: VoidFunction} | VoidFunction;
+type Deinit = DeinitHandle | DeinitHandle[];
 
 type FeatureID = string & {feature: true};
 interface FeatureMeta {
@@ -38,6 +38,7 @@ interface GlobalEventHandlersEventMap {
 }
 
 declare namespace JSX {
+	/* eslint-disable @typescript-eslint/no-redundant-type-constituents -- https://github.com/refined-github/refined-github/pull/5654#discussion_r878891540 */
 	interface IntrinsicElements {
 		'clipboard-copy': IntrinsicElements.button & {for?: string};
 		'details-dialog': IntrinsicElements.div & {tabindex: string};
@@ -50,6 +51,7 @@ declare namespace JSX {
 		'tab-container': IntrinsicElements.div;
 		'time-ago': IntrinsicElements.div & {datetime: string; format?: string};
 	}
+	/* eslint-enable @typescript-eslint/no-redundant-type-constituents */
 
 	type BaseElement = IntrinsicElements['div'];
 	interface IntrinsicAttributes extends BaseElement {


### PR DESCRIPTION
Follow-up of #5654 

1. Make `Deinit` actually useful
2. Allow it to be an array
3. Enable `no-redundant-type-constituents` lint rule