### PR TITLE
Fix `quick-review` and `comment-on-draft-pr-indicator`

### DIFF
--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -1,29 +1,19 @@
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onElementReplacement from '../helpers/on-element-replacement';
+import observe from '../helpers/selector-observer';
 
 function addIndicator(button: HTMLElement): void {
-	button.classList.add('rgh-draft-pr-indicator');
 	const preposition = button.textContent!.includes('Add') ? ' to ' : ' on ';
 	button.textContent! += preposition + 'draft PR';
 }
 
 function init(signal: AbortSignal): void {
-	const buttons = select.all([
+	observe([
 		'.review-simple-reply-button', // "Add single comment" button
 		'.add-comment-label', // "Add review comment" button
 		'.start-review-label', // "Start a review" button
-	]);
-	for (const button of buttons) {
-		addIndicator(button);
-	}
-
-	if (pageDetect.isPRConversation()) {
-		// The button is part of a .js-updatable-content partial
-		void onElementReplacement('#partial-new-comment-form-actions .btn-primary:not(.rgh-draft-pr-indicator)', addIndicator, {runCallbackOnStart: true, signal});
-	}
+	], addIndicator, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -34,6 +24,7 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
 	],
-	deduplicate: 'has-rgh-inner',
+	awaitDomReady: false,
+	deduplicate: false,
 	init,
 });

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -5,23 +5,30 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '.';
-import onDiscussionSidebarUpdate from '../github-events/on-discussion-sidebar-update';
+import observe from '../helpers/selector-observer';
+import attachElement from '../helpers/attach-element';
 
-async function addSidebarReviewButton(): Promise<void | false> {
-	const sidebarReviewsSection = await elementReady('[aria-label="Select reviewers"] .discussion-sidebar-heading');
-	if (select.exists('[data-hotkey="v"]', sidebarReviewsSection)) {
-		return false;
-	}
-
+function createReviewLink(): Element {
 	const reviewFormUrl = new URL(location.href);
 	reviewFormUrl.pathname += '/files';
 	reviewFormUrl.hash = 'review-changes-modal';
 
-	sidebarReviewsSection!.append(
+	return (
 		<span className="text-normal">
 			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v" data-pjax="#repo-content-pjax-container">review now</a>
-		</span>,
+		</span>
 	);
+}
+
+function addSidebarReviewButton(reviewersSection: Element): void {
+	attachElement({
+		anchor: reviewersSection,
+		append: createReviewLink,
+	});
+}
+
+function initSidebarReviewButton(signal: AbortSignal): void {
+	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading', addSidebarReviewButton, {signal});
 }
 
 function focusReviewTextarea({delegateTarget}: DelegateEvent<Event, HTMLDetailsElement>): void {
@@ -43,12 +50,9 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	additionalListeners: [
-		onDiscussionSidebarUpdate,
-	],
 	awaitDomReady: false,
 	deduplicate: false,
-	init: addSidebarReviewButton,
+	init: initSidebarReviewButton,
 }, {
 	shortcuts: {
 		v: 'Open PR review popup',


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5815
- Part of #5992 
- Part of #5871 

- Part of https://github.com/refined-github/refined-github/issues/5895

## Test URLs

- `quick-review`: This PR
-  `comment-on-draft-pr-indicator`: https://github.com/refined-github/sandbox/pull/7/files

## Screenshot

###  `quick-review`

<img width="309" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/190640656-987ec00b-7a8d-46b2-a177-81f10900b078.png">


### First review 

<img width="867" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/190638998-d9c1c628-d418-4c11-a785-0573555c46c4.png">

### Successive comments

<img width="889" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/190639026-faebfcf3-09b0-4464-95e9-d7ba588d6328.png">
