### PR TITLE
Drop `hide-repo-badges` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,6 @@ Thanks for contributing! 🦋🙌
 - [](# "quick-repo-deletion") [Lets you delete your repos in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
-- [](# "hide-repo-badges") [Hide repo badges ("Public", "Template", etc.) in the repo header and pinned repo cards.](https://user-images.githubusercontent.com/46634000/148645393-d3fa4ca9-6df4-4bb2-b810-7d73cc057772.png)
 - [](# "repo-avatars") [Adds the profile picture to the header of public repositories.](https://user-images.githubusercontent.com/44045911/177211845-c9b0fa37-c157-4449-890e-af2602c312e3.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/source/features/hide-repo-badges.css
+++ b/source/features/hide-repo-badges.css
@@ -1,7 +1,0 @@
-.rgh-hide-repo-badges :is(
-#repository-container-header h1, /* GHE */
-#repository-container-header h2,
-.pinned-item-list-item-content,
-) .Label {
-	display: none !important;
-}

--- a/source/features/hide-repo-badges.tsx
+++ b/source/features/hide-repo-badges.tsx
@@ -1,9 +1,0 @@
-import './hide-repo-badges.css';
-import * as pageDetect from 'github-url-detection';
-
-import features from '.';
-
-void features.addCssFeature(import.meta.url, [
-	pageDetect.isRepo,
-	pageDetect.isUserProfile,
-]);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -32,7 +32,6 @@ import './features/clean-dashboard';
 import './features/hide-noisy-newsfeed-events';
 import './features/minimize-upload-bar';
 import './features/hide-diff-signs';
-import './features/hide-repo-badges';
 import './features/clean-rich-text-editor';
 
 import './features/useful-not-found-page';


### PR DESCRIPTION
As mentioned in https://github.com/refined-github/refined-github/issues/5546, it doesn't work and it became counterproductive with `repo-avatars` in #5778