### PR TITLE
`use-first-commit-message-for-new-prs` Support formatted commits

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -14,16 +14,15 @@ function restoreMarkdown(node: ChildNode): string {
 }
 
 function getFirstCommit(): {title: string; body: string | undefined} {
-	const title = select('.js-commits-list-item:first-child p')!;
+	const titleParts = select('.js-commits-list-item:first-child p')!.childNodes;
 	const body = select('.js-commits-list-item:first-child .Details-content--hidden pre')
 		?.textContent!.trim() ?? undefined;
 
-	// GitHub loses the backticks when it renders them, so we must restore them
-	const reformattedTitle = [...title.childNodes]
+	const title = [...titleParts]
 		.map(node => restoreMarkdown(node))
 		.join('')
 		.trim();
-	return {title: reformattedTitle, body};
+	return {title, body};
 }
 
 async function init(): Promise<void | false> {

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -6,11 +6,19 @@ import * as textFieldEdit from 'text-field-edit';
 import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
-/** Restore backticks that GitHub loses when rendering them */
-function restoreMarkdown(node: ChildNode): string {
-	return node instanceof Element && node.tagName === 'CODE'
-		? '`' + node.textContent! + '`'
-		: node.textContent!;
+function interpretNode(node: ChildNode): string | void {
+	const text = node.textContent!;
+	const tagName = node instanceof Element && node.tagName;
+	switch (node instanceof Element && node.tagName) {
+		case false:
+		case 'A':
+			return text;
+		case 'CODE':
+			// Restore backticks that GitHub loses when rendering them
+			return '`' + text + '`';
+		default:
+			// Ignore other nodes, like `<span>...</span>` that appears when commits have a body
+	}
 }
 
 function getFirstCommit(): {title: string; body: string | undefined} {
@@ -19,9 +27,10 @@ function getFirstCommit(): {title: string; body: string | undefined} {
 		?.textContent!.trim() ?? undefined;
 
 	const title = [...titleParts]
-		.map(node => restoreMarkdown(node))
+		.map(node => interpretNode(node))
 		.join('')
 		.trim();
+
 	return {title, body};
 }
 

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -6,7 +6,8 @@ import * as textFieldEdit from 'text-field-edit';
 import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
-function formattedContent(node: ChildNode): string {
+/** Restore backticks that GitHub loses when rendering them */
+function restoreMarkdown(node: ChildNode): string {
 	return node instanceof Element && node.tagName === 'CODE'
 		? '`' + node.textContent! + '`'
 		: node.textContent!;
@@ -17,9 +18,9 @@ function getFirstCommit(): {title: string; body: string | undefined} {
 	const body = select('.js-commits-list-item:first-child .Details-content--hidden pre')
 		?.textContent!.trim() ?? undefined;
 
-	// GitHub loses the backticks when it renders them, so we must recover them
+	// GitHub loses the backticks when it renders them, so we must restore them
 	const reformattedTitle = [...title.childNodes]
-		.map(node => formattedContent(node))
+		.map(node => restoreMarkdown(node))
 		.join('')
 		.trim();
 	return {title: reformattedTitle, body};

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -38,3 +38,9 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	init,
 });
+
+/*
+Test URLs
+https://github.com/refined-github/sandbox/compare/linked-commit-title?expand=1
+https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1
+*/

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -7,15 +7,13 @@ import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
 function interpretNode(node: ChildNode): string | void {
-	const text = node.textContent!;
-	const tagName = node instanceof Element && node.tagName;
 	switch (node instanceof Element && node.tagName) {
 		case false:
 		case 'A':
-			return text;
+			return node.textContent!;
 		case 'CODE':
 			// Restore backticks that GitHub loses when rendering them
-			return '`' + text + '`';
+			return '`' + node.textContent! + '`';
 		default:
 			// Ignore other nodes, like `<span>...</span>` that appears when commits have a body
 	}

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -61,4 +61,5 @@ void features.add(import.meta.url, {
 Test URLs
 https://github.com/refined-github/sandbox/compare/linked-commit-title?expand=1
 https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1
+https://github.com/refined-github/sandbox/compare/github-moji?expand=1
 */

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -6,19 +6,6 @@ import * as textFieldEdit from 'text-field-edit';
 import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
-function getFirstCommitMessage(): string[] {
-	const commitSummaryWrapper = select('.js-commits-list-item a.Link--primary')!.parentElement!;
-	const commitDescription = select('.js-commits-list-item pre')?.textContent ?? '';
-
-	// Linkified commit summaries are split into several adjacent links #5382
-	const commitSummary = select.all(':scope > a', commitSummaryWrapper)
-		.map(commitTitleLink => commitTitleLink.innerHTML)
-		.join('')
-		.replace(/<\/?code>/g, '`');
-
-	return [commitSummary, commitDescription];
-}
-
 async function init(): Promise<void | false> {
 	const requestedContent = new URL(location.href).searchParams;
 	const commitCountIcon = await elementReady('div.Box.mb-3 .octicon-git-commit');
@@ -27,18 +14,19 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const [prTitle, ...prBody] = getFirstCommitMessage();
+	const prTitle = select('.js-commits-list-item p')!;
+	const prBody = prTitle.parentElement!.querySelector('.Details-content--hidden pre');
 	if (!requestedContent.has('pull_request[title]')) {
 		textFieldEdit.set(
 			select('.discussion-topic-header input')!,
-			prTitle,
+			prTitle.textContent!.trim(),
 		);
 	}
 
-	if (!requestedContent.has('pull_request[body]')) {
+	if (prBody && !requestedContent.has('pull_request[body]')) {
 		textFieldEdit.insert(
 			select('#new_pull_request textarea[aria-label="Comment body"]')!,
-			prBody.join('\n\n'),
+			prBody.textContent!,
 		);
 	}
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5694

Missing:

- [x] Support backticks, currently lost


## Test URLs

https://github.com/refined-github/sandbox/compare/linked-commit-title?expand=1
https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1

## Screenshot

<img width="214" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/176148887-b87f9881-d329-456e-9b5e-8f929fbb1161.png">


<img width="105" alt="Screen Shot 15" src="https://user-images.githubusercontent.com/1402241/176148900-5b73a9e7-2820-4b63-b2e6-41efe06a74c7.png">
