### PR TITLE
Fix link selection in `open-issue-to-latest-comment`

### DIFF
--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -10,7 +10,7 @@ const selector = `
 
 function init(): void {
 	for (const link of select.all<HTMLAnchorElement>(selector)) {
-		link.hash = '#issue-comment-box';
+		link.hash = '#partial-timeline';
 	}
 }
 

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -3,9 +3,14 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
+const selector = `
+	:is(.js-issue-row, .js-pinned-issue-list-item)
+	.Link--muted:is([aria-label$="comment"], [aria-label$="comments"])
+`;
+
 function init(): void {
-	for (const link of select.all('.js-issue-row a[aria-label*="comment"], .js-pinned-issue-list-item a[aria-label*="comment"]')) {
-		link.hash = '#partial-timeline';
+	for (const link of select.all<HTMLAnchorElement>(selector)) {
+		link.hash = '#issue-comment-box';
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/refined-github/refined-github/issues/5813 but it doesn't fix it.

The selector was selecting the "mobile" links as well, pointing them to the bottom of the page.


## Test URLs

- https://github.com/refined-github/refined-github/issues?q=+comment+in%3Atitle

## Bug demo

<img width="1008" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/178913561-755a1543-7bd1-4232-9340-290f45a50094.png">

