### PR TITLE
Restore `tag-changes-link`

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -34,7 +34,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 
 function parseTags(element: HTMLElement): TagDetails {
 	// Safari doesn't correctly parse links if they're loaded via AJAX #3899
-	const {pathname: tagUrl} = new URL(select('a[href*="/tree/"])', element)!.href);
+	const {pathname: tagUrl} = new URL(select('a[href*="/tree/"]', element)!.href);
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 
 	return {


### PR DESCRIPTION
Hopefully https://github.com/g-plane/typed-query-selector/issues/25 will help us avoid this in the future 



## Test URLs

- https://github.com/refined-github/refined-github/releases


## Before

```
📕 0.0.0 → DOMException: Failed to execute 'querySelector' on 'Element': 'a[href*="/tree/"])' is not a valid selector.
```
<img width="171" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/192233551-5e1e0187-da61-432d-a0f3-ddf7086caefe.png">

## After



<img width="195" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/192233575-a7712f3e-3613-44d7-b19a-5e75c049b370.png">

