### PR TITLE
Restore `linkify-user-location` on ajax navigation

### DIFF
--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -43,7 +43,7 @@ function hovercardInit(): void {
 }
 
 void features.add(import.meta.url, {
-	init
+	init,
 }, {
 	init: onetime(hovercardInit),
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
+import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {wrap, isEditable} from '../helpers/dom-utils';
@@ -44,6 +45,9 @@ function hovercardInit(): void {
 
 void features.add(import.meta.url, {
 	init,
+	include: [
+		pageDetect.isProfile,
+	],
 }, {
 	init: onetime(hovercardInit),
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -16,7 +16,14 @@ function addLocation(baseElement: HTMLElement): void {
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 
 		location.before(' '); // Keeps the link’s underline from extending out to the icon
-		wrap(location, <a href={googleMapsLink}/>);
+		const link = <a className="Link--primary" href={googleMapsLink}/>;
+
+		// The location is in a hovercard
+		if (baseElement !== document.body) {
+			link.classList.add('text-underline');
+		}
+
+		wrap(location, link);
 	}
 }
 
@@ -26,7 +33,9 @@ const hovercardObserver = new MutationObserver(([mutation]) => {
 
 function init(): void {
 	addLocation(document.body);
+}
 
+function hovercardInit(): void {
 	const hovercardContainer = select('.js-hovercard-content > .Popover-message');
 	if (hovercardContainer) {
 		hovercardObserver.observe(hovercardContainer, {childList: true});
@@ -34,5 +43,7 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	init: onetime(init),
+	init
+}, {
+	init: onetime(hovercardInit),
 });


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Well, technically speaking not really a bug, since this type of navigation used to not exist.

Also included style fixes from [`08f6678` (#5113)](https://github.com/refined-github/refined-github/pull/5113/commits/08f667824863fffd935bd62befb5beb8d8e95217) (or dare I say, #5142)

## Test URLs


https://github.com/cheap-glitch

## Screenshot

Before:

https://user-images.githubusercontent.com/44045911/178342110-ed9cc8ce-ab7c-4cbb-bca7-74b8190e6164.mov

After:

https://user-images.githubusercontent.com/44045911/178342127-bdf33db9-2cf6-4440-a46c-e146eef61c44.mov

