### PR TITLE
Fix: #5757 clean-conversation-sidebar wrongly hiding projects

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -40,9 +40,14 @@ function cleanSection(selector: string): boolean {
 
 	const heading = select(':scope > details, :scope > .discussion-sidebar-heading', container)!;
 
-	// Magic. Do not touch.
-	// Section is empty if: no sibling element OR empty sibling element
-	if (heading.nextElementSibling?.firstElementChild) {
+	const labelsUniqueSelector = '.IssueLabel';
+	const mileStonesUniqueSelector = '.Progress-item';
+	const developmentsUniqueSelector = '[data-hovercard-type]';
+	const projectsUniqueSelector = '.octicon';
+
+	// Labels `labelsUniqueSelector` closest defaults to `.discussion-sidebar-item`
+	if (heading.closest('form, .discussion-sidebar-item')!.querySelector(`${labelsUniqueSelector},${mileStonesUniqueSelector},
+		${developmentsUniqueSelector}, ${projectsUniqueSelector}`)) {
 		return false;
 	}
 


### PR DESCRIPTION
Closes https://github.com/refined-github/refined-github/issues/5757

Test URLs
https://github.com/godotengine/godot/issues/62552
https://github.com/godotengine/godot-proposals/issues/4548

https://github.com/joule-labs/webln/issues/47
https://github.com/parcel-bundler/parcel/issues/4015