### PR TITLE
Replace `selector-observer`

### DIFF
--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -26,14 +26,15 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 	detailsLink.href = detailsUrl;
 }
 
-// This selector excludes URLs that are already external
-const thirdPartyApps = [
-	`a:not([href="/apps/github-actions"]) ~ div a.status-actions[href^="${location.origin}"]:not(.rgh-bypass-link)`, // Hovercard status checks
-	'a:not([href="/apps/github-actions"]) ~ div a.status-actions[href^="/"]:not(.rgh-bypass-link)',
-] as const;
-
 function init(signal: AbortSignal): void {
-	observe(thirdPartyApps, bypass, {signal});
+	// This selector excludes URLs that are already external
+	// `location.origin` is for the hovercard status checks
+	observe(`
+		a:not([href="/apps/github-actions"]) ~ div a.status-actions:is(
+			[href^="${location.origin}"],
+			[href^="/"]
+		)
+	`, bypass, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -28,7 +28,8 @@ async function bypass(detailsLink: HTMLAnchorElement): Promise<void> {
 
 function init(signal: AbortSignal): void {
 	// This selector excludes URLs that are already external
-	// `location.origin` is for the hovercard status checks
+	// `location.origin` is for the status checks’ in the hovercard
+	// TODO: Clarify/retest comment
 	observe(`
 		a:not([href="/apps/github-actions"]) ~ div a.status-actions:is(
 			[href^="${location.origin}"],

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -30,8 +30,8 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 const selectors = [
-	'[itemprop="name codeRepository"]', // `isUserProfileRepoTab`
-	'[data-hydro-click*=\'"model_name":"Repository"\']', // `isGlobalSearchResults`
+	'a[itemprop="name codeRepository"]', // `isUserProfileRepoTab`
+	'a[data-hydro-click*=\'"model_name":"Repository"\']', // `isGlobalSearchResults`
 ] as const;
 function init(signal: AbortSignal): void {
 	observe(selectors, addConversationLinks, {signal});

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -44,3 +44,13 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+Test URLs
+
+isUserProfileRepoTab:
+https://github.com/fregante?tab=repositories
+
+isGlobalSearchResults:
+https://github.com/search?q=fregante
+*/

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -1,10 +1,10 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 import {GitPullRequestIcon, IssueOpenedIcon} from '@primer/octicons-react';
 
 import features from '.';
+import observe from '../helpers/selector-observer';
 
 function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 	repositoryLink.classList.add('rgh-discussion-links');
@@ -30,14 +30,12 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 	);
 }
 
-function init(): Deinit {
-	return observe([
-		'[itemprop="name codeRepository"]:not(.rgh-discussion-links)', // `isUserProfileRepoTab`
-		'[data-hydro-click*=\'"model_name":"Repository"\']:not(.rgh-discussion-links)', // `isGlobalSearchResults`
-	].join(','), {
-		constructor: HTMLAnchorElement,
-		add: addConversationLinks,
-	});
+const selectors = [
+	'[itemprop="name codeRepository"]', // `isUserProfileRepoTab`
+	'[data-hydro-click*=\'"model_name":"Repository"\']', // `isGlobalSearchResults`
+] as const;
+function init(signal: AbortSignal): void {
+	observe(selectors, addConversationLinks, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -7,7 +7,6 @@ import features from '.';
 import observe from '../helpers/selector-observer';
 
 function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
-	repositoryLink.classList.add('rgh-discussion-links');
 	const repository = repositoryLink.closest('li')!;
 
 	// Remove the "X issues need help" link

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -1,19 +1,19 @@
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {getUsername} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
-function init(): Deinit {
-	return observe('#dashboard .news .watch_started, #dashboard .news .fork', {
-		constructor: HTMLElement,
-		add(item) {
-			if (select.exists(`a[href^="/${getUsername()!}"]`, item)) {
-				item.style.display = 'none';
-			}
-		},
-	});
+function hide(item: HTMLElement): void {
+	if (select.exists(`a[href^="/${getUsername()!}"]`, item)) {
+		item.style.display = 'none';
+	}
+}
+
+function init(signal: AbortSignal): void {
+	/* TODO: Use :has()  and skip select.exists */
+	observe('#dashboard .news .watch_started, #dashboard .news .fork', hide, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -12,7 +12,7 @@ function hide(item: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	/* TODO: Use :has()  and skip select.exists */
+	/* TODO: Use :has() and skip select.exists */
 	observe('#dashboard .news .watch_started, #dashboard .news .fork', hide, {signal});
 }
 

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -1,12 +1,12 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {onDiffFileLoad} from '../github-events/on-fragment-load';
+import observe from '../helpers/selector-observer';
 
 async function loadDeferred(jumpList: Element): Promise<void> {
 	// This event will trigger the loading, but if run too early, GitHub might not have attached the listener yet, so we try multiple times.
@@ -18,8 +18,6 @@ async function loadDeferred(jumpList: Element): Promise<void> {
 }
 
 function highlightFilename(filename: HTMLAnchorElement, sourceIcon: SVGSVGElement): void {
-	filename.classList.add('rgh-pr-file-state');
-
 	const icon = sourceIcon.cloneNode(true);
 	const action = icon.getAttribute('title')!;
 	if (action === 'added') {
@@ -38,7 +36,7 @@ function highlightFilename(filename: HTMLAnchorElement, sourceIcon: SVGSVGElemen
 	);
 }
 
-async function init(): Promise<Deinit> {
+async function init(signal: AbortSignal): Promise<void> {
 	const fileList = await elementReady([
 		'.toc-select details-menu[src*="/show_toc?"]', // `isPR`
 		'.toc-diff-stats + .content', // `isSingleCommit` and `isCompare`
@@ -49,16 +47,13 @@ async function init(): Promise<Deinit> {
 	}
 
 	// Link--primary excludes CODEOWNERS icon #5565
-	return observe('.file-info .Link--primary:not(.rgh-pr-file-state)', {
-		constructor: HTMLAnchorElement,
-		add(filename) {
-			const sourceIcon = pageDetect.isPR()
-				? select(`[href="${filename.hash}"] svg`, fileList)!
-				: select(`svg + [href="${filename.hash}"]`, fileList)?.previousElementSibling as SVGSVGElement;
+	observe('.file-info a.Link--primary', filename => {
+		const sourceIcon = pageDetect.isPR()
+			? select(`[href="${filename.hash}"] svg`, fileList)!
+			: select(`svg + [href="${filename.hash}"]`, fileList)?.previousElementSibling as SVGSVGElement;
 
-			highlightFilename(filename, sourceIcon);
-		},
-	});
+		highlightFilename(filename, sourceIcon);
+	}, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/jump-to-change-requested-comment.tsx
+++ b/source/features/jump-to-change-requested-comment.tsx
@@ -1,23 +1,23 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
 import features from '.';
+import observe from '../helpers/selector-observer';
 
-function init(): Deinit {
-	return observe('.review-item .dropdown-item[href^="#pullrequestreview-"]:not(.rgh-jump-to-change-requested-comment)', {
-		constructor: HTMLAnchorElement,
-		add(messageContainer) {
-			messageContainer.classList.add('rgh-jump-to-change-requested-comment');
+function init(signal: AbortSignal): void {
+	observe(
+		'.review-item a.dropdown-item[href^="#pullrequestreview-"])',
+		messageContainer => {
 			const element = select('.review-status-item div[title*="requested changes"]')?.lastChild;
 
 			if (element) {
 				wrap(element, <a href={messageContainer.href}/>);
 			}
 		},
-	});
+		{signal},
+	);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/jump-to-change-requested-comment.tsx
+++ b/source/features/jump-to-change-requested-comment.tsx
@@ -27,3 +27,9 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+Test URLs
+
+https://github.com/ipaddress-gem/ipaddress/pull/22#partial-pull-merging
+*/

--- a/source/features/jump-to-change-requested-comment.tsx
+++ b/source/features/jump-to-change-requested-comment.tsx
@@ -6,18 +6,14 @@ import {wrap} from '../helpers/dom-utils';
 import features from '.';
 import observe from '../helpers/selector-observer';
 
-function init(signal: AbortSignal): void {
-	observe(
-		'.review-item a.dropdown-item[href^="#pullrequestreview-"])',
-		messageContainer => {
-			const element = select('.review-status-item div[title*="requested changes"]')?.lastChild;
+function linkify(textLine: HTMLElement): void {
+	const url = select('a.dropdown-item[href^="#pullrequestreview-"]', textLine.parentElement!);
+	// `lastChild` is a textNode
+	wrap(textLine.lastChild!, <a href={url!.hash}/>);
+}
 
-			if (element) {
-				wrap(element, <a href={messageContainer.href}/>);
-			}
-		},
-		{signal},
-	);
+function init(signal: AbortSignal): void {
+	observe('.merge-status-item.review-item [title*="requested changes"]', linkify, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -7,7 +7,6 @@ import features from '.';
 import observe from '../helpers/selector-observer';
 
 function addToConversation(discussionHeader: HTMLElement): void {
-	discussionHeader.classList.add('rgh-jump-to-conversation-close-event');
 	// Avoid native `title` by disabling pointer events, we have our own `aria-label`. We can't drop the `title` attribute because some features depend on it.
 	discussionHeader.style.pointerEvents = 'none';
 
@@ -23,7 +22,11 @@ function addToConversation(discussionHeader: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe(
-		'#partial-discussion-header :is([title="Status: Closed"], [title="Status: Merged"], [title="Status: Closed as not planned"]):not(.rgh-jump-to-conversation-close-event)',
+		`#partial-discussion-header :is(
+			[title="Status: Closed"],
+			[title="Status: Merged"],
+			[title="Status: Closed as not planned"]
+		)`,
 		addToConversation,
 		{signal},
 	);

--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -1,10 +1,10 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
 import features from '.';
+import observe from '../helpers/selector-observer';
 
 function addToConversation(discussionHeader: HTMLElement): void {
 	discussionHeader.classList.add('rgh-jump-to-conversation-close-event');
@@ -21,11 +21,12 @@ function addToConversation(discussionHeader: HTMLElement): void {
 	);
 }
 
-function init(): Deinit {
-	return observe('#partial-discussion-header :is([title="Status: Closed"], [title="Status: Merged"], [title="Status: Closed as not planned"]):not(.rgh-jump-to-conversation-close-event)', {
-		constructor: HTMLElement,
-		add: addToConversation,
-	});
+function init(signal: AbortSignal): void {
+	observe(
+		'#partial-discussion-header :is([title="Status: Closed"], [title="Status: Merged"], [title="Status: Closed as not planned"]):not(.rgh-jump-to-conversation-close-event)',
+		addToConversation,
+		{signal},
+	);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -1,4 +1,5 @@
 import React from 'dom-chef';
+import {css} from 'code-tag';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
@@ -22,11 +23,13 @@ function addToConversation(discussionHeader: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe(
-		`#partial-discussion-header :is(
-			[title="Status: Closed"],
-			[title="Status: Merged"],
-			[title="Status: Closed as not planned"]
-		)`,
+		css`
+			#partial-discussion-header :is(
+				[title="Status: Closed"],
+				[title="Status: Merged"],
+				[title="Status: Closed as not planned"]
+			)
+		`,
 		addToConversation,
 		{signal},
 	);

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -1,11 +1,11 @@
 import React from 'dom-chef';
-import {observe} from 'selector-observer';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {LinkExternalIcon} from '@primer/octicons-react';
 
 import features from '.';
 import {getRepo} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
 function getLinkToGitHubIo(repoTitle: HTMLElement): JSX.Element {
 	return (
@@ -27,17 +27,12 @@ async function initRepo(): Promise<void> {
 	repoTitle.after(link);
 }
 
-function initRepoList(): Deinit {
-	return observe('a[href$=".github.io"][itemprop="name codeRepository"]:not(.rgh-github-io)', {
-		constructor: HTMLAnchorElement,
-		add(repoTitle) {
-			repoTitle.classList.add('rgh-github-io');
-			repoTitle.after(
-				' ',
-				getLinkToGitHubIo(repoTitle),
-			);
-		},
-	});
+function addLink(repoTitle: HTMLAnchorElement): void {
+	repoTitle.after(' ', getLinkToGitHubIo(repoTitle));
+}
+
+function initRepoList(signal: AbortSignal): void {
+	observe('a[href$=".github.io"][itemprop="name codeRepository"]', addLink, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -15,7 +15,7 @@ function linkify(avatar: HTMLImageElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('details-dialog .Box-header .mr-3 > img:not([alt*="[bot]"])', linkify,{signal});
+	observe('details-dialog .Box-header .mr-3 > img:not([alt*="[bot]"])', linkify, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -1,22 +1,21 @@
 import React from 'dom-chef';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
 import features from '.';
+import observe from '../helpers/selector-observer';
 
-function init(): Deinit {
-	return observe('details-dialog .Box-header .mr-3 > img:not([alt*="[bot]"])', {
-		constructor: HTMLImageElement,
-		add(avatar) {
-			const userName = avatar.alt.slice(1);
-			// Linkify name first
-			wrap(avatar.nextElementSibling!, <a className="Link--primary" href={`/${userName}`}/>);
+function linkify(avatar: HTMLImageElement): void {
+	const userName = avatar.alt.slice(1);
+	// Linkify name first
+	wrap(avatar.nextElementSibling!, <a className="Link--primary" href={`/${userName}`}/>);
 
-			// Then linkify avatar
-			wrap(avatar, <a href={`/${userName}`}/>);
-		},
-	});
+	// Then linkify avatar
+	wrap(avatar, <a href={`/${userName}`}/>);
+}
+
+function init(signal: AbortSignal): void {
+	observe('details-dialog .Box-header .mr-3 > img:not([alt*="[bot]"])', linkify,{signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -3,7 +3,6 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
 import {XIcon} from '@primer/octicons-react';
-import {observe} from 'selector-observer';
 import {assertError} from 'ts-extras';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
@@ -12,6 +11,7 @@ import features from '.';
 import * as api from '../github-helpers/api';
 import showToast from '../github-helpers/toast';
 import {getConversationNumber} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
 const canNotEditLabels = onetime((): boolean => !select.exists('.label-select-menu .octicon-gear'));
 
@@ -51,15 +51,12 @@ function addRemoveLabelButton(label: HTMLElement): void {
 	);
 }
 
-async function init(signal: AbortSignal): Promise<Deinit> {
+async function init(signal: AbortSignal): Promise<void> {
 	await api.expectToken();
 
 	delegate(document, '.rgh-quick-label-removal:not([disabled])', 'click', removeLabelButtonClickHandler, {signal});
 
-	return observe('.js-issue-labels .IssueLabel:not(.rgh-quick-label-removal-already-added)', {
-		constructor: HTMLElement,
-		add: addRemoveLabelButton,
-	});
+	observe('.js-issue-labels .IssueLabel:not(.rgh-quick-label-removal-already-added)', addRemoveLabelButton, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -38,7 +38,7 @@ async function removeLabelButtonClickHandler(event: DelegateEvent<MouseEvent, HT
 }
 
 function addRemoveLabelButton(label: HTMLElement): void {
-	label.classList.add('rgh-quick-label-removal-already-added', 'd-inline-flex');
+	label.classList.add('d-inline-flex');
 	label.append(
 		<button
 			type="button"
@@ -56,7 +56,7 @@ async function init(signal: AbortSignal): Promise<void> {
 
 	delegate(document, '.rgh-quick-label-removal:not([disabled])', 'click', removeLabelButtonClickHandler, {signal});
 
-	observe('.js-issue-labels .IssueLabel:not(.rgh-quick-label-removal-already-added)', addRemoveLabelButton, {signal});
+	observe('.js-issue-labels .IssueLabel', addRemoveLabelButton, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -1,15 +1,12 @@
 import onetime from 'onetime';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {linkifiedURLClass, shortenLink} from '../github-helpers/dom-formatters';
+import observe from '../helpers/selector-observer';
 
-function init(): void {
-	observe(`a[href]:not(.${linkifiedURLClass})`, {
-		constructor: HTMLAnchorElement,
-		add: shortenLink,
-	});
+function init(signal: AbortSignal): void {
+	observe(`a[href]:not(.${linkifiedURLClass})`, shortenLink, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -5,8 +5,9 @@ import features from '.';
 import {linkifiedURLClass, shortenLink} from '../github-helpers/dom-formatters';
 import observe from '../helpers/selector-observer';
 
-function init(signal: AbortSignal): void {
-	observe(`a[href]:not(.${linkifiedURLClass})`, shortenLink, {signal});
+/* This feature is currently so broad that it's not de-inited via signal, it's just run once for all pageloads #5889 */
+function init(): void {
+	observe(`a[href]:not(.${linkifiedURLClass})`, shortenLink);
 }
 
 void features.add(import.meta.url, {

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -26,7 +26,7 @@ Get unique ID by using the line:column of the call (or its parents) as seed. Eve
 
 @param index The line of the Error#stack generated inside this function
 */
-function getSnapshotUUID(index = 3): string {
+export function getSnapshotUUID(index = 3): string {
 	return hashString(new Error('Get stack').stack!.split('\n')[index]);
 }
 

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -26,7 +26,7 @@ Get unique ID by using the line:column of the call (or its parents) as seed. Eve
 
 @param index The line of the Error#stack generated inside this function
 */
-export function getSnapshotUUID(index = 3): string {
+function getSnapshotUUID(index = 3): string {
 	return hashString(new Error('Get stack').stack!.split('\n')[index]);
 }
 

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -24,10 +24,10 @@ type Attachments<NewElement extends Element> = Attachment<NewElement> & {
 /**
 Get unique ID by using the line:column of the call (or its parents) as seed. Every call from the same place will return the same ID, as long as the index is set to the parents that matters to you.
 
-@param index The line of the Error#stack generated inside this function
+@param ancestor Which call in the stack should be used as key. 0 means the exact line where getSnapshotUUID is called. Defaults to 1 because it's usually used inside a helper.
 */
-export function getSnapshotUUID(index = 3): string {
-	return hashString(new Error('Get stack').stack!.split('\n')[index]);
+export function getSnapshotUUID(ancestor = 1): string {
+	return hashString(new Error('Get stack').stack!.split('\n')[ancestor + 2]);
 }
 
 export default function attachElement<NewElement extends Element>({

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -7,10 +7,9 @@ import {ParseSelector} from 'typed-query-selector/parser';
 import {getSnapshotUUID} from './attach-element';
 
 const animation = 'rgh-selector-observer';
-const seen = new Map<string, WeakSet<EventTarget>>();
 const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
 	const target = event.target as ExpectedElement;
-	if (seen.get(selector)?.has(target) || !target.matches(selector)) {
+	if (!target.matches(selector)) {
 		return;
 	}
 
@@ -20,8 +19,6 @@ const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, 
 	if (!/shortenLink|bypass/.test(callback.toString())) {
 		console.log('selector-observer', target, callback);
 	}
-
-	seen.get(selector)!.add(target);
 
 	callback(target);
 });
@@ -51,7 +48,6 @@ export default function observe<
 			animation: 1ms ${animation};
 		}
 	`);
-	seen.set(String(selector), new WeakSet());
 	getTag().append(rule);
 	signal?.addEventListener('abort', () => {
 		rule.remove();

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -16,10 +16,6 @@ const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, 
 	// Removes this specific selector’s animation once it was seen
 	target.classList.add(seenMark);
 
-	if (!/shortenLink|bypass/.test(callback.toString())) {
-		console.log('selector-observer', target, callback);
-	}
-
 	callback(target);
 });
 
@@ -42,7 +38,7 @@ export default function observe<
 	}
 
 	const selector = String(selectors); // Array#toString() creates a comma-separated string
