### PR TITLE
Bypass checks on all repo pages (not only PR conversations)

### DIFF
--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -40,7 +40,10 @@ function init(signal: AbortSignal): void {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isPRConversation,
+		pageDetect.isRepo,
+	],
+	exclude: [
+		pageDetect.isEmptyRepo,
 	],
 	deduplicate: 'has-rgh-inner',
 	init,


### PR DESCRIPTION
`bypass-checks` works great in PR conversations, thanks a lot for this, I wondered for a long time how to get rid of this additional click until I realised refined-github had the feature!

The thing is that `ci-links` will add CI status in other pages outside of PR conversations, and the links are not rewritten by `bypass-checks`.

In this PR I used a similar code as in `bypass-checks` as in `ci-links`:
https://github.com/refined-github/refined-github/blob/eca69b438a9c820a040c38884579c8d1c5af3fe0/source/features/ci-link.tsx#L52-L61

I believe with this change ,`bypass-checks` will run both on PR conversations and all pages where `ci-links` adds a CI status.

I also tested this locally following https://github.com/refined-github/refined-github/blob/main/contributing.md and it seems to work fine.

## Test URLs

On this root repo page https://github.com/scikit-learn/scikit-learn.

Clicking on the CI status added by `ci-links` will show some URL that points to Github checks i.e. are not rewritten by `bypass-checks`

## Screenshot

![image](https://user-images.githubusercontent.com/1680079/185638696-6397eafa-0ee9-4f65-9942-ca970a840c86.png)

You can see on the bottom left that some links, namely the Azure Pipelines ones (blue icons) are not rewritten to skip the Check page, i.e. it goes to `github.com/scikit-learn/scikit-learn/runs/<something>`)
