### PR TITLE
Fix: Repo tabs are hidden in Actions on Firefox

### DIFF
--- a/source/features/more-dropdown-links.css
+++ b/source/features/more-dropdown-links.css
@@ -3,7 +3,6 @@
 	visibility: visible !important;
 }
 
-
 /* Only show the divider if there are other items above it */
 .UnderlineNav-actions [hidden] + .dropdown-divider {
 	display: none;

--- a/source/features/more-dropdown-links.css
+++ b/source/features/more-dropdown-links.css
@@ -3,10 +3,6 @@
 	visibility: visible !important;
 }
 
-/* Keep the dropdown on the right on non-responsive pages #3548 */
-main > :first-child {
-	position: relative;
-}
 
 /* Only show the divider if there are other items above it */
 .UnderlineNav-actions [hidden] + .dropdown-divider {


### PR DESCRIPTION

This rule was conflicting with GitHub’s own overflow-nav logic, which ended up hiding every tab.

- Fixes https://github.com/refined-github/refined-github/issues/5921
- Reverts the ancient https://github.com/refined-github/refined-github/issues/3548

## Test URLs

- https://github.com/jerone/eslint-formatter-checklist/runs/7950750517?check_suite_focus=true


## Before

<img width="540" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/186121107-60d0e797-c8a9-4e3a-a4e7-c96e536dd9b1.png">


## After

<img width="540" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/186121061-ddf42521-450a-4258-b94b-f1cb02c7159c.png">

