### PR TITLE
Restore `clean-conversation-sidebar`

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -5,7 +5,6 @@ import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import selectHas from '../helpers/select-has';
 import onElementRemoval from '../helpers/on-element-removal';
 import onDiscussionSidebarUpdate from '../github-events/on-discussion-sidebar-update';
 
@@ -34,7 +33,7 @@ Expected DOM:
 @param selector Element that contains `details` or `.discussion-sidebar-heading` or distinctive element inside it
 */
 function cleanSection(selector: string): boolean {
-	const container = selectHas(`:is(form, .discussion-sidebar-item):has(${selector})`);
+	const container = select(`:is(form, .discussion-sidebar-item):has(${selector})`);
 	if (!container) {
 		return false;
 	}
@@ -46,7 +45,10 @@ function cleanSection(selector: string): boolean {
 		'[aria-label="Select projects"] .Link--primary',
 	];
 
-	const heading = select('.discussion-sidebar-heading', container)!;
+	const heading = select([
+		'details:has(> .discussion-sidebar-heading)', // Can edit sidebar, has a dropdown
+		'.discussion-sidebar-heading', // Cannot editor sidebar, has a plain heading
+	], container)!;
 	if (heading.closest('form, .discussion-sidebar-item')!.querySelector(identifiers.join(','))) {
 		return false;
 	}
@@ -100,7 +102,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	// Labels
 	if (!cleanSection('.js-issue-labels') && !canEditSidebar()) {
 		// Hide heading in any case except `canEditSidebar`
-		selectHas('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading')!
+		select('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading')!
 			.remove();
 	}
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5843

Not the most optimal solution, but the fastest one. 

Note: No Firefox support, sorry.


### Future improvements

- [ ] Rewrite using `:has()` selectors that encapsulate more logic (the only reason why this can't be a CSS-only feature is because most hideable parts are text nodes 😰)
- [ ] Reduce/fix spacing. The sidebar’s height slightly increases when the milestones dropdown is opened


## Testing

The actions change depending on:

- issue / PR
- editable / non editable

Tested URLs:

- This PR
- https://github.com/refined-github/refined-github/issues/5843
- https://github.com/facebook/react/issues/13991


## Screenshot

<img width="339" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/190999108-c0bf059f-cdab-42e2-8c65-fafd327b07a7.png">

<img width="289" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/190999123-e11356c6-280b-4967-a197-e276c4f7973c.png">
