### PR TITLE
Add support for `bug-fix`/`bugfix` labels in `bugs-tab`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug|bug-fix)$/iu;
+const supportedLabels = /^(bug|bug-?fix|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
-const supportedLabels = /^(bug|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(bug|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug|bug-fix)$/iu;
 const getBugLabelCacheKey = (): string => 'bugs-label:' + getRepo()!.nameWithOwner;
 const getBugLabel = async (): Promise<string | undefined> => cache.get<string>(getBugLabelCacheKey());
 const isBugLabel = (label: string): boolean => supportedLabels.test(label.replace(/\s/g, ''));


### PR DESCRIPTION
Some repositories with more than 1k stars that use the `bug-fix` label:

* https://github.com/axios/axios/issues?q=is%3Aissue+label%3Abug-fix+
* https://github.com/toolkit-for-ynab/toolkit-for-ynab/issues?q=is%3Aissue+label%3Abug-fix
* https://github.com/cloud-hypervisor/cloud-hypervisor/issues?q=is%3Aissue+label%3Abug-fix+ (also has the `bug` label but no issues with it)
* https://github.com/diem/diem/issues?q=is%3Aissue+label%3Abug-fix+ (also has the `bug` label)
* https://github.com/OpenVPN/easy-rsa/issues?q=is%3Aissue+label%3ABUG-FIX+ (also has the `BUG` label)
* https://github.com/JohnSnowLabs/spark-nlp/issues?q=is%3Aissue+label%3Abug-fix+ (also has the `bug` label)
* https://github.com/algorand/go-algorand/issues?q=is%3Aissue+sort%3Aupdated-desc+label%3ABug-Fix+ (also has the `bug` label)
* https://github.com/vearch/vearch/issues?q=is%3Aissue+label%3ABug-fix+ (also has the `Bug` label)