### PR TITLE
Fit large images in the window when viewing single files

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -187,7 +187,7 @@ pr-branches
 	display: block !important;
 }
 
-/* Resize large images for blob preview */
+/* Fit large images in the window when viewing single files */
 div[data-target='readme-toc.content'] div.blob-wrapper img {
 	max-width: 100%;
 	max-height: 100%;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -188,7 +188,7 @@ pr-branches
 }
 
 /* Resize large images for blob preview */
-div[data-target="readme-toc.content"] div.blob-wrapper img {
-    max-width: 100%;
-    max-height: 100%;
+div[data-target='readme-toc.content'] div.blob-wrapper img {
+	max-width: 100%;
+	max-height: 100%;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -190,5 +190,4 @@ pr-branches
 /* Fit large images in the window when viewing single files */
 div[data-target='readme-toc.content'] div.blob-wrapper img {
 	max-width: 100%;
-	max-height: 100%;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -186,3 +186,9 @@ pr-branches
 .TimelineItem[id^='event-'] .TimelineItem-body :is(ins, del) {
 	display: block !important;
 }
+
+/* Resize large images for blob preview */
+div[data-target="readme-toc.content"] div.blob-wrapper img {
+    max-width: 100%;
+    max-height: 100%;
+}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #5740

Adds the following css to restrict image blob sizes:
```css
div[data-target='readme-toc.content'] div.blob-wrapper img {
	max-width: 100%;
}
```

## Test URLs

https://github.com/KatsuteDev/Mal4J/blob/main/assets/banner-sq.png

## Screenshot

![github com_KatsuteDev_Mal4J_blob_main_assets_banner-sq png (2)](https://user-images.githubusercontent.com/58778985/176534012-eac4230b-4d4c-4d84-b59d-5e010a8bba7f.png)
