### PR TITLE
Meta: Ensure API calls vary depending on the repo (WIP)

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -18,20 +18,18 @@ const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(g
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));
 
 async function countBugsWithUnknownLabel(): Promise<number> {
-	const {repository} = await api.v4(`
-		repository() {
-			labels(query: "bug", first: 10) {
-				nodes {
-					name
-					issues(states: OPEN) {
-						totalCount
-					}
+	const labels = await api.v4repository(`
+		labels(query: "bug", first: 10) {
+			nodes {
+				name
+				issues(states: OPEN) {
+					totalCount
 				}
 			}
 		}
 	`);
 
-	const label: AnyObject | undefined = repository.labels.nodes
+	const label: AnyObject | undefined = labels.nodes
 		.find((label: AnyObject) => isBugLabel(label.name));
 	if (!label) {
 		return 0;
@@ -41,18 +39,16 @@ async function countBugsWithUnknownLabel(): Promise<number> {
 	return label.issues.totalCount ?? 0;
 }
 
-async function countIssuesWithLabel(label: string): Promise<number> {
-	const {repository} = await api.v4(`
-		repository() {
-			label(name: "${label}") {
-				issues(states: OPEN) {
-					totalCount
-				}
+async function countIssuesWithLabel(name: string): Promise<number> {
+	const label = await api.v4repository(`
+		label(name: "${name}") {
+			issues(states: OPEN) {
+				totalCount
 			}
 		}
 	`);
 
-	return repository.label?.issues.totalCount ?? 0;
+	return label?.issues.totalCount ?? 0;
 }
 
 const countBugs = cache.function(async (): Promise<number> => {

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -8,8 +8,9 @@ import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 
 const hasAnyProjects = cache.function(async (): Promise<boolean> => {
+	const {owner, name} = getRepo()!;
 	const {repository, organization} = await api.v4(`
-		repository() {
+		repository(owner: "${owner}", name: "${name}") {
 			projects { totalCount }
 		}
 		organization(login: "${getRepo()!.owner}") {

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -62,11 +62,9 @@ const getWikiPageCount = cache.function(async (): Promise<number> => {
 });
 
 const getWorkflowsCount = cache.function(async (): Promise<number> => {
-	const {repository: {workflowFiles}} = await api.v4(`
-		repository() {
-			workflowFiles: object(expression: "HEAD:.github/workflows") {
-				... on Tree { entries { oid } }
-			}
+	const workflowFiles = await api.v4repository(`
+		workflowFiles: object(expression: "HEAD:.github/workflows") {
+			... on Tree { entries { oid } }
 		}
 	`);
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -11,15 +11,13 @@ import {linkifiedURLClass} from '../github-helpers/dom-formatters';
 import {buildRepoURL, isPermalink} from '../github-helpers';
 
 async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> {
-	const {repository} = await api.v4(`
-		repository() {
-			ref(qualifiedName: "${url.branch}") {
-				target {
-					... on Commit {
-						history(first: 1, until: "${date}") {
-							nodes {
-								oid
-							}
+	const {ref} = await api.v4repository(`
+		ref(qualifiedName: "${url.branch}") {
+			target {
+				... on Commit {
+					history(first: 1, until: "${date}") {
+						nodes {
+							oid
 						}
 					}
 				}
@@ -27,7 +25,7 @@ async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> 
 		}
 	`);
 
-	const [{oid}] = repository.ref.target.history.nodes;
+	const [{oid}] = ref.target.history.nodes;
 	select('a.rgh-link-date')!.pathname = url.assign({branch: oid}).pathname;
 }
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -18,16 +18,12 @@ function isClosed(prLink: HTMLElement): boolean {
 }
 
 function buildQuery(issueIds: string[]): string {
-	return `
-		repository() {
-			${issueIds.map(id => `
+	return issueIds.map(id => `
 				${id}: pullRequest(number: ${id.replace(/\D/g, '')}) {
 					baseRef {id}
 					baseRefName
 				}
-			`).join('\n')}
-		}
-	`;
+			`).join('\n');
 }
 
 async function init(): Promise<false | void> {
@@ -38,7 +34,7 @@ async function init(): Promise<false | void> {
 
 	const query = buildQuery(prLinks.map(pr => pr.id));
 	const [data, defaultBranch] = await Promise.all([
-		api.v4(query),
+		api.v4repository(query),
 		getDefaultBranch(),
 	]);
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -29,21 +29,19 @@ function parseFromDom(): false {
 }
 
 const getChangelogName = cache.function(async (): Promise<string | false> => {
-	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "HEAD:") {
-				...on Tree {
-					entries {
-						name
-						type
-					}
+	const {entries} = await api.v4repository(`
+		object(expression: "HEAD:") {
+			...on Tree {
+				entries {
+					name
+					type
 				}
 			}
 		}
 	`);
 
 	const files: string[] = [];
-	for (const entry of repository.object.entries as FileType[]) {
+	for (const entry of entries as FileType[]) {
 		if (entry.type === 'blob') {
 			files.push(entry.name);
 		}

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -65,23 +65,21 @@ function getSingleButton(prNumber: number): HTMLElement {
 @returns prsByFile {"filename1": [10, 3], "filename2": [2]}
 */
 const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> => {
-	const {repository} = await api.v4(`
-		repository() {
-			pullRequests(
-				first: 25,
-				states: OPEN,
-				baseRefName: "${await getDefaultBranch()}",
-				orderBy: {
-					field: UPDATED_AT,
-					direction: DESC
-				}
-			) {
-				nodes {
-					number
-					files(first: 100) {
-						nodes {
-							path
-						}
+	const {pullRequests} = await api.v4(`
+		pullRequests(
+			first: 25,
+			states: OPEN,
+			baseRefName: "${await getDefaultBranch()}",
+			orderBy: {
+				field: UPDATED_AT,
+				direction: DESC
+			}
+		) {
+			nodes {
+				number
+				files(first: 100) {
+					nodes {
+						path
 					}
 				}
 			}
@@ -90,7 +88,7 @@ const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> 
 
 	const files: Record<string, number[]> = {};
 
-	for (const pr of repository.pullRequests.nodes) {
+	for (const pr of pullRequests.nodes) {
 		for (const {path} of pr.files.nodes) {
 			files[path] = files[path] ?? [];
 			if (files[path].length < 10) {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -9,19 +9,17 @@ import features from '.';
 import * as api from '../github-helpers/api';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
-	const {repository} = await api.v4(`
-		repository() {
-			${commits.map((commit: string) => `
-				${api.escapeKey(commit)}: object(expression: "${commit}") {
-				... on Commit {
-						parents {
-							totalCount
-						}
+	const repository = await api.v4repository(
+		commits.map((commit: string) => `
+			${api.escapeKey(commit)}: object(expression: "${commit}") {
+			... on Commit {
+					parents {
+						totalCount
 					}
 				}
-			`).join('\n')}
-		}
-	`);
+			}
+		`).join('\n'),
+	);
 
 	const mergeCommits = [];
 	for (const [key, commit] of objectEntries(repository)) {

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -13,15 +13,13 @@ interface IssueInfo {
 }
 
 const getLastUpdated = cache.function(async (issueNumbers: number[]): Promise<Record<string, IssueInfo>> => {
-	const {repository} = await api.v4(`
-		repository() {
-			${issueNumbers.map(number => `
-				${api.escapeKey(number)}: issue(number: ${number}) {
-					updatedAt
-				}
-			`).join('\n')}
-		}
-	`);
+	const repository = await api.v4repository(
+		issueNumbers.map(number => `
+			${api.escapeKey(number)}: issue(number: ${number}) {
+				updatedAt
+			}
+		`).join('\n'),
+	);
 
 	return repository;
 }, {

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -8,18 +8,16 @@ import * as api from '../github-helpers/api';
 import pluralize from '../helpers/pluralize';
 
 const getCommitChanges = cache.function(async (commit: string): Promise<[additions: number, deletions: number]> => {
-	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "${commit}") {
-				... on Commit {
-					additions
-					deletions
-				}
+	const {additions, deletions} = await api.v4repository(`
+		object(expression: "${commit}") {
+			... on Commit {
+				additions
+				deletions
 			}
 		}
 	`);
 
-	return [repository.object.additions, repository.object.deletions];
+	return [additions, deletions];
 }, {
 	cacheKey: ([commit]) => 'commit-changes:' + commit,
 });

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -63,15 +63,13 @@ function addDraftFilter({delegateTarget: reviewsFilter}: delegate.Event): void {
 }
 
 const hasChecks = cache.function(async (): Promise<boolean> => {
-	const {repository} = await api.v4(`
-		repository() {
-			head: object(expression: "HEAD") {
-				... on Commit {
-					history(first: 10) {
-						nodes {
-							statusCheckRollup {
-								state
-							}
+	const head = await api.v4repository(`
+		head: object(expression: "HEAD") {
+			... on Commit {
+				history(first: 10) {
+					nodes {
+						statusCheckRollup {
+							state
 						}
 					}
 				}
@@ -79,7 +77,7 @@ const hasChecks = cache.function(async (): Promise<boolean> => {
 		}
 	`);
 
-	return repository.head.history.nodes.some((commit: AnyObject) => commit.statusCheckRollup);
+	return head.history.nodes.some((commit: AnyObject) => commit.statusCheckRollup);
 }, {
 	maxAge: {days: 3},
 	cacheKey: () => 'has-checks:' + getRepo()!.nameWithOwner,

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -21,20 +21,18 @@ interface Asset {
 
 type Tag = Record<string, Asset[]>;
 async function getAssetsForTag(tags: string[]): Promise<Tag> {
-	const {repository} = await api.v4(`
-		repository() {
-			${tags.map(tag => `
-				${api.escapeKey(tag)}: release(tagName:"${tag}") {
-					releaseAssets(first: 100) {
-						nodes {
-							name
-							downloadCount
-						}
+	const repository = await api.v4repository(
+		tags.map(tag => `
+			${api.escapeKey(tag)}: release(tagName:"${tag}") {
+				releaseAssets(first: 100) {
+					nodes {
+						name
+						downloadCount
 					}
 				}
-			`).join(',')}
-		}
-	`);
+			}
+		`).join(','),
+	);
 
 	const assets: Tag = {};
 	for (const [tag, release] of Object.entries(repository)) {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -26,15 +26,13 @@ async function parseCountFromDom(): Promise<number> {
 }
 
 async function fetchFromApi(): Promise<number> {
-	const {repository} = await api.v4(`
-		repository() {
-			refs(refPrefix: "refs/tags/") {
-				totalCount
-			}
+	const {tags} = await api.v4(`
+		tags: refs(refPrefix: "refs/tags/") {
+			totalCount
 		}
 	`);
 
-	return repository.refs.totalCount;
+	return tags.totalCount;
 }
 
 const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi(), {

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -16,28 +16,24 @@ Get the current base commit of this PR. It should change after rebases and merge
 This value is not consistently available on the page (appears in `/files` but not when only 1 commit is selected)
 */
 const getBaseReference = onetime(async (): Promise<string> => {
-	const {repository} = await api.v4(`
-		repository() {
-			pullRequest(number: ${getConversationNumber()!}) {
-				baseRefOid
-			}
+	const {pullRequest} = await api.v4repository(`
+		pullRequest(number: ${getConversationNumber()!}) {
+			baseRefOid
 		}
 	`);
-	return repository.pullRequest.baseRefOid;
+	return pullRequest.baseRefOid;
 });
 
 async function getFile(filePath: string): Promise<{isTruncated: boolean; text: string} | undefined> {
-	const {repository} = await api.v4(`
-		repository() {
-			file: object(expression: "${await getBaseReference()}:${filePath}") {
-				... on Blob {
-					isTruncated
-					text
-				}
+	const {file} = await api.v4repository(`
+		file: object(expression: "${await getBaseReference()}:${filePath}") {
+			... on Blob {
+				isTruncated
+				text
 			}
 		}
 	`);
-	return repository.file;
+	return file;
 }
 
 async function restoreFile(progress: (message: string) => void, menuItem: Element, filePath: string): Promise<void> {

--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -16,16 +16,14 @@ interface WorkflowDetails {
 }
 
 const getWorkflowsDetails = cache.function(async (): Promise<Record<string, WorkflowDetails> | false> => {
-	const {repository: {workflowFiles}} = await api.v4(`
-		repository() {
-			workflowFiles: object(expression: "HEAD:.github/workflows") {
-				... on Tree {
-					entries {
-						name
-						object {
-							... on Blob {
-								text
-							}
+	const {workflowFiles} = await api.v4repository(`
+		workflowFiles: object(expression: "HEAD:.github/workflows") {
+			... on Tree {
+				entries {
+					name
+					object {
+						... on Blob {
+							text
 						}
 					}
 				}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -55,20 +55,18 @@ function parseCurrentURL(): string[] {
 }
 
 async function getLatestCommitToFile(branch: string, filePath: string): Promise<string | void> {
-	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "${branch}") {
-				... on Commit {
-					history(first: 1, path: "${filePath}") {
-						nodes {
-							oid
-						}
+	const {details} = await api.v4repository(`
+		details: object(expression: "${branch}") {
+			... on Commit {
+				history(first: 1, path: "${filePath}") {
+					nodes {
+						oid
 					}
 				}
 			}
 		}
 	`);
-	const commit = repository.object?.history.nodes[0];
+	const commit = details?.history.nodes[0];
 	return commit?.oid;
 }
 

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -174,8 +174,6 @@ export const v4 = mem(async (
 		throw new TypeError('`query` should only be what’s inside \'query {...}\', like \'user(login: "foo") { name }\', but is \n' + query);
 	}
 
-	query = query.replace('repository() {', () => `repository(owner: "${getRepo()!.owner}", name: "${getRepo()!.name}") {`);
-
 	features.log.http(`{
 		${query}
 	}`);
@@ -209,6 +207,20 @@ export const v4 = mem(async (
 }, {
 	cacheKey: JSON.stringify,
 });
+
+export async function v4repository(
+	query: string,
+	options: GHGraphQLApiOptions = v4defaults,
+): ReturnType<typeof v4> {
+	const {owner, name} = getRepo()!;
+	const {repository} = await v4(`
+		repository(owner: "${owner}", name: "${name}") {
+			${query}
+		}
+	`, options);
+
+	return repository;
+}
 
 export async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError> {
 	const {personalToken} = await settings;

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -11,14 +11,12 @@ interface PullRequestInfo {
 }
 
 export default async function getPrInfo(number = getConversationNumber()!): Promise<PullRequestInfo> {
-	const {repository} = await api.v4(`
-		repository() {
-			pullRequest(number: ${number}) {
-				baseRefOid
-				mergeable
-				viewerCanEditFiles
-			}
+	const {pullRequest} = await api.v4repository(`
+		pullRequest(number: ${number}) {
+			baseRefOid
+			mergeable
+			viewerCanEditFiles
 		}
 	`);
-	return repository.pullRequest;
+	return pullRequest;
 }

--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -39,16 +39,14 @@ export function getLastCommitStatus(): CommitStatus {
 }
 
 export async function getCommitStatus(commitSha: string): Promise<CommitStatus> {
-	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "${commitSha}") {
-				... on Commit {
-					checkSuites(first: 100) {
-						nodes {
-							checkRuns { totalCount }
-							status
-							conclusion
-						}
+	const {commit} = await api.v4repository(`
+		commit: object(expression: "${commitSha}") {
+			... on Commit {
+				checkSuites(first: 100) {
+					nodes {
+						checkRuns { totalCount }
+						status
+						conclusion
 					}
 				}
 			}
@@ -56,11 +54,11 @@ export async function getCommitStatus(commitSha: string): Promise<CommitStatus> 
 		# Cache buster: ${Date.now()}
 	`);
 
-	if (repository.object.checkSuites.nodes === 0) {
+	if (commit.checkSuites.nodes === 0) {
 		return false; // The commit doesn't have any CI checks associated to it
 	}
 
-	for (const {checkRuns, status, conclusion} of repository.object.checkSuites.nodes) {
+	for (const {checkRuns, status, conclusion} of commit.checkSuites.nodes) {
 		// Check suites with no runs will always have a status of "QUEUED" (e.g. Dependabot when it's disabled on the repo)
 		if (checkRuns.totalCount === 0) {
 			continue;


### PR DESCRIPTION
- Probably solution for https://github.com/refined-github/refined-github/issues/5821

The fix for the issue above is rather easy: change `api.v4`’s  `cacheKey` to include the repo as well as its parameters.

However I didn't think about that until I was half-way through this, and thought it was still worth the simplification.

Every single v4 call using `repository()` (except one) _only_ queried `repository()`, so it made sense to wrap that into a specific helper instead of having a replaceable `repository() {` string. This has the nice side effect that we skip some awkward template strings we had to use. Example below

Untested, quick search and replace. Must be reviewed without whitespace.

