### PR TITLE
Restore many features in Firefox

### DIFF
--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -25,7 +25,7 @@ Get unique ID by using the line:column of the call (or its parents) as seed. Eve
 export function getSnapshotUUID(ancestor = 1): string {
 	const stack = new Error('Get stack').stack!.split('\n');
 	if (stack[0] === 'Error: Get stack') {
-		stack.splice(0, 1);
+		stack.shift(); // Remove non-stacktrace line from array (only present in Chrome) #6032
 	}
 
 	return hashString(stack[ancestor + 1]);

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -23,7 +23,11 @@ Get unique ID by using the line:column of the call (or its parents) as seed. Eve
 @param ancestor Which call in the stack should be used as key. 0 means the exact line where getSnapshotUUID is called. Defaults to 1 because it's usually used inside a helper.
 */
 export function getSnapshotUUID(ancestor = 1): string {
-	return hashString(new Error('Get stack').stack!.split('\n')[ancestor + 2]);
+	const stack = new Error('Get stack').stack!.split('\n');
+	if (stack[0] === 'Error: Get stack') {
+		stack.splice(0, 1);
+	}
+	return hashString(stack[ancestor + 1]);
 }
 
 export default function attachElement<NewElement extends Element>(

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import {RequireAtLeastOne} from 'type-fest';
 import {isDefined} from 'ts-extras';
 
-import hashString from './hash-string';
+import getCallerID from './caller-id';
 
 type Position = 'append' | 'prepend' | 'before' | 'after' | 'forEach';
 
@@ -17,25 +17,11 @@ type Attachment<NewElement extends Element, Callback = (E: Element) => NewElemen
 	allowMissingAnchor?: boolean;
 }, Position>;
 
-/**
-Get unique ID by using the line:column of the call (or its parents) as seed. Every call from the same place will return the same ID, as long as the index is set to the parents that matters to you.
-
-@param ancestor Which call in the stack should be used as key. 0 means the exact line where getSnapshotUUID is called. Defaults to 1 because it's usually used inside a helper.
-*/
-export function getSnapshotUUID(ancestor = 1): string {
-	const stack = new Error('Get stack').stack!.split('\n');
-	if (stack[0] === 'Error: Get stack') {
-		stack.shift(); // Remove non-stacktrace line from array (only present in Chrome) #6032
-	}
-
-	return hashString(stack[ancestor + 1]);
-}
-
 export default function attachElement<NewElement extends Element>(
 	// eslint-disable-next-line @typescript-eslint/ban-types --  Allows dom traversing without requiring `!`
 	anchor: Element | string | undefined | null,
 	{
-		className = 'rgh-' + getSnapshotUUID(),
+		className = 'rgh-' + getCallerID(),
 		append,
 		prepend,
 		before,
@@ -79,7 +65,7 @@ export default function attachElement<NewElement extends Element>(
 }
 
 export function attachElements<NewElement extends Element>(anchors: string | string[], {
-	className = 'rgh-' + getSnapshotUUID(),
+	className = 'rgh-' + getCallerID(),
 	...options
 }: Attachment<NewElement>): NewElement[] {
 	return select.all(`:is(${String(anchors)}):not(.${className})`)

--- a/source/helpers/attach-element.ts
+++ b/source/helpers/attach-element.ts
@@ -27,6 +27,7 @@ export function getSnapshotUUID(ancestor = 1): string {
 	if (stack[0] === 'Error: Get stack') {
 		stack.splice(0, 1);
 	}
+
 	return hashString(stack[ancestor + 1]);
 }
 

--- a/source/helpers/caller-id.test.ts
+++ b/source/helpers/caller-id.test.ts
@@ -1,0 +1,13 @@
+import {test, assert} from 'vitest';
+
+import {getStackLine} from './caller-id';
+
+test('getCallerID: getStackLine', () => {
+	assert.equal(getStackLine('A\nB', 0), 'A');
+	assert.equal(getStackLine('A\nB', 1), 'B');
+
+	assert.equal(getStackLine('Error: Get stack\nA\nB', 0), 'A');
+	assert.equal(getStackLine('Error: Get stack\nA\nB', 1), 'B');
+
+	assert.isTrue(getStackLine('Error: Get stack\nA\nB', 42).startsWith('0.'));
+});

--- a/source/helpers/caller-id.ts
+++ b/source/helpers/caller-id.ts
@@ -1,0 +1,24 @@
+import hashString from './hash-string';
+
+/**
+Get unique ID by using the line:column of the call (or its parents) as seed. Every call from the same place will return the same ID, as long as the index is set to the parents that matters to you.
+
+@param ancestor Which call in the stack should be used as key. 0 means the exact line where getCallerID is called. Defaults to 1 because it's usually used inside a helper.
+*/
+export default function getCallerID(ancestor = 1): string {
+	/* +1 because the first line comes from this function */
+	return hashString(getStackLine(new Error('Get stack').stack!, ancestor + 1));
+}
+
+export function getStackLine(stack: string, line: number): string {
+	return stack
+		// Remove non-stacktrace line from array (missing in Firefox) #6032
+		.replace('Error: Get stack\n', '')!
+		.split('\n')
+		.at(line) ?? warn(stack, line);
+}
+
+function warn(stack: string, line: number): string {
+	console.warn('The stack doesn’t have the line', {line, stack});
+	return Math.random().toString(16);
+}

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -4,7 +4,7 @@ import {css} from 'code-tag';
 import onetime from 'onetime';
 import {ParseSelector} from 'typed-query-selector/parser';
 
-import {getSnapshotUUID} from './attach-element';
+import getCallerID from './caller-id';
 
 const animation = 'rgh-selector-observer';
 const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
@@ -38,7 +38,7 @@ export default function observe<
 	}
 
 	const selector = String(selectors); // Array#toString() creates a comma-separated string
-	const seenMark = 'rgh-seen-' + getSnapshotUUID();
+	const seenMark = 'rgh-seen-' + getCallerID();
 	const rule = new Text(css`
 		:where(${String(selector)}):not(.${seenMark}) {
 			animation: 1ms ${animation};


### PR DESCRIPTION
Fixes #5988.

The Chrome stacktrace is starting with an additional line `Error: Get stack`. Firefox already starts with the first stack entry in the first line.

## Test URLs

* This PR (see that `reaction-avatars` is working again)
* https://github.com/refined-github/refined-github (see that `toggle-files-button` is working again)
* Basically every other page
