### PR TITLE
Fix `clean-repo-tabs` wiki count

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -50,6 +50,7 @@ const getWikiPageCount = cache.function(async (): Promise<number> => {
 	const dom = await fetchDom(buildRepoURL('wiki'));
 	const counter = dom.querySelector('#wiki-pages-box .Counter');
 
+	// "Home" page may not exist #5831
 	if (counter) {
 		return looseParseInt(counter);
 	}

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -47,8 +47,15 @@ function onlyShowInDropdown(id: string): void {
 }
 
 const getWikiPageCount = cache.function(async (): Promise<number> => {
-	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-pages-box .Counter');
-	return looseParseInt(wikiPages);
+	const dom = await fetchDom(buildRepoURL('wiki'));
+	const counter = dom.querySelector('#wiki-pages-box .Counter');
+
+	if (counter) {
+		return looseParseInt(counter);
+	}
+
+	const wikiPages = dom.querySelector('#wiki-content > .Box > ul');
+	return wikiPages?.childElementCount ?? 0;
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -47,8 +47,8 @@ function onlyShowInDropdown(id: string): void {
 }
 
 const getWikiPageCount = cache.function(async (): Promise<number> => {
-	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-content .Box-row');
-	return wikiPages.length;
+	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-content .Box');
+	return wikiPages.querySelectorAll('.Box-row').length;
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -7,6 +7,7 @@ import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 import * as api from '../github-helpers/api';
 import getTabCount from '../github-helpers/get-tab-count';
+import looseParseInt from '../helpers/loose-parse-int';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {buildRepoURL, getRepo} from '../github-helpers';
 import {unhideOverflowDropdown} from './more-dropdown-links';
@@ -46,8 +47,14 @@ function onlyShowInDropdown(id: string): void {
 }
 
 const getWikiPageCount = cache.function(async (): Promise<number> => {
-	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-content .Box');
-	return wikiPages?.querySelectorAll('.Box-row')?.length ?? 0;
+	const dom = await fetchDom(buildRepoURL('wiki'));
+	const counter = dom.querySelector('#wiki-pages-box .Counter');
+
+	if (counter) {
+		return looseParseInt(counter);
+	}
+
+	return dom.querySelectorAll('#wiki-content > .Box .Box-row').length;
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -7,7 +7,6 @@ import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 import * as api from '../github-helpers/api';
 import getTabCount from '../github-helpers/get-tab-count';
-import looseParseInt from '../helpers/loose-parse-int';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {buildRepoURL, getRepo} from '../github-helpers';
 import {unhideOverflowDropdown} from './more-dropdown-links';
@@ -48,7 +47,7 @@ function onlyShowInDropdown(id: string): void {
 
 const getWikiPageCount = cache.function(async (): Promise<number> => {
 	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-content .Box');
-	return wikiPages.querySelectorAll('.Box-row').length;
+	return wikiPages?.querySelectorAll('.Box-row')?.length ?? 0;
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -47,16 +47,8 @@ function onlyShowInDropdown(id: string): void {
 }
 
 const getWikiPageCount = cache.function(async (): Promise<number> => {
-	const dom = await fetchDom(buildRepoURL('wiki'));
-	const counter = dom.querySelector('#wiki-pages-box .Counter');
-
-	// "Home" page may not exist #5831
-	if (counter) {
-		return looseParseInt(counter);
-	}
-
-	const wikiPages = dom.querySelector('#wiki-content > .Box > ul');
-	return wikiPages?.childElementCount ?? 0;
+	const wikiPages = await fetchDom(buildRepoURL('wiki'), '#wiki-content .Box-row');
+	return wikiPages.length;
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

The code assumes the page counter always exists in a wiki, which is not the case if a page named "Home" doesn't exist (and thus failing back to a simple list view).

## Test URLs

- Wiki with "Home" page: https://github.com/pixiebrix/pixiebrix-extension/wiki
- Wiki without "Home" page: https://github.com/refined-github/refined-github/wiki

## Screenshot

<img width="719" alt="image" src="https://user-images.githubusercontent.com/44045911/179342674-603d02f2-b78b-4ea6-8e09-1bd93aaca27e.png">
