### PR TITLE
Restore `action-used-by-link`

### DIFF
--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -7,7 +7,7 @@ import features from '.';
 import selectHas from '../helpers/select-has';
 
 function init(): void {
-	const actionRepo = selectHas('a:has(aside .octicon-repo)')!
+	const actionRepo = selectHas('aside a:has(.octicon-repo)')!
 		.pathname
 		.slice(1);
 


### PR DESCRIPTION
- Closes https://github.com/marketplace/actions/urlchecker-action

URL: https://github.com/marketplace/actions/urlchecker-action

<img width="271" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/181674597-5e626afd-66c0-4e67-a04a-88a1a5d5a71f.png">

