### PR TITLE
Don't show `update-pr-from-base-branch` when there are conflicts

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -83,11 +83,6 @@ async function addButton(position: Element): Promise<void> {
 async function init(): Promise<false | Deinit> {
 	await api.expectToken();
 
-	// "Resolve conflicts" is the native button to update the PR
-	if (select.exists('.js-merge-pr a[href$="/conflicts"]')) {
-		return false;
-	}
-
 	// Quick check before using selector-observer on it
 	if (!select.exists(selectorForPushablePRNotice)) {
 		return false;

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -53,7 +53,8 @@ async function addButton(position: Element): Promise<void> {
 		getPrInfo(),
 
 		// TODO: Find how to determine whether the branch needs to be updated via v4
-		api.v3(`compare/${base}...${head}`),
+		// `page=10000` avoids fetching any commit information, which is heavy
+		api.v3(`compare/${base}...${head}?page=10000`),
 	]);
 
 	if (comparison.status === 'diverged' && pr.viewerCanEditFiles && pr.mergeable !== 'CONFLICTING') {

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -101,3 +101,13 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+Test URLs
+
+PR without conflicts
+https://github.com/refined-github/sandbox/pull/11
+
+Native "Resolve conflicts" button
+https://github.com/refined-github/sandbox/pull/9
+*/

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -108,6 +108,9 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isClosedPR,
 		() => select('.head-ref')!.title === 'This repository has been deleted',
+
+		// Native button https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/
+		() => select.exists('.js-update-branch-form'),
 	],
 	deduplicate: 'has-rgh-inner',
 	init,

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -184,6 +184,7 @@ export const v4 = mem(async (
 		headers: {
 			'User-Agent': 'Refined GitHub',
 			Authorization: `bearer ${personalToken}`,
+			Accept: 'application/vnd.github.merge-info-preview+json',
 		},
 		method: 'POST',
 		body: JSON.stringify({query: `{${query}}`}),

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -10,7 +10,6 @@ interface PullRequestInfo {
 	viewerCanEditFiles: boolean;
 }
 
-/*  */
 export default async function getPrInfo(number = getConversationNumber()!): Promise<PullRequestInfo> {
 	const {repository} = await api.v4(`
 		repository() {

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -1,0 +1,25 @@
+import * as api from './api';
+import {getConversationNumber} from '.';
+
+interface PullRequestInfo {
+	// TODO: Probably can be used for #3863 and #4679
+	baseRefOid: string;
+
+	// https://docs.github.com/en/graphql/reference/enums#mergeablestate
+	mergeable: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN';
+	viewerCanEditFiles: boolean;
+}
+
+/*  */
+export default async function getPrInfo(number = getConversationNumber()!): Promise<PullRequestInfo> {
+	const {repository} = await api.v4(`
+		repository() {
+			pullRequest(number: ${number}) {
+				baseRefOid
+				mergeable
+				viewerCanEditFiles
+			}
+		}
+	`);
+	return repository.pullRequest;
+}


### PR DESCRIPTION
- Close https://github.com/refined-github/refined-github/issues/5586

## Test URLs

Native button: https://github.com/refined-github/sandbox/pull/9
Our feature: https://github.com/refined-github/sandbox/pull/11

## Before

<img width="737" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/177037066-053bd09e-8644-414a-9ec3-934d98941ce6.png">

## After

<img width="620" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/177037072-2e658930-00a4-4ba1-be4c-f5f82b33f212.png">

