### PR TITLE
Add notice to `clear-pr-merge-commit-message`

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -25,7 +25,7 @@ function init(): void | false {
 		<p className="note rgh-sync-pr-commit-title-note">
 			The description field was cleared by <a target="_blank" href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message" rel="noreferrer">Refined GitHub</a>.
 		</p>,
-		<hr />
+		<hr/>,
 	);
 }
 

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,19 +1,32 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
-function init(): void {
+function init(): void | false {
 	const messageField = select('textarea#merge_message_field')!;
+	const originalMessage = messageField.value;
 	const deduplicatedAuthors = new Set();
 
 	// This method ensures that "Co-authored-by" capitalization doesn't affect deduplication
-	for (const [, author] of messageField.value.matchAll(/co-authored-by: ([^\n]+)/gi)) {
+	for (const [, author] of originalMessage.matchAll(/co-authored-by: ([^\n]+)/gi)) {
 		deduplicatedAuthors.add('Co-authored-by: ' + author);
 	}
 
-	messageField.value = [...deduplicatedAuthors].join('\n');
+	const cleanedMessage = [...deduplicatedAuthors].join('\n');
+	if (cleanedMessage === originalMessage.trim()) {
+		return false;
+	}
+
+	messageField.value = cleanedMessage;
+	messageField.after(
+		<p className="note rgh-sync-pr-commit-title-note">
+			The description field was cleared by <a target="_blank" href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message" rel="noreferrer">Refined GitHub</a>.
+		</p>,
+		<hr />
+	);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Replaces and closes https://github.com/refined-github/refined-github/pull/5967
- Part of https://github.com/refined-github/refined-github/issues/5155

This is the minimum we can do to make the feature louder since it overrides the user’s settings.

## Test URLs

This PR


## Screenshot

<img width="922" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/192137126-2960d952-427c-44f2-9e0c-61d7b40ac98b.png">

