### PR TITLE
Fix back-forth navigation delay caused by some features

### DIFF
--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -1,4 +1,3 @@
-import mem from 'mem';
 import React from 'dom-chef';
 import {css} from 'code-tag';
 import onetime from 'onetime';
@@ -7,7 +6,7 @@ import {ParseSelector} from 'typed-query-selector/parser';
 import getCallerID from './caller-id';
 
 const animation = 'rgh-selector-observer';
-const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
+const getListener = <ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
 	const target = event.target as ExpectedElement;
 	// The target can match a selector even if the animation actually happened on a ::before pseudo-element, so it needs an explicit exclusion here
 	if (target.classList.contains(seenMark) || !target.matches(selector)) {
@@ -18,12 +17,10 @@ const getListener = mem(<ExpectedElement extends HTMLElement>(seenMark: string, 
 	target.classList.add(seenMark);
 
 	callback(target);
-});
+}
 
-const getTag = onetime((): JSX.Element => {
-	const style = <style>{`@keyframes ${animation} {}`}</style>;
-	document.head.append(style);
-	return style;
+const registerAnimation = onetime((): void => {
+	document.head.append(<style>{`@keyframes ${animation} {}`}</style>);
 });
 
 export default function observe<
@@ -39,12 +36,16 @@ export default function observe<
 
 	const selector = String(selectors); // Array#toString() creates a comma-separated string
 	const seenMark = 'rgh-seen-' + getCallerID();
-	const rule = new Text(css`
+
+	registerAnimation();
+
+	const rule = document.createElement('style');
+	rule.textContent = css`
 		:where(${String(selector)}):not(.${seenMark}) {
 			animation: 1ms ${animation};
 		}
-	`);
-	getTag().append(rule);
+	`;
+	document.head.append(rule);
 	signal?.addEventListener('abort', () => {
 		rule.remove();
 	});


### PR DESCRIPTION
- Probably fixes https://github.com/refined-github/refined-github/issues/6028

Here's what I think happens:

- Turbo caches the style elements by `outerHTML`
- We alter the content of the `style` element
- Turbo finds "a new style element" (same element, but different `outerHTML`)
- No load/error events are fired because the element is the same

I assume this issue exists in every browser so it makes sense to use a fix that works in every browser. I haven't experienced it because I'm on the LTS version (Safari 🥲)