### PR TITLE
Fix `first-published-tag-for-merged-pr` wrapping and wording

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -17,18 +17,6 @@ import onConversationHeaderUpdate from '../github-events/on-conversation-header-
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
 
-function getTimelineEvent(tagUrl: string, tagName: string): JSX.Element {
-	return (
-		<TimelineItem>
-			{createBanner({
-				text: <>The PR first appeared in <span className="text-mono text-small">{tagName}</span></>,
-				url: tagUrl,
-				buttonLabel: <><TagIcon/> See release</>,
-			})}
-		</TimelineItem>
-	);
-}
-
 const getFirstTag = cache.function(async (commit: string): Promise<string | undefined> => {
 	const firstTag = await fetchDom(
 		buildRepoURL('branch_commits', commit),
@@ -75,7 +63,15 @@ function addExistingTagLink(tagName: string): void {
 	attachElement({
 		anchor: '#issue-comment-box',
 		position: 'before',
-		getNewElement: () => getTimelineEvent(tagUrl, tagName),
+		getNewElement: () => (
+			<TimelineItem>
+				{createBanner({
+					text: <>The PR first appeared in <span className="text-mono text-small">{tagName}</span></>,
+					url: tagUrl,
+					buttonLabel: <><TagIcon/> See release</>,
+				})}
+			</TimelineItem>
+		),
 	});
 }
 
@@ -85,12 +81,11 @@ function addLinkToCreateRelease(text = 'Now you can release this change'): void 
 		position: 'before',
 		getNewElement: () => (
 			<TimelineItem>
-				<div className="flash">
-					{text}
-					<a href={buildRepoURL('releases/new')} className="btn btn-sm flash-action">
-						<TagIcon/> Draft a new release
-					</a>
-				</div>
+				{createBanner({
+					text,
+					url: buildRepoURL('releases/new'),
+					buttonLabel: <><TagIcon/> Draft a new release</>,
+				})}
 			</TimelineItem>
 		),
 	});

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -35,7 +35,7 @@ async function init(): Promise<void> {
 	if (tagName) {
 		addExistingTagLink(tagName);
 	} else if (canCreateRelease()) {
-		addLinkToCreateRelease('This PR doesn’t appear to have been released yet');
+		addLinkToCreateRelease('This PR seems to be unreleased');
 	}
 }
 
@@ -67,6 +67,7 @@ function addExistingTagLink(tagName: string): void {
 			<TimelineItem>
 				{createBanner({
 					text: <>The PR first appeared in <span className="text-mono text-small">{tagName}</span></>,
+					classes: ['flash-success'],
 					url: tagUrl,
 					buttonLabel: <><TagIcon/> See release</>,
 				})}

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -7,6 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 import onPrMerge from '../github-events/on-pr-merge';
+import createBanner from '../github-helpers/banner';
 import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
 import {canEditEveryComment} from './quick-comment-edit';
@@ -15,6 +16,18 @@ import onConversationHeaderUpdate from '../github-events/on-conversation-header-
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
+
+function getTimelineEvent(tagUrl: string, tagName: string): JSX.Element {
+	return (
+		<TimelineItem>
+			{createBanner({
+				text: <>The PR first appeared in <span className="text-mono text-small">{tagName}</span></>,
+				url: tagUrl,
+				buttonLabel: <><TagIcon/> See release</>,
+			})}
+		</TimelineItem>
+	);
+}
 
 const getFirstTag = cache.function(async (commit: string): Promise<string | undefined> => {
 	const firstTag = await fetchDom(
@@ -62,16 +75,7 @@ function addExistingTagLink(tagName: string): void {
 	attachElement({
 		anchor: '#issue-comment-box',
 		position: 'before',
-		getNewElement: () => (
-			<TimelineItem>
-				<div className="flash flash-success">
-					The PR first appeared in <span className="text-mono text-small">{tagName}</span>
-					<a href={tagUrl} className="btn btn-sm flash-action">
-						<TagIcon/> See release
-					</a>
-				</div>
-			</TimelineItem>
-		),
+		getNewElement: () => getTimelineEvent(tagUrl, tagName),
 	});
 }
 

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -1,0 +1,25 @@
+import React from 'dom-chef';
+import {RequireAllOrNone} from 'type-fest';
+
+type BannerProps = RequireAllOrNone<{
+	text: Array<string | JSX.Element> | string | JSX.Element;
+	url: string;
+	buttonLabel: JSX.Element | string;
+}, 'buttonLabel' | 'url'>;
+
+// This could be a `<Banner/>` element but dom-chef doesn't pass props
+// https://github.com/vadimdemedes/dom-chef/issues/77
+export default function createBanner(props: BannerProps): JSX.Element {
+	// Classes copied from "had recent pushes" banner from repo home
+	return (
+		<div className="flash">
+			<div className="d-sm-flex">
+				<div className="flex-auto">{props.text}</div>
+				{props.url && (
+					<a href={props.url} className="flex-shrink-0 btn btn-sm ml-sm-3 mt-2 mt-sm-n2 mb-sm-n2 mr-sm-n1 flex-self-center">
+						{props.buttonLabel}
+					</a>)}
+			</div>
+		</div>
+	);
+}

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -13,7 +13,7 @@ type BannerProps = RequireAllOrNone<{
 export default function createBanner(props: BannerProps): JSX.Element {
 	// Classes copied from "had recent pushes" banner from repo home
 	return (
-		<div className={["flash", ...props.classes ?? ''].join(' ')}>
+		<div className={['flash', ...props.classes ?? ''].join(' ')}>
 			<div className="d-sm-flex">
 				<div className="flex-auto">{props.text}</div>
 				{props.url && (

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -5,6 +5,7 @@ type BannerProps = RequireAllOrNone<{
 	text: Array<string | JSX.Element> | string | JSX.Element;
 	url: string;
 	buttonLabel: JSX.Element | string;
+	classes?: string[];
 }, 'buttonLabel' | 'url'>;
 
 // This could be a `<Banner/>` element but dom-chef doesn't pass props
@@ -12,7 +13,7 @@ type BannerProps = RequireAllOrNone<{
 export default function createBanner(props: BannerProps): JSX.Element {
 	// Classes copied from "had recent pushes" banner from repo home
 	return (
-		<div className="flash">
+		<div className={["flash", ...props.classes ?? ''].join(' ')}>
 			<div className="d-sm-flex">
 				<div className="flex-auto">{props.text}</div>
 				{props.url && (


### PR DESCRIPTION
- Follows #5769 

## Test URLs

- Released PR: https://github.com/refined-github/refined-github/pull/5752
- Unreleased PR: https://github.com/refined-github/sandbox/pull/23

## Before

<img width="502" alt="Screen Shot 19" src="https://user-images.githubusercontent.com/1402241/177068668-c29e153a-3dd1-4e42-8638-c6b047e41981.png">


## After

<img width="508" alt="Screen Shot 20" src="https://user-images.githubusercontent.com/1402241/177068673-2ff07676-6bd5-48a8-a009-7dc8c746a8b4.png">
<img width="483" alt="Screen Shot 21" src="https://user-images.githubusercontent.com/1402241/177068675-4ff206d8-c88e-4c7b-924e-257cbb9e5abb.png">



<img width="633" alt="Screen Shot 22" src="https://user-images.githubusercontent.com/1402241/177068587-93199b24-4c28-4673-b5d5-a29c45bff72c.png">

<img width="641" alt="Screen Shot 23" src="https://user-images.githubusercontent.com/1402241/177068583-e74d866f-b71f-4eb6-a90d-d61cfed6ff10.png">