### PR TITLE
Fix `sticky-file-header` overlap and position

### DIFF
--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -1,4 +1,5 @@
-:root .file-header {
+/* `.sticky-file-header` excludes native sticky header */
+:root .file-header:not(.sticky-file-header) {
 	position: sticky;
 	z-index: 6; /* isBlame, isEditingFile */
 	top: 0;
@@ -8,8 +9,13 @@
 	top: 129px;
 }
 
+/* Same as `.sticky-file-header.has-open-dropdown` */
+.file-header.has-open-dropdown:not(.sticky-file-header) {
+	z-index: 10;
+}
+
 /* Consider the File List fixed header/sidebar in commits */
-:root diff-layout .file-header {
+:root diff-layout .file-header:not(.sticky-file-header) {
 	top: 60px;
 }
 
@@ -22,5 +28,5 @@ https://github.com/refined-github/refined-github/edit/main/readme.md
 https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327
 
 Exclude:
-https://github.com/refined-github/refined-github/pull/5460/files (actually included, but natively supported anyway)
+https://github.com/refined-github/refined-github/pull/5460/files
 */


### PR DESCRIPTION
- Closes #5823
- Closes #5800


## Test URLs

- Any "PR Files", but you must come from a notification

Also, unchanged:


- https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807
- https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
- https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
- https://github.com/refined-github/refined-github/edit/main/readme.md
- https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327

## Native

<img width="378" alt="native" src="https://user-images.githubusercontent.com/1402241/180389160-c8e6997f-8e14-41cb-8485-08f16296dbe2.png">

## With RG

<img width="378" alt="rg" src="https://user-images.githubusercontent.com/1402241/180389146-18cc6875-4050-4b73-a84c-2df551e022c6.png">