### PR TITLE
Fix duplication of `profile-gists-link` and `show-user-top-repositories`

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -9,6 +9,7 @@ import features from '.';
 import * as api from '../github-helpers/api';
 import {getCleanPathname} from '../github-helpers';
 import createDropdownItem from '../github-helpers/create-dropdown-item';
+import attachElement from '../helpers/attach-element';
 
 const getGistCount = cache.function(async (username: string): Promise<number> => {
 	const {user} = await api.v4(`
@@ -50,7 +51,12 @@ async function init(): Promise<void> {
 	}
 
 	// Add gist counter to profile
-	navigationBar.append(link);
+	attachElement({
+		anchor: navigationBar,
+		append: () => link,
+	});
+
+	// This triggers a refresh logic for GitHub’s overlow menu
 	navigationBar.replaceWith(navigationBar);
 
 	select('.js-responsive-underlinenav .dropdown-menu ul')!.append(
@@ -58,8 +64,12 @@ async function init(): Promise<void> {
 	);
 
 	const count = await getGistCount(username);
+
 	if (count > 0) {
-		link.append(<span className="Counter">{count}</span>);
+		attachElement({
+			anchor: link,
+			append: () => <span className="Counter">{count}</span>,
+		});
 	}
 }
 

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -44,8 +44,10 @@ async function init(): Promise<void> {
 	const navigationBar = (await elementReady('.UnderlineNav-body'))!;
 
 	// If the button already exists, skip adding it
-	const isGistButtonAlreadyAdded = !!select(".UnderlineNav-body [data-tab-item='rgh-gists-item']");
-	if(isGistButtonAlreadyAdded) return;
+	const isGistButtonAlreadyAdded = Boolean(select('.UnderlineNav-body [data-tab-item=\'rgh-gists-item\']'));
+	if(isGistButtonAlreadyAdded) {
+		return;
+	};
 
 	// Add gist counter to profile
 	navigationBar.append(link);

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -44,12 +44,6 @@ async function init(): Promise<void> {
 
 	const navigationBar = (await elementReady('.UnderlineNav-body'))!;
 
-	// If the button already exists, skip adding it
-	const isGistButtonAlreadyAdded = Boolean(select('.UnderlineNav-body [data-tab-item=\'rgh-gists-item\']'));
-	if (isGistButtonAlreadyAdded) {
-		return;
-	}
-
 	// Add gist counter to profile
 	attachElement({
 		anchor: navigationBar,

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -45,9 +45,10 @@ async function init(): Promise<void> {
 
 	// If the button already exists, skip adding it
 	const isGistButtonAlreadyAdded = Boolean(select('.UnderlineNav-body [data-tab-item=\'rgh-gists-item\']'));
-	if(isGistButtonAlreadyAdded) {
+	if (isGistButtonAlreadyAdded) {
 		return;
-	};
+
+	}
 
 	// Add gist counter to profile
 	navigationBar.append(link);

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -42,6 +42,12 @@ async function init(): Promise<void> {
 	);
 
 	const navigationBar = (await elementReady('.UnderlineNav-body'))!;
+
+	// If the button already exists, skip adding it
+	const isGistButtonAlreadyAdded = !!select(".UnderlineNav-body [data-tab-item='rgh-gists-item']");
+	if(isGistButtonAlreadyAdded) return;
+
+	// Add gist counter to profile
 	navigationBar.append(link);
 	navigationBar.replaceWith(navigationBar);
 

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -47,7 +47,6 @@ async function init(): Promise<void> {
 	const isGistButtonAlreadyAdded = Boolean(select('.UnderlineNav-body [data-tab-item=\'rgh-gists-item\']'));
 	if (isGistButtonAlreadyAdded) {
 		return;
-
 	}
 
 	// Add gist counter to profile

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -14,7 +14,9 @@ function init(): void {
 
 	// If already added, skip
 	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
-	if(pinnedText.innerHTML.includes("Top repositories")) return;
+	if(pinnedText.innerHTML.includes('Top repositories')) {
+		return;
+	};
 
 	// Add top repositories link
 	pinnedText.firstChild!.after(

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -16,7 +16,6 @@ function init(): void {
 	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
 	if (pinnedText.innerHTML.includes('Top repositories')) {
 		return;
-
 	}
 
 	// Add top repositories link

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -17,7 +17,7 @@ function init(): void {
 	if(pinnedText.innerHTML.includes("Top repositories")) return;
 
 	// Add top repositories link
-	select('.js-pinned-items-reorder-container .text-normal')!.firstChild!.after(
+	pinnedText.firstChild!.after(
 		' / ',
 		<a href={url.href}>Top repositories</a>,
 	);

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -14,9 +14,10 @@ function init(): void {
 
 	// If already added, skip
 	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
-	if(pinnedText.innerHTML.includes('Top repositories')) {
+	if (pinnedText.innerHTML.includes('Top repositories')) {
 		return;
-	};
+
+	}
 
 	// Add top repositories link
 	pinnedText.firstChild!.after(

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -12,7 +12,11 @@ function init(): void {
 		sort: 'stargazers',
 	}).toString();
 
-	// Showcase title
+	// If already added, skip
+	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
+	if(pinnedText.innerHTML.includes("Top repositories")) return;
+
+	// Add top repositories link
 	select('.js-pinned-items-reorder-container .text-normal')!.firstChild!.after(
 		' / ',
 		<a href={url.href}>Top repositories</a>,

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import attachElement from '../helpers/attach-element';
 
 function init(): void {
 	const url = new URL(location.pathname, location.href);
@@ -12,17 +13,18 @@ function init(): void {
 		sort: 'stargazers',
 	}).toString();
 
-	// If already added, skip
-	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
-	if (pinnedText.innerHTML.includes('Top repositories')) {
-		return;
-	}
-
 	// Add top repositories link
-	pinnedText.firstChild!.after(
-		' / ',
-		<a href={url.href}>Top repositories</a>,
+	const pinnedText = select('.js-pinned-items-reorder-container .text-normal')!;
+	const topReposLink = (
+		<span>
+			/&nbsp;<a href={url.href}>Top repositories</a>
+		</span>
 	);
+
+	attachElement({
+		anchor: pinnedText,
+		append: () => topReposLink,
+	});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Hoping it's okay I open this - I was poking around the code and saw this issue was open and figured I'd take a crack at it

Closes #5995

## Test URLs

I'm assuming this affects any users profile page when using the extension. Tested against this URL along with some other private profiles:
- https://github.com/minaminao

## Screenshot

![Untitled_ Sep 18, 2022 4_46 AM](https://user-images.githubusercontent.com/25781487/190896147-2b2e0eec-d1a9-4619-aacc-e1ac2fdd176b.gif)