### PR TITLE
Make `no-unnecessary-split-diff-view` lighter and immediate 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-latest'
         with:
-         name: refined-github
-         path: distribution
+          name: refined-github
+          path: distribution
 
   Safari:
     runs-on: macos-12

--- a/contributing.md
+++ b/contributing.md
@@ -133,7 +133,7 @@ Node.prototype.dispatchEvent = function (...a) {
 	console.log(...a);
 	// debugger; // Uncomment when necessary
 	d.apply(this, a);
-}
+};
 ```
 
 <img width="379" alt="screen" src="https://user-images.githubusercontent.com/1402241/79168882-406ea100-7deb-11ea-9e9c-ad657202422f.png">

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -251,6 +251,10 @@ const add = async (url: string, ...loaders: FeatureLoader[]): Promise<void> => {
 			additionalListeners = [],
 		} = loader;
 
+		if (include?.length === 0) {
+			throw new Error(`${id}: \`include\` cannot be an empty array, it means "run nowhere"`);
+		}
+
 		// Register feature shortcuts
 		for (const [hotkey, description] of Object.entries(shortcuts)) {
 			shortcutMap.set(hotkey, description);
@@ -279,7 +283,7 @@ const add = async (url: string, ...loaders: FeatureLoader[]): Promise<void> => {
 	}
 };
 
