### PR TITLE
Restore `hidden-review-comments-indicator` 

### DIFF
--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -1,12 +1,20 @@
+.rgh-comments-indicator {
+	position: absolute;
+}
+
 .show-inline-notes .rgh-comments-indicator {
 	display: none;
 }
 
-.rgh-comments-indicator {
-	border: none !important; /* Needs to override .blob-num’s */
-	position: unset !important; /* Needs to override .blob-num’s */
-	border-top: 1px solid !important; /* Needs to override .blob-num’s */
+.rgh-comments-indicator:is(::before, ::after) {
+	content: '' !important; /* Needs to override .blob-num’s */
+	position: absolute;
+	top: -1px;
 	left: 0;
+	width: 200%;
+	border-top: solid 1px;
+	opacity: 40%;
+	transform: translateY(-50%);
 }
 
 /* This is only used to improve the clickability */
@@ -22,7 +30,7 @@
 
 .rgh-comments-indicator button {
 	position: absolute;
-	left: -40px;
+	right: 100%;
 	transform: translateY(-50%);
 	padding: 5px 8px;
 	color: inherit;
@@ -41,5 +49,4 @@
 
 .file-diff-split .rgh-comments-indicator button {
 	padding-right: 1px;
-	left: -30px;
 }

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -8,7 +8,7 @@
 
 .rgh-comments-indicator:is(::before, ::after) {
 	content: '' !important; /* Needs to override .blob-num’s */
-	position: absolute;
+	position: absolute !important;/* Needs to override .blob-num’s */
 	top: -1px;
 	left: 0;
 	width: 200%;
@@ -30,7 +30,7 @@
 
 .rgh-comments-indicator button {
 	position: absolute;
-	right: 100%;
+	right: 90%;
 	transform: translateY(-50%);
 	padding: 5px 8px;
 	color: inherit;

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -6,6 +6,10 @@
 	border-top: 1px solid; /* Needs to override .blob-num’s */
 }
 
+.rgh-no-unnecessary-split-diff-view-visited .rgh-comments-indicator.button-container {
+	left: -10px;
+}
+
 .rgh-comments-indicator.button-container {
 	border: none !important;
 	position: absolute !important;

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -1,13 +1,15 @@
-.rgh-comments-indicator {
-	position: absolute;
-}
-
 .show-inline-notes .rgh-comments-indicator {
 	display: none;
 }
 
-.rgh-comments-indicator:is(::before, ::after) {
-	position: absolute !important; /* Needs to override .blob-num’s */
+.rgh-comments-indicator{
+	border-top: 1px solid; /* Needs to override .blob-num’s */
+}
+
+.rgh-comments-indicator.button-container{
+	border: none !important;
+	position: absolute !important;
+    left: 0;
 }
 
 /* This is only used to improve the clickability */

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -3,16 +3,9 @@
 }
 
 .rgh-comments-indicator {
-	border-top: 1px solid; /* Needs to override .blob-num’s */
-}
-
-.rgh-no-unnecessary-split-diff-view-visited .rgh-comments-indicator.button-container {
-	left: -10px;
-}
-
-.rgh-comments-indicator.button-container {
-	border: none !important;
-	position: absolute !important;
+	border: none !important; /* Needs to override .blob-num’s */
+	position: unset !important; /* Needs to override .blob-num’s */
+	border-top: 1px solid !important; /* Needs to override .blob-num’s */
 	left: 0;
 }
 
@@ -29,7 +22,7 @@
 
 .rgh-comments-indicator button {
 	position: absolute;
-	right: 95%;
+	left: -40px;
 	transform: translateY(-50%);
 	padding: 5px 8px;
 	color: inherit;
@@ -48,4 +41,5 @@
 
 .file-diff-split .rgh-comments-indicator button {
 	padding-right: 1px;
+	left: -30px;
 }

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -1,4 +1,4 @@
-.rgh-comments-indicator {
+:root .rgh-comments-indicator {
 	position: absolute;
 }
 

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -7,14 +7,7 @@
 }
 
 .rgh-comments-indicator:is(::before, ::after) {
-	content: '' !important; /* Needs to override .blob-num’s */
 	position: absolute !important; /* Needs to override .blob-num’s */
-	top: -1px;
-	left: 0;
-	width: 200%;
-	border-top: solid 1px;
-	opacity: 40%;
-	transform: translateY(-50%);
 }
 
 /* This is only used to improve the clickability */
@@ -30,7 +23,7 @@
 
 .rgh-comments-indicator button {
 	position: absolute;
-	right: 90%;
+	right: 95%;
 	transform: translateY(-50%);
 	padding: 5px 8px;
 	color: inherit;

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -2,14 +2,14 @@
 	display: none;
 }
 
-.rgh-comments-indicator{
+.rgh-comments-indicator {
 	border-top: 1px solid; /* Needs to override .blob-num’s */
 }
 
-.rgh-comments-indicator.button-container{
+.rgh-comments-indicator.button-container {
 	border: none !important;
 	position: absolute !important;
-    left: 0;
+	left: 0;
 }
 
 /* This is only used to improve the clickability */

--- a/source/features/hidden-review-comments-indicator.css
+++ b/source/features/hidden-review-comments-indicator.css
@@ -8,7 +8,7 @@
 
 .rgh-comments-indicator:is(::before, ::after) {
 	content: '' !important; /* Needs to override .blob-num’s */
-	position: absolute !important;/* Needs to override .blob-num’s */
+	position: absolute !important; /* Needs to override .blob-num’s */
 	top: -1px;
 	left: 0;
 	width: 200%;

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -29,7 +29,8 @@ const addIndicator = mem((commentThread: HTMLElement): void => {
 
 	commentThread.before(
 		<tr>
-			<td className="rgh-comments-indicator blob-num" colSpan={2}>
+			<td className="rgh-comments-indicator blob-num" colSpan={2} />
+			<td className="rgh-comments-indicator button-container blob-num">
 				<button type="button" className="btn-link">
 					<CommentIcon/>
 					<span>{commentCount}</span>

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -26,34 +26,17 @@ const handleIndicatorClick = ({delegateTarget}: DelegateEvent): void => {
 // `mem` avoids adding the indicator twice to the same thread
 const addIndicator = mem((commentThread: HTMLElement): void => {
 	const commentCount = commentThread.querySelectorAll('.review-comment.js-comment').length;
-	const splitView = select('.rgh-no-unnecessary-split-diff-view-visited')
 	
-	if(!splitView){
-		commentThread.before(
-			<tr>
-				<td className="rgh-comments-indicator blob-num" colSpan={2}/>
-				<td className="rgh-comments-indicator button-container blob-num">
-					<button type="button" className="btn-link">
-						<CommentIcon/>
-						<span>{commentCount}</span>
-					</button>
-				</td>
-			</tr>,
-		);
-	} else {
-		commentThread.before(
-			<tr>
-				<td className="rgh-comments-indicator blob-num"/>
-				<td className="rgh-comments-indicator button-container blob-num">
-					<button type="button" className="btn-link">
-						<CommentIcon/>
-						<span>{commentCount}</span>
-					</button>
-				</td>
-				<td className="rgh-comments-indicator blob-num"/>
-			</tr>,
-		);
-	}
+	commentThread.before(
+		<tr>
+			<td className="rgh-comments-indicator blob-num" colSpan={2}>
+				<button type="button" className="btn-link">
+					<CommentIcon/>
+					<span>{commentCount}</span>
+				</button>
+			</td>
+		</tr>,
+	);	
 });
 //rgh-no-unnecessary-split-diff-view-visited
 

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -25,7 +25,7 @@ const handleIndicatorClick = ({delegateTarget}: DelegateEvent): void => {
 
 // `mem` avoids adding the indicator twice to the same thread
 const addIndicator = mem((commentThread: HTMLElement): void => {
-	const commentCount = commentThread.querySelectorAll('.review-comment .js-comment').length;
+	const commentCount = commentThread.querySelectorAll('.review-comment.js-comment').length;
 
 	commentThread.before(
 		<tr>

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -26,7 +26,6 @@ const handleIndicatorClick = ({delegateTarget}: DelegateEvent): void => {
 // `mem` avoids adding the indicator twice to the same thread
 const addIndicator = mem((commentThread: HTMLElement): void => {
 	const commentCount = commentThread.querySelectorAll('.review-comment.js-comment').length;
-	
 	commentThread.before(
 		<tr>
 			<td className="rgh-comments-indicator blob-num" colSpan={2}>
@@ -38,7 +37,6 @@ const addIndicator = mem((commentThread: HTMLElement): void => {
 		</tr>,
 	);	
 });
-//rgh-no-unnecessary-split-diff-view-visited
 
 // Add indicator when the `show-inline-notes` class is removed (i.e. the comments are hidden)
 const observer = new MutationObserver(mutations => {

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -29,7 +29,7 @@ const addIndicator = mem((commentThread: HTMLElement): void => {
 
 	commentThread.before(
 		<tr>
-			<td className="rgh-comments-indicator blob-num" colSpan={2} />
+			<td className="rgh-comments-indicator blob-num" colSpan={2}/>
 			<td className="rgh-comments-indicator button-container blob-num">
 				<button type="button" className="btn-link">
 					<CommentIcon/>

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -26,19 +26,36 @@ const handleIndicatorClick = ({delegateTarget}: DelegateEvent): void => {
 // `mem` avoids adding the indicator twice to the same thread
 const addIndicator = mem((commentThread: HTMLElement): void => {
 	const commentCount = commentThread.querySelectorAll('.review-comment.js-comment').length;
-
-	commentThread.before(
-		<tr>
-			<td className="rgh-comments-indicator blob-num" colSpan={2}/>
-			<td className="rgh-comments-indicator button-container blob-num">
-				<button type="button" className="btn-link">
-					<CommentIcon/>
-					<span>{commentCount}</span>
-				</button>
-			</td>
-		</tr>,
-	);
+	const splitView = select('.rgh-no-unnecessary-split-diff-view-visited')
+	
+	if(!splitView){
+		commentThread.before(
+			<tr>
+				<td className="rgh-comments-indicator blob-num" colSpan={2}/>
+				<td className="rgh-comments-indicator button-container blob-num">
+					<button type="button" className="btn-link">
+						<CommentIcon/>
+						<span>{commentCount}</span>
+					</button>
+				</td>
+			</tr>,
+		);
+	} else {
+		commentThread.before(
+			<tr>
+				<td className="rgh-comments-indicator blob-num"/>
+				<td className="rgh-comments-indicator button-container blob-num">
+					<button type="button" className="btn-link">
+						<CommentIcon/>
+						<span>{commentCount}</span>
+					</button>
+				</td>
+				<td className="rgh-comments-indicator blob-num"/>
+			</tr>,
+		);
+	}
 });
+//rgh-no-unnecessary-split-diff-view-visited
 
 // Add indicator when the `show-inline-notes` class is removed (i.e. the comments are hidden)
 const observer = new MutationObserver(mutations => {

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -35,7 +35,7 @@ const addIndicator = mem((commentThread: HTMLElement): void => {
 				</button>
 			</td>
 		</tr>,
-	);	
+	);
 });
 
 // Add indicator when the `show-inline-notes` class is removed (i.e. the comments are hidden)


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

- Part of #5897 

## Test URLs
https://github.com/refined-github/sandbox/pull/18/files

## Screenshot
<img width="677" alt="Screen Shot 2022-09-08 at 11 07 41" src="https://user-images.githubusercontent.com/26499470/189083464-cbc57bfc-f690-4970-aa51-ba24b370d979.png">



## Description

Class `.blob-num` was overwriting plugin's css, added `!important` to fix the issue.
Counter was not working, it was using the wrong selector
