### PR TITLE
Disable broken `more-dropdown-links` on mobile

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -118,9 +118,11 @@ async function initProjects(): Promise<void | false> {
 	projectsTab!.remove();
 }
 
-async function init(): Promise<void> {
+async function init(): Promise<void | false> {
 	// The user may have disabled `more-dropdown-links` so un-hide it
-	await unhideOverflowDropdown();
+	if (!await unhideOverflowDropdown()) {
+		return false;
+	}
 
 	// Wait for the nav dropdown to be loaded #5244
 	await elementReady('.UnderlineNav-actions ul');

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -14,7 +14,7 @@ export async function unhideOverflowDropdown(): Promise<boolean> {
 	// Wait for the tab bar to be loaded
 	const repoNavigationBar = await elementReady('.UnderlineNav-body');
 
-	// No dropdown on mobile https://github.com/refined-github/refined-github/issues/5781
+	// No dropdown on mobile #5781
 	if (!select.exists('.js-responsive-underlinenav')) {
 		return false;
 	}
@@ -49,7 +49,7 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isEmptyRepo,
 
-		// No dropdown on mobile https://github.com/refined-github/refined-github/issues/5781
+		// No dropdown on mobile #5781
 		() => !select.exists('.js-responsive-underlinenav'),
 	],
 	awaitDomReady: false,

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -10,10 +10,17 @@ import createDropdownItem from '../github-helpers/create-dropdown-item';
 import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 
 // eslint-disable-next-line import/prefer-default-export
-export async function unhideOverflowDropdown(): Promise<void> {
+export async function unhideOverflowDropdown(): Promise<boolean> {
 	// Wait for the tab bar to be loaded
 	const repoNavigationBar = await elementReady('.UnderlineNav-body');
+
+	// No dropdown on mobile https://github.com/refined-github/refined-github/issues/5781
+	if (!select.exists('.js-responsive-underlinenav')) {
+		return false;
+	}
+
 	repoNavigationBar!.parentElement!.classList.add('rgh-has-more-dropdown');
+	return true;
 }
 
 async function init(): Promise<void> {
@@ -41,6 +48,8 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isEmptyRepo,
+
+		// No dropdown on mobile https://github.com/refined-github/refined-github/issues/5781
 		() => !select.exists('.js-responsive-underlinenav'),
 	],
 	awaitDomReady: false,

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -1,5 +1,6 @@
 import './more-dropdown-links.css';
 import React from 'dom-chef';
+import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
@@ -40,6 +41,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isEmptyRepo,
+		() => !select.exists('.js-responsive-underlinenav'),
 	],
 	awaitDomReady: false,
 	init,

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -65,7 +65,7 @@ async function addReleasesTab(): Promise<false | void> {
 				data-selected-links="repo_releases"
 				data-tab-item="rgh-releases-item"
 			>
-				<TagIcon className="UnderlineNav-octicon"/>
+				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline"/>
 				<span data-content="Releases">Releases</span>
 				{count && <span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>}
 			</a>


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/5781


## Test URLs

Any repo page


## Before

<img width="413" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/177310258-adec98d4-2773-4084-b838-3fc8b0b1f3e5.png">

## After


<img width="413" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/177310243-31693e9b-98aa-48f3-bbb5-a18c967cfc1d.png">
