### PR TITLE
Skip some features on private user profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"filter-altered-clicks": "^1.0.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^5.12.1",
+				"github-url-detection": "^5.13.0",
 				"image-promise": "^7.0.1",
 				"indent-textarea": "^2.1.0",
 				"js-abbreviation-number": "^1.4.0",
@@ -4113,9 +4113,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.12.1.tgz",
-			"integrity": "sha512-HrQmA0XkaP+4GfSpA5gHuKnrBPJnCkz6GRfszh4dW8JBsyZo9IecHY3+/gzg6nbYYJED7dd2B4KkCVyFoIqLDg==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.13.0.tgz",
+			"integrity": "sha512-bhBinR4r01vB75Ta+AVu8tqfgAeKwy+WIMOQaVcouXytvKEMSDJar8m0rrEMZ8UHnFMScE9ersbSWkhJZpdsAQ==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -13300,9 +13300,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"github-url-detection": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.12.1.tgz",
-			"integrity": "sha512-HrQmA0XkaP+4GfSpA5gHuKnrBPJnCkz6GRfszh4dW8JBsyZo9IecHY3+/gzg6nbYYJED7dd2B4KkCVyFoIqLDg=="
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.13.0.tgz",
+			"integrity": "sha512-bhBinR4r01vB75Ta+AVu8tqfgAeKwy+WIMOQaVcouXytvKEMSDJar8m0rrEMZ8UHnFMScE9ersbSWkhJZpdsAQ=="
 		},
 		"glob": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"filter-altered-clicks": "^1.0.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^5.12.1",
