### PR TITLE
Avoid duplicate `on-click-diff-options`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"test": "run-p vitest lint:* build:* test:features",
 		"test:features": "node --loader ts-node/esm \"build/verify-features.ts\"",
 		"watch": "run-p watch:* --continue-on-error",
-		"watch:vitest": "vitest",
 		"watch:typescript": "tsc --noEmit --watch --preserveWatchOutput",
 		"watch:webpack": "cross-env NODE_OPTIONS=\"--loader ts-node/esm\" webpack --mode=development --watch"
 	},

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -108,21 +108,20 @@ function initPR(): false | void {
 function attachButtons(nativeDiffButtons: HTMLElement): void {
 	// TODO: Replace with :has()
 	const anchor = nativeDiffButtons.parentElement;
-	if (anchor?.classList.contains('float-right')) {
-		attachElement({
-			anchor,
-			after: () => (
-				<div className="float-right mr-3">
-					{createWhitespaceButton()}
-				</div>
-			),
-		});
-	} else {
-		attachElement({
-			anchor,
-			before: createWhitespaceButton,
-		});
-	}
+
+	// `usesFloats` is necessary to ensure the order and spacing as seen in #5958
+	const usesFloats = anchor?.classList.contains('float-right');
+	attachElement(usesFloats ? {
+		anchor,
+		after: () => (
+			<div className="float-right mr-3">
+				{createWhitespaceButton()}
+			</div>
+		),
+	} : {
+		anchor,
+		before: createWhitespaceButton,
+	});
 }
 
 function init(): false | void {


### PR DESCRIPTION
- Closes #5893 


## Compare, in "Files changed" tab

https://github.com/rancher/rancher/compare/v2.6.3...v2.6.6

<img width="389" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/189521895-d9cfc5aa-c574-4f03-9951-5ea7254e14cb.png">


## Compare, without tab

https://github.com/rancher/rancher/compare/v2.6.5...v2.6.6

<img width="344" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/189521965-9a1339fe-8426-48f8-ac81-5d984caec9f0.png">


## Single commit

https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e


<img width="318" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/189521970-438598a1-4395-46bf-8abf-cd794c61b812.png">

