### PR TITLE
Fix: `select-notifications` causes button overlap on mobile

### DIFF
--- a/source/features/select-notifications.css
+++ b/source/features/select-notifications.css
@@ -1,5 +1,9 @@
-.js-notifications-mark-selected-actions > *,
-.rgh-open-selected-button {
-	/* Allow clicking on "Done" and other toolbar buttons even when the dropdown (z-index of 99) is open #4753 */
-	z-index: 100;
+/* Only when the meny is shown as a dropdown, not as a modal (mobile) #5796 */
+/* The media query matches the native one exactly, inverted via `not` */
+@media screen and not (max-width: 543px) {
+	.js-notifications-mark-selected-actions > *,
+	.rgh-open-selected-button {
+		/* Allow clicking on "Done" and other toolbar buttons even when the dropdown (z-index of 99) is open #4753 */
+		z-index: 100;
+	}
 }


### PR DESCRIPTION
- Fix #5796

## Test URLs

https://github.com/notifications

## Before

<img width="530" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/189964228-b10f1a98-5e65-4ac8-8b8a-b05a0c0b4542.png">


## After

<img width="530" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/189964212-8be33cc4-f095-40c4-89db-c5dfa58caeaa.png">


