### PR TITLE
Meta: Drop deprecated color classes

### DIFF
--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -21,7 +21,7 @@ function init(): void {
 
 	select('.d-block.mb-2[href^="/contact"]')!.after(
 		<a href={actionURL.href} className="d-block mb-2">
-			<SearchIcon width={14} className="color-text-primary color-fg-default mr-2"/>Usage examples
+			<SearchIcon width={14} className="color-fg-default mr-2"/>Usage examples
 		</a>,
 	);
 }

--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -16,7 +16,7 @@
 	margin-left: 4px;
 }
 
-.rgh-align-issue-labels .js-issue-row .mt-1.text-small:is(.color-text-secondary, .color-fg-muted) { /* Issue details line */
+.rgh-align-issue-labels .js-issue-row .mt-1.text-small.color-fg-muted { /* Issue details line */
 	flex-basis: 100%;
 }
 

--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -8,7 +8,7 @@
 */
 
 /* Hide duplicate repo name in some non-grouped events */
-.rgh-clean-dashboard .dashboard :is(.watch_started, .repo, .public) :is(.color-border-secondary, .color-border-muted).flex-items-baseline .text-bold:is(.color-text-primary, .color-fg-default) {
+.rgh-clean-dashboard .dashboard :is(.watch_started, .repo, .public) .color-border-muted.flex-items-baseline .text-bold.color-fg-default {
 	display: none;
 }
 
@@ -59,12 +59,12 @@
 }
 
 /* Hide footer date on Created Repository events */
-.rgh-clean-dashboard .dashboard .repo .f6:is(.color-text-secondary, .color-fg-muted) {
+.rgh-clean-dashboard .dashboard .repo .f6.color-fg-muted {
 	display: none;
 }
 
 /* Grouped events: Make repo name smaller */
-.rgh-clean-dashboard .dashboard .Details .flex-items-baseline .text-bold:is(.color-text-primary, .color-fg-default) {
+.rgh-clean-dashboard .dashboard .Details .flex-items-baseline .text-bold.color-fg-default {
 	font-size: 1em !important;
 }
 

--- a/source/features/clean-mergeability-box.css
+++ b/source/features/clean-mergeability-box.css
@@ -16,7 +16,7 @@
 	font-weight: 600;
 }
 
-.mergeability-details .js-details-container :is(.color-text-danger, .color-fg-danger) + .status-meta {
+.mergeability-details .js-details-container .color-fg-danger + .status-meta {
 	color: var(--rgh-red);
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -27,7 +27,7 @@ async function cleanReleases(): Promise<void> {
 		.classList.add('border-0', 'pb-0');
 
 	// Align latest tag icon with the icons of other meta links
-	const tagIcon = select('.octicon-tag:not(.color-text-success, .color-fg-success)', releasesSection)!;
+	const tagIcon = select('.octicon-tag:not(.color-fg-success)', releasesSection)!;
 	if (tagIcon) {
 		tagIcon.classList.add('mr-2');
 		// Remove whitespace node

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -60,7 +60,7 @@ async function init(): Promise<false | void> {
 		if (data[pr.key].pullRequest.mergeable === 'CONFLICTING') {
 			pr.link.after(
 				<a
-					className="rgh-conflict-marker tooltipped tooltipped-e color-text-secondary color-fg-muted ml-2"
+					className="rgh-conflict-marker tooltipped tooltipped-e color-fg-muted ml-2"
 					aria-label="This PR has conflicts that must be resolved"
 					href={`${pr.link.pathname}#partial-pull-merging`}
 				>

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -166,8 +166,8 @@ async function addWidget(header: string, state: State): Promise<void> {
 			id="rgh-conversation-activity-filter-select-menu"
 		>
 			<summary>
-				<EyeIcon className="color-text-secondary color-fg-muted"/>
-				<EyeClosedIcon className="color-icon-danger color-fg-danger"/>
+				<EyeIcon className="color-fg-muted"/>
+				<EyeClosedIcon className="color-fg-danger"/>
 				<div className="dropdown-caret ml-1"/>
 			</summary>
 			<details-menu

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -12,7 +12,7 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 .rgh-dim-bot:not(.rgh-tagged) .mb-1 ~ .d-flex,
 .rgh-dim-bot:not(.rgh-tagged) > .d-md-block,
 .rgh-dim-bot:not(.rgh-tagged) .labels, /* PR labels */
-.rgh-dim-bot:not(.rgh-tagged) .text-small:is(.color-text-secondary, .color-fg-muted) /* PR meta */ {
+.rgh-dim-bot:not(.rgh-tagged) .text-small.color-fg-muted /* PR meta */ {
 	/* Delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items. */
 	transition: 0.1s;
 	transition-delay: 0.3s;
@@ -39,7 +39,7 @@ ALL the following rules define the non-focused state
 }
 
 .rgh-dim-bot:not(.rgh-tagged, .navigation-focus, :hover) .labels, /* PR labels */
-.rgh-dim-bot:not(.rgh-tagged, .navigation-focus, :hover) .text-small:is(.color-text-secondary, .color-fg-muted) /* PR meta */ {
+.rgh-dim-bot:not(.rgh-tagged, .navigation-focus, :hover) .text-small.color-fg-muted /* PR meta */ {
 	margin-bottom: -2em;
 	visibility: hidden;
 	transition-delay: 0s, var(--rgh-dim-bots-delay), calc(var(--rgh-dim-bots-delay) - 0.1s);

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -3,7 +3,7 @@
 /* stylelint-disable-next-line media-feature-name-no-vendor-prefix -- It's the only cross-browser media query */
 @media (-webkit-min-device-pixel-ratio: 2) {
 	.js-issue-row [aria-label='Open draft pull request'] svg {
-		stroke: var(--color-fg-muted, var(--color-text-secondary, #586069));
+		stroke: var(--color-fg-muted);
 		stroke-width: 1.2px;
 		color: var(--rgh-background) !important;
 		paint-order: stroke;

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -14,7 +14,7 @@ const getBufferField = onetime((): HTMLInputElement => (
 		style={{
 			backgroundColor: 'transparent',
 			outline: 0,
-			color: 'var(--color-fg-default, var(--color-text-primary))',
+			color: 'var(--color-fg-default)',
 		}}
 		placeholder="Search file…"
 	/> as unknown as HTMLInputElement
@@ -30,7 +30,7 @@ function pjaxStartHandler(event: CustomEvent): void {
 	bufferField.value = '';
 
 	select('.pagehead h1 strong, [itemprop="name"]')!.after(
-		<span className="mr-1 ml-n1 flex-self-stretch color-text-secondary color-fg-muted">/</span>,
+		<span className="mr-1 ml-n1 flex-self-stretch color-fg-muted">/</span>,
 		<span className="flex-self-stretch mr-2">{bufferField}</span>,
 	);
 	bufferField.focus();

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -49,7 +49,7 @@ function addExistingTagLink(tagName: string): void {
 
 		discussionHeader.parentElement!.append(
 			<span>
-				<TagIcon className="ml-2 mr-1 color-text-secondary color-fg-muted"/>
+				<TagIcon className="ml-2 mr-1 color-fg-muted"/>
 				<a
 					href={tagUrl}
 					className="commit-ref"

--- a/source/features/git-checkout-pr.tsx
+++ b/source/features/git-checkout-pr.tsx
@@ -48,7 +48,7 @@ function checkoutOption(remote?: string, remoteType?: 'HTTPS' | 'SSH'): JSX.Elem
 						tabindex="0"
 					>
 						<CopyIcon className="js-clipboard-copy-icon m-2"/>
-						<CheckIcon className="js-clipboard-check-icon color-text-success color-fg-success d-none m-2"/>
+						<CheckIcon className="js-clipboard-check-icon color-fg-success d-none m-2"/>
 					</clipboard-copy>
 				</div>
 				<pre id={`rgh-checkout-pr-${remoteType!}`} className="mb-2 rgh-linkified-code">{/* `.rgh-linkified-code` is intentionally added to avoid parsing */}
@@ -93,7 +93,7 @@ async function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): Pro
 	const remoteName = getRemoteName();
 	select('.octicon-terminal', dropdown)!.closest('li.Box-row')!.after(
 		<li className="Box-row p-3 mt-0">
-			<span className="d-flex flex-items-center color-text-primary color-fg-default text-bold no-underline">
+			<span className="d-flex flex-items-center color-fg-default text-bold no-underline">
 				<TerminalIcon className="mr-2"/>
 				Checkout with Git
 			</span>
@@ -105,7 +105,7 @@ async function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): Pro
 						checkoutOption(remoteName, 'SSH'),
 					] : checkoutOption()}
 				</tab-container>
-				<p className="mb-0 f6 color-text-secondary color-fg-muted">
+				<p className="mb-0 f6 color-fg-muted">
 					Run in your project repository{remoteName && ', pick either one'}.
 				</p>
 			</div>

--- a/source/features/hide-low-quality-comments.css
+++ b/source/features/hide-low-quality-comments.css
@@ -1,7 +1,7 @@
 .rgh-low-quality-comments-note {
 	margin: 15px 0 10px 60px;
 	font-size: 12px;
-	color: var(--color-fg-muted, var(--color-text-secondary, #586069));
+	color: var(--color-fg-muted);
 }
 
 .rgh-hidden-comment .timeline-comment {

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -53,7 +53,7 @@ function highlightBestComment(bestComment: Element): void {
 	select('.unminimized-comment', bestComment)!.classList.add('rgh-highest-rated-comment');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span
-			className="color-text-success color-fg-success tooltipped tooltipped-s"
+			className="color-fg-success tooltipped tooltipped-s"
 			aria-label="This comment has the most positive reactions on this issue."
 		>
 			<CheckCircleFillIcon/>
@@ -75,7 +75,7 @@ function linkBestComment(bestComment: HTMLElement): void {
 	const avatar = select('img.avatar', bestComment)!.cloneNode();
 
 	bestComment.parentElement!.firstElementChild!.after(
-		<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment timeline-comment color-bg-tertiary color-bg-subtle px-2 d-flex flex-items-center">
+		<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment timeline-comment color-bg-subtle px-2 d-flex flex-items-center">
 			{avatar}
 
 			<h3 className="timeline-comment-header-text f5 color-fg-muted text-normal text-italic css-truncate css-truncate-overflow mr-2">

--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -1,5 +1,5 @@
 .rgh-collaborator {
-	border: 1px solid var(--color-border-default, var(--color-border-tertiary, #c0d3eb));
+	border: 1px solid var(--color-border-default);
 	border-radius: 2em;
 	padding: 2px 5px;
 }

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -21,9 +21,9 @@ function highlightFilename(filename: HTMLAnchorElement, sourceIcon: SVGSVGElemen
 	const icon = sourceIcon.cloneNode(true);
 	const action = icon.getAttribute('title')!;
 	if (action === 'added') {
-		icon.classList.add('color-text-success', 'color-fg-success');
+		icon.classList.add('color-fg-success');
 	} else if (action === 'removed') {
-		icon.classList.add('color-text-danger', 'color-fg-danger');
+		icon.classList.add('color-fg-danger');
 	} else {
 		return;
 	}

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -56,7 +56,7 @@ async function init(): Promise<false | void> {
 
 		const branch = pr.baseRef && buildRepoURL(`tree/${pr.baseRefName}`);
 
-		prLink.parentElement!.querySelector('.text-small:is(.color-text-secondary, .color-fg-muted) .d-none.d-md-inline-flex')!.append(
+		prLink.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!.append(
 			<span className="issue-meta-section ml-2">
 				<GitPullRequestIcon/>
 				{' To '}

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -68,7 +68,7 @@ async function init(): Promise<void | false> {
 			style={pageDetect.isEnterprise() ? {padding: '6px 16px'} : {}}
 			role="button"
 		>
-			<BookIcon className="color-text-link color-fg-accent mr-2"/>
+			<BookIcon className="color-fg-accent mr-2"/>
 			<span>Changelog</span>
 		</a>
 	);

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -7,7 +7,7 @@ import features from '.';
 function init(): void {
 	for (const header of select.all('.js-notifications-group h6')) {
 		header.append(
-			<a className="text-inherit color-fg-inherit" href={'/' + header.textContent!.trim()}>
+			<a className="color-fg-inherit" href={'/' + header.textContent!.trim()}>
 				{header.firstChild}
 			</a>,
 		);

--- a/source/features/list-prs-for-branch.tsx
+++ b/source/features/list-prs-for-branch.tsx
@@ -9,9 +9,9 @@ import {getPullRequestsAssociatedWithBranch, stateIcon} from './show-associated-
 
 // Taken from https://github.com/fregante/github-issue-link-status/blob/98792f2837352bacbf80664f3edbcec8e579ed17/source/github-issue-link-status.js#L10
 const stateColorMap = {
-	OPEN: 'color-text-success color-fg-success',
-	CLOSED: 'color-text-danger color-fg-danger',
-	MERGED: 'color-purple-5 color-fg-done',
+	OPEN: 'color-fg-success',
+	CLOSED: 'color-fg-danger',
+	MERGED: 'color-fg-done',
 	DRAFT: '',
 };
 

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -11,7 +11,7 @@ function makeLink(type: string, icon: Element, selected: boolean): JSX.Element {
 	const url = new URL(location.href);
 	url.searchParams.set('diff', type);
 	const classes = pageDetect.isPR()
-		? 'tooltipped tooltipped-s d-none d-lg-block ml-2 color-icon-secondary color-fg-muted'
+		? 'tooltipped tooltipped-s d-none d-lg-block ml-2 color-fg-muted'
 		: 'tooltipped tooltipped-s btn btn-sm BtnGroup-item ' + (selected ? 'selected' : '');
 
 	return (
@@ -60,8 +60,8 @@ function createWhitespaceButton(): HTMLElement {
 	}
 
 	const classes = pageDetect.isPR()
-		? 'tooltipped tooltipped-s d-none d-lg-block color-icon-secondary color-fg-muted'
-		: 'tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-text-tertiary color-fg-subtle' : '');
+		? 'tooltipped tooltipped-s d-none d-lg-block color-fg-muted'
+		: 'tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-fg-subtle' : '');
 
 	return (
 		<a

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -18,7 +18,7 @@ function init(): void {
 		'.js-socket-channel[data-url*="/header_partial"] h3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
 		'#wiki-wrapper .gh-header-title', // `isWiki` page title
-		'.issues_labeled :is(.color-text-primary, .color-fg-default) > a', // `isDashboard` "help wanted" event titles
+		'.issues_labeled .color-fg-default > a', // `isDashboard` "help wanted" event titles
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
 		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 		'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -45,7 +45,7 @@ async function init(): Promise<void | false> {
 		const {updatedAt} = lastUpdated[api.escapeKey(issueNumber)];
 		select('.pinned-item-desc', pinnedIssue)!.append(
 			' • ',
-			<span className="color-text-secondary color-fg-muted d-inline-block">
+			<span className="color-fg-muted d-inline-block">
 				updated <relative-time datetime={updatedAt}/>
 			</span>,
 		);

--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -1,9 +1,9 @@
 /* Show approvals count in PR list */
-.js-issue-row :is(.color-text-secondary, .color-fg-muted) [href$='#partial-pull-merging'][aria-label*='approval'] {
+.js-issue-row .color-fg-muted [href$='#partial-pull-merging'][aria-label*='approval'] {
 	font-size: 0;
 }
 
-.js-issue-row :is(.color-text-secondary, .color-fg-muted) [href$='#partial-pull-merging'][aria-label*='approval']::before {
+.js-issue-row .color-fg-muted [href$='#partial-pull-merging'][aria-label*='approval']::before {
 	all: unset;
 	content: attr(aria-label);
 	display: inline !important;
@@ -11,11 +11,11 @@
 	font-size: 12px;
 }
 
-.js-issue-row :is(.color-text-secondary, .color-fg-muted) [href$='#partial-pull-merging'][aria-label*='changes'] {
+.js-issue-row .color-fg-muted [href$='#partial-pull-merging'][aria-label*='changes'] {
 	color: var(--rgh-red) !important;
 }
 
 /* Disable now-duplicate tooltip */
-.js-issue-row :is(.color-text-secondary, .color-fg-muted) [href$='#partial-pull-merging'][aria-label*='approval']::after {
+.js-issue-row .color-fg-muted [href$='#partial-pull-merging'][aria-label*='approval']::after {
 	content: none;
 }

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -31,8 +31,8 @@ async function init(): Promise<void> {
 	const diffstat = await elementReady('.diffstat', {waitForChildren: false});
 	diffstat!.replaceWith(
 		<span className="ml-2 diffstat tooltipped tooltipped-s" aria-label={tooltip}>
-			<span className="color-text-success color-fg-success">+{additions}</span>{' '}
-			<span className="color-text-danger color-fg-danger">−{deletions}</span>{' '}
+			<span className="color-fg-success">+{additions}</span>{' '}
+			<span className="color-fg-danger">−{deletions}</span>{' '}
 			<span className="diffstat-block-neutral"/>
 			<span className="diffstat-block-neutral"/>
 			<span className="diffstat-block-neutral"/>

--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -44,7 +44,7 @@ function generateSubmenu(hideButton: Element): void {
 	});
 
 	// Imitate existing menu
-	hideCommentForm.classList.add('dropdown-menu', 'dropdown-menu-sw', 'color-text-primary', 'color-fg-default', 'show-more-popover', 'anim-scale-in');
+	hideCommentForm.classList.add('dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in');
 
 	detailsElement.append(hideCommentForm);
 }

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -83,14 +83,14 @@ function handleSelection({target}: Event): void {
 
 function createDropdownList(category: Category, filters: Filter[]): JSX.Element {
 	const icons: {[Key in Filter]: JSX.Element} = {
-		'Pull requests': <GitPullRequestIcon className="color-text-secondary color-fg-muted"/>,
-		Issues: <IssueOpenedIcon className="color-text-secondary color-fg-muted"/>,
-		Open: <CheckCircleIcon className="color-text-success color-fg-success"/>,
-		Closed: <XCircleIcon className="color-text-danger color-fg-danger"/>,
-		Draft: <GitPullRequestDraftIcon className="color-text-tertiary color-fg-subtle"/>,
+		'Pull requests': <GitPullRequestIcon className="color-fg-muted"/>,
+		Issues: <IssueOpenedIcon className="color-fg-muted"/>,
+		Open: <CheckCircleIcon className="color-fg-success"/>,
+		Closed: <XCircleIcon className="color-fg-danger"/>,
+		Draft: <GitPullRequestDraftIcon className="color-fg-subtle"/>,
 		Merged: <GitMergeIcon className="color-fg-done"/>,
-		Read: <DotIcon className="color-text-link color-fg-accent"/>,
-		Unread: <DotFillIcon className="color-text-link color-fg-accent"/>,
+		Read: <DotIcon className="color-fg-accent"/>,
+		Unread: <DotFillIcon className="color-fg-accent"/>,
 	};
 
 	return (

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -63,7 +63,7 @@ async function init(): Promise<false | void> {
 		const insertionPoint = parentElement!.tagName === 'STRONG' ? parentElement! : usernameElement;
 		insertionPoint.after(
 			' ',
-			<span className="color-text-secondary color-fg-muted css-truncate d-inline-block">
+			<span className="color-fg-muted css-truncate d-inline-block">
 				(<bdo className="css-truncate-target" style={{maxWidth: '200px'}}>{name}</bdo>)
 			</span>,
 			' ',

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -10,7 +10,7 @@ import * as api from '../github-helpers/api';
 import getPrInfo from '../github-helpers/get-pr-info';
 import {getConversationNumber} from '../github-helpers';
 
-const selectorForPushablePRNotice = '.merge-pr > :is(.color-text-secondary, .color-fg-muted):first-child';
+const selectorForPushablePRNotice = '.merge-pr > .color-fg-muted:first-child';
 let observer: Observer;
 
 function getBranches(): {base: string; head: string} {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -36,7 +36,7 @@ async function is404(url: string): Promise<boolean> {
 }
 
 function getStrikeThrough(text: string): HTMLElement {
-	return <del className="color-text-tertiary color-fg-subtle">{text}</del>;
+	return <del className="color-fg-subtle">{text}</del>;
 }
 
 async function checkAnchor(anchor: HTMLElement): Promise<void> {

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -131,7 +131,7 @@ async function insertUserLocalTime(hovercardContainer: Element): Promise<void> {
 
 	const placeholder = <span className="ml-1">Guessing local time…</span>;
 	const container = (
-		<div className="mt-2 color-text-secondary color-fg-muted text-small d-flex">
+		<div className="mt-2 color-fg-muted text-small d-flex">
 			<ClockIcon/> {placeholder}
 		</div>
 	);

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -21,7 +21,7 @@ const doesUserFollow = cache.function(async (userA: string, userB: string): Prom
 async function init(): Promise<void> {
 	if (await doesUserFollow(getCleanPathname(), getUsername()!)) {
 		select('.js-profile-editable-area [href$="?tab=following"]')!.after(
-			<span className="color-text-secondary color-fg-muted"> · Follows you</span>,
+			<span className="color-fg-muted"> · Follows you</span>,
 		);
 	}
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -2,7 +2,7 @@
 	--rgh-green: var(--color-fg-success, #1a7f37);
 	--rgh-red: var(--color-fg-danger, #cf222e);
 	--rgh-border-color: var(--color-border-muted, #d8dee4);
-	--rgh-background: var(--color-canvas-default, var(--color-bg-canvas, #fff));
+	--rgh-background: var(--color-canvas-default, #fff);
 }
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
@@ -106,12 +106,12 @@ highlight-collaborators-and-own-conversations
 parse-backticks
 pr-branches
 */
-.js-issue-row .text-small:is(.color-text-secondary, .color-fg-muted) {
+.js-issue-row .text-small.color-fg-muted {
 	line-height: 1.8;
 }
 
 /* Reset `vertical-align` for .octicons to work with above increased line-height */
-.js-issue-row .text-small:is(.color-text-secondary, .color-fg-muted) .octicon {
+.js-issue-row .text-small.color-fg-muted .octicon {
 	vertical-align: middle;
 }
 


### PR DESCRIPTION
As noted in https://github.com/refined-github/refined-github/issues/5222#issuecomment-1178789903, drops all deprecated color classes from https://primer.style/css/support/v18-migration.

Follows #4970 and #4982. 

## Test URLs

Basically every page on GitHub :see_no_evil: