### PR TITLE
Only prompt the user to create a release if any already exist

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -13,6 +13,7 @@ import attachElement from '../helpers/attach-element';
 import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers';
+import {getReleaseCount} from './releases-tab';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
@@ -75,7 +76,11 @@ function addExistingTagLink(tagName: string): void {
 	});
 }
 
-function addLinkToCreateRelease(text = 'Now you can release this change'): void {
+async function addLinkToCreateRelease(text = 'Now you can release this change'): Promise<void> {
+	if (await getReleaseCount() > 0) {
+		return;
+	}
+
 	const url = isRefinedGitHubRepo()
 		? 'https://github.com/refined-github/refined-github/actions/workflows/release.yml'
 		: buildRepoURL('releases/new');

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -10,10 +10,10 @@ import onPrMerge from '../github-events/on-pr-merge';
 import createBanner from '../github-helpers/banner';
 import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
+import {getReleaseCount} from './releases-tab';
 import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers';
-import {getReleaseCount} from './releases-tab';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -10,10 +10,10 @@ import onPrMerge from '../github-events/on-pr-merge';
 import createBanner from '../github-helpers/banner';
 import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
-import {getReleaseCount} from './releases-tab';
 import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers';
+import {getReleaseCount} from './releases-tab';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -36,7 +36,7 @@ async function init(): Promise<void> {
 	if (tagName) {
 		addExistingTagLink(tagName);
 	} else if (canCreateRelease()) {
-		addLinkToCreateRelease('This pull request seems to be unreleased');
+		void addLinkToCreateRelease('This pull request seems to be unreleased');
 	}
 }
 
@@ -119,7 +119,7 @@ void features.add(import.meta.url, {
 	],
 	onlyAdditionalListeners: true,
 	init() {
-		addLinkToCreateRelease();
+		void addLinkToCreateRelease();
 	},
 });
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -37,7 +37,7 @@ async function fetchFromApi(): Promise<number> {
 	return repository.refs.totalCount;
 }
 
-const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi(), {
+export const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi(), {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},
 	cacheKey: getCacheKey,


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/pull/5769#issuecomment-1193189879


## Test URLs

- https://github.com/fregante/Awesome-WebExtensions/pull/74
