### PR TITLE
Polish `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -2,7 +2,7 @@ import './latest-tag-button.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import * as pageDetect from 'github-url-detection';
-import {DiffIcon, TagIcon} from '@primer/octicons-react';
+import {GitCompareIcon, TagIcon} from '@primer/octicons-react';
 
 import features from '.';
 import * as api from '../github-helpers/api';
@@ -129,7 +129,10 @@ async function init(): Promise<false | void> {
 	}
 
 	if (pageDetect.isRepoHome() || onDefaultBranch) {
-		link.append(<sup> {aheadBy === undeterminableAheadBy ? '*' : `+${aheadBy}`}</sup>);
+		if (aheadBy !== undeterminableAheadBy) {
+			link.append(<sup> +{aheadBy}</sup>);
+		}
+
 		link.setAttribute(
 			'aria-label',
 			isAhead
@@ -145,7 +148,7 @@ async function init(): Promise<false | void> {
 					data-pjax="#repo-content-pjax-container"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>
-					<DiffIcon className="v-align-middle"/>
+					<GitCompareIcon className="v-align-middle"/>
 				</a>
 			);
 			groupButtons([link, compareLink]).classList.add('d-flex');


### PR DESCRIPTION

1. Use compare icon, not commit/diff: https://github.com/pixiebrix/pixiebrix-extension/compare/main
2. Drop useless indicator: if we show the compare link, then it's "behind"; Saying "I don't know how behind" isn't necessary


## Test URLs

- 12 commits: https://github.com/webpack/webpack
- Undeterminable: https://github.com/microsoft/typescript


## Before

<img width="163" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/177069638-7aabecf1-534c-4c33-8545-b4a6375c1b13.png"><img width="163" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/177069890-dd154cbf-095b-40a7-aecd-578b65d2176a.png">

## After

<img width="163" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/177069642-df34f171-23b5-4a3f-b5ee-645e5de53406.png"><img width="163" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/177069873-2bae9525-e01e-48be-9478-6b8e0995cfa5.png">