### PR TITLE
Meta: Default to `deduplicate: false` and rename manager to `./feature-manager`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -62,17 +62,19 @@ void features.add(import.meta.url, {
 	// Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true
 	awaitDomReady: false,
 
-	// When pressing the back button, DOM changes and listeners are still there, so normally `init` isn’t called again thanks to an automatic duplicate detection.
-	// This detection however might cause problems or not work correctly in some cases #3945, so it can be disabled with `false`
-	deduplicate: false,
+	// Every one of these must match
 	asLongAs: [
 		pageDetect.isForkedRepo,
 	],
+
+	// At least one of these must match
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
+
+	// None of these must match
 	exclude: [
 		pageDetect.isRepoRoot,
 	],

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -35,8 +35,9 @@ type FeatureLoader = {
 	/** Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady?: false;
 
-	/** When pressing the back button, DOM changes and listeners are still there, so normally `init` isn’t called again thanks to an automatic duplicate detection.
-	This detection however might cause problems or not work correctly in some cases #3945, so it can be disabled with `false` or by passing a custom selector to use as duplication check
+	/** When pressing the back button, DOM changes and listeners are still there. Using a selector here would use the integrated deduplication logic, but it cannot be used with `delegate` and it shouldn't use `has-rgh` and `has-inner-rgh` anymore. #5871 #
+	@deprecated
+	@default false
 	*/
 	deduplicate?: string;
 

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -269,7 +269,7 @@ const add = async (url: string, ...loaders: FeatureLoader[]): Promise<void> => {
 			exclude,
 			init,
 			awaitDomReady = true,
-			deduplicate = 'has-rgh',
+			deduplicate = false,
 			onlyAdditionalListeners = false,
 			additionalListeners = [],
 		} = loader;

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -5,14 +5,14 @@ import stripIndent from 'strip-indent';
 import {Promisable} from 'type-fest';
 import * as pageDetect from 'github-url-detection';
 
-import waitFor from '../helpers/wait-for';
-import onAbort from '../helpers/abort-controller';
-import ArrayMap from '../helpers/map-of-arrays';
-import onNewComments from '../github-events/on-new-comments';
-import bisectFeatures from '../helpers/bisect';
-import {shouldFeatureRun} from '../github-helpers';
-import polyfillTurboEvents from '../github-helpers/turbo-events-polyfill';
-import optionsStorage, {RGHOptions} from '../options-storage';
+import waitFor from './helpers/wait-for';
+import onAbort from './helpers/abort-controller';
+import ArrayMap from './helpers/map-of-arrays';
+import onNewComments from './github-events/on-new-comments';
+import bisectFeatures from './helpers/bisect';
+import {shouldFeatureRun} from './github-helpers';
+import polyfillTurboEvents from './github-helpers/turbo-events-polyfill';
+import optionsStorage, {RGHOptions} from './options-storage';
 import {
 	applyStyleHotfixes,
 	getStyleHotfix,
@@ -21,7 +21,7 @@ import {
 	updateHotfixes,
 	updateLocalStrings,
 	_,
-} from '../helpers/hotfix';
+} from './helpers/hotfix';
 
 type BooleanFunction = () => boolean;
 export type CallerFunction = (callback: VoidFunction, signal: AbortSignal) => void | Promise<void> | Deinit;
@@ -38,7 +38,7 @@ type FeatureLoader = {
 	/** When pressing the back button, DOM changes and listeners are still there, so normally `init` isn’t called again thanks to an automatic duplicate detection.
 	This detection however might cause problems or not work correctly in some cases #3945, so it can be disabled with `false` or by passing a custom selector to use as duplication check
 	*/
-	deduplicate: false | string;
+	deduplicate?: string;
 
 	/** When true, don’t run the `init` on page load but only add the `additionalListeners`. @default false */
 	onlyAdditionalListeners?: true;
@@ -307,7 +307,6 @@ const addCssFeature = async (url: string, include: BooleanFunction[] | undefined
 	const id = getFeatureID(url);
 	void add(id, {
 		include,
-		deduplicate: false,
 		awaitDomReady: false,
 		init() {
 			document.documentElement.classList.add('rgh-' + id);
@@ -339,7 +338,6 @@ This means that the old features will still be on the page and don't need to re-
 This marks each as "processed"
 */
 void add('rgh-deduplicator' as FeatureID, {
-	deduplicate: false,
 	async init() {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -30,5 +30,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isMarketplaceAction,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import {SearchIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import selectHas from '../helpers/select-has';
 
 function init(): void {

--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -1,6 +1,6 @@
 import './align-issue-labels.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.isIssueOrPRList]);

--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import {isMac} from '../github-helpers';
-import features from '.';
+import features from '../feature-manager';
 
 function onKeyDown(event: DelegateEvent<KeyboardEvent, HTMLInputElement>): void {
 	const field = event.delegateTarget;
@@ -64,6 +64,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import clickAll from '../helpers/click-all';
 import showToast from '../github-helpers/toast';
 import getItemsBetween from '../helpers/get-items-between';
@@ -82,6 +82,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRFiles,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -5,7 +5,7 @@ import {BugIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 import SearchQuery from '../github-helpers/search-query';
@@ -185,6 +185,5 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -1,6 +1,6 @@
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import observe from '../helpers/selector-observer';
 

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {buildRepoURL} from '../github-helpers';
 import attachElement from '../helpers/attach-element';

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -57,6 +57,7 @@ void features.add(import.meta.url, {
 		pageDetect.isEmptyRepo,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import {ArrowLeftIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import selectHas from '../helpers/select-has';
 import onElementRemoval from '../helpers/on-element-removal';
 import onDiscussionSidebarUpdate from '../github-events/on-discussion-sidebar-update';

--- a/source/features/clean-dashboard.tsx
+++ b/source/features/clean-dashboard.tsx
@@ -1,6 +1,6 @@
 import './clean-dashboard.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.isDashboard]);

--- a/source/features/clean-header-search-field.tsx
+++ b/source/features/clean-header-search-field.tsx
@@ -2,7 +2,7 @@ import onetime from 'onetime';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 async function init(): Promise<void> {
 	(await elementReady('input.header-search-input'))!.value = '';

--- a/source/features/clean-pinned-issues.tsx
+++ b/source/features/clean-pinned-issues.tsx
@@ -1,6 +1,6 @@
 import './clean-pinned-issues.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.isRepoIssueList]);

--- a/source/features/clean-repo-filelist-actions.tsx
+++ b/source/features/clean-repo-filelist-actions.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import {PlusIcon, SearchIcon, CodeIcon} from '@primer/octicons-react';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 
 /** Add tooltip on a wrapper to avoid breaking dropdown functionality */
 function addTooltipToSummary(childElement: Element, tooltip: string): void {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -4,7 +4,7 @@ import domLoaded from 'dom-loaded';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -141,6 +141,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 }, {
 	include: [
@@ -148,17 +149,20 @@ void features.add(import.meta.url, {
 		pageDetect.isOrganizationProfile,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initProjects,
 }, {
 	include: [
 		pageDetect.isRepo,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initActions,
 }, {
 	include: [
 		pageDetect.isRepo,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initWiki,
 });

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import * as api from '../github-helpers/api';
 import getTabCount from '../github-helpers/get-tab-count';

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -1,6 +1,6 @@
 import './clean-rich-text-editor.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
 function init(): void {
@@ -29,6 +29,5 @@ void features.add(import.meta.url, {
 	],
 	onlyAdditionalListeners: true,
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import onetime from 'onetime';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 const visible = new Set();
 const observer = new IntersectionObserver(entries => {
@@ -55,6 +55,5 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import {TagIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import onPrMerge from '../github-events/on-pr-merge';
 import createBanner from '../github-helpers/banner';
@@ -122,7 +122,6 @@ void features.add(import.meta.url, {
 		onPrMerge,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: false,
 	init() {
 		void addReleaseBanner();
 	},

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import smartBlockWrap from '../helpers/smart-block-wrap';
 import {onCommentEdit} from '../github-events/on-fragment-load';
 import {attachElements} from '../helpers/attach-element';
@@ -57,6 +57,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/command-palette-navigation-shortcuts.tsx
+++ b/source/features/command-palette-navigation-shortcuts.tsx
@@ -30,5 +30,6 @@ void features.add(import.meta.url, {
 		'ctrl p': 'Select previous item in command palette',
 	},
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/command-palette-navigation-shortcuts.tsx
+++ b/source/features/command-palette-navigation-shortcuts.tsx
@@ -2,7 +2,7 @@ import onetime from 'onetime';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import {isMac} from '../github-helpers';
-import features from '.';
+import features from '../feature-manager';
 
 function commandPaletteKeydown(event: DelegateEvent<KeyboardEvent>): void {
 	const {key, ctrlKey, delegateTarget} = event;
@@ -30,6 +30,5 @@ void features.add(import.meta.url, {
 		'ctrl p': 'Select previous item in command palette',
 	},
 	awaitDomReady: false,
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/command-palette-navigation-shortcuts.tsx
+++ b/source/features/command-palette-navigation-shortcuts.tsx
@@ -30,6 +30,6 @@ void features.add(import.meta.url, {
 		'ctrl p': 'Select previous item in command palette',
 	},
 	awaitDomReady: false,
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -4,7 +4,7 @@ import {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import filterAlteredClicks from 'filter-altered-clicks';
 
-import features from '.';
+import features from '../feature-manager';
 import {onCommentFieldKeydown} from '../github-events/on-field-keydown';
 
 function handleEscapeKey(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement>, targetField: HTMLTextAreaElement): void {

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -1,6 +1,6 @@
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function addIndicator(button: HTMLElement): void {
@@ -25,6 +25,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 import addNotice from '../github-widgets/notice-bar';

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -142,5 +142,6 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoTree,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: showTimeMachineBar,
 });

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -88,5 +88,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -5,7 +5,7 @@ import {AlertIcon} from '@primer/octicons-react';
 import oneMutation from 'one-mutation';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 
 type PRConfig = {

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import {CheckIcon, EyeClosedIcon, EyeIcon, XIcon} from '@primer/octicons-react';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import onNewComments from '../github-events/on-new-comments';
 import {registerHotkey} from '../github-helpers/hotkey';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {GitPullRequestIcon, IssueOpenedIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function addConversationLinks(repositoryLink: HTMLAnchorElement): void {

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -42,6 +42,7 @@ void features.add(import.meta.url, {
 		pageDetect.isUserProfileRepoTab,
 		pageDetect.isGlobalSearchResults,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -4,7 +4,7 @@ import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import IconLoading from '../github-helpers/icon-loading';
 
 function closeModal({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
@@ -39,6 +39,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import LoadingIcon from '../github-helpers/icon-loading';
 import attachElement from '../helpers/attach-element';

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import {groupButtons} from '../github-helpers/group-buttons';
 
 function handleClick({delegateTarget: button}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {isEditable} from '../helpers/dom-utils';
 
 const handler = ({key, target}: KeyboardEvent): void => {
@@ -25,6 +25,5 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {addHotkey} from '../github-helpers/hotkey';
 import addQuickSubmit from './submission-via-ctrl-enter-everywhere';
 

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -17,6 +17,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isReleasesOrTags,
 	],
+	deduplicate: 'has-rgh',
 	init,
 }, {
 	include: [
@@ -24,5 +25,6 @@ void features.add(import.meta.url, {
 		pageDetect.isNewRelease,
 		pageDetect.isEditingRelease,
 	],
+	deduplicate: 'has-rgh',
 	init: addQuickSubmit,
 });

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void | false {
 	const lastBranchAction = select.last('.TimelineItem-body .user-select-contain.commit-ref');

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -6,7 +6,7 @@ import {VersionsIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 import showToast from '../github-helpers/toast';

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -110,5 +110,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isBlame,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -3,7 +3,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {ChevronLeftIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 import {groupButtons} from '../github-helpers/group-buttons';
 import getDefaultBranch from '../github-helpers/get-default-branch';

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -2,7 +2,7 @@ import './dim-bots.css';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const botNames = [
 	'actions-user',

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 
 function getDropdownItem(downloadUrl: URL): JSX.Element {

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 function toggleCommitMessage(event: DelegateEvent<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
@@ -31,6 +31,5 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/easy-toggle-files.tsx
+++ b/source/features/easy-toggle-files.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function toggleFile(event: DelegateEvent<MouseEvent>): void {
 	const elementClicked = event.target as HTMLElement;
@@ -25,6 +25,5 @@ void features.add(import.meta.url, {
 		pageDetect.isGistRevision,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import {PencilIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 import {isPermalink} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -72,5 +72,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -3,7 +3,7 @@ import domify from 'doma';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getCleanPathname} from '../github-helpers';
 
 function parseGistLink(link: HTMLAnchorElement): string | undefined {

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -29,5 +29,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleGist,
 	],
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	const embedViaScript = select('.file-navigation-option button[value^="<script"]')!;
@@ -29,6 +29,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleGist,
 	],
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -29,6 +29,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleGist,
 	],
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -4,7 +4,7 @@ import {GitBranchIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 
 /** Rebuilds the "View file" link because it points to the base repo and to the commit, instead of the head repo and its branch */
@@ -66,7 +66,6 @@ void features.add(import.meta.url, {
 		// If you're viewing changes from partial commits, ensure you're on the latest one.
 		() => select.exists('.js-commits-filtered') && !select.exists('[aria-label="You are viewing the latest commit"]'),
 	],
-	deduplicate: false,
 	init,
 }, {
 	asLongAs: [
@@ -76,6 +75,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isCompare,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/esc-to-cancel.tsx
+++ b/source/features/esc-to-cancel.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {onConversationTitleFieldKeydown} from '../github-events/on-field-keydown';
 
 function handleEscPress(event: DelegateEvent<KeyboardEvent>): void {

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -1,6 +1,6 @@
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {isEditable} from '../helpers/dom-utils';
 
 function isLineSelected(): boolean {

--- a/source/features/expand-all-hidden-comments.tsx
+++ b/source/features/expand-all-hidden-comments.tsx
@@ -3,7 +3,7 @@ import oneEvent from 'one-event';
 import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const paginationButtonSelector = '.ajax-pagination-form button[type="submit"]';
 
@@ -37,7 +37,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
 	],
-	deduplicate: false,
 	init,
 });
 

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -76,5 +76,6 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalIssueOrPRList,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -4,7 +4,7 @@ import {CheckIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 
 function addMergeLink(): void {

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function expandDiff(event: DelegateEvent): void {
 	// Skip if the user clicked directly on the icon
@@ -20,6 +20,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasFiles,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -5,7 +5,7 @@ import onetime from 'onetime';
 import {isSafari} from 'webext-detect-page';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const getBufferField = onetime((): HTMLInputElement => (
 	<input

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -70,5 +70,6 @@ void features.add(import.meta.url, {
 		isSafari,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -5,7 +5,7 @@ import {isSafari} from 'webext-detect-page';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
 function inputListener({target}: Event): void {
@@ -45,7 +45,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		isSafari,
 	],
-	deduplicate: false,
 	init,
 }, {
 	include: [
@@ -58,6 +57,5 @@ void features.add(import.meta.url, {
 		onPrMergePanelOpen,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: false,
 	init: fitPrCommitMessageBox,
 });

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 import doesFileExist from '../github-helpers/does-file-exist';
 import getDefaultBranch from '../github-helpers/get-default-branch';
@@ -46,6 +46,5 @@ void features.add(import.meta.url, {
 		pageDetect.isForkedRepo,
 	],
 	// We can't use `exclude` because the header is outside the ajaxed area so it must be manually reset even when the feature doesn't apply there
-	deduplicate: false,
 	init,
 });

--- a/source/features/git-checkout-pr.tsx
+++ b/source/features/git-checkout-pr.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 import {CopyIcon, CheckIcon, TerminalIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo, getUsername} from '../github-helpers';
 
 // Logic explained in https://github.com/refined-github/refined-github/pull/3596#issuecomment-720910840
@@ -125,6 +125,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isClosedPR,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -45,5 +45,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isGlobalIssueOrPRList,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 
 function init(): void {

--- a/source/features/global-search-filters.tsx
+++ b/source/features/global-search-filters.tsx
@@ -3,7 +3,7 @@ import {XIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 import {getUsername} from '../github-helpers';
 

--- a/source/features/global-search-filters.tsx
+++ b/source/features/global-search-filters.tsx
@@ -49,5 +49,6 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalSearchResults,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -6,7 +6,7 @@ import {CommentIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import preserveScroll from '../helpers/preserve-scroll';
 import {onDiffFileLoad} from '../github-events/on-fragment-load';
 import onAbort from '../helpers/abort-controller';
@@ -77,6 +77,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/hide-diff-signs.tsx
+++ b/source/features/hide-diff-signs.tsx
@@ -1,7 +1,7 @@
 import './hide-diff-signs.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [
 	pageDetect.hasCode,

--- a/source/features/hide-disabled-milestone-sorter.tsx
+++ b/source/features/hide-disabled-milestone-sorter.tsx
@@ -15,5 +15,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isMilestone,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/hide-disabled-milestone-sorter.tsx
+++ b/source/features/hide-disabled-milestone-sorter.tsx
@@ -1,7 +1,7 @@
 import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): Deinit {
 	return observe('[aria-label="You do not have permission to edit this milestone."]', {

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import onNewComments from '../github-events/on-new-comments';
 
 function init(): void {

--- a/source/features/hide-issue-list-autocomplete.tsx
+++ b/source/features/hide-issue-list-autocomplete.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	select('.subnav-search')!.setAttribute('autocomplete', 'off');

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -92,6 +92,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isIssue,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import isLowQualityComment from '../helpers/is-low-quality-comment';
 
 export const singleParagraphCommentSelector = '.comment-body > p:only-child';

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -1,7 +1,7 @@
 import './hide-navigation-hover-highlight.css';
 import onetime from 'onetime';
 
-import features from '.';
+import features from '../feature-manager';
 
 const className = 'rgh-no-navigation-highlight';
 
@@ -14,6 +14,5 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -14,5 +14,6 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -14,6 +14,6 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/hide-newsfeed-noise.tsx
+++ b/source/features/hide-newsfeed-noise.tsx
@@ -1,6 +1,6 @@
 import './hide-newsfeed-noise.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.isDashboard]);

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -20,5 +20,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDashboard,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {ArrowDownIcon, CheckCircleFillIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import looseParseInt from '../helpers/loose-parse-int';
 import isLowQualityComment from '../helpers/is-low-quality-comment';
 import {singleParagraphCommentSelector} from './hide-low-quality-comments';

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import {buildRepoURL, getRepo, getUsername} from '../github-helpers';
 

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -4,7 +4,7 @@ import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {onDiffFileLoad} from '../github-events/on-fragment-load';
 import observe from '../helpers/selector-observer';
 
@@ -79,7 +79,6 @@ void features.add(import.meta.url, {
 		onDiffFileLoad,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: false,
 	init,
 });
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {GitPullRequestIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {buildRepoURL} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const isSingleHTMLFile = (): boolean => pageDetect.isSingleFile() && /\.html?$/.test(location.pathname);
 

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
 
-import features from '.';
+import features from '../feature-manager';
 import {isEditable} from '../helpers/dom-utils';
 
 function splitKeys(keys: string): DocumentFragment[] {
@@ -54,6 +54,5 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -54,5 +54,6 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -54,6 +54,6 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	awaitDomReady: false,
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -37,8 +37,8 @@ type FeatureLoader = {
 
 	/** When pressing the back button, DOM changes and listeners are still there, so normally `init` isn’t called again thanks to an automatic duplicate detection.
 	This detection however might cause problems or not work correctly in some cases #3945, so it can be disabled with `false` or by passing a custom selector to use as duplication check
-	@default true */
-	deduplicate?: false | string;
+	*/
+	deduplicate: false | string;
 
 	/** When true, don’t run the `init` on page load but only add the `additionalListeners`. @default false */
 	onlyAdditionalListeners?: true;

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -59,6 +59,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDashboard,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import debounce from 'debounce-fn';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 const loadMore = debounce(() => {

--- a/source/features/jump-to-change-requested-comment.tsx
+++ b/source/features/jump-to-change-requested-comment.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function linkify(textLine: HTMLElement): void {

--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function addToConversation(discussionHeader: HTMLElement): void {

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {isEditable} from '../helpers/dom-utils';
 
 const isCommentGroupMinimized = (comment: HTMLElement): boolean =>

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -4,7 +4,7 @@ import cache from 'webext-storage-cache';
 import * as pageDetect from 'github-url-detection';
 import {GitCompareIcon, TagIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import pluralize from '../helpers/pluralize';
 import GitHubURL from '../github-helpers/github-url';

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -5,7 +5,7 @@ import {BookIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {wrapAll} from '../helpers/dom-utils';
 import {buildRepoURL, getRepo} from '../github-helpers';

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -97,5 +97,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoHome,
 	],
+	deduplicate: 'has-rgh',
 	init: parseFromDom,
 });

--- a/source/features/link-to-compare-diff.tsx
+++ b/source/features/link-to-compare-diff.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {wrapAll} from '../helpers/dom-utils';
 import selectHas from '../helpers/select-has';
 

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -39,11 +39,13 @@ void features.add(import.meta.url, {
 	asLongAs: [
 		() => Boolean(getRepo()?.name.endsWith('.github.io')),
 	],
+	deduplicate: 'has-rgh',
 	init: initRepo,
 }, {
 	include: [
 		pageDetect.isUserProfileRepoTab,
 		pageDetect.isOrganizationProfile,
 	],
+	deduplicate: 'has-rgh',
 	init: initRepoList,
 });

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -3,7 +3,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {LinkExternalIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	for (const link of select.all('a.reblame-link')) {

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -14,5 +14,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isBlame,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -64,7 +64,9 @@ void features.add(import.meta.url, {
 		pageDetect.isEditingFile,
 		pageDetect.isDeletingFile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 }, {
+	deduplicate: 'has-rgh',
 	init: hovercardInit,
 });

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 import {buildRepoURL} from '../github-helpers';
 

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -46,6 +46,7 @@ void features.add(import.meta.url, {
 		pageDetect.isGist,
 		pageDetect.isPRFiles,
 	],
+	deduplicate: 'has-rgh',
 	init,
 }, {
 	include: [

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import {codeElementsSelector, linkifiedURLClass, linkifyURLs, linkifyIssues} from '../github-helpers/dom-formatters';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';

--- a/source/features/linkify-commit-sha.tsx
+++ b/source/features/linkify-commit-sha.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	const element = select('.sha.user-select-contain');

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -28,5 +28,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDashboard,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -4,7 +4,7 @@ import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 
 function linkifyLabel(label: Element): void {
 	const activity = label.closest('div:not([class])')!;

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -21,5 +21,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank, // Empty notification list
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	for (const header of select.all('.js-notifications-group h6')) {

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	if (select('.file-mode')?.textContent === 'symbolic link') {

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -16,5 +16,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleFile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function linkify(avatar: HTMLImageElement): void {

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import {buildRepoURL} from '../github-helpers';
 import getCommentAuthor from '../github-helpers/get-comment-author';
 

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -32,6 +32,7 @@ void features.add(import.meta.url, {
 	asLongAs: [
 		pageDetect.isRepo,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -44,10 +44,12 @@ function hovercardInit(): void {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init,
 	include: [
 		pageDetect.isProfile,
 	],
 }, {
+	deduplicate: 'has-rgh',
 	init: onetime(hovercardInit),
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {wrap, isEditable} from '../helpers/dom-utils';
 
 function addLocation(baseElement: HTMLElement): void {

--- a/source/features/list-prs-for-branch.tsx
+++ b/source/features/list-prs-for-branch.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getCurrentCommittish} from '../github-helpers';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -201,5 +201,6 @@ void features.add(import.meta.url, {
 		pageDetect.isEditingFile,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initEditing,
 });

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {GitPullRequestIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -5,7 +5,7 @@ import {GitMergeIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import {EyeClosedIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getUsername} from '../github-helpers';
 

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -39,5 +39,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isOwnUserProfile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/minimize-upload-bar.tsx
+++ b/source/features/minimize-upload-bar.tsx
@@ -1,6 +1,6 @@
 import './minimize-upload-bar.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 void features.addCssFeature(import.meta.url, [pageDetect.hasRichTextEditor]);

--- a/source/features/more-conversation-filters.tsx
+++ b/source/features/more-conversation-filters.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 
 function init(): void {

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -52,5 +52,6 @@ void features.add(import.meta.url, {
 		() => !select.exists('.js-responsive-underlinenav'),
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import createDropdownItem from '../github-helpers/create-dropdown-item';
 import {buildRepoURL, getCurrentCommittish} from '../github-helpers';

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 
 function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
@@ -36,6 +36,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasFiles,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -4,7 +4,7 @@ import delegate from 'delegate-it';
 import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import selectHas from '../helpers/select-has';
 import attachElement from '../helpers/attach-element';
@@ -67,7 +67,6 @@ void features.add(import.meta.url, {
 		pageDetect.isNewRepo,
 		pageDetect.isNewRepoTemplate,
 	],
-	deduplicate: false,
 	init,
 }, {
 	include: [

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -74,5 +74,6 @@ void features.add(import.meta.url, {
 		() => Boolean(sessionStorage.rghNewRepo),
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: disableWikiAndProjects,
 });

--- a/source/features/no-duplicate-list-update-time.tsx
+++ b/source/features/no-duplicate-list-update-time.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function parseTime(element: HTMLElement): number {
 	return new Date(element.getAttribute('datetime')!).getTime();

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -2,7 +2,7 @@ import './no-unnecessary-split-diff-view.css';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {onDiffFileLoad} from '../github-events/on-fragment-load';
 
 function isUnifiedDiff(): boolean {

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -4,7 +4,7 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import {BookIcon, CheckIcon, DiffIcon, DiffModifiedIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import selectHas from '../helpers/select-has';
 import attachElement from '../helpers/attach-element';
 import observe from '../helpers/selector-observer';
@@ -168,7 +168,6 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleCommit,
 		pageDetect.isCompare,
 	],
-	deduplicate: false,
 	init,
 });
 

--- a/source/features/one-click-pr-or-gist.tsx
+++ b/source/features/one-click-pr-or-gist.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import selectHas from '../helpers/select-has';
 
 function init(): void | false {

--- a/source/features/one-click-pr-or-gist.tsx
+++ b/source/features/one-click-pr-or-gist.tsx
@@ -48,5 +48,6 @@ void features.add(import.meta.url, {
 		pageDetect.isCompare,
 		pageDetect.isGist,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -4,7 +4,7 @@ import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import {CheckIcon, FileDiffIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import looseParseInt from '../helpers/loose-parse-int';
 
 function init(signal: AbortSignal): false | void {

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -2,7 +2,7 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import {onCommentFieldKeydown, onConversationTitleFieldKeydown, onCommitTitleFieldKeydown} from '../github-events/on-field-keydown';
 
 const formattingCharacters = ['`', '\'', '"', '[', '(', '{', '*', '_', '~', '“', '‘'];
@@ -51,6 +51,5 @@ void features.add(import.meta.url, {
 		pageDetect.isDeletingFile,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/open-all-conversations.tsx
+++ b/source/features/open-all-conversations.tsx
@@ -55,5 +55,6 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalIssueOrPRList,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/open-all-conversations.tsx
+++ b/source/features/open-all-conversations.tsx
@@ -4,7 +4,7 @@ import delegate from 'delegate-it';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import openTabs from '../helpers/open-tabs';
 
 function getUrlFromItem(issue: Element): string {

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import {LinkExternalIcon} from '@primer/octicons-react';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import openTabs from '../helpers/open-tabs';
 import {appendBefore} from '../helpers/dom-utils';
 import showToast from '../github-helpers/toast';
@@ -141,6 +141,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank, // Empty notification list
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/open-ci-details-in-new-tab.tsx
+++ b/source/features/open-ci-details-in-new-tab.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	const CIDetailsLinks = select.all('a.status-actions');

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const selector = `
 	:is(.js-issue-row, .js-pinned-issue-list-item)

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {addHotkey} from '../github-helpers/hotkey';
 
 const nextPageButtonSelectors = [
@@ -40,6 +40,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRCommit,
 		pageDetect.isUserProfileRepoTab,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -2,7 +2,7 @@ import './parse-backticks.css';
 import onetime from 'onetime';
 import {observe} from 'selector-observer';
 
-import features from '.';
+import features from '../feature-manager';
 import {parseBackticks} from '../github-helpers/dom-formatters';
 
 function init(): void {
@@ -34,6 +34,5 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -34,5 +34,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -34,6 +34,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getCleanPathname} from '../github-helpers';
 
 function init(): void {

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -3,7 +3,7 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -4,7 +4,7 @@ import {InfoIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import onPrMerge from '../github-events/on-pr-merge';
 import featureLink from '../helpers/feature-link';
 import attachElement from '../helpers/attach-element';
@@ -45,6 +45,5 @@ void features.add(import.meta.url, {
 		onPrMerge,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: false,
 	init,
 });

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -3,7 +3,7 @@ import cache from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import pluralize from '../helpers/pluralize';
 

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -6,7 +6,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function jumpToFirstNonViewed(): void {
 	const firstNonViewedFile = select('.file:not([data-file-user-viewed])')!;
@@ -27,6 +27,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPRFile404,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/prevent-duplicate-pr-submission.tsx
+++ b/source/features/prevent-duplicate-pr-submission.tsx
@@ -1,7 +1,7 @@
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 let previousSubmission = 0;
 
@@ -21,6 +21,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isCompare,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import {
 	prCommitUrlRegex,
 	preventPrCommitLinkLoss,
@@ -73,6 +73,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/prevent-pr-merge-panel-opening.tsx
+++ b/source/features/prevent-pr-merge-panel-opening.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 async function sessionResumeHandler(): Promise<void> {
 	await Promise.resolve(); // The `session:resume` event fires a bit too early

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {upperCaseFirst} from '../github-helpers';
 
 function init(): void {

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): false | void {
 	const originalPreviousNext = select('.commit .BtnGroup.float-right');

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -59,5 +59,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isUserProfile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {CodeSquareIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getCleanPathname} from '../github-helpers';
 import createDropdownItem from '../github-helpers/create-dropdown-item';

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -15,6 +15,6 @@ void features.add(import.meta.url, {
 		'g m': 'Go to Profile',
 	},
 	awaitDomReady: false,
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -15,5 +15,6 @@ void features.add(import.meta.url, {
 		'g m': 'Go to Profile',
 	},
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import onetime from 'onetime';
 import {isEnterprise} from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
 
 function init(): void {
@@ -15,6 +15,5 @@ void features.add(import.meta.url, {
 		'g m': 'Go to Profile',
 	},
 	awaitDomReady: false,
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {addHotkey} from '../github-helpers/hotkey';
 
 function init(): void {
@@ -32,6 +32,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPR,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -4,7 +4,7 @@ import {observe} from 'selector-observer';
 import {PencilIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function addQuickEditButton(commentForm: Element): void {
 	const commentBody = commentForm.closest('.js-comment')!;

--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function generateSubmenu(hideButton: Element): void {
 	if (hideButton.closest('.rgh-quick-comment-hiding-details')) {
@@ -84,6 +84,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -5,7 +5,7 @@ import {PencilIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 import {isPermalink} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
@@ -47,6 +47,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isArchivedRepo,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -7,7 +7,7 @@ import {assertError} from 'ts-extras';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import showToast from '../github-helpers/toast';
 import {getConversationNumber} from '../github-helpers';
@@ -67,6 +67,5 @@ void features.add(import.meta.url, {
 		canNotEditLabels,
 		pageDetect.isArchivedRepo,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -7,7 +7,7 @@ import * as textFieldEdit from 'text-field-edit';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
 import onNewComments from '../github-events/on-new-comments';
 

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -8,7 +8,7 @@ import {assertError} from 'ts-extras';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getForkedRepo, getRepo} from '../github-helpers';
 import pluralize from '../helpers/pluralize';
@@ -164,6 +164,5 @@ void features.add(import.meta.url, {
 		pageDetect.isForkedRepo,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -5,7 +5,7 @@ import {TrashIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import loadDetailsMenu from '../github-helpers/load-details-menu';
 
 async function onButtonClick({delegateTarget: button}: DelegateEvent): Promise<void> {
@@ -43,6 +43,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 import attachElement from '../helpers/attach-element';
 
@@ -51,7 +51,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init: initSidebarReviewButton,
 }, {
 	shortcuts: {
@@ -61,6 +60,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init: initReviewButtonEnhancements,
 });

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -5,7 +5,7 @@ import {observe} from 'selector-observer';
 import {flatZip} from 'flat-zip';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
 import getUserAvatar from '../github-helpers/get-user-avatar';
 import onAbort from '../helpers/abort-controller';

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -121,5 +121,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDiscussion,
 	],
+	deduplicate: 'has-rgh',
 	init: discussionInit,
 });

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -5,7 +5,7 @@ import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import {abbreviateNumber} from 'js-abbreviation-number';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 
 type Release = {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -6,7 +6,7 @@ import {TagIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import looseParseInt from '../helpers/loose-parse-int';
 import abbreviateNumber from '../helpers/abbreviate-number';
@@ -118,6 +118,5 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -20,6 +20,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -3,7 +3,7 @@ import onetime from 'onetime';
 import loadImage from 'image-promise';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 async function handleErroredImage({delegateTarget}: DelegateEvent<ErrorEvent, HTMLImageElement>): Promise<void> {
 	await delay(5000);
@@ -20,6 +20,5 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -20,5 +20,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -5,7 +5,7 @@ import {RepoIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -41,6 +41,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
 	],
+	deduplicate: 'has-rgh',
 	init,
 	awaitDomReady: false,
 });

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import getUserAvatar from '../github-helpers/get-user-avatar';
 
@@ -41,7 +41,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
 	],
+	awaitDomReady: false,
 	deduplicate: 'has-rgh',
 	init,
-	awaitDomReady: false,
 });

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -27,5 +27,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isFileFinder,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -17,5 +17,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConflicts,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 async function init(): Promise<void> {
 	await elementReady('.CodeMirror', {

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -5,7 +5,7 @@ import pushForm from 'push-form';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import fetchDom from '../helpers/fetch-dom';
 import showToast from '../github-helpers/toast';
@@ -126,6 +126,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {wrapAll} from '../helpers/dom-utils';
 import {featuresMeta} from '../../readme.md';
 import {getNewFeatureName} from '../options-storage';

--- a/source/features/rgh-improve-new-issue-form.tsx
+++ b/source/features/rgh-improve-new-issue-form.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import openOptions from '../helpers/open-options';
 import clearCacheHandler from '../helpers/clear-cache-handler';
 import {expectTokenScope} from '../github-helpers/api';

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import featureLink from '../helpers/feature-link';
 import {getNewFeatureName} from '../options-storage';
 import {isAnyRefinedGitHubRepo} from '../github-helpers';

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -27,7 +27,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo, getUsername} from '../github-helpers';
 
 async function wiggleWiggleWiggle(): Promise<void> {
@@ -112,6 +112,5 @@ void features.add(import.meta.url, {
 		pageDetect.isOwnUserProfile,
 		pageDetect.isPrivateUserProfile,
 	],
-	deduplicate: false,
 	init: handleSponsorButton,
 });

--- a/source/features/rgh-welcome-issue.tsx
+++ b/source/features/rgh-welcome-issue.tsx
@@ -2,7 +2,7 @@ import './rgh-welcome-issue.css';
 import select from 'select-dom';
 import delegate from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import openOptions from '../helpers/open-options';
 
 /**

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void | false {
 	for (const author of select.all('#repo-content-pjax-container .js-navigation-container a.commit-author')) {

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -1,7 +1,7 @@
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import GitHubURL from '../github-helpers/github-url';
 
 function followLocalLink(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void {
@@ -19,6 +19,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleFile,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -6,7 +6,7 @@ import {parseCron} from '@cheap-glitch/mi-cron';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 

--- a/source/features/select-all-notifications-shortcut.tsx
+++ b/source/features/select-all-notifications-shortcut.tsx
@@ -23,5 +23,6 @@ void features.add(import.meta.url, {
 		pageDetect.isBlank, // Empty notification list
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/select-all-notifications-shortcut.tsx
+++ b/source/features/select-all-notifications-shortcut.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {registerHotkey} from '../github-helpers/hotkey';
 
 function selectAllNotifications(): void {

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -16,7 +16,7 @@ import {
 	XCircleIcon,
 } from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 import attachElement from '../helpers/attach-element';
 
@@ -180,6 +180,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank, // Empty notification list
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -29,6 +29,6 @@ void features.add(import.meta.url, {
 	shortcuts: {
 		'shift o': 'Open selection in new tab',
 	},
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -29,5 +29,6 @@ void features.add(import.meta.url, {
 	shortcuts: {
 		'shift o': 'Open selection in new tab',
 	},
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import onetime from 'onetime';
 
-import features from '.';
+import features from '../feature-manager';
 import {registerHotkey} from '../github-helpers/hotkey';
 
 function openInNewTab(): void {
@@ -29,6 +29,5 @@ void features.add(import.meta.url, {
 	shortcuts: {
 		'shift o': 'Open selection in new tab',
 	},
-	deduplicate: false,
 	init: onetime(init),
 });

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -27,11 +27,13 @@ async function init(): Promise<void> {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init,
 	exclude: [
 		pageDetect.isPrivateUserProfile,
 	],
 }, {
+	deduplicate: 'has-rgh',
 	init: profileDropdown,
 	exclude: [
 		pageDetect.isGist, // "Your repositories" does not exist

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function addSourceTypeToLink(link: HTMLAnchorElement): void {

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -10,7 +10,7 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 });
 

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -1,6 +1,6 @@
 import onetime from 'onetime';
 
-import features from '.';
+import features from '../feature-manager';
 import {linkifiedURLClass, shortenLink} from '../github-helpers/dom-formatters';
 import observe from '../helpers/selector-observer';
 
@@ -10,7 +10,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	deduplicate: false,
 	init: onetime(init),
 });
 

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -10,6 +10,7 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 });
 

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -113,5 +113,6 @@ void features.add(import.meta.url, {
 		pageDetect.isBranches,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -4,7 +4,7 @@ import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 import {GitMergeIcon, GitPullRequestIcon, GitPullRequestClosedIcon, GitPullRequestDraftIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo, upperCaseFirst} from '../github-helpers';
 

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -2,7 +2,7 @@ import './show-names.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getUsername, compareNames} from '../github-helpers';
 import observe from '../helpers/selector-observer';
@@ -90,6 +90,5 @@ void features.add(import.meta.url, {
 	// 	pageDetect.isDashboard,
 	// 	pageDetect.hasComments,
 	// ],
-	deduplicate: false,
 	init,
 });

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -95,6 +95,7 @@ void features.add(import.meta.url, {
 		pageDetect.isForkedRepo,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initHeadHint,
 }, {
 	asLongAs: [
@@ -104,5 +105,6 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoMainSettings,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: initDeleteHint,
 });

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import pluralize from '../helpers/pluralize';
 import {getForkedRepo, getUsername, getRepo} from '../github-helpers';

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	const url = new URL(location.pathname, location.href);

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -26,5 +26,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPrivateUserProfile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -1,7 +1,7 @@
 import './show-whitespace.css';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {codeElementsSelector} from '../github-helpers/dom-formatters';
 import showWhiteSpacesOnLine from '../helpers/show-whitespace-on-line';
 import onAbort from '../helpers/abort-controller';
@@ -31,7 +31,6 @@ void features.add(import.meta.url, {
 		pageDetect.hasCode,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });
 

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 
 /** Keep the original URL on the element so that `shorten-links` can use it reliably #5890 */

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import SearchQuery from '../github-helpers/search-query';
 
 function cleanLinks(): void {

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -59,5 +59,6 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoSearch,
 		pageDetect.isGlobalSearchResults,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -2,7 +2,7 @@ import './sticky-sidebar.css';
 import debounce from 'debounce-fn';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 import onAbort from '../helpers/abort-controller';
 import calculateCssCalcString from '../helpers/calculate-css-calc-string';
@@ -71,6 +71,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		() => screen.availWidth < minimumViewportWidthForSidebar,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 
-import features from '.';
+import features from '../feature-manager';
 
 let progressLoader: HTMLElement;
 const progressLoaderLoadingClass = 'is-loading';

--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -45,5 +45,6 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -1,6 +1,6 @@
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 const hasNotificationBar = (): boolean =>
 	location.search.startsWith('?notification_referrer_id=')
@@ -24,6 +24,5 @@ void features.add(import.meta.url, {
 		hasNotificationBar,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/submission-via-ctrl-enter-everywhere.tsx
+++ b/source/features/submission-via-ctrl-enter-everywhere.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 export default function addQuickSubmit(): void {
 	select([

--- a/source/features/submission-via-ctrl-enter-everywhere.tsx
+++ b/source/features/submission-via-ctrl-enter-everywhere.tsx
@@ -20,5 +20,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
+	deduplicate: 'has-rgh',
 	init: addQuickSubmit,
 });

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import onPrCommitMessageRestore from '../github-events/on-pr-commit-message-restore';
 
 const className = 'rgh-suggest-commit-title-limit';
@@ -28,7 +28,6 @@ void features.add(import.meta.url, {
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation,
 	],
-	deduplicate: false,
 	init,
 }, {
 	include: [
@@ -39,7 +38,6 @@ void features.add(import.meta.url, {
 		onPrCommitMessageRestore,
 	],
 	onlyAdditionalListeners: true,
-	deduplicate: false,
 	init: validateInput,
 });
 

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '.';
+import features from '../feature-manager';
 import {buildRepoURL, getRepo} from '../github-helpers';
 
 function init(): void {

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -30,5 +30,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		() => /\.\.+/.exec(location.pathname)?.[0]!.length === 2,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -5,7 +5,7 @@ import regexJoin from 'regex-join';
 import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 
-import features from '.';
+import features from '../feature-manager';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 import {getConversationNumber} from '../github-helpers';
 import onPrCommitMessageRestore from '../github-events/on-pr-commit-message-restore';
@@ -94,6 +94,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -1,7 +1,7 @@
 import {eventHandler} from 'indent-textarea';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {onCommentFieldKeydown} from '../github-events/on-field-keydown';
 
 function init(signal: AbortSignal): void {

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import smartBlockWrap from '../helpers/smart-block-wrap';
 import {onCommentEdit} from '../github-events/on-fragment-load';
 
@@ -82,6 +82,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -6,7 +6,7 @@ import {DiffIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import tinyVersionCompare from 'tiny-version-compare';
 
-import features from '.';
+import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import {buildRepoURL, getRepo, parseTag} from '../github-helpers';
 

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import {buildRepoURL} from '../github-helpers';
 import {ToastSpinner} from '../github-helpers/toast';
 

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -5,7 +5,7 @@ import {TagIcon} from '@primer/octicons-react';
 import arrayUnion from 'array-union';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getCommitHash} from './mark-merge-commits-in-list';
 import {buildRepoURL, getRepo} from '../github-helpers';

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -1,7 +1,7 @@
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import clickAll from '../helpers/click-all';
 
 function minimizedCommentsSelector(clickedItem: HTMLElement): string {
@@ -53,6 +53,5 @@ void features.add(import.meta.url, {
 		pageDetect.hasFiles,
 		pageDetect.isCommitList,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -6,7 +6,7 @@ import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import {FoldIcon, UnfoldIcon, ArrowUpIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import selectHas from '../helpers/select-has';
 import attachElement from '../helpers/attach-element';
 import observe from '../helpers/selector-observer';
@@ -92,6 +92,5 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoTree,
 	],
 	awaitDomReady: false,
-	deduplicate: false,
 	init,
 });

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 let documentTitle: string | undefined;
 let submitting: number | undefined;
@@ -45,6 +45,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/unwrap-unnecessary-dropdowns.tsx
+++ b/source/features/unwrap-unnecessary-dropdowns.tsx
@@ -40,5 +40,6 @@ void features.add(import.meta.url, {
 		pageDetect.isNotifications,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: unwrapNotifications,
 });

--- a/source/features/unwrap-unnecessary-dropdowns.tsx
+++ b/source/features/unwrap-unnecessary-dropdowns.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 // Replace dropdown while keeping its sizing/positioning classes
 function replaceDropdownInPlace(dropdown: Element, form: Element): void {

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import {observe, Observer} from 'selector-observer';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import getPrInfo from '../github-helpers/get-pr-info';
 import {getConversationNumber} from '../github-helpers';
@@ -97,7 +97,6 @@ void features.add(import.meta.url, {
 		// Native button https://github.blog/changelog/2022-02-03-more-ways-to-keep-your-pull-request-branch-up-to-date/
 		() => select.exists('.js-update-branch-form'),
 	],
-	deduplicate: false,
 	init,
 });
 

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -3,7 +3,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 
-import features from '.';
+import features from '../feature-manager';
 import looseParseInt from '../helpers/loose-parse-int';
 
 function interpretNode(node: ChildNode): string | void {

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -61,6 +61,7 @@ void features.add(import.meta.url, {
 		pageDetect.isCompare,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 });
 

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -3,7 +3,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {RepoForkedIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';
 import attachElement from '../helpers/attach-element';

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -53,6 +53,7 @@ void features.add(import.meta.url, {
 		pageDetect.isEnterprise,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init,
 }, {
 	asLongAs: [
@@ -61,5 +62,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isArchivedRepo,
 	],
+	deduplicate: 'has-rgh',
 	init: initArchivedRepoBanner,
 });

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -4,7 +4,7 @@ import onetime from 'onetime';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 import getDefaultBranch from '../github-helpers/get-default-branch';
@@ -209,7 +209,6 @@ void features.add(import.meta.url, 	{
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
-	deduplicate: false,
 	init: onetime(init),
 }, {
 	include: [

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -209,7 +209,7 @@ void features.add(import.meta.url, 	{
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
-	deduplicate: 'has-rgh',
+	deduplicate: false,
 	init: onetime(init),
 }, {
 	include: [

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -197,6 +197,7 @@ void features.add(import.meta.url, 	{
 		pageDetect.is404,
 		() => parseCurrentURL().length > 1,
 	],
+	deduplicate: 'has-rgh',
 	init: showMissingPart,
 },
 {
@@ -208,11 +209,13 @@ void features.add(import.meta.url, 	{
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 }, {
 	include: [
 		pageDetect.isPRCommit404,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh',
 	init: onetime(initPRCommit),
 });

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -10,7 +10,7 @@ import {observe} from 'selector-observer';
 import {ClockIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getUsername, getCleanPathname} from '../github-helpers';
 

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -191,6 +191,7 @@ async function profileInit(): Promise<void> {
 }
 
 void features.add(import.meta.url, {
+	deduplicate: 'has-rgh',
 	init: onetime(init),
 }, {
 	include: [
@@ -199,5 +200,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPrivateUserProfile,
 	],
+	deduplicate: 'has-rgh',
 	init: profileInit,
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -34,5 +34,6 @@ void features.add(import.meta.url, {
 		pageDetect.isOwnUserProfile,
 		pageDetect.isPrivateUserProfile,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -3,7 +3,7 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getUsername, getCleanPathname} from '../github-helpers';
 

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -43,5 +43,6 @@ void features.add(import.meta.url, {
 	include: [
 		hasFrontMatter,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 // https://github.com/github/markup/blob/cd01f9ec87c86ce5a7c70188a74ef40fc4669c5b/lib/github/markup/markdown.rb#L34
 const hasFrontMatter = (): boolean => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee)$/.test(location.pathname);

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {LinkExternalIcon} from '@primer/octicons-react';
 
-import features from '.';
+import features from '../feature-manager';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
 
 const deploymentSelector = '.js-timeline-item [data-url$="deployed"] .TimelineItem-body .btn[target="_blank"]';

--- a/source/features/wait-for-attachments.tsx
+++ b/source/features/wait-for-attachments.tsx
@@ -5,7 +5,7 @@
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 
 const attribute = 'data-required-trimmed';
 const attributeBackup = 'data-rgh-required-trimmed';

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import pRetry, {AbortError} from 'p-retry';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import observeElement from '../helpers/simplified-element-observer';
 import * as prCiStatus from '../github-helpers/pr-ci-status';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
@@ -192,6 +192,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isDraftPR,
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-import features from '.';
+import features from '../feature-manager';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getRepo} from '../github-helpers';
 

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -34,5 +34,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
+	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -5,7 +5,7 @@ import onetime from 'onetime';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 import attachElement from '../helpers/attach-element';
 
 const getWarning = onetime(() => (
@@ -48,6 +48,5 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 		// No need to exclude `isClosedPR` as the checkbox won't be present
 	],
-	deduplicate: false,
 	init,
 });

--- a/source/github-events/on-discussion-sidebar-update.ts
+++ b/source/github-events/on-discussion-sidebar-update.ts
@@ -1,5 +1,5 @@
 import onElementReplacement from '../helpers/on-element-replacement';
-import type {CallerFunction} from '../features';
+import type {CallerFunction} from '../feature-manager';
 
 const onDiscussionSidebarUpdate: CallerFunction = (runFeature, signal) => {
 	void onElementReplacement('#partial-discussion-sidebar', runFeature, {signal});

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -29,7 +29,7 @@ import mem from 'mem';
 import * as pageDetect from 'github-url-detection';
 import {JsonObject, AsyncReturnType} from 'type-fest';
 
-import features from '../features';
+import features from '../feature-manager';
 import {getRepo} from '.';
 import optionsStorage from '../options-storage';
 

--- a/source/helpers/fetch-dom.ts
+++ b/source/helpers/fetch-dom.ts
@@ -2,7 +2,7 @@ import mem from 'mem';
 import domify from 'doma';
 import type {ParseSelector} from 'typed-query-selector/parser';
 
-import features from '../features';
+import features from '../feature-manager';
 
 async function fetchDom(url: string): Promise<DocumentFragment>;
 async function fetchDom<Selector extends string, TElement extends HTMLElement = ParseSelector<Selector, HTMLElement>>(url: string, selector: Selector): Promise<TElement | undefined>;


### PR DESCRIPTION
- Part of https://github.com/refined-github/refined-github/issues/5895
- Part of https://github.com/refined-github/refined-github/issues/5871


We're probably going to drop the integrated deduplication logic, so this change makes it more visible.