### PR TITLE
Fix `forked-to` spacing

### DIFF
--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -54,7 +54,7 @@ async function updateUI(forks: string[]): Promise<void> {
 		? (
 			<a
 				href={createLink(forks[0])}
-				className="btn btn-sm px-2  rgh-forked-link"
+				className="btn btn-sm px-2 rgh-forked-link"
 				title={`Open your fork at ${forks[0]}`}
 			>
 				<ChevronRightIcon className="v-align-text-top"/>

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -8,6 +8,7 @@ import {CheckIcon, ChevronRightIcon, TriangleDownIcon, XIcon} from '@primer/octi
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 import GitHubURL from '../github-helpers/github-url';
+import {groupButtons} from '../github-helpers/group-buttons';
 import {getUsername, getForkedRepo, getRepo} from '../github-helpers';
 
 const getForkSourceRepo = (): string => getForkedRepo() ?? getRepo()!.nameWithOwner;
@@ -49,13 +50,13 @@ async function updateUI(forks: string[]): Promise<void> {
 	await elementReady('.page-actions');
 
 	const forkButton = select('.pagehead-actions [aria-label^="Fork your own copy of"]')!;
-	forkButton.classList.add('rounded-left-2', 'BtnGroup-item', 'mr-0');
+	forkButton.classList.add('rounded-left-2', 'mr-0');
 
 	if (forks.length === 1) {
 		forkButton.after(
 			<a
 				href={createLink(forks[0])}
-				className="btn btn-sm BtnGroup-item px-2 rgh-forked-button rgh-forked-link"
+				className="btn btn-sm px-2 rgh-forked-button rgh-forked-link"
 				title={`Open your fork at ${forks[0]}`}
 			>
 				<ChevronRightIcon className="v-align-text-top"/>
@@ -64,11 +65,11 @@ async function updateUI(forks: string[]): Promise<void> {
 	} else {
 		forkButton.after(
 			<details
-				className="details-reset details-overlay BtnGroup-parent position-relative"
+				className="details-reset details-overlay position-relative rgh-forked-button"
 				id="rgh-forked-to-select-menu"
 			>
 				<summary
-					className="btn btn-sm BtnGroup-item px-2 float-none rgh-forked-button"
+					className="btn btn-sm px-2 float-none"
 				>
 					<TriangleDownIcon className="v-align-text-top"/>
 				</summary>
@@ -101,6 +102,8 @@ async function updateUI(forks: string[]): Promise<void> {
 			</details>,
 		);
 	}
+
+	groupButtons([forkButton, select('.rgh-forked-button')!]);
 }
 
 async function init(): Promise<void | false> {

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -50,22 +50,18 @@ async function updateUI(forks: string[]): Promise<void> {
 	await elementReady('.page-actions');
 
 	const forkButton = select('.pagehead-actions [aria-label^="Fork your own copy of"]')!;
-	forkButton.classList.add('rounded-left-2', 'mr-0');
-
-	if (forks.length === 1) {
-		forkButton.after(
+	const forkedToButton = forks.length === 1
+		? (
 			<a
 				href={createLink(forks[0])}
-				className="btn btn-sm px-2 rgh-forked-button rgh-forked-link"
+				className="btn btn-sm px-2  rgh-forked-link"
 				title={`Open your fork at ${forks[0]}`}
 			>
 				<ChevronRightIcon className="v-align-text-top"/>
-			</a>,
-		);
-	} else {
-		forkButton.after(
+			</a>
+		) : (
 			<details
-				className="details-reset details-overlay position-relative rgh-forked-button"
+				className="details-reset details-overlay position-relative"
 				id="rgh-forked-to-select-menu"
 			>
 				<summary
@@ -99,18 +95,17 @@ async function updateUI(forks: string[]): Promise<void> {
 						</div>
 					</div>
 				</details-menu>
-			</details>,
+			</details>
 		);
-	}
 
-	groupButtons([forkButton, select('.rgh-forked-button')!]);
+	groupButtons([forkButton, forkedToButton]);
 }
 
 async function init(): Promise<void | false> {
 	const forks = await cache.get<string[]>(getCacheKey());
 
 	// If the feature has already run on this page, only update its links
-	if (forks && select.exists('.rgh-forked-button')) {
+	if (forks && select.exists('.rgh-forked-link')) {
 		for (const fork of forks) {
 			select(`a.rgh-forked-link[href^="/${fork}"]`)!.href = createLink(fork);
 		}


### PR DESCRIPTION
## Does this PR close/fix an existing issue?

There is a gap between the fork button of a GitHub repository and the forked-to button added to the page from refined-github. This PR removes that gap, making it look neater.

## Comparison (Images)

Before
![172073087-cbda305e-8471-4e82-9a6a-2e352beb723a](https://user-images.githubusercontent.com/79479981/173238741-7d667e30-57ab-4f43-8bc6-6489c25ea4d3.png)

After
![172073040-2242f5b8-48cd-499e-b0e9-8cbdf869d7c0](https://user-images.githubusercontent.com/79479981/173238758-e020aa7c-5926-47c0-8007-3ab30a5b8fce.png)

## Test URLs

Tested on the [refined-github](https://github.com/refined-github/refined-github) repository after making a fork.
