### PR TITLE
Less attention grabbing hint to draft a new release

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -91,7 +91,7 @@ async function addLinkToCreateRelease(text = 'Now you can release this change.')
 				<p className="TimelineItem-body">
 					{text}
 					<a href={url}>
-						<TagIcon/> Draft a new release
+						Draft a new release
 					</a>
 				</p>
 			</TimelineItem>

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -36,7 +36,7 @@ async function init(): Promise<void> {
 	if (tagName) {
 		addExistingTagLink(tagName);
 	} else if (canCreateRelease()) {
-		void addLinkToCreateRelease('This pull request seems to be unreleased');
+		void addLinkToCreateRelease('This pull request seems to be unreleased.');
 	}
 }
 
@@ -76,7 +76,7 @@ function addExistingTagLink(tagName: string): void {
 	});
 }
 
-async function addLinkToCreateRelease(text = 'Now you can release this change'): Promise<void> {
+async function addLinkToCreateRelease(text = 'Now you can release this change.'): Promise<void> {
 	if (await getReleaseCount() > 0) {
 		return;
 	}
@@ -88,11 +88,12 @@ async function addLinkToCreateRelease(text = 'Now you can release this change'):
 		anchor: '#issue-comment-box',
 		before: () => (
 			<TimelineItem>
-				{createBanner({
-					text,
-					url,
-					buttonLabel: <><TagIcon/> Draft a new release</>,
-				})}
+				<p class="TimelineItem-body">
+					<>{text}</>
+					<a href={url}>
+						<TagIcon/> Draft a new release
+					</a>
+				</p>
 			</TimelineItem>
 		),
 	});

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -88,7 +88,7 @@ async function addLinkToCreateRelease(text = 'Now you can release this change.')
 		anchor: '#issue-comment-box',
 		before: () => (
 			<TimelineItem>
-				<p class="TimelineItem-body">
+				<p className="TimelineItem-body">
 					<>{text}</>
 					<a href={url}>
 						<TagIcon/> Draft a new release

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -89,7 +89,7 @@ async function addLinkToCreateRelease(text = 'Now you can release this change.')
 		before: () => (
 			<TimelineItem>
 				<p className="TimelineItem-body">
-					<>{text}</>
+					{text}
 					<a href={url}>
 						<TagIcon/> Draft a new release
 					</a>

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -36,7 +36,7 @@ async function init(): Promise<void> {
 	if (tagName) {
 		addExistingTagLink(tagName);
 	} else if (canCreateRelease()) {
-		void addLinkToCreateRelease('This pull request seems to be unreleased.');
+		void addLinkToCreateRelease('This pull request seems not to be part of a release.');
 	}
 }
 

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -90,6 +90,7 @@ async function addLinkToCreateRelease(text = 'Now you can release this change.')
 			<TimelineItem>
 				<p className="TimelineItem-body">
 					{text}
+					{' '}
 					<a href={url}>
 						Draft a new release
 					</a>


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5851.

On merged PRs which are not (yet) part of a release a banner is shown to hint to create a release. This PR changes it from a banner & button, to regular text & link.

I also changed the wording a little, but if this is not wished it can be reversed of course. I did it can be confused for other forms of 'releasing', like deploying. I didn't remove the word 'release', just used other language to make it more understood as a noun.

I'm unsure about the conventions of html elements & classes. I borrowed a class from GitHub to make the text color a little more muted. Is that okay or should a RG class be made & used?

## Test URLs

It can be seen on any merged PR which is not part of a release. _Note that due to https://github.com/refined-github/refined-github/pull/5850, the banner/text isn't shown when the repository doesn't use releases at all._

Current example: https://github.com/refined-github/refined-github/pull/5850.

## Screenshots

From current situation:
![afbeelding](https://user-images.githubusercontent.com/511245/180996001-3e01c8d5-2270-4028-9353-32f4fc7467f1.png)

To new situation:
![afbeelding](https://user-images.githubusercontent.com/511245/180747982-17d12405-7b89-40a8-999b-c002346a4594.png)
