### PR TITLE
Notify users of errors in `open-all-notifications`

### DIFF
--- a/source/features/open-all-conversations.tsx
+++ b/source/features/open-all-conversations.tsx
@@ -20,7 +20,7 @@ const issueListSelector = pageDetect.isGlobalIssueOrPRList()
 
 function onButtonClick(): void {
 	const issues = select.all(`${issueListSelector} .js-issue-row`);
-	openTabs(issues.map(issue => getUrlFromItem(issue)));
+	void openTabs(issues.map(issue => getUrlFromItem(issue)));
 }
 
 async function init(signal: AbortSignal): Promise<void | false> {

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -22,13 +22,13 @@ function getUnreadNotifications(container: ParentNode = document): HTMLElement[]
 	return select.all('.notification-unread', container);
 }
 
-function openNotifications(notifications: Element[], markAsDone = false): void {
+async function openNotifications(notifications: Element[], markAsDone = false): Promise<void> {
 	const urls: string[] = [];
 	for (const notification of notifications) {
 		urls.push(notification.querySelector('a')!.href);
 	}
 
-	if (!openTabs(urls)) {
+	if (!await openTabs(urls)) {
 		return;
 	}
 

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -50,12 +50,6 @@ async function openNotifications(notifications: Element[], markAsDone = false): 
 	}
 }
 
-function removeOpenAllButtons(container: ParentNode = document): void {
-	for (const button of select.all(openUnread.selector, container)) {
-		button.remove();
-	}
-}
-
 async function openUnreadNotifications({delegateTarget, altKey}: DelegateEvent<MouseEvent>): Promise<void> {
 	const container = delegateTarget.closest('.js-notifications-group') ?? document;
 	await openNotifications(getUnreadNotifications(container), altKey);

--- a/source/github-helpers/toast.tsx
+++ b/source/github-helpers/toast.tsx
@@ -13,7 +13,7 @@ export function ToastSpinner(): JSX.Element {
 }
 
 type ProgressCallback = (message: string) => void;
-type Task = Promise<unknown>| ((progress?: ProgressCallback) => Promise<unknown>);
+type Task = Promise<unknown> | ((progress?: ProgressCallback) => Promise<unknown>);
 export default async function showToast(
 	task: Task | Error,
 	{

--- a/source/github-helpers/toast.tsx
+++ b/source/github-helpers/toast.tsx
@@ -13,7 +13,7 @@ export function ToastSpinner(): JSX.Element {
 }
 
 type ProgressCallback = (message: string) => void;
-type Task = (progress?: ProgressCallback) => Promise<unknown>;
+type Task = Promise<unknown>| ((progress?: ProgressCallback) => Promise<unknown>);
 export default async function showToast(
 	task: Task | Error,
 	{
@@ -45,7 +45,13 @@ export default async function showToast(
 			throw task;
 		}
 
-		await task(updateToast);
+		// eslint-disable-next-line unicorn/prefer-ternary -- Naw man, that's less readable
+		if (typeof task === 'function') {
+			await task(updateToast);
+		} else {
+			await task;
+		}
+
 		toast.classList.replace('Toast--loading', 'Toast--success');
 		updateToast(doneMessage);
 		iconWrapper.firstChild!.replaceWith(<CheckIcon/>);

--- a/source/helpers/open-tabs.ts
+++ b/source/helpers/open-tabs.ts
@@ -1,9 +1,9 @@
-export default function openTabs(urls: string[]): boolean {
+export default async function openTabs(urls: string[]): Promise<boolean> {
 	if (urls.length >= 10 && !confirm(`This will open ${urls.length} new tabs. Continue?`)) {
 		return false;
 	}
 
-	void browser.runtime.sendMessage({
+	await browser.runtime.sendMessage({
 		openUrls: urls,
 	});
 


### PR DESCRIPTION
Partial solution to https://github.com/refined-github/refined-github/issues/5798

I think the background page is broken on mobile so the messages aren't received and the tabs aren't opened. This at least stops RG from marking the notifications as read if it fails.

## Test URL

- https://github.com/notifications

## Demo

I added a toast to show the error, but I thought I'd leave it to also show success.

https://user-images.githubusercontent.com/1402241/189962947-fd3ee98e-4e49-4044-86ea-e9ab137b4438.mov



## Related-ish

- https://github.com/npmhub/npmhub/pull/152

