### PR TITLE
Restore support for unmarked bots in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -20,7 +20,7 @@ const commitSelectors = botNames.map(bot => `.commit-author[href$="?author=${bot
 commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic `[bot]` label in author name
 const commitSelector = commitSelectors.join(',');
 
-const prSelectors = botNames.map(bot => `.opened-by [title="pull requests created by ${bot}"]`);
+const prSelectors = botNames.map(bot => `.opened-by [title*="pull requests created by ${bot}"]`);
 prSelectors.push(
 	'.opened-by [href*="author%3Aapp%2F"]', // Search query `is:pr+author:app/*`
 	'.labels [href$="label%3Abot"]', // PR tagged with `bot` label

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -20,7 +20,7 @@ const commitSelectors = botNames.map(bot => `.commit-author[href$="?author=${bot
 commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic `[bot]` label in author name
 const commitSelector = commitSelectors.join(',');
 
-const prSelectors = botNames.map(bot => `.opened-by [title="pull requests opened by ${bot}"]`);
+const prSelectors = botNames.map(bot => `.opened-by [title="pull requests created by ${bot}"]`);
 prSelectors.push(
 	'.opened-by [href*="author%3Aapp%2F"]', // Search query `is:pr+author:app/*`
 	'.labels [href$="label%3Abot"]', // PR tagged with `bot` label

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -20,12 +20,11 @@ const commitSelectors = botNames.map(bot => `.commit-author[href$="?author=${bot
 commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic `[bot]` label in author name
 const commitSelector = commitSelectors.join(',');
 
-const prSelectors = [
-	...botNames.map(bot => `.opened-by [title*="pull requests opened by ${bot}"]`),
-	...botNames.map(bot => `.opened-by [title*="pull requests created by ${bot}"]`), // PRs in https://github.com/pulls page
+const prSelectors = botNames.map(bot => `.opened-by [title="pull requests opened by ${bot}"]`);
+prSelectors.push(
 	'.opened-by [href*="author%3Aapp%2F"]', // Search query `is:pr+author:app/*`
 	'.labels [href$="label%3Abot"]', // PR tagged with `bot` label
-];
+);
 const prSelector = prSelectors.join(',');
 
 function init(): void {

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -20,11 +20,12 @@ const commitSelectors = botNames.map(bot => `.commit-author[href$="?author=${bot
 commitSelectors.push('.commit-author[href$="%5Bbot%5D"]'); // Generic `[bot]` label in author name
 const commitSelector = commitSelectors.join(',');
 
-const prSelectors = botNames.map(bot => `.opened-by [title="pull requests opened by ${bot}"]`);
-prSelectors.push(
+const prSelectors = [
+	...botNames.map(bot => `.opened-by [title*="pull requests opened by ${bot}"]`),
+	...botNames.map(bot => `.opened-by [title*="pull requests created by ${bot}"]`), // PRs in https://github.com/pulls page
 	'.opened-by [href*="author%3Aapp%2F"]', // Search query `is:pr+author:app/*`
 	'.labels [href$="label%3Abot"]', // PR tagged with `bot` label
-);
+];
 const prSelector = prSelectors.join(',');
 
 function init(): void {


### PR DESCRIPTION
## Issue

Closes #5945 
Follow the work done in https://github.com/refined-github/refined-github/pull/5512

## Test URLs

Check the PRs opened in: https://github.com/gravitee-io/gravitee-policy-oauth2/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

If there is no PRs opened by Renovate or Snyk by the time this PR is reviewed please refer to the screenshot below ⬇️ 


## Screenshot

**Before**
![image](https://user-images.githubusercontent.com/4112568/188504161-c3a74f75-f71a-40b0-84ca-c78c87acf9e4.png)

**After**

![image](https://user-images.githubusercontent.com/4112568/188504208-ec0e4d61-0c74-435f-aa4b-a7f31d8e727a.png)


