### PR TITLE
Meta: Improve CI speed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,11 +64,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build:webpack -- --json webpack-stats.json
-      - uses: actions/upload-artifact@v2
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: refined-github
-          path: distribution
       - name: Send webpack stats to RelativeCI
         if: matrix.os == 'ubuntu-latest'
         uses: relative-ci/agent-action@v1.1.0
@@ -77,14 +72,11 @@ jobs:
           key: ${{ secrets.RELATIVE_CI_KEY }}
 
   Safari:
-    runs-on: macos-11
-    needs: Build
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2 # npm install+build seems slow and problematic on macOS
-        with:
-          name: refined-github
-          path: distribution
+      - run: npm ci
+      - run: npm run build:webpack
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest


### PR DESCRIPTION
- Re: https://github.com/refined-github/refined-github/pull/5282#issuecomment-1178651790

# Ideal

Total time: 41s + 53s (no windows build dependency)

I'm not sure this is easily feasible other than by manually splitting the `matrix`

# Before

Total time: 1m20s + 53s

<img width="552" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/177941735-a1f42d73-69ae-415c-808b-05de4e28619b.png">

# After

Total time: 1m49s

<img width="310" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/177941757-46ba6525-2fbd-4be7-8509-3d0d015767cb.png">
