### PR TITLE
Add `linkify-user-labels` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,7 @@ Thanks for contributing! 🦋🙌
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif)
 - [](# "esc-to-cancel") [Adds a shortcut to cancel editing a conversation title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
 - [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
+- [](# "linkify-user-labels") [Links the "Contributor" and "Member" labels on comments to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -29,6 +29,9 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
+	asLongAs: [
+		pageDetect.isRepo
+	],
 	init,
 });
 

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -30,7 +30,7 @@ void features.add(import.meta.url, {
 		pageDetect.hasComments,
 	],
 	asLongAs: [
-		pageDetect.isRepo
+		pageDetect.isRepo,
 	],
 	init,
 });

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -1,0 +1,59 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import {wrap} from '../helpers/dom-utils';
+import {getRepo} from '../github-helpers';
+import getCommentAuthor from '../github-helpers/get-comment-author';
+
+const selectors = [
+	'[aria-label*="a member of the"]',
+	'[aria-label^="This user has previously committed"]',
+].map(selector => `.Label${selector}:not(.rgh-linkified-user-label)`);
+
+function init(): void {
+	for (const label of select.all(selectors)) {
+		if (label.closest('a')) {
+			features.log.error(import.meta.url, 'Already linkified, feature needs to be updated');
+			continue;
+		}
+
+		const author = getCommentAuthor(label);
+		const url = new URL(`/${getRepo()!.nameWithOwner}/commits`, location.origin);
+		url.searchParams.set('author', author);
+		wrap(label, <a className="Link--secondary" href={url.href}/>);
+	}
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.hasComments,
+	],
+	init,
+});
+
+/*
+Test URLs:
+
+Bot PR
+https://github.com/webpack/webpack/pull/15926#issue-1264092372
+
+Bot comment
+https://github.com/webpack/webpack/pull/15926#issuecomment-1149371743
+
+Bot commented on behalf of
+https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173
+
+Member review
+https://github.com/refined-github/refined-github/pull/5721#pullrequestreview-1018226910
+
+Contributor review comment
+https://github.com/refined-github/refined-github/pull/5691#discussion_r895191327
+
+Contributor review second comment
+https://github.com/refined-github/refined-github/pull/5691#discussion_r895192800
+
+Contributor review second comment in Files tab
+https://github.com/refined-github/refined-github/pull/2667/files#r366433031
+*/

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -2,9 +2,9 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
 import {wrap} from '../helpers/dom-utils';
-import {getRepo} from '../github-helpers';
+import features from '.';
+import {buildRepoURL} from '../github-helpers';
 import getCommentAuthor from '../github-helpers/get-comment-author';
 
 const selectors = [
@@ -19,9 +19,8 @@ function init(): void {
 			continue;
 		}
 
-		const author = getCommentAuthor(label);
-		const url = new URL(`/${getRepo()!.nameWithOwner}/commits`, location.origin);
-		url.searchParams.set('author', author);
+		const url = new URL(buildRepoURL('commits'));
+		url.searchParams.set('author', getCommentAuthor(label));
 		wrap(label, <a className="Link--secondary" href={url.href}/>);
 	}
 }

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -1,0 +1,36 @@
+/**
+Given any element in a comment, returns the comment’s author
+
+This works on:
+- First comment
+- Following comments
+- Main review comment
+- Following review comments
+- Gist comments
+- Bots
+
+Note: Bots are used as `name[bot]`, `app/name`, or `apps/name` depending on the context:
+- https://github.com/webpack/webpack/commits?author=dependabot%5Bbot%5D
+- https://github.com/webpack/webpack/pulls/app%2Fdependabot
+- https://github.com/apps/dependabot
+
+@returns user-name
+@returns dependabot[bot]
+
+*/
+export default function getCommentAuthor(anyElementInsideComment: Element): string {
+	const avatar = anyElementInsideComment
+		.closest('.TimelineItem, .review-comment')!
+		.querySelector('.TimelineItem-avatar img, img.avatar')!;
+
+	const name = avatar
+		.alt // Occasionally ends with `[bot]`
+		.replace(/^@/, ''); // May or may not be present
+
+	if (!name.endsWith('[bot]') && avatar.closest('[href^="https://github.com/apps/"]')) {
+		// Example: https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173
+		return name + '[bot]';
+	}
+
+	return name;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -213,3 +213,4 @@ import './features/command-palette-navigation-shortcuts';
 import './features/link-to-compare-diff';
 import './features/hide-low-quality-comments';
 import './features/submission-via-ctrl-enter-everywhere';
+import './features/linkify-user-labels';


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/4362

## Screenshot

<img width="503" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png">


## Test URLs

Bot PR
https://github.com/webpack/webpack/pull/15926#issue-1264092372

Bot comment
https://github.com/webpack/webpack/pull/15926#issuecomment-1149371743

Bot commented on behalf of
https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173

Member review
https://github.com/refined-github/refined-github/pull/5721#pullrequestreview-1018226910

Contributor review comment
https://github.com/refined-github/refined-github/pull/5691#discussion_r895191327

Contributor review second comment
https://github.com/refined-github/refined-github/pull/5691#discussion_r895192800

Contributor review second comment in Files tab
https://github.com/refined-github/refined-github/pull/2667/files#r366433031
