### PR TITLE
Fix spacing between team member statuses and footer on dashboard

### DIFF
--- a/source/features/infinite-scroll.css
+++ b/source/features/infinite-scroll.css
@@ -2,3 +2,8 @@ aside[aria-label='Explore'] > .footer {
 	position: sticky !important;
 	top: 24px;
 }
+
+/* Add some spacing after the list of team member statuses */
+aside.team-left-column > [data-team-hovercards-enabled] {
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
## Test URLs

https://github.com/orgs/refined-github/dashboard

## Screenshot

**Before**

![before](https://user-images.githubusercontent.com/46634000/175783129-82b9ced0-5b3f-4d99-be66-303b8ac1e7dd.png)

**After**

![after](https://user-images.githubusercontent.com/46634000/175783133-30a85397-76cb-4654-8aca-3253ba826736.png)