### PR TITLE
Fix `fork-source-link-same-view` on tags/releases

### DIFF
--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -16,7 +16,7 @@ async function getEquivalentURL(): Promise<string> {
 	const defaultUrl = '/' + forkedRepository.nameWithOwner;
 
 	// Do not use `isConversation` https://github.com/refined-github/refined-github/pull/5494#discussion_r829019629
-	if (pageDetect.isIssue() || pageDetect.isPR() || pageDetect.isRepoRoot()) {
+	if (pageDetect.isIssue() || pageDetect.isPR() || pageDetect.isRepoRoot() || pageDetect.isSingleTag()) {
 		// We must reset the link because the header is outside the ajaxed area
 		return defaultUrl;
 	}


### PR DESCRIPTION
Closes #5770

As far as I tested, the releases and tags pages work Ok. I only updated the link for a single tag. I assume we want to fallback to the `defaultUrl` in this case.

## Test URLs

https://github.com/GehDoc/textile-js/releases/tag/v2.0.114

## Screenshot

![1](https://user-images.githubusercontent.com/616399/183270521-81235f22-1d84-419f-b15d-eede020eee65.png)
![2](https://user-images.githubusercontent.com/616399/183270528-ec1bc636-fdad-4506-9295-61bfb377d928.png)