### PR TITLE
Disable `clean-rich-text-editor` on mobile

### DIFF
--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -1,4 +1,7 @@
-/* Hide unnecessary comment toolbar items */
-.rgh-clean-rich-text-editor :is(md-mention, md-ref, md-header, md-bold, md-italic) {
-	display: none !important; /* Has to override `.d-inline-block` */
+/* Hide unnecessary comment toolbar items, but only on desktop #5743 */
+/* Kinda excludes "soft keyboards" devices https://github.com/w3c/csswg-drafts/issues/3871 */
+@media (hover: hover) and (pointer: fine) {
+	.rgh-clean-rich-text-editor :is(md-mention, md-ref, md-header, md-bold, md-italic) {
+		display: none !important; /* Has to override `.d-inline-block` */
+	}
 }


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5743



## Test URLs

This page

## Screenshot

### Desktop

Untouched


<img width="864" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/183232631-10a3add7-5d3f-4faf-85cc-d8cc952e01fb.png">


### Mobile

Icons restored

<img width="490" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/183232638-fb3f4597-4cb2-4a86-94f1-d7c2b824e0fb.png">