-	const seenMark = 'rgh-' + getSnapshotUUID();
+	const seenMark = 'rgh-seen-' + getSnapshotUUID();
 	const rule = new Text(css`
 		:where(${String(selector)}):not(.${seenMark}) {
 			animation: 1ms ${animation};

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -4,19 +4,24 @@ import {css} from 'code-tag';
 import onetime from 'onetime';
 import {ParseSelector} from 'typed-query-selector/parser';
 
+import {getSnapshotUUID} from './attach-element';
+
 const animation = 'rgh-selector-observer';
-const tracked = new Map<string, WeakSet<EventTarget>>();
-const getListener = mem(<ExpectedElement extends HTMLElement>(selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
+const seen = new Map<string, WeakSet<EventTarget>>();
+const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
 	const target = event.target as ExpectedElement;
-	if (tracked.get(selector)?.has(target) || !target.matches(selector)) {
+	if (seen.get(selector)?.has(target) || !target.matches(selector)) {
 		return;
 	}
+
+	// Removes this specific selector’s animation once it was seen
+	target.classList.add(seenMark);
 
 	if (!/shortenLink|bypass/.test(callback.toString())) {
 		console.log('selector-observer', target, callback);
 	}
 
-	tracked.get(selector)!.add(target);
+	seen.get(selector)!.add(target);
 
 	callback(target);
 });
@@ -40,15 +45,16 @@ export default function observe<
 	}
 
 	const selector = String(selectors); // Array#toString() creates a comma-separated string
+	const seenMark = 'rgh-' + getSnapshotUUID();
 	const rule = new Text(css`
-		:where(${String(selector)}) {
+		:where(${String(selector)}):not(.${seenMark}) {
 			animation: 1ms ${animation};
 		}
 	`);
-	tracked.set(String(selector), new WeakSet());
+	seen.set(String(selector), new WeakSet());
 	getTag().append(rule);
 	signal?.addEventListener('abort', () => {
 		rule.remove();
 	});
-	window.addEventListener('animationstart', getListener(selector, listener), {signal});
+	window.addEventListener('animationstart', getListener(seenMark, selector, listener), {signal});
 }

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import onetime from 'onetime';
 import {ParseSelector} from 'typed-query-selector/parser';
 
-import {getSnapshotUUID} from './attach-element';
+import hashString from './hash-string';
 
 const tracked = new WeakSet<EventTarget>();
 const getListener = mem(<ExpectedElement extends HTMLElement>(id: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
@@ -34,7 +34,7 @@ export default function observe<
 		return;
 	}
 
-	const id = getSnapshotUUID();
+	const id = 'rgh-' + hashString(String(Math.random()));
 	const style = new Text(`
 		@keyframes ${id} {}
 		${String(selector)} {animation: 1ms ${id}}

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -27,10 +27,9 @@ const getTag = onetime((): JSX.Element => {
 
 export default function observe<
 	Selector extends string,
-	ExpectedElement extends HTMLElement = ParseSelector<Selector, HTMLElement>,
 >(
 	selectors: Selector | readonly Selector[],
-	listener: (element: ExpectedElement) => void,
+	listener: (element: ParseSelector<Selector, HTMLElement>) => void,
 	{signal}: {signal?: AbortSignal} = {},
 ): void {
 	if (signal?.aborted) {

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -1,0 +1,47 @@
+import mem from 'mem';
+import React from 'dom-chef';
+import onetime from 'onetime';
+import {ParseSelector} from 'typed-query-selector/parser';
+
+import {getSnapshotUUID} from './attach-element';
+
+const tracked = new WeakSet<EventTarget>();
+const getListener = mem(<ExpectedElement extends HTMLElement>(id: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
+	const target = event.target as ExpectedElement;
+	if (event.animationName !== id || tracked.has(target)) {
+		return;
+	}
+
+	tracked.add(target);
+
+	callback(target);
+});
+
+const getTag = onetime((): JSX.Element => {
+	const style = <style/>;
+	document.head.append(style);
+	return style;
+});
+export default function observe<
+	Selector extends string,
+	ExpectedElement extends HTMLElement = ParseSelector<Selector, HTMLElement>,
+>(
+	selector: Selector | readonly Selector[],
+	listener: (element: ExpectedElement) => void,
+	{signal}: {signal?: AbortSignal} = {},
+): void {
+	if (signal?.aborted) {
+		return;
+	}
+
+	const id = getSnapshotUUID();
+	const style = new Text(`
+		@keyframes ${id} {}
+		${String(selector)} {animation: 1ms ${id}}
+	`);
+	getTag().append(style);
+	signal?.addEventListener('abort', () => {
+		style.remove();
+	});
+	window.addEventListener('animationstart', getListener(id, listener), {signal});
+}


### PR DESCRIPTION
- Closes #5874 

Not tested.

If the WeakSet doesn't match existing elements, the function will also need to attach a temporary class because I removed our custom `:not(rgh-etc)` selectors