### PR TITLE
Avoid incorrect `restore-file` on PRs with force pushes

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -13,7 +13,7 @@ import {getConversationNumber} from '../github-helpers';
 const selectorForPushablePRNotice = '.merge-pr > :is(.color-text-secondary, .color-fg-muted):first-child:not(.rgh-update-pr)';
 let observer: Observer;
 
-function getBranches(): {base: string; head: string} {
+export function getBranches(): {base: string; head: string} {
 	return {
 		base: select('.base-ref')!.textContent!.trim(),
 		head: select('.head-ref')!.textContent!.trim(),

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -2,7 +2,8 @@ import * as api from './api';
 import {getConversationNumber} from '.';
 
 interface PullRequestInfo {
-	// TODO: Probably can be used for #3863 and #4679
+	// TODO: Probably can be used for #3863
+	// Note: May fall out of date after a force-push
 	baseRefOid: string;
 
 	// https://docs.github.com/en/graphql/reference/enums#mergeablestate


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/4679

This fixes a GitHub bug related to force pushes:

> Note: API v4 `repository.pullRequest.baseRefOid` falls out out of date after an "update branch" + force push


## Repro

1. Create PR modifying a file
2. Modify the same file on `main`
3. "Update branch" on PR (this updates the `baseRefOid`)
4. Undo commit and force push
5. Note: `baseRefOid` does not revert 
6. Restore file

I found v3’s compare API to be more reliable, but this needs to be tested further.