### PR TITLE
Always show `first-published-tag-for-merged-pr`

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -77,7 +77,7 @@ function addExistingTagLink(tagName: string): void {
 }
 
 async function addLinkToCreateRelease(text = 'Now you can release this change'): Promise<void> {
-	if (await getReleaseCount() > 0) {
+	if (await getReleaseCount() === 0) {
 		return;
 	}
 
@@ -117,7 +117,6 @@ void features.add(import.meta.url, {
 	additionalListeners: [
 		onPrMerge,
 	],
-	onlyAdditionalListeners: true,
 	deduplicate: false,
 	init() {
 		void addLinkToCreateRelease();
@@ -125,11 +124,9 @@ void features.add(import.meta.url, {
 });
 
 /*
-
-# Test URLs
+Test URLs
 
 - PR: https://github.com/refined-github/refined-github/pull/5600
 - Locked PR: https://github.com/eslint/eslint/pull/17
 - Archived repo: https://github.com/fregante/iphone-inline-video/pull/130
-
 */

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -35,8 +35,8 @@ async function init(): Promise<void> {
 
 	if (tagName) {
 		addExistingTagLink(tagName);
-	} else if (canCreateRelease()) {
-		void addLinkToCreateRelease('This pull request seems to be unreleased');
+	} else {
+		void addReleaseBanner('This pull request has not yet appeared in a release');
 	}
 }
 
@@ -76,14 +76,16 @@ function addExistingTagLink(tagName: string): void {
 	});
 }
 
-async function addLinkToCreateRelease(text = 'Now you can release this change'): Promise<void> {
+async function addReleaseBanner(text = 'Now you can release this change'): Promise<void> {
 	if (await getReleaseCount() === 0) {
 		return;
 	}
 
-	const url = isRefinedGitHubRepo()
-		? 'https://github.com/refined-github/refined-github/actions/workflows/release.yml'
-		: buildRepoURL('releases/new');
+	const url = canCreateRelease() ? (
+		isRefinedGitHubRepo()
+			? 'https://github.com/refined-github/refined-github/actions/workflows/release.yml'
+			: buildRepoURL('releases/new')
+	) : undefined;
 	attachElement({
 		anchor: '#issue-comment-box',
 		before: () => (
@@ -99,6 +101,7 @@ async function addLinkToCreateRelease(text = 'Now you can release this change'):
 }
 
 void features.add(import.meta.url, {
+	// When arriving on an already-merged PR
 	asLongAs: [
 		pageDetect.isPRConversation,
 		pageDetect.isMergedPR,
@@ -109,6 +112,7 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 }, {
+	// This catches a PR while it's being merged
 	asLongAs: [
 		pageDetect.isPRConversation,
 		pageDetect.isOpenPR,
@@ -117,9 +121,10 @@ void features.add(import.meta.url, {
 	additionalListeners: [
 		onPrMerge,
 	],
+	onlyAdditionalListeners: true,
 	deduplicate: false,
 	init() {
-		void addLinkToCreateRelease();
+		void addReleaseBanner();
 	},
 });
 

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -1,12 +1,11 @@
 import React from 'dom-chef';
-import {RequireAllOrNone} from 'type-fest';
 
-type BannerProps = RequireAllOrNone<{
+interface BannerProps {
 	text: Array<string | JSX.Element> | string | JSX.Element;
-	url: string;
+	url?: string;
 	buttonLabel: JSX.Element | string;
 	classes?: string[];
-}, 'buttonLabel' | 'url'>;
+}
 
 // This could be a `<Banner/>` element but dom-chef doesn't pass props
 // https://github.com/vadimdemedes/dom-chef/issues/77


### PR DESCRIPTION
Before it was shown:

- on released PRs
- right after merging a PR

Now it's shown:

- when a PR is closed
	- released? show link
	- else can release? show link
	- else show without link


## Screenshot

### Closed PR, can release

- https://github.com/refined-github/sandbox/pull/35

<img width="557" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/183234436-111e108b-2b9d-4ffb-ba58-474be165df47.png">


### Closed PR, cannot release

- https://github.com/facebook/react/pull/25044

<img width="557" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/183234471-8511e57f-9670-45f6-a427-b67ca92e4f1b.png">


### Merging PR



![text](https://user-images.githubusercontent.com/1402241/183234448-7096bf55-3efa-48a2-966f-bd1f3cb854c8.gif)



## Related

- https://github.com/refined-github/refined-github/pull/5854