### PR TITLE
Fix `sticky-file-header` on commits

### DIFF
--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,16 +1,9 @@
 /* `.sticky-file-header` excludes native sticky header */
 .file-header:not(.sticky-file-header) {
 	position: sticky;
-	top: 0;
-	/* Same as `.sticky-file-header.is-stuck */
-	z-index: 6;
-}
-
-/* Same as `.sticky-file-header.has-open-dropdown` */
-.file-header.has-open-dropdown:not(.sticky-file-header) {
-	z-index: 10;
+	top: 60px;
 }
 
 .notification-shelf ~ .application-main .file-header:not(.sticky-file-header) {
-	top: 69px;
+	top: 129px;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Broken by GitHub's Pull Request File Tree feature added a while ago.

## Test URLs

https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807

## Screenshot

https://user-images.githubusercontent.com/44045911/175102994-8b4e0eb2-1229-4d26-bc69-28f2c67cc995.mov

---

I would really like to add https://github.com/kidonng/cherry/commit/997ccdf5bd36f4f888622d5c5a06426da81509ab as well, since that's pretty much the only place left with no sticky file header (and technically speaking, GitHub already enabled it for markup i.e. Markdown files).

---

P.S. it's funny GitHUb pushed a bug when I'm working on this

<img width="921" alt="image" src="https://user-images.githubusercontent.com/44045911/175104569-d0cc9f85-147d-4336-a57e-9854d1eff00e.png">
