### PR TITLE
Disable broken `one-click-diff-options` on GitHub Enterprise

### DIFF
--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -163,6 +163,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isPRFile404,
+		pageDetect.isEnterprise, // #5820
 	],
 	init: initPR,
 }, {


### PR DESCRIPTION
- For #5820

The feature actively breaks GitHub’s UI on Enterprise, so I had to disable it there. An actual bugfix would be ideal.

@ELLIOTTCABLE @nicolasff @busches 