### PR TITLE
Avoid triggering `pr-branch-auto-delete` when simply watching a PR

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -6,7 +6,6 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
-import onPrMerge from '../github-events/on-pr-merge';
 import createBanner from '../github-helpers/banner';
 import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
@@ -14,6 +13,7 @@ import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers';
 import {getReleaseCount} from './releases-tab';
+import observe from '../helpers/selector-observer';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
@@ -100,6 +100,10 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 	});
 }
 
+function initOpenPr(signal: AbortSignal): void {
+	observe('.discussion-timeline-actions .TimelineItem-badge .octicon-git-merge', addReleaseBanner, {signal});
+}
+
 void features.add(import.meta.url, {
 	// When arriving on an already-merged PR
 	asLongAs: [
@@ -118,14 +122,8 @@ void features.add(import.meta.url, {
 		pageDetect.isOpenPR,
 		canCreateRelease,
 	],
-	additionalListeners: [
-		onPrMerge,
-	],
-	onlyAdditionalListeners: true,
 	deduplicate: false,
-	init() {
-		void addReleaseBanner();
-	},
+	init: initOpenPr,
 });
 
 /*

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -6,6 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
+import onPrMerge from '../github-events/on-pr-merge';
 import createBanner from '../github-helpers/banner';
 import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
@@ -13,7 +14,6 @@ import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers';
 import {getReleaseCount} from './releases-tab';
-import observe from '../helpers/selector-observer';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
@@ -100,10 +100,6 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 	});
 }
 
-function initOpenPr(signal: AbortSignal): void {
-	observe('.discussion-timeline-actions .TimelineItem-badge .octicon-git-merge', addReleaseBanner, {signal});
-}
-
 void features.add(import.meta.url, {
 	// When arriving on an already-merged PR
 	asLongAs: [
@@ -122,8 +118,14 @@ void features.add(import.meta.url, {
 		pageDetect.isOpenPR,
 		canCreateRelease,
 	],
+	additionalListeners: [
+		onPrMerge,
+	],
+	onlyAdditionalListeners: true,
 	deduplicate: false,
-	init: initOpenPr,
+	init() {
+		void addReleaseBanner();
+	},
 });
 
 /*

--- a/source/github-events/on-pr-merge.ts
+++ b/source/github-events/on-pr-merge.ts
@@ -1,12 +1,14 @@
-import select from 'select-dom';
+import delegate from 'delegate-it';
 
-import observeElement from '../helpers/simplified-element-observer';
+import onAbort from '../helpers/abort-controller';
+import observe from '../helpers/selector-observer';
 
-export default function onPrMerge(callback: VoidFunction): Deinit {
-	return observeElement('.discussion-timeline-actions', (_, observer) => {
-		if (select.exists('.TimelineItem-badge .octicon-git-merge')) {
-			observer.disconnect();
-			callback();
-		}
-	}, {childList: true});
+export default function onPrMerge(callback: VoidFunction, signal: AbortSignal): void {
+	// TODO: Drop after https://github.com/fregante/delegate-it/issues/30
+	const controller = new AbortController();
+	onAbort(signal, controller);
+	delegate(document, '.js-merge-commit-button', 'click', () => {
+		controller.abort();
+		observe('.discussion-timeline-actions .TimelineItem-badge .octicon-git-merge', callback, {signal});
+	}, {signal});
 }

--- a/source/github-events/on-pr-merge.ts
+++ b/source/github-events/on-pr-merge.ts
@@ -9,6 +9,6 @@ export default function onPrMerge(callback: VoidFunction, signal: AbortSignal): 
 	onAbort(signal, controller);
 	delegate(document, '.js-merge-commit-button', 'click', () => {
 		controller.abort();
-		observe('.discussion-timeline-actions .TimelineItem-badge .octicon-git-merge', callback, {signal});
+		observe('.TimelineItem-badge .octicon-git-merge', callback, {signal});
 	}, {signal});
 }


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5868

## Test


Any PR:

- that you can merge
- on a repo without native branch auto-deletion

### Test bugfix

1. Open the PR in two browser, one with RG, one without
2. Merge the PR in the browser without RG
3. The branch should not be deleted 

## Test feature

1. Merge the PR
3. The branch should be deleted 
