### PR TITLE
Restore `linkify-labels-on-dashboard` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -385,6 +385,7 @@ Thanks for contributing! 🦋🙌
 - [](# "embed-gist-via-iframe") [Adds a menu item to embed a gist via `<iframe>`.](https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png)
 - [](# "link-to-prior-blame-line") [Preserves the current line on “View blame prior to this change” links.](https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png)
 - [](# "enable-file-links-in-compare-view") [Points the "View file" on compare view pages to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.](https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png)
+- [](# "linkify-labels-on-dashboard") [Makes labels clickable on the dashboard.](https://user-images.githubusercontent.com/46634000/136909258-88031d07-6efa-4339-b436-5636e8075964.png)
 - [](# "reload-failed-proxied-images") [Retries downloading images that failed downloading due to GitHub limited proxying.](https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png)
 - [](# "unwrap-unnecessary-dropdowns") [Makes some dropdowns 1-click instead of unnecessarily 2-click.](https://user-images.githubusercontent.com/1402241/80859624-9bfdb300-8c62-11ea-837f-7b7a28e6fdfc.png)
 - [](# "prevent-link-loss") [Suggests fixing links that are wrongly shortened by GitHub.](https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif)

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -1,10 +1,9 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
-import features from '../feature-manager';
+import observe from '../helpers/selector-observer';
 
 function linkifyLabel(label: Element): void {
 	const activity = label.closest('div:not([class])')!;
@@ -17,17 +16,13 @@ function linkifyLabel(label: Element): void {
 	wrap(label, <a href={url.href}/>);
 }
 
-function init(): Deinit {
-	// A `:not(.rgh)` selector is not needed since we already check for `not(a)` #3625
-	return observe('.news :not(a) > .IssueLabel', {
-		add: linkifyLabel,
-	});
+function init(signal: AbortSignal): void {
+	observe('.news :not(a) > .IssueLabel', linkifyLabel, {signal});
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDashboard,
 	],
-	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
+import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function linkifyLabel(label: Element): void {

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -1,0 +1,33 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import {observe} from 'selector-observer';
+import * as pageDetect from 'github-url-detection';
+
+import {wrap} from '../helpers/dom-utils';
+import features from '../feature-manager';
+
+function linkifyLabel(label: Element): void {
+	const activity = label.closest('div:not([class])')!;
+	const isPR = select.exists('.octicon-git-pull-request', activity);
+	const repository = select('a[data-hovercard-type="repository"]', activity)!;
+	const url = new URL(`${repository.href}/${isPR ? 'pulls' : 'issues'}`);
+	const labelName = label.textContent!.trim();
+
+	url.searchParams.set('q', `is:${isPR ? 'pr' : 'issue'} is:open sort:updated-desc label:"${labelName}"`);
+	wrap(label, <a href={url.href}/>);
+}
+
+function init(): Deinit {
+	// A `:not(.rgh)` selector is not needed since we already check for `not(a)` #3625
+	return observe('.news :not(a) > .IssueLabel', {
+		add: linkifyLabel,
+	});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isDashboard,
+	],
+	deduplicate: 'has-rgh',
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -136,6 +136,7 @@ import './features/link-to-prior-blame-line';
 import './features/dim-bots';
 import './features/conflict-marker';
 import './features/html-preview-link';
+import './features/linkify-labels-on-dashboard';
 import './features/linkify-user-location';
 import './features/repo-age';
 import './features/user-local-time';


### PR DESCRIPTION
Reverts refined-github/refined-github#6016