### PR TITLE
Restore `convert-release-to-draft` feature

### DIFF
--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -7,11 +7,10 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import features from '.';
 import * as api from '../github-helpers/api';
 import LoadingIcon from '../github-helpers/icon-loading';
+import attachElement from '../helpers/attach-element';
+import {getRepo} from '../github-helpers';
 
-const editReleaseButtonSelector = [
-	'.BtnGroup a[href*="releases/edit"]', // Before "Releases UI refresh" #4902
-	'.Box-btn-octicon[aria-label="Edit"]',
-].join(',');
+const getReleaseEditLinkSelector = (): string => `a[href^="/${getRepo()!.nameWithOwner}/releases/edit"]`;
 
 async function convertToDraft({delegateTarget: draftButton}: DelegateEvent): Promise<void> {
 	try {
@@ -26,7 +25,7 @@ async function convertToDraft({delegateTarget: draftButton}: DelegateEvent): Pro
 			},
 		});
 
-		select(editReleaseButtonSelector)!.click(); // Visit "Edit release" page
+		select(getReleaseEditLinkSelector())!.click(); // Visit "Edit release" page
 	} catch (error) {
 		draftButton.textContent = 'Error. Check console or retry';
 		features.log.error(import.meta.url, error);
@@ -36,27 +35,25 @@ async function convertToDraft({delegateTarget: draftButton}: DelegateEvent): Pro
 async function init(signal: AbortSignal): Promise<void | false> {
 	await api.expectToken();
 
-	const editButton = await elementReady(editReleaseButtonSelector);
+	const editButton = await elementReady(getReleaseEditLinkSelector());
 	if (!editButton || select.exists('.label-draft')) {
 		return false;
 	}
 
-	const convertToDraftButton = (
-		<button
-			type="button"
-			className={'btn rgh-convert-draft ' + (pageDetect.isEnterprise() ? 'BtnGroup-item' : 'btn-sm ml-3')}
-		>
-			Convert to draft
-		</button>
-	);
+	// Fix spacing but avoid the two buttons sticking together
+	editButton.classList.replace('ml-1', 'ml-0');
 
-	if (pageDetect.isEnterprise()) { // Before "Releases UI refresh" #4902
-		editButton.after(convertToDraftButton);
-	} else {
-		editButton.before(convertToDraftButton);
-		// Fix spacing but avoid the two buttons sticking together
-		editButton.classList.replace('ml-1', 'ml-0');
-	}
+	attachElement({
+		anchor: editButton,
+		before: () => (
+			<button
+				type="button"
+				className={'btn rgh-convert-draft ' + (pageDetect.isEnterprise() ? 'BtnGroup-item' : 'btn-sm ml-3')}
+			>
+				Convert to draft
+			</button>
+		),
+	});
 
 	delegate(document, '.rgh-convert-draft', 'click', convertToDraft, {signal});
 }
@@ -66,6 +63,6 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleTag,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
+	deduplicate: '.rgh-convert-draft',
 	init,
 });


### PR DESCRIPTION




## Test URLs

- any release you can edit
- WARNING: do no click the button https://github.com/refined-github/refined-github/releases/tag/22.8.8

## Before

<img width="377" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/186127077-31eca6e9-05be-4943-afe4-d48863e7eb6d.png">

## After
<img width="377" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/186127085-4394fba0-8b23-41e6-938d-f588e9b92099.png">