+		"github-url-detection": "^5.13.0",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.1.0",
 		"js-abbreviation-number": "^1.4.0",

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -28,7 +28,7 @@ import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {getRepo, getUsername} from '../github-helpers';
+import {getRepo, getUsername, isPrivateUserProfile} from '../github-helpers';
 
 async function wiggleWiggleWiggle(): Promise<void> {
 	await cache.set('did-it-wiggle', 'yup', {days: 7});
@@ -107,6 +107,10 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 		pageDetect.isUserProfile,
 		pageDetect.isOrganizationProfile,
+	],
+	exclude: [
+		pageDetect.isOwnUserProfile,
+		isPrivateUserProfile,
 	],
 	init: handleSponsorButton,
 });

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -28,7 +28,7 @@ import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {getRepo, getUsername, isPrivateUserProfile} from '../github-helpers';
+import {getRepo, getUsername} from '../github-helpers';
 
 async function wiggleWiggleWiggle(): Promise<void> {
 	await cache.set('did-it-wiggle', 'yup', {days: 7});
@@ -110,7 +110,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isOwnUserProfile,
-		isPrivateUserProfile,
+		pageDetect.isPrivateUserProfile,
 	],
 	init: handleSponsorButton,
 });

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -3,6 +3,7 @@ import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {isPrivateUserProfile} from '../github-helpers';
 import onProfileDropdownLoad from '../github-events/on-profile-dropdown-load';
 
 function addSourceTypeToLink(link: HTMLAnchorElement): void {
@@ -30,6 +31,9 @@ async function init(): Promise<void> {
 
 void features.add(import.meta.url, {
 	init,
+	exclude: [
+		isPrivateUserProfile,
+	],
 }, {
 	exclude: [
 		pageDetect.isGist, // "Your repositories" does not exist

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -3,7 +3,6 @@ import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {isPrivateUserProfile} from '../github-helpers';
 import onProfileDropdownLoad from '../github-events/on-profile-dropdown-load';
 
 function addSourceTypeToLink(link: HTMLAnchorElement): void {
@@ -32,7 +31,7 @@ async function init(): Promise<void> {
 void features.add(import.meta.url, {
 	init,
 	exclude: [
-		isPrivateUserProfile,
+		pageDetect.isPrivateUserProfile,
 	],
 }, {
 	exclude: [

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -3,7 +3,6 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {isPrivateUserProfile} from '../github-helpers';
 
 function init(): void {
 	const url = new URL(location.pathname, location.href);
@@ -25,7 +24,7 @@ void features.add(import.meta.url, {
 		pageDetect.isUserProfileMainTab,
 	],
 	exclude: [
-		isPrivateUserProfile,
+		pageDetect.isPrivateUserProfile,
 	],
 	init,
 });

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {isPrivateUserProfile} from '../github-helpers';
 
 function init(): void {
 	const url = new URL(location.pathname, location.href);
@@ -22,6 +23,9 @@ function init(): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isUserProfileMainTab,
+	],
+	exclude: [
+		isPrivateUserProfile,
 	],
 	init,
 });

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -12,7 +12,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getUsername, getCleanPathname} from '../github-helpers';
+import {getUsername, getCleanPathname, isPrivateUserProfile} from '../github-helpers';
 
 interface Commit {
 	url: string;
@@ -195,6 +195,9 @@ void features.add(import.meta.url, {
 }, {
 	include: [
 		pageDetect.isUserProfile,
+	],
+	exclude: [
+		isPrivateUserProfile,
 	],
 	init: profileInit,
 });

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -12,7 +12,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getUsername, getCleanPathname, isPrivateUserProfile} from '../github-helpers';
+import {getUsername, getCleanPathname} from '../github-helpers';
 
 interface Commit {
 	url: string;
@@ -197,7 +197,7 @@ void features.add(import.meta.url, {
 		pageDetect.isUserProfile,
 	],
 	exclude: [
-		isPrivateUserProfile,
+		pageDetect.isPrivateUserProfile,
 	],
 	init: profileInit,
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getUsername, getCleanPathname, isPrivateUserProfile} from '../github-helpers';
+import {getUsername, getCleanPathname} from '../github-helpers';
 
 const doesUserFollow = cache.function(async (userA: string, userB: string): Promise<boolean> => {
 	const {httpStatus} = await api.v3(`/users/${userA}/following/${userB}`, {
@@ -32,7 +32,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isOwnUserProfile,
-		isPrivateUserProfile,
+		pageDetect.isPrivateUserProfile,
 	],
 	init,
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -5,6 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
+import {isPrivateUserProfile} from '../github-helpers';
 import {getUsername, getCleanPathname} from '../github-helpers';
 
 const doesUserFollow = cache.function(async (userA: string, userB: string): Promise<boolean> => {
@@ -32,6 +33,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isOwnUserProfile,
+		isPrivateUserProfile,
 	],
 	init,
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -5,8 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {isPrivateUserProfile} from '../github-helpers';
-import {getUsername, getCleanPathname} from '../github-helpers';
+import {getUsername, getCleanPathname, isPrivateUserProfile} from '../github-helpers';
 
 const doesUserFollow = cache.function(async (userA: string, userB: string): Promise<boolean> => {
 	const {httpStatus} = await api.v3(`/users/${userA}/following/${userB}`, {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -178,6 +178,3 @@ export const addHotkey = (button: HTMLAnchorElement | HTMLButtonElement | undefi
 		button.dataset.hotkey = [...hotkeys].join(',');
 	}
 };
-
-// TODO: Drop after https://github.com/refined-github/github-url-detection/pull/125
-export const isPrivateUserProfile = (): boolean => pageDetect.isUserProfile() && !select.exists('.user-following-container');

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -178,3 +178,6 @@ export const addHotkey = (button: HTMLAnchorElement | HTMLButtonElement | undefi
 		button.dataset.hotkey = [...hotkeys].join(',');
 	}
 };
+
+// TODO: Drop after https://github.com/refined-github/github-url-detection/pull/125
+export const isPrivateUserProfile = (): boolean => pageDetect.isUserProfile() && !select.exists('.user-following-container');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Part of #5356 (do I even remember that)

First thing to know: query strings (e.g. `sort=stargazers`) have no effect on private profiles.

- `rgh-sponsor-button`: I'm not sure if users in the program can make their profile private, but there probably won't be a sponsor button there
- `set-default-repositories-type-to-sources`: relies on query strings, so it doesn't work for the repositories tab. There's no organization listed either.
- `show-user-top-repositories`: relies on query strings; "popular repositories" element doesn't exist.
- `user-local-time`: can't get their events/commits
- `user-profile-follower-badge`: can't get their followers

## Test URLs

https://github.com/Centril

## Screenshot

N/A