### PR TITLE
Meta: Drop code specific to "Releases UI refresh"

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -73,18 +73,14 @@ async function init(): Promise<void | false> {
 		</a>
 	);
 
-	if (pageDetect.isEnterprise()) { // Before "Releases UI refresh" #4902
-		(await elementReady('.subnav div', {waitForChildren: false}))!.after(changelogButton);
-	} else {
-		const releasesOrTagsNavbarSelector = [
-			'nav[aria-label^="Releases and Tags"]', // Release list
-			'.subnav-links', // Tag list
-		].join(',');
+	const releasesOrTagsNavbarSelector = [
+		'nav[aria-label^="Releases and Tags"]', // Release list
+		'.subnav-links', // Tag list
+	].join(',');
 
-		const navbar = (await elementReady(releasesOrTagsNavbarSelector, {waitForChildren: false}))!;
-		navbar.classList.remove('flex-1');
-		wrapAll([navbar, changelogButton], <div className="d-flex flex-justify-start flex-1"/>);
-	}
+	const navbar = (await elementReady(releasesOrTagsNavbarSelector, {waitForChildren: false}))!;
+	navbar.classList.remove('flex-1');
+	wrapAll([navbar, changelogButton], <div className="d-flex flex-justify-start flex-1"/>);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -34,10 +34,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 
 function parseTags(element: HTMLElement): TagDetails {
 	// Safari doesn't correctly parse links if they're loaded via AJAX #3899
-	const {pathname: tagUrl} = new URL(select([
-		'a:is([href*="/releases/tag/"]', // Before "Releases UI refresh" #4902
-		'a[href*="/tree/"])',
-	], element)!.href);
+	const {pathname: tagUrl} = new URL(select('a[href*="/tree/"])', element)!.href);
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 
 	return {
@@ -80,11 +77,7 @@ async function init(): Promise<void> {
 
 	const tagsSelector = [
 		// https://github.com/facebook/react/releases (release in releases list)
-		'.release:not(.label-draft)', // Before "Releases UI refresh" #4902
 		'.repository-content .col-md-2',
-
-		// https://github.com/facebook/react/releases?after=v16.7.0 (tags in releases list)
-		'.release-main-section .commit', // Before "Releases UI refresh" #4902
 
 		// https://github.com/facebook/react/tags (tags list)
 		'.Box-row .commit',
@@ -105,7 +98,6 @@ async function init(): Promise<void> {
 		}
 
 		const lastLinks = select.all([
-			'.list-style-none > .d-block:nth-child(2)', // Link to commit in release sidebar -- Before "Releases UI refresh" #4902
 			'.Link--muted[data-hovercard-type="commit"]', // Link to commit in release sidebar
 			'.list-style-none > .d-inline-block:last-child', // Link to source tarball under release tag
 		], container.element);


### PR DESCRIPTION
The "Releases UI Refresh" (#4902) was nearly one year ago, so let's drop code still targets the old layout.

## Test URLs

* https://github.com/facebook/react/releases
* https://github.com/facebook/react/tags
* https://github.com/facebook/react/releases/tag/v17.0.2