-const addCssFeature = async (url: string, include: BooleanFunction[] | undefined): Promise<void> => {
+const addCssFeature = async (url: string, include?: BooleanFunction[]): Promise<void> => {
 	const id = getFeatureID(url);
 	void add(id, {
 		include,

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,27 +1,30 @@
+/* The selector looks for diff tables WITHOUT changes on the left XOR on the right */
+/* Instead of duplicating this selector for each rule, we set a variable and pick it up where needed */
 .rgh-no-unnecessary-split-diff-view .js-diff-table:not(
 :has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
-) :is([data-hunk], .blob-expanded) td:nth-child(2),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
-:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
-) :is([data-hunk], .blob-expanded) td:nth-child(4) {
-	display: none !important;
-	width: 0 !important;
-}
-
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
-:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
-),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
-:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
 ) {
+	--rgh-only-additions: none;
 	table-layout: auto !important;
 }
 
 .rgh-no-unnecessary-split-diff-view .js-diff-table:not(
-:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
-) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
 :has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
-) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
-	display: none !important;
+) {
+	--rgh-only-deletions: none;
+	table-layout: auto !important;
+}
+
+/* Only additions: Hide the left side */
+.rgh-no-unnecessary-split-diff-view :is([data-hunk], .blob-expanded) td:nth-child(2) {
+	display: var(--rgh-only-additions, table-cell) !important;
+}
+
+/* Only deletions: Hide the right side */
+.rgh-no-unnecessary-split-diff-view :is([data-hunk], .blob-expanded) td:nth-child(4) {
+	display: var(--rgh-only-deletions, table-cell) !important;
+}
+
+/* Any applicable situation: Re-align annotations, which are always on the left */
+.rgh-no-unnecessary-split-diff-view :is(.inline-comments, .js-inline-annotations) td:nth-child(2) {
+	display: var(--rgh-only-additions, var(--rgh-only-deletions, table-cell)) !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,29 +1,15 @@
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is([data-hunk], .blob-expanded)
-	td:nth-child(2),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is([data-hunk], .blob-expanded)
-	td:nth-child(4) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(2),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(4) {
 	display: none !important;
 	width: 0 !important;
 }
 
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion))),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion))) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) {
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is(.inline-comments, .js-inline-annotations)
-	.empty-cell:not(.blob-num),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is(.inline-comments, .js-inline-annotations)
-	.empty-cell:not(.blob-num) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
 	display: none !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,13 +1,29 @@
-[data-rgh-hide-empty-split-diff-side] {
-	table-layout: auto !important;
-}
-
-[data-rgh-hide-empty-split-diff-side='left'] :is([data-hunk], .blob-expanded) td:nth-child(2),
-[data-rgh-hide-empty-split-diff-side='right'] :is([data-hunk], .blob-expanded) td:nth-child(4) {
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is([data-hunk], .blob-expanded)
+	td:nth-child(2),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is([data-hunk], .blob-expanded)
+	td:nth-child(4) {
 	display: none !important;
 	width: 0 !important;
 }
 
-[data-rgh-hide-empty-split-diff-side] :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion))),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion))) {
+	table-layout: auto !important;
+}
+
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is(.inline-comments, .js-inline-annotations)
+	.empty-cell:not(.blob-num),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is(.inline-comments, .js-inline-annotations)
+	.empty-cell:not(.blob-num) {
 	display: none !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,29 +1,15 @@
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is([data-hunk], .blob-expanded)
-	td:nth-child(2),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is([data-hunk], .blob-expanded)
-	td:nth-child(4) {
-		display: none !important;
-		width: 0 !important;
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(2),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(4) {
+	display: none !important;
+	width: 0 !important;
 }
 
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion))),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion))) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) {
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is(.inline-comments, .js-inline-annotations)
-	.empty-cell:not(.blob-num),
-.rgh-no-unnecessary-split-diff-view
-	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
-	:is(.inline-comments, .js-inline-annotations)
-	.empty-cell:not(.blob-num) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
 	display: none !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,15 +1,27 @@
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(2),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(4) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
+) :is([data-hunk], .blob-expanded) td:nth-child(2),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
+) :is([data-hunk], .blob-expanded) td:nth-child(4) {
 	display: none !important;
 	width: 0 !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
+),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
+) {
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
+) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
+.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
+) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
 	display: none !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,15 +1,29 @@
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(2),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is([data-hunk], .blob-expanded) td:nth-child(4) {
-	display: none !important;
-	width: 0 !important;
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is([data-hunk], .blob-expanded)
+	td:nth-child(2),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is([data-hunk], .blob-expanded)
+	td:nth-child(4) {
+		display: none !important;
+		width: 0 !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) {
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion))),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion))) {
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num),
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(:has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))) :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="left"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is(.inline-comments, .js-inline-annotations)
+	.empty-cell:not(.blob-num),
+.rgh-no-unnecessary-split-diff-view
+	.js-diff-table:not(:has([data-split-side="right"]:is(.blob-code-addition, .blob-code-deletion)))
+	:is(.inline-comments, .js-inline-annotations)
+	.empty-cell:not(.blob-num) {
 	display: none !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -3,41 +3,71 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
-import {onDiffFileLoad} from '../github-events/on-fragment-load';
+import observe from '../helpers/selector-observer';
 
 function isUnifiedDiff(): boolean {
+	// TODO: Maybe use this when available on isCompare
+	// select.exists('meta[name="diff-view"][content="split"]'),
 	return select.exists([
 		'[value="unified"][checked]', // Form in PR
 		'.table-of-contents .selected[href*="diff=unified"]', // Link in single commit
 	]);
 }
 
+// TODO: Replace with CSS-only :has?
 function init(): void {
-	for (const diffTable of select.all('.js-diff-table:not(.rgh-no-unnecessary-split-diff-view-visited)')) {
-		diffTable.classList.add('rgh-no-unnecessary-split-diff-view-visited');
+	observe('.js-diff-table', diffTable => {
 		for (const side of ['left', 'right']) {
 			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
 				diffTable.setAttribute('data-rgh-hide-empty-split-diff-side', side);
 				break;
 			}
 		}
-	}
+	});
 }
