### PR TITLE
Consistently `shorten-links` even if other features altered them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"regex-join": "^1.0.0",
 				"select-dom": "^7.1.1",
 				"selector-observer": "^2.1.6",
-				"shorten-repo-url": "^2.3.0",
+				"shorten-repo-url": "^3.0.0",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^3.1.9001",
 				"tiny-version-compare": "^4.0.0",
@@ -7926,14 +7926,17 @@
 			"dev": true
 		},
 		"node_modules/shorten-repo-url": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.3.0.tgz",
-			"integrity": "sha512-n9iDxMHcYTbjRNtIgdpL3wFCWByD6ZtDrqt1jAam6AR7/AVXiJDJ0255x7EKGDgd7Dol+93m8+XZgErZnq9Pug==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-3.0.0.tgz",
+			"integrity": "sha512-h7tDyHGhQVzBTNnmKHhunuWgYRXDTbp0fsG1OXcH91XcM3iuLQ/Plltv+yS9Nv68LChxdEaT7zwWrG8Wzu1bQA==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.4"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
 			}
 		},
 		"node_modules/side-channel": {
@@ -16411,9 +16414,9 @@
 			"dev": true
 		},
 		"shorten-repo-url": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.3.0.tgz",
-			"integrity": "sha512-n9iDxMHcYTbjRNtIgdpL3wFCWByD6ZtDrqt1jAam6AR7/AVXiJDJ0255x7EKGDgd7Dol+93m8+XZgErZnq9Pug==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-3.0.0.tgz",
+			"integrity": "sha512-h7tDyHGhQVzBTNnmKHhunuWgYRXDTbp0fsG1OXcH91XcM3iuLQ/Plltv+yS9Nv68LChxdEaT7zwWrG8Wzu1bQA==",
 			"requires": {
 				"github-reserved-names": "^2.0.4"
 			}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"regex-join": "^1.0.0",
 		"select-dom": "^7.1.1",
 		"selector-observer": "^2.1.6",
-		"shorten-repo-url": "^2.3.0",
+		"shorten-repo-url": "^3.0.0",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^3.1.9001",
 		"tiny-version-compare": "^4.0.0",

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -9,6 +9,7 @@ import GitHubURL from '../github-helpers/github-url';
 import addNotice from '../github-widgets/notice-bar';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters';
 import {buildRepoURL, isPermalink} from '../github-helpers';
+import {saveOriginalHref} from './sort-conversations-by-update-time';
 
 async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> {
 	const {repository} = await api.v4(`
@@ -85,6 +86,8 @@ function addInlineLinks(menu: HTMLElement, timestamp: string): void {
 		if (/^[\da-f]{40}$/.test(linkParts[4])) {
 			continue;
 		}
+
+		saveOriginalHref(link);
 
 		const searchParameters = new URLSearchParams(link.search);
 		searchParameters.set('rgh-link-date', timestamp);

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -4,6 +4,12 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import SearchQuery from '../github-helpers/search-query';
 
+export function saveOriginalHref(link: HTMLAnchorElement): void {
+	if (!link.dataset.originalHref) {
+		link.dataset.originalHref = link.href;
+	}
+}
+
 function selectCurrentConversationFilter(): void {
 	const currentSearchURL = location.href.replace('/pulls?', '/issues?'); // Replacement needed to make up for the redirection of "Your pull requests" link
 	const currentFilter = select(`#filters-select-menu a.SelectMenu-item[href="${currentSearchURL}"]`);
@@ -25,17 +31,19 @@ function init(): void {
 		// + skip pagination links
 		// + skip pr/issue filter dropdowns (some are lazyloaded)
 		if (pageDetect.isIssueOrPRList(link)) {
-			const isRelativeAttribute = link.getAttribute('href')!.startsWith('/');
-			link.href = SearchQuery.from(link).add('sort:updated-desc').href;
+			saveOriginalHref(link);
+
+			const newUrl = SearchQuery.from(link).add('sort:updated-desc').href;
 
 			// Preserve relative attributes as such #5435
-			if (isRelativeAttribute) {
-				link.href = link.href.replace(location.origin, '');
-			}
+			const isRelativeAttribute = link.getAttribute('href')!.startsWith('/');
+			link.href = isRelativeAttribute ? newUrl.replace(location.origin, '') : newUrl;
 		}
 
 		// Also sort projects #4957
 		if (pageDetect.isProjects()) {
+			saveOriginalHref(link);
+
 			// Projects use a different parameter name so don't use SearchQuery
 			const search = new URLSearchParams(link.search);
 			const query = search.get('query') ?? 'is:open'; // Default value query is missing

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -4,6 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import SearchQuery from '../github-helpers/search-query';
 
+/** Keep the original URL on the element so that `shorten-links` can use it reliably #5890 */
 export function saveOriginalHref(link: HTMLAnchorElement): void {
 	if (!link.dataset.originalHref) {
 		link.dataset.originalHref = link.href;


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5890
- Fixes https://github.com/refined-github/refined-github/pull/473
- Includes https://github.com/refined-github/shorten-repo-url/pull/38

## Live test

### `sort-conversations-by-update-time`

- Blah blah https://github.com/refined-github/yolo/issues and blah.

### `comments-time-machine-links`

- https://github.com/sindresorhus/refined-github/tree/v0.12


## Screenshot


<table>
<tr>
	<td><img width="390" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/189799120-ebff4e19-2b1a-427c-b36c-75f0cf04a20b.png">
</table>