### PR TITLE
Avoid duplication of `useful-not-found-page` on back button

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -197,8 +197,7 @@ void features.add(import.meta.url, 	{
 		pageDetect.is404,
 		() => parseCurrentURL().length > 1,
 	],
-	deduplicate: 'has-rgh',
-	init: showMissingPart,
+	init: onetime(showMissingPart),
 },
 {
 	asLongAs: [
@@ -215,6 +214,5 @@ void features.add(import.meta.url, 	{
 		pageDetect.isPRCommit404,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh',
 	init: onetime(initPRCommit),
 });


### PR DESCRIPTION
- Fixes #6005 

## Test URLs

- https://github.com/refined-github/refined-github/blob/main/source/features/good-soup.tsx
