### PR TITLE
Make `clear-pr-merge-commit-message` manual to avoid conflicts with user settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ Thanks for contributing! 🦋🙌
 - [](# "one-click-pr-or-gist") [Lets you create draft pull requests and public gists in one click.](https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
 - [](# "quick-review") [Adds a review button to the PR sidebar, automatically focuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
-- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif)
+- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -292,9 +292,9 @@ Thanks for contributing! 🦋🙌
 - [](# "pull-request-hotkeys") [Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>](https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png).
 - [](# "pr-branch-auto-delete") [Automatically deletes the branch right after merging a PR, if possible.](https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png)
 - [](# "one-click-pr-or-gist") [Lets you create draft pull requests and public gists in one click.](https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png)
-- [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
+- [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
 - [](# "quick-review") [Adds a review button to the PR sidebar, automatically focuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
-- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif)
+- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ Thanks for contributing! 🦋🙌
 - [](# "one-click-pr-or-gist") [Lets you create draft pull requests and public gists in one click.](https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
 - [](# "quick-review") [Adds a review button to the PR sidebar, automatically focuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
-- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
+- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ Thanks for contributing! 🦋🙌
 - [](# "one-click-pr-or-gist") [Lets you create draft pull requests and public gists in one click.](https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
 - [](# "quick-review") [Adds a review button to the PR sidebar, automatically focuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
-- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
+- [](# "use-first-commit-message-for-new-prs") [Uses the first commit for a new PR’s title and description.](https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,11 +1,23 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
+import delegate, { DelegateEvent } from 'delegate-it';
 
 import features from '.';
-import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
+import attachElement from '../helpers/attach-element';
+import observe from '../helpers/selector-observer';
 
-function init(): void {
-	const messageField = select('textarea#merge_message_field')!;
+const button = features.getIdentifiers(import.meta.url);
+
+const buttonStyle = {
+	position: 'absolute',
+	top: '2px',
+	right: '2px',
+	borderRadius: '4px',
+} as const;
+
+function clearField(event: DelegateEvent): void {
+	const messageField = event.delegateTarget.previousElementSibling as HTMLTextAreaElement;
 	const deduplicatedAuthors = new Set();
 
 	// This method ensures that "Co-authored-by" capitalization doesn't affect deduplication
@@ -16,6 +28,18 @@ function init(): void {
 	messageField.value = [...deduplicatedAuthors].join('\n');
 }
 
+function attachButton(textarea: HTMLTextAreaElement): void {
+	attachElement({
+		anchor: textarea,
+		after: () => <button type="button" className={'btn btn-sm ' + button.class} style={buttonStyle}>Clear</button>,
+	});
+}
+
+function init(signal: AbortSignal): void {
+	observe('textarea#merge_message_field', attachButton, {signal});
+	delegate(document, button.selector, 'click', clearField, {signal});
+}
+
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
@@ -24,11 +48,6 @@ void features.add(import.meta.url, {
 		// Don't clear 1-commit PRs #3140
 		() => select.all('.TimelineItem.js-commit').length === 1,
 	],
-	additionalListeners: [
-		onPrMergePanelOpen,
-	],
-	onlyAdditionalListeners: true,
-	awaitDomReady: false,
 	deduplicate: false,
 	init,
 });

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import delegate, { DelegateEvent } from 'delegate-it';
+import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '.';
 import attachElement from '../helpers/attach-element';


### PR DESCRIPTION
- Part of https://github.com/refined-github/refined-github/issues/5155
- Part of https://github.com/refined-github/refined-github/issues/5992


## Why

GitHub implemented a per-repo option to decide this, meaning we’re effectively overriding it, regardless of what the user picks or leaves as default.

Given that this feature has been a little controversial and troublesome, I think making it manual would avoid these gripes.

## Test URLs

- This PR, if you have merging permissions 


## Screenshot


![gif](https://user-images.githubusercontent.com/1402241/189611458-e07c602b-0258-4838-b10d-734d50d757f9.gif)
