### PR TITLE
Disable `clean-header-search-field` on global search pages

### DIFF
--- a/source/features/clean-header-search-field.tsx
+++ b/source/features/clean-header-search-field.tsx
@@ -11,7 +11,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isIssueOrPRList,
 		pageDetect.isGlobalIssueOrPRList,
-		pageDetect.isGlobalSearchResults,
 		pageDetect.isRepoSearch,
 	],
 	awaitDomReady: false,


### PR DESCRIPTION
Global search pages don't have a duplicate search bar, so the header field should not be emptied


## Test URLs


https://github.com/search?q=repo%3Amicroscaling%2Fimagelayers-graph+is%3Aopen+author%3APeterDaveHello+archived%3Atrue&type=repositories


## Before
<img width="847" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/193536926-e8927f9f-dcf4-45ef-9838-8934dfcbefd2.png">


## After

 
<img width="847" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/193536936-03fb932b-d57d-4dee-9ff4-c1fc569e9c2b.png">


