### PR TITLE
Limit `shorten-links` to only Markdown links

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -1,5 +1,4 @@
 import onetime from 'onetime';
-import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {linkifiedURLClass, shortenLink} from '../github-helpers/dom-formatters';
@@ -7,21 +6,15 @@ import observe from '../helpers/selector-observer';
 
 /* This feature is currently so broad that it's not de-inited via signal, it's just run once for all pageloads #5889 */
 function init(): void {
-	observe(`a[href]:not(.${linkifiedURLClass})`, shortenLink);
+	observe(`.comment-body a[href]:not(.${linkifiedURLClass})`, shortenLink);
 }
 
 void features.add(import.meta.url, {
-	exclude: [
-		// Due to GitHub’s bug: #2828
-		pageDetect.isGlobalSearchResults,
-	],
 	init: onetime(init),
 });
 
 /*
-
 ## Test URLs
 
 https://github.com/refined-github/sandbox/pull/14
-
 */

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -17,4 +17,5 @@ void features.add(import.meta.url, {
 ## Test URLs
 
 https://github.com/refined-github/sandbox/pull/14
+https://github.com/refined-github/refined-github/pull/473
 */


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5889

## Test URLs

Yes: https://github.com/refined-github/refined-github/pull/473
No: https://github.com/refined-github/sandbox/pull/14