### PR TITLE
Exclude PRs from archived repos in `show-open-prs-of-forks`

### DIFF
--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -18,7 +18,7 @@ const countPRs = cache.function(async (forkedRepo: string): Promise<[prCount: nu
 		search(
 			first: 100,
 			type: ISSUE,
-			query: "repo:${forkedRepo} is:pr is:open author:${getUsername()!}"
+			query: "is:pr is:open archived:false repo:${forkedRepo} author:${getUsername()!}"
 		) {
 			nodes {
 				... on PullRequest {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6010


## Test URLs

https://github.com/PeterDaveHelloKitchen/imagelayers-graph

or:

1. Visit https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3A%40me+archived%3Afalse+sort%3Aupdated-desc
2. Open any PRs
3. Visit your own fork from there
4. You should not see this:

![image](https://user-images.githubusercontent.com/3691490/193530583-25f8623f-bb79-49de-b4be-48a71f5f50fe.png)
