### PR TITLE
Don't deduplicate event-only features

### DIFF
--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -64,6 +64,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -82,6 +82,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRFiles,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -29,6 +29,6 @@ void features.add(import.meta.url, {
 	],
 	onlyAdditionalListeners: true,
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -39,6 +39,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -7,7 +7,7 @@ import features from '.';
 import {groupButtons} from '../github-helpers/group-buttons';
 
 function handleClick({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const file = button.closest('.js-gist-file-update-container')!;
+	const file = button.closest('.Box, .js-gist-file-update-container')!;
 	const content = select.all('.blob-code-inner', file)
 		// eslint-disable-next-line unicorn/prefer-dom-node-text-content -- Must be `.innerText`
 		.map(({innerText: line}) => line === '\n' ? '' : line)
@@ -16,7 +16,10 @@ function handleClick({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLBut
 }
 
 function renderButton(): void {
-	for (const button of select.all('.file-actions .btn[href*="/raw/"]')) {
+	for (const button of select.all([
+		'.file-actions .btn[href*="/raw/"]', // `isGist`
+		'[data-hotkey="b"]',
+	])) {
 		const copyButton = (
 			<clipboard-copy
 				className="btn btn-sm js-clipboard-copy tooltipped tooltipped-n BtnGroup-item rgh-copy-file"
@@ -45,8 +48,10 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	asLongAs: [
 		() => select.exists('table.highlight'), // Rendered page
+		() => !select.exists('remote-clipboard-copy'), // Native copy button #4802
 	],
 	include: [
+		pageDetect.isSingleFile,
 		pageDetect.isGist,
 	],
 	deduplicate: '.rgh-copy-file', // #3945

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -7,7 +7,7 @@ import features from '.';
 import {groupButtons} from '../github-helpers/group-buttons';
 
 function handleClick({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const file = button.closest('.Box, .js-gist-file-update-container')!;
+	const file = button.closest('.js-gist-file-update-container')!;
 	const content = select.all('.blob-code-inner', file)
 		// eslint-disable-next-line unicorn/prefer-dom-node-text-content -- Must be `.innerText`
 		.map(({innerText: line}) => line === '\n' ? '' : line)
@@ -16,10 +16,7 @@ function handleClick({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLBut
 }
 
 function renderButton(): void {
-	for (const button of select.all([
-		'.file-actions .btn[href*="/raw/"]', // `isGist`
-		'[data-hotkey="b"]',
-	])) {
+	for (const button of select.all('.file-actions .btn[href*="/raw/"]')) {
 		const copyButton = (
 			<clipboard-copy
 				className="btn btn-sm js-clipboard-copy tooltipped tooltipped-n BtnGroup-item rgh-copy-file"
@@ -48,10 +45,8 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	asLongAs: [
 		() => select.exists('table.highlight'), // Rendered page
-		() => !select.exists('remote-clipboard-copy'), // Native copy button #4802
 	],
 	include: [
-		pageDetect.isSingleFile,
 		pageDetect.isGist,
 	],
 	deduplicate: '.rgh-copy-file', // #3945

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -31,6 +31,6 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/easy-toggle-files.tsx
+++ b/source/features/easy-toggle-files.tsx
@@ -25,6 +25,6 @@ void features.add(import.meta.url, {
 		pageDetect.isGistRevision,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -66,7 +66,6 @@ void features.add(import.meta.url, {
 		// If you're viewing changes from partial commits, ensure you're on the latest one.
 		() => select.exists('.js-commits-filtered') && !select.exists('[aria-label="You are viewing the latest commit"]'),
 	],
-	awaitDomReady: false,
 	deduplicate: false,
 	init,
 }, {

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -66,7 +66,8 @@ void features.add(import.meta.url, {
 		// If you're viewing changes from partial commits, ensure you're on the latest one.
 		() => select.exists('.js-commits-filtered') && !select.exists('[aria-label="You are viewing the latest commit"]'),
 	],
-	deduplicate: 'has-rgh-inner',
+	awaitDomReady: false,
+	deduplicate: false,
 	init,
 }, {
 	asLongAs: [
@@ -76,5 +77,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isCompare,
 	],
+	deduplicate: false,
 	init,
 });

--- a/source/features/expand-all-hidden-comments.tsx
+++ b/source/features/expand-all-hidden-comments.tsx
@@ -37,6 +37,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -20,6 +20,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasFiles,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -118,6 +118,7 @@ void features.add(import.meta.url, {
 		onPrMerge,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init() {
 		void addLinkToCreateRelease();
 	},

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -45,6 +45,7 @@ void features.add(import.meta.url, {
 	exclude: [
 		isSafari,
 	],
+	deduplicate: false,
 	init,
 }, {
 	include: [
@@ -53,10 +54,10 @@ void features.add(import.meta.url, {
 	exclude: [
 		isSafari,
 	],
-	deduplicate: 'has-rgh-inner',
 	additionalListeners: [
 		onPrMergePanelOpen,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init: fitPrCommitMessageBox,
 });

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -78,6 +78,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -84,6 +84,7 @@ void features.add(import.meta.url, {
 		onDiffFileLoad,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init,
 });
 

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -36,6 +36,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasFiles,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -142,5 +142,6 @@ void features.add(import.meta.url, {
 		onDiffFileLoad,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init: initCommitAndCompare,
 });

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -83,7 +83,7 @@ function init(signal: AbortSignal): false | void {
 				control.disabled = true;
 			}
 		});
-	});
+	}, {signal});
 
 	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment and no other review comments are pending
 	delegate(form, 'button', 'click', ({delegateTarget: {value}}) => {

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -45,6 +45,6 @@ void features.add(import.meta.url, {
 		pageDetect.isDeletingFile,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -45,5 +45,6 @@ void features.add(import.meta.url, {
 		onPrMerge,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init,
 });

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -27,6 +27,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPRFile404,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/prevent-duplicate-pr-submission.tsx
+++ b/source/features/prevent-duplicate-pr-submission.tsx
@@ -21,5 +21,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isCompare,
 	],
+	deduplicate: false,
 	init,
 });

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -72,6 +72,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -84,6 +84,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -70,6 +70,6 @@ void features.add(import.meta.url, {
 		canNotEditLabels,
 		pageDetect.isArchivedRepo,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -43,7 +43,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
 	],
-	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -137,6 +137,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -112,5 +112,6 @@ void features.add(import.meta.url, {
 		pageDetect.isOwnUserProfile,
 		pageDetect.isPrivateUserProfile,
 	],
+	deduplicate: false,
 	init: handleSponsorButton,
 });

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -19,5 +19,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleFile,
 	],
+	deduplicate: false,
 	init,
 });

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -84,6 +84,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
-	deduplicate: 'has-rgh-inner',
+	onlyAdditionalListeners: true,
+	deduplicate: false,
 	init,
 });

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -44,7 +44,7 @@ void features.add(import.meta.url, {
 		onNewComments,
 		onDiffFileLoad,
 	],
-	deduplicate: '.rgh-observing-whitespace',
+	deduplicate: false,
 	init,
 });
 

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -24,5 +24,6 @@ void features.add(import.meta.url, {
 		hasNotificationBar,
 	],
 	awaitDomReady: false,
+	deduplicate: false,
 	init,
 });

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -25,7 +25,7 @@ void features.add(import.meta.url, {
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 }, {
 	include: [
@@ -36,7 +36,7 @@ void features.add(import.meta.url, {
 		onPrCommitMessageRestore,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init: validateInput,
 });
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -94,6 +94,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -53,6 +53,6 @@ void features.add(import.meta.url, {
 		pageDetect.hasFiles,
 		pageDetect.isCommitList,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -45,6 +45,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -97,7 +97,7 @@ void features.add(import.meta.url, {
 		// Native button https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/
 		() => select.exists('.js-update-branch-form'),
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });
 

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -10,7 +10,7 @@ import * as api from '../github-helpers/api';
 import getPrInfo from '../github-helpers/get-pr-info';
 import {getConversationNumber} from '../github-helpers';
 
-const selectorForPushablePRNotice = '.merge-pr > :is(.color-text-secondary, .color-fg-muted):first-child:not(.rgh-update-pr)';
+const selectorForPushablePRNotice = '.merge-pr > :is(.color-text-secondary, .color-fg-muted):first-child';
 let observer: Observer;
 
 function getBranches(): {base: string; head: string} {
@@ -72,17 +72,18 @@ async function init(signal: AbortSignal): Promise<false | Deinit> {
 	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler, {signal});
 
 	// Quick check before using selector-observer on it
-	// NOTE: This selector may match the feature across page loads, so `delegate` must run before it just in case
 	if (!select.exists(selectorForPushablePRNotice)) {
 		return false;
 	}
 
-	return observe(selectorForPushablePRNotice, {
+	observer = observe(`:is(${selectorForPushablePRNotice}):not(.rgh-update-pr)`, {
 		add(position) {
 			position.classList.add('rgh-update-pr');
 			void addButton(position);
 		},
 	});
+
+	return observer;
 }
 
 void features.add(import.meta.url, {

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -69,21 +69,20 @@ async function addButton(position: Element): Promise<void> {
 async function init(signal: AbortSignal): Promise<false | Deinit> {
 	await api.expectToken();
 
+	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler, {signal});
+
 	// Quick check before using selector-observer on it
+	// NOTE: This selector may match the feature across page loads, so `delegate` must run before it just in case
 	if (!select.exists(selectorForPushablePRNotice)) {
 		return false;
 	}
 
-	observer = observe(selectorForPushablePRNotice, {
+	return observe(selectorForPushablePRNotice, {
 		add(position) {
 			position.classList.add('rgh-update-pr');
 			void addButton(position);
 		},
 	});
-
-	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler, {signal});
-
-	return observer;
 }
 
 void features.add(import.meta.url, {

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -192,6 +192,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isDraftPR,
 	],
-	deduplicate: 'has-rgh-inner',
+	deduplicate: false,
 	init,
 });


### PR DESCRIPTION
- Partial fix for #5871 

Drops deduplication from:

- delegate-only features
- onlyAdditionalListener features

Mixed "change dom + delegate" features are still broken as per #5871, they will need changes like:

- https://github.com/refined-github/refined-github/pull/5872
- custom deduplication detection

I think basically we need to move away from `has-rgh` and its affordances
