### PR TITLE
Allow replacing quotes in `one-key-formatting`

### DIFF
--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -24,7 +24,7 @@ function eventHandler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement | 
 		return;
 	}
 
-	// Allow replacing quotes
+	// Allow replacing quotes #5960
 	if (quoteCharacters.has(formattingChar) && end - start === 1 && quoteCharacters.has(field.value.at(start)!)) {
 		return;
 	}

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -7,24 +7,32 @@ import {onCommentFieldKeydown, onConversationTitleFieldKeydown, onCommitTitleFie
 
 const formattingCharacters = ['`', '\'', '"', '[', '(', '{', '*', '_', '~', '“', '‘'];
 const matchingCharacters = ['`', '\'', '"', ']', ')', '}', '*', '_', '~', '”', '’'];
+const quoteCharacters = new Set(['`', '\'', '"']);
 
 function eventHandler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement | HTMLInputElement>): void {
 	const field = event.delegateTarget;
+	const formattingChar = event.key;
 
-	if (!formattingCharacters.includes(event.key)) {
+	if (!formattingCharacters.includes(formattingChar)) {
 		return;
 	}
 
 	const [start, end] = [field.selectionStart, field.selectionEnd];
 
 	// If `start` and `end` of selection are the same, then no text is selected
-	if (start === end) {
+	if (start === end || start === null || end === null) {
+		return;
+	}
+
+	const selectedText = field.value.slice(start, end);
+
+	// Allow replacing quotes
+	if (quoteCharacters.has(formattingChar) && quoteCharacters.has(selectedText)) {
 		return;
 	}
 
 	event.preventDefault();
 
-	const formattingChar = event.key;
 	const matchingEndChar = matchingCharacters[formattingCharacters.indexOf(formattingChar)];
 	textFieldEdit.wrapSelection(field, formattingChar, matchingEndChar);
 }

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -17,17 +17,15 @@ function eventHandler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement | 
 		return;
 	}
 
-	const [start, end] = [field.selectionStart, field.selectionEnd];
+	const [start, end] = [field.selectionStart!, field.selectionEnd!];
 
 	// If `start` and `end` of selection are the same, then no text is selected
-	if (start === end || start === null || end === null) {
+	if (start === end) {
 		return;
 	}
 
-	const selectedText = field.value.slice(start, end);
-
 	// Allow replacing quotes
-	if (quoteCharacters.has(formattingChar) && quoteCharacters.has(selectedText)) {
+	if (quoteCharacters.has(formattingChar) && end - start === 1 && quoteCharacters.has(field.value.at(start)!)) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #5960.

## Test URLs

Any page with a Markdown textarea, e.g. the "new comment" field on this page.
