### PR TITLE
Make `toggle-files-button` act faster and more reliably

### DIFF
--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -10,8 +10,8 @@ body.rgh-files-hidden .rgh-toggle-files .octicon-fold {
 }
 
 .rgh-files-hidden #files ~ :is(
-	.Details, /* Loaded */
-	include-fragment[src*="/file-list/"] /* Loading skeleton */
+.Details, /* Loaded */
+include-fragment[src*='/file-list/'] /* Loading skeleton */
 ) {
 	display: none;
 }

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -4,12 +4,15 @@
 	padding: 10px 13px;
 }
 
-.repository-content:not(.rgh-files-hidden) .rgh-toggle-files .octicon-unfold,
-.repository-content.rgh-files-hidden .rgh-toggle-files .octicon-fold {
+body:not(.rgh-files-hidden) .rgh-toggle-files .octicon-unfold,
+body.rgh-files-hidden .rgh-toggle-files .octicon-fold {
 	display: none !important;
 }
 
-.rgh-files-hidden #files ~ .Details {
+.rgh-files-hidden #files ~ :is(
+	.Details, /* Loaded */
+	include-fragment[src*="/file-list/"] /* Loading skeleton */
+) {
 	display: none;
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -3,14 +3,13 @@ import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {FoldIcon, UnfoldIcon, ArrowUpIcon} from '@primer/octicons-react';
 
 import features from '.';
 import selectHas from '../helpers/select-has';
 import attachElement from '../helpers/attach-element';
-import observeElement from '../helpers/simplified-element-observer';
+import observe from '../helpers/selector-observer';
 
 const cacheKey = 'files-hidden';
 const hiddenFilesClass = 'rgh-files-hidden';
@@ -20,9 +19,9 @@ const noticeClass = 'rgh-files-hidden-notice';
 // 19px align this icon with the <UnfoldIcon/> above it
 const noticeStyle = {paddingRight: '19px'};
 
-function addButton(): void {
+function addButton(filesBox: HTMLElement): void {
 	attachElement({
-		anchor: selectHas('.repository-content ul:has(.octicon-history)')!,
+		anchor: selectHas('ul:has(.octicon-history)', filesBox)!,
 		allowMissingAnchor: true,
 		className: toggleButtonClass,
 		append: () => (
@@ -38,10 +37,10 @@ function addButton(): void {
 	});
 }
 
-function addFilesHiddenNotice(repoContent: Element): void {
+function addFilesHiddenNotice(fileBox: Element): void {
 	// Add notice so the user knows that the list was collapsed #5524
 	attachElement({
-		anchor: select('.Box', repoContent),
+		anchor: fileBox,
 		className: noticeClass,
 		after: () => (
 			<div
@@ -54,26 +53,38 @@ function addFilesHiddenNotice(repoContent: Element): void {
 	});
 }
 
+function toggle(toggle?: boolean): boolean {
+	return document.body.classList.toggle(hiddenFilesClass, toggle);
+}
+
 async function toggleHandler(): Promise<void> {
 	// Remove notice after the first click
 	select(`.${noticeClass}`)?.remove();
 
-	const isHidden = select('.repository-content')!.classList.toggle(hiddenFilesClass);
+	const isHidden = toggle();
 	await cache.set(cacheKey, isHidden);
 }
 
-async function init(signal: AbortSignal): Promise<Deinit> {
-	const repoContent = (await elementReady('.repository-content'))!;
-
+async function updateView(anchor: HTMLHeadingElement): Promise<void> {
+	const filesBox = anchor.parentElement!;
+	addButton(filesBox);
 	if (await cache.get<boolean>(cacheKey)) {
-		repoContent.classList.add(hiddenFilesClass);
-		addFilesHiddenNotice(repoContent);
+		addFilesHiddenNotice(filesBox);
 	}
+}
 
+async function loadPreviousState(): Promise<void> {
+	const wasHidden = await cache.get<boolean>(cacheKey);
+	if (wasHidden) {
+		toggle(true);
+	}
+}
+
+async function init(signal: AbortSignal): Promise<void> {
+	// TODO: Use `.Box:has(> #files)` instead
+	observe('.repository-content h2#files', updateView, {signal});
 	delegate(document, `.${toggleButtonClass}, .${noticeClass}`, 'click', toggleHandler, {signal});
-
-	// TODO: Use new `selector-observer` when `:has` becomes available, so its element can be used as `anchor` inside `addButton`
-	return observeElement(repoContent, addButton);
+	await loadPreviousState();
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION



## Reliable position

- Fixes https://github.com/refined-github/refined-github/issues/5978

Test URL: https://github.com/fregante/refined-github

<img width="664" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/190135039-32d1eba5-0cd3-4439-8d96-9a5787b18ffa.png">

## Faster UI update

- Described in https://github.com/refined-github/refined-github/issues/5979#issuecomment-1246502644

Due to this skeleton, `.Details` was not available to be hidden (a selector in the CSS file)

<img width="670" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/190135092-49bdeb58-d008-4355-a080-3d66b2c82e7b.png">



