### PR TITLE
Don't activate `comment-fields-keyboard-shortcuts` with `cmd-⬆️`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"dom-loaded": "^3.0.0",
 				"doma": "^3.0.1",
 				"element-ready": "^6.2.1",
+				"filter-altered-clicks": "^1.0.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
 				"github-url-detection": "^5.10.0",
@@ -4349,6 +4350,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/filter-altered-clicks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/filter-altered-clicks/-/filter-altered-clicks-1.0.1.tgz",
+			"integrity": "sha512-tCjyoHHx1QxmNxAUhoQEzsYoQXg6rvf5V5YYLo5OdOVwz1vPCQ/+SPHunI7s0lyB044FebOSRBkj9uzJBVTh6g=="
 		},
 		"node_modules/find-cache-dir": {
 			"version": "3.3.2",
@@ -14389,6 +14395,11 @@
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
+		},
+		"filter-altered-clicks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/filter-altered-clicks/-/filter-altered-clicks-1.0.1.tgz",
+			"integrity": "sha512-tCjyoHHx1QxmNxAUhoQEzsYoQXg6rvf5V5YYLo5OdOVwz1vPCQ/+SPHunI7s0lyB044FebOSRBkj9uzJBVTh6g=="
 		},
 		"find-cache-dir": {
 			"version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"dom-loaded": "^3.0.0",
 		"doma": "^3.0.1",
 		"element-ready": "^6.2.1",
+		"filter-altered-clicks": "^1.0.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
 		"github-url-detection": "^5.10.0",

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -2,11 +2,12 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
+import filterAlteredClicks from 'filter-altered-clicks';
 
 import features from '.';
 import {onCommentFieldKeydown} from '../github-events/on-field-keydown';
 
-function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): void {
+const eventHandler = filterAlteredClicks((event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): void => {
 	const field = event.delegateTarget;
 
 	if (event.key === 'Escape') {
@@ -56,7 +57,7 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>)
 			});
 		}
 	}
-}
+});
 
 function init(): Deinit {
 	return onCommentFieldKeydown(eventHandler);

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -16,6 +16,9 @@ interface Window {
 }
 
 declare module 'markdown-wasm/dist/markdown.node.js';
+declare module 'filter-altered-clicks' {
+	export default function filterAlteredClicks<Listener>(handler: Listener): Listener;
+}
 
 declare module 'size-plugin';
 


### PR DESCRIPTION

## Test URLs

1. Leave a comment here
2. Press `cmd-up` 

Expected: nothing happens
Actual: the comment you left becomes editable


## Screenshot

n/a