### PR TITLE
Restore `center-reactions-popup` feature

### DIFF
--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -3,9 +3,6 @@
 	left: 50% !important;
 	right: auto !important;
 	transform: translate(-50%) !important;
-}
-
-/* Avoid clipping popup of comments on the right side of split file views - https://github.com/refined-github/sandbox/pull/38/files?diff=split */
-.line-comments[data-split-side='right'] .dropdown-menu-reactions {
-	transform: translate(-75%) !important;
+	display: grid !important;
+	grid-template: auto / repeat(4, auto); /* Restore two-line layout */
 }

--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -1,58 +1,11 @@
-/* Hide reaction popover text */
-.js-add-reaction-popover :is(.color-text-secondary, .color-fg-muted),
-.js-add-reaction-popover .dropdown-divider {
-	display: none;
-}
-
-/* Center reactions popup and its triangle */
-.add-reaction-popover,
-.add-reaction-popover::before,
-.add-reaction-popover::after {
-	right: auto !important;
+.dropdown-menu-reactions {
+	top: 100% !important;
 	left: 50% !important;
+	right: auto !important;
 	transform: translate(-50%) !important;
 }
 
-.add-reaction-popover {
-	animation-name: rgh-scale-in-centered !important;
-}
-
-@keyframes rgh-scale-in-centered {
-	0% {
-		transform: translate(-50%) scale(0.5);
-		opacity: 0%;
-	}
-
-	100% {
-		transform: translate(-50%);
-	}
-}
-
-/*
-Undo reactions popup centering in split file view on the right.
-The popup is clipped on the right otherwise.
-The selector considers
-- Unified view (skipped)
-- Split view with comment on the left only (skipped)
-- Split view with comment on the right only
-- Split view with comments on the left and right
-*/
-td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover {
-	left: -15px !important;
-}
-
-td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::before,
-td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::after {
-	left: 140px !important;
-}
-
-/* Never show loading spinner for reactions */
-.js-reaction-popover-container .reaction-popover-form .loading-spinner {
-	display: none !important;
-}
-
-/* Keep colored button when reaction popup is open */
-.dropdown-details[open] .timeline-comment-action {
-	opacity: 100%;
-	color: var(--color-mktg-btn-bg, #4078c0);
+/* Avoid clipping popup of comments on the right side of split file views - https://github.com/refined-github/sandbox/pull/38/files?diff=split */
+.line-comments[data-split-side='right'] .dropdown-menu-reactions {
+	transform: translate(-75%) !important;
 }

--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -1,4 +1,4 @@
-.dropdown-menu-reactions {
+.dropdown-menu-reactions.dropdown-menu-reactions { /* Double selector to override .d-flex on Chrome */
 	top: 100% !important;
 	left: 50% !important;
 	right: auto !important;


### PR DESCRIPTION
Fix https://github.com/refined-github/refined-github/issues/5881

## Test URLs

- This page
- [Split view with review comments](https://github.com/refined-github/sandbox/pull/38/files?diff=split)

## Screenshots

**Regular comment**

![image](https://user-images.githubusercontent.com/46634000/187085106-e1e909c7-2e84-4523-b2ab-ed35f5a76189.png)

**Review comment in split diff view**

![image](https://user-images.githubusercontent.com/46634000/187085144-7b4e7869-3ec7-4396-8f14-513311943d62.png)