### PR TITLE
Fix `show-whitespace` peekaboo bug

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -2,7 +2,8 @@
 	line-height: 1em;
 	background-clip: border-box;
 	background-repeat: repeat-x;
-	background-position: left center;
+	/* 2px because of #4991 */
+	background-position: 2px center;
 }
 
 [data-rgh-whitespace='tab'] {


### PR DESCRIPTION
- fixes #4991


## Test URLs

- https://github.com/fregante/code-tag
- https://github.com/fregante/webext-content-scripts

## Before

You have to zoom in to see it near the `}` character and `.and` selector
<img src="https://user-images.githubusercontent.com/1402241/180240342-7925fc82-ea48-4736-90a8-cfe187b51664.png">

## After

<img src="https://user-images.githubusercontent.com/1402241/180240347-da40ffa8-8e2f-4e22-9528-33280c1f6493.png">





