### PR TITLE
Fix `preview-hidden-comments` overflow on mobile

### DIFF
--- a/source/features/preview-hidden-comments.css
+++ b/source/features/preview-hidden-comments.css
@@ -1,0 +1,4 @@
+/* Avoid overflow on mobile due to change of flex-direction #5750 */
+.rgh-preview-hidden-comments h3 {
+	max-width: 100%;
+}

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -1,3 +1,4 @@
+import './preview-hidden-comments.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5750


## Test URLs

https://github.com/refined-github/refined-github/issues/5546

## Screenshot

Mobile fixed:

<img width="518" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/177792719-35a1037c-4129-4870-87c0-609a84bb35fd.png">

Desktop unaffected:


<img width="609" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/177792709-1c283702-02a2-4497-afb3-a8cf0e562e10.png">