+
+// Make sure the class names we need exist on the page #4483
+const hasRequiredClasses = (): boolean => select.exists(`
+	.js-diff-table
+	:is(
+		[data-split-side="left"],
+		[data-split-side="right"]
+	):is(
+		.blob-code-addition,
+		.blob-code-deletion
+	)
+`);
 
 void features.add(import.meta.url, {
 	asLongAs: [
-		// Make sure the class names we need exist on the page #4483
-		() => select.exists('.js-diff-table :is([data-split-side="left"], [data-split-side="right"]):is(.blob-code-addition, .blob-code-deletion)'),
-	],
-	include: [
+		hasRequiredClasses,
+		isUnifiedDiff,
 		pageDetect.hasFiles,
 	],
-	exclude: [
-		isUnifiedDiff,
-	],
-	additionalListeners: [
-		onDiffFileLoad,
-	],
-	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+## Test URLs
+### Right side only
+
+https://github.com/sindresorhus/refined-github/pull/4296/files?diff=split
+
+### Left side only
+
+https://github.com/sindresorhus/refined-github/pull/3637/files?diff=split
+
+### Single-side split diffs & regular split diffs
+
+https://github.com/sindresorhus/refined-github/pull/4382/files?diff=split
+
+### Compare page
+
+https://github.com/sindresorhus/refined-github/compare/main...cheap-glitch:add-hide-empty-split-diff-side?diff=split
+
+### Single commit
+
+https://github.com/sindresorhus/refined-github/commit/3b1359ea465ff5c4d3f0f79e2d6781c7ce9a8283?diff=split
+
+*/

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -15,6 +15,10 @@ void features.addCssFeature(import.meta.url, [
 
 https://github.com/refined-github/sandbox/pull/50/files?diff=split
 
+### PR files with annotations
+
+https://github.com/fregante/sandbox/pull/30/files
+
 ### Compare page
 
 https://github.com/refined-github/sandbox/compare/no-unnecessary-split-diff-view?expand=1&diff=split

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -10,24 +10,17 @@ void features.addCssFeature(import.meta.url, [
 /*
 
 ## Test URLs
-### Right side only
 
-https://github.com/sindresorhus/refined-github/pull/4296/files?diff=split
+### PR files
 
-### Left side only
-
-https://github.com/sindresorhus/refined-github/pull/3637/files?diff=split
-
-### Single-side split diffs & regular split diffs
-
-https://github.com/sindresorhus/refined-github/pull/4382/files?diff=split
+https://github.com/refined-github/sandbox/pull/50/files?diff=split
 
 ### Compare page
 
-https://github.com/sindresorhus/refined-github/compare/main...cheap-glitch:add-hide-empty-split-diff-side?diff=split
+https://github.com/refined-github/sandbox/compare/no-unnecessary-split-diff-view?expand=1&diff=split
 
 ### Single commit
 
-https://github.com/sindresorhus/refined-github/commit/3b1359ea465ff5c4d3f0f79e2d6781c7ce9a8283?diff=split
+https://github.com/refined-github/sandbox/commit/c28cc8e5271452b5b4c347d46a63f717c29417d6?diff=split
 
 */

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -1,51 +1,11 @@
 import './no-unnecessary-split-diff-view.css';
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
-import observe from '../helpers/selector-observer';
 
-function isUnifiedDiff(): boolean {
-	// TODO: Maybe use this when available on isCompare
-	// select.exists('meta[name="diff-view"][content="split"]'),
-	return select.exists([
-		'[value="unified"][checked]', // Form in PR
-		'.table-of-contents .selected[href*="diff=unified"]', // Link in single commit
-	]);
-}
-
-// TODO: Replace with CSS-only :has?
-function init(): void {
-	observe('.js-diff-table', diffTable => {
-		for (const side of ['left', 'right']) {
-			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
-				diffTable.setAttribute('data-rgh-hide-empty-split-diff-side', side);
-				break;
-			}
-		}
-	});
-}
-
-// Make sure the class names we need exist on the page #4483
-const hasRequiredClasses = (): boolean => select.exists(`
-	.js-diff-table
-	:is(
-		[data-split-side="left"],
-		[data-split-side="right"]
-	):is(
-		.blob-code-addition,
-		.blob-code-deletion
-	)
-`);
-
-void features.add(import.meta.url, {
-	asLongAs: [
-		hasRequiredClasses,
-		isUnifiedDiff,
-		pageDetect.hasFiles,
-	],
-	init,
-});
+void features.addCssFeature(import.meta.url, [
+	pageDetect.hasFiles,
+]);
 
 /*
 


### PR DESCRIPTION
Works like magic 🤯

But `features.addCssFeature` isn't working? 🤔 


## Demo

### PR files

https://github.com/refined-github/sandbox/pull/50/files?diff=split

<img width="1039" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/194265975-6f52d3cf-586d-4999-9dae-afca47b0319e.png">


### Compare page

https://github.com/refined-github/sandbox/compare/no-unnecessary-split-diff-view?expand=1&diff=split

<img width="1039" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/194266016-fc94805e-9815-477b-90a7-5d88a40d98e5.png">


### Single commit

https://github.com/refined-github/sandbox/commit/c28cc8e5271452b5b4c347d46a63f717c29417d6?diff=split

<img width="1039" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/194266040-7426dcb9-7889-4b2b-9ee6-7a7c057bd62e.png">

