### PR TITLE
Fix feature cache across ajaxed page loads

### DIFF
--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -207,7 +207,17 @@ export const v4 = mem(async (
 
 	throw await getError(apiResponse as JsonObject);
 }, {
-	cacheKey: JSON.stringify,
+	cacheKey([query, options]) {
+		// `repository()` uses global state and must be handled explicitly
+		// https://github.com/refined-github/refined-github/issues/5821
+		// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864
+		const key = [query, options];
+		if (query.includes('repository() {')) {
+			key.push(getRepo()?.nameWithOwner);
+		}
+
+		return JSON.stringify(key);
+	},
 });
 
 export async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError> {


### PR DESCRIPTION
Partial and perhaps temporary solution to:

- https://github.com/refined-github/refined-github/issues/5821

We have two separate issues:

- all of our "current repo" API calls use global state
- plenty of our "cached functions" use global state


The first one is easily fixable by including the state in the key itself, manually, when `repository({global state})` is requested. https://github.com/refined-github/refined-github/pull/5839 offers an alternative approach but it requires a lot of testing. I just want to fix most of these issues in today’s release.

The second one is particularly an issue because I think `webext-storage-cache` does not correctly use the provided `cacheKey` for in-memory cache, just for in-storage one. As you can see the `microMemoize` call only uses the parameters as key: https://github.com/fregante/webext-storage-cache/blob/d49454ae720d64f17d3c984734bdf2af22e7e873/index.ts#L160

## Test

0. Clear cache
1. Open https://github.com/refined-github/sandbox/pulls (it uses a non-standard default branch name)
2. Open the notifications
3. Open any other repo
4. Visit the Pull requests page on that repo
5. See `highlight-non-default-base-branch` showing `main` even if it's the default for the current repo
