### PR TITLE
Fix shorten-links doesn't (always) apply to links to links we alter #5890

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -80,6 +80,7 @@ function addInlineLinks(menu: HTMLElement, timestamp: string): void {
 	`, comment);
 
 	for (const link of links) {
+		link.dataset.baseUrl = link.href;
 		const linkParts = link.pathname.split('/');
 		// Skip permalinks
 		if (/^[\da-f]{40}$/.test(linkParts[4])) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #5890 

## Test URLs
https://github.com/refined-github/refined-github/pull/473

## Screenshot

<img width="925" alt="image" src="https://user-images.githubusercontent.com/26499470/189624043-26a70b61-58a9-459c-ae87-5227662d1343.png">

## Note:
This Fix depends on [this PR](https://github.com/refined-github/shorten-repo-url/pull/39)
