### PR TITLE
Add `clean-checks-list` feature

### DIFF
--- a/source/features/clean-checks-list.css
+++ b/source/features/clean-checks-list.css
@@ -23,7 +23,7 @@
 
 /* Dim successful/skipped/neutral checks */
 .merge-status-list:has(.octicon-x, .text-italic) /* Only if any checks are failing or in progress */
-.merge-status-item:has(.octicon-check, .octicon-skip, .octicon-square-fill) {
+.merge-status-item:has(.octicon-check, .octicon-skip, .octicon-square-fill):not(:hover) {
 	opacity: 50%;
 }
 

--- a/source/features/clean-checks-list.css
+++ b/source/features/clean-checks-list.css
@@ -1,0 +1,34 @@
+/* Bringing running checks and failed checks to the top of the list */
+/* .octicon-check targets "successful" checks */
+/* .octicon-x targets "failed" checks */
+/* .octicon-skip targets "skipped" checks */
+/* .octicon-square-fill targets "neutral" checks */
+/* .text-italic targets "running" or "waiting" checks */
+
+/* Required to allow sorting */
+.merge-status-list {
+	display: flex;
+	flex-direction: column;
+}
+
+/* Push running checks below failed checks */
+.merge-status-item:has(.text-italic) {
+	order: 1;
+}
+
+/* Push successful/skipped/neutral checks below running checks */
+.merge-status-item:has(.octicon-check, .octicon-skip, .octicon-square-fill) {
+	order: 2;
+}
+
+/* Dim successful/skipped/neutral checks */
+.merge-status-list:has(.octicon-x, .text-italic) /* Only if any checks are failing or in progress */
+.merge-status-item:has(.octicon-check, .octicon-skip, .octicon-square-fill) {
+	opacity: 0.5;
+}
+
+/*
+Test URLs
+https://github.com/refined-github/refined-github/commit/5c9d630423d66732cb1e2bd7935fc67c133f6072
+https://github.com/refined-github/refined-github/pull/5776
+*/

--- a/source/features/clean-checks-list.css
+++ b/source/features/clean-checks-list.css
@@ -24,7 +24,7 @@
 /* Dim successful/skipped/neutral checks */
 .merge-status-list:has(.octicon-x, .text-italic) /* Only if any checks are failing or in progress */
 .merge-status-item:has(.octicon-check, .octicon-skip, .octicon-square-fill) {
-	opacity: 0.5;
+	opacity: 50%;
 }
 
 /*

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -22,6 +22,7 @@ import './features/hide-watch-and-fork-count.css';
 import './features/clean-commit-form.css';
 import './features/sticky-file-header.css';
 import './features/readable-title-change-events.css';
+import './features/highlight-failing-checks.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -22,7 +22,7 @@ import './features/hide-watch-and-fork-count.css';
 import './features/clean-commit-form.css';
 import './features/sticky-file-header.css';
 import './features/readable-title-change-events.css';
-import './features/highlight-failing-checks.css';
+import './features/clean-checks-list.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/5856

This feature:

- brings failing and pending checks to the top
- dims successful checks unless it's 100% successful

Support:

- Chrome: not yet (v105+)
- Firefox: not yet (v199+)
- Safari: not yet (next RG release unknown)

This is [a feature for no one](https://www.youtube.com/watch?v=VOhGevqqA1I).


## Test URLs


https://github.com/refined-github/refined-github/commit/5c9d630423d66732cb1e2bd7935fc67c133f6072
https://github.com/refined-github/refined-github/pull/5776

## Screenshot

<img width="561" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/181184077-3f6cbceb-908c-4a0d-9875-38d14f5cd21b.png">



_If you like to watch paint dry_

### With failing/skipped steps


https://user-images.githubusercontent.com/1402241/181183668-1df3a099-2197-43d9-8c23-71ccb24d5081.mov

### Full, successful run

https://user-images.githubusercontent.com/1402241/181183948-dd170b6d-e4ed-4432-b04c-e7ba96ff35bc.mov



