### PR TITLE
Don't add a workflow count to the actions tab in `clean-repo-tabs`

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -93,10 +93,10 @@ async function initActions(): Promise<void | false> {
 
 	const actionsCount = await getWorkflowsCount();
 	if (actionsCount > 0 || mustKeepTab(actionsTab)) {
-		setTabCounter(actionsTab, actionsCount);
-	} else {
-		onlyShowInDropdown('actions-tab');
+		return false;
 	}
+
+	onlyShowInDropdown('actions-tab');
 }
 
 async function initProjects(): Promise<void | false> {


### PR DESCRIPTION
I was going to suggest a feature to drop this count when I realized we're adding it.

I don't find it particularly useful and it appears to be noise. 

Drop?