### PR TITLE
Fix `sticky-file-header` positioning

### DIFF
--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -17,6 +17,7 @@
 Test URLs
 https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807
 https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
+https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 
 Exclude:
 https://github.com/refined-github/refined-github/edit/main/readme.md

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,4 +1,4 @@
-:not(blob-editor) > .file-header {
+.file-header {
 	position: sticky;
 	top: 0;
 }
@@ -12,13 +12,18 @@ diff-layout .file-header {
 	top: 60px;
 }
 
+/* CodeMirror header in isEditingFile */
+blob-editor .file-header {
+	z-index: 6;
+}
+
 /*
 Test URLs
 https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807
 https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
 https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+https://github.com/refined-github/refined-github/edit/main/readme.md
 
 Exclude:
-https://github.com/refined-github/refined-github/edit/main/readme.md
 https://github.com/refined-github/refined-github/pull/5460/files (actually included, but natively supported anyway)
 */

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,16 +1,15 @@
-/* `.sticky-file-header` excludes native sticky header */
-/* `blob-editor` excludes isEditFile */
-:not(blob-editor) > .file-header:not(.sticky-file-header) {
+:not(blob-editor) > .file-header {
 	position: sticky;
-	top: 60px;
+	top: 0;
 }
 
-.notification-shelf ~ .application-main .file-header:not(.sticky-file-header) {
+.notification-shelf ~ .application-main .file-header {
 	top: 129px;
 }
 
-.js-gist-file-update-container .file-header {
-	top: 0 !important;
+/* Consider the File List fixed header/sidebar in commits */
+diff-layout .file-header {
+	top: 60px;
 }
 
 /*
@@ -21,4 +20,5 @@ https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 
 Exclude:
 https://github.com/refined-github/refined-github/edit/main/readme.md
+https://github.com/refined-github/refined-github/pull/5460/files (actually included, but natively supported anyway)
 */

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,5 +1,6 @@
 /* `.sticky-file-header` excludes native sticky header */
-.file-header:not(.sticky-file-header) {
+/* `blob-editor` excludes isEditFile */
+:not(blob-editor) > .file-header:not(.sticky-file-header) {
 	position: sticky;
 	top: 60px;
 }
@@ -7,3 +8,12 @@
 .notification-shelf ~ .application-main .file-header:not(.sticky-file-header) {
 	top: 129px;
 }
+
+/*
+Test URLs
+https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807
+https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
+
+Exclude:
+https://github.com/refined-github/refined-github/edit/main/readme.md
+*/

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -9,6 +9,10 @@
 	top: 129px;
 }
 
+.js-gist-file-update-container .file-header {
+	top: 0 !important;
+}
+
 /*
 Test URLs
 https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,5 +1,6 @@
-.file-header {
+:root .file-header {
 	position: sticky;
+	z-index: 6; /* isBlame, isEditingFile */
 	top: 0;
 }
 
@@ -8,13 +9,8 @@
 }
 
 /* Consider the File List fixed header/sidebar in commits */
-diff-layout .file-header {
+:root diff-layout .file-header {
 	top: 60px;
-}
-
-/* CodeMirror header in isEditingFile */
-blob-editor .file-header {
-	z-index: 6;
 }
 
 /*
@@ -23,6 +19,7 @@ https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb
 https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
 https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 https://github.com/refined-github/refined-github/edit/main/readme.md
+https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327
 
 Exclude:
 https://github.com/refined-github/refined-github/pull/5460/files (actually included, but natively supported anyway)


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/5717

## Before

<img width="572" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/176117428-7f521296-36b9-4483-b2ab-536fa037c324.png">


# PR (Native)

https://github.com/refined-github/refined-github/pull/5460/files

<img width="267" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/176454859-4fa38bf4-e47e-4562-a709-5f32157b91b8.png">

# Gist

https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

<img width="267" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/176454871-129a267d-4306-4c14-abe5-d03b4043f91c.png">

# Compare

https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket

<img width="267" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/176454875-26cf7156-5f80-4f0a-b5c4-16a48718d97d.png">

# Commit

https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807

<img width="267" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/176454879-d7c7b23f-5892-4bf9-ba9e-70a66531c296.png">

# File editing 

https://github.com/refined-github/refined-github/edit/main/readme.md

<img width="267" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/176476406-102277f3-adfe-4c46-b5ee-5a397b1d35cc.png">


# Commit with notification bar

![before](https://user-images.githubusercontent.com/1402241/176455895-0a87f5fb-cabf-44cc-bf40-00e14256b5c3.gif)

# Blame

https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327

<img width="199" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/176638514-15bcfc63-40ee-4cd3-953f-319aefcaa8b6.png">