### PR TITLE
Fix position of sticky file headers after opening notification

### DIFF
--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -5,7 +5,7 @@
 	top: 0;
 }
 
-.notification-shelf ~ .application-main .file-header {
+.notification-shelf ~ .application-main .file-header:not(.sticky-file-header) {
 	top: 129px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/issues/5914

## Test URLs

1. Open a notification pointing to a PR (or PR files)
2. Go to the Files tab
3. This still happens if you go back to the "Conversation" tab, reload the page, and go to "Files" again

## Screenshot

**Before**

![01-before](https://user-images.githubusercontent.com/46634000/186638596-a99ecb39-e978-4f31-9646-4b8137991a81.png)

**After**

![02-after](https://user-images.githubusercontent.com/46634000/186638602-390da0c5-ac25-4bea-b848-ffc202985fbe.png)