### PR TITLE
Detect new page loads (no-work no-progress)

### DIFF
--- a/source/github-events/on-load.tsx
+++ b/source/github-events/on-load.tsx
@@ -1,0 +1,16 @@
+const gitHub = new EventTarget();
+
+export default gitHub;
+
+let isPopstate = false;
+window.addEventListener('popstate', () => {
+	console.log('NEW: popstate');
+	isPopstate = true;
+});
+document.addEventListener('turbo:visit', () => {
+	console.log('NEW: turbo:visit');
+	gitHub.dispatchEvent(new CustomEvent(isPopstate ? 'popstate' : 'load'));
+
+	// Reset for future events
+	isPopstate = false;
+});


### PR DESCRIPTION
cc @refined-github/maintainers 

- Follows https://github.com/refined-github/refined-github/pull/5742
- Testing on https://github.com/refined-github/refined-github/issues/5866

I thought we could just distinguish new page loads from history navigation and all would be good.

All in't good.

Even if we detect new page load correctly, we still need to deduplicate features that still exist on the page, outside the frame.

1. Now I wonder, is this load/popstate distinction useful in any way?
2. I think the only way out of this mess is to completely do away with global deduplication logic, and just deal with it in each feature, for example with `attachElement`
3. It's also possible that GitHub is actively messing with our logic (involuntarily), see https://github.com/refined-github/refined-github/issues/5857

I think that Turbo does more than just swapping elements.