### PR TITLE
Restore star button in `clean-dashboard`

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -8,8 +8,8 @@
 */
 
 /* Hide duplicate repo name in some non-grouped events */
-.rgh-clean-dashboard .dashboard :is(.watch_started, .repo, .public) .color-border-muted.flex-items-baseline .text-bold.color-fg-default {
-	display: none;
+.rgh-clean-dashboard .dashboard :is(.watch_started, .repo, .public) .f4 .Link--primary {
+	display: none !important;
 }
 
 /* Drop "box" style from the repos */
@@ -58,6 +58,18 @@
 	margin-bottom: 0;
 }
 
+/* Star button: Hide label */
+.rgh-clean-dashboard .starring-container button {
+	letter-spacing: -1em;
+	color: transparent;
+	padding-inline: 0.8em 0.5em;
+}
+
+/* Star button: Make it less prominent */
+.rgh-clean-dashboard .starring-container .BtnGroup-item {
+	background: none;
+}
+
 /* Hide footer date on Created Repository events */
 .rgh-clean-dashboard .dashboard .repo .f6.color-fg-muted {
 	display: none;
@@ -79,6 +91,11 @@
 	padding-right: 0 !important;
 }
 
+/* Grouped events: ... but restore some padding inside */
+.rgh-clean-dashboard .news .js-news-feed-event-group .Box {
+	padding-right: 16px !important;
+}
+
 /* Grouped events: Keep open */
 .rgh-clean-dashboard .Details.js-news-feed-event-group .js-details-target {
 	/* Hide toggle */
@@ -89,11 +106,6 @@
 	/* Always show content. */
 	/* Selector must be stronger to override the native one. Yes, even with !important, for some reason. Firefox */
 	display: block !important;
-}
-
-/* Hide star button */
-.rgh-clean-dashboard .dashboard .starring-container {
-	display: none !important;
 }
 
 /* Restore right margin for repo descriptions #5024 */


### PR DESCRIPTION
While starring an unknown repo seems strange, adding it to a "To check out" list might be reasonable:

<img width="355" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/193770266-f96a7cb6-c9bf-448e-a9f1-07665f1c239b.png">

I'm thinking about restoring the widget, but making it a little smaller and less prominent. However it's still noisy especially on grouped events. Thoughts?

<img width="575" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/193770516-74fa94bc-36d6-4690-9cb4-de013e46b79f.png">

### Related

- https://github.com/refined-github/refined-github/issues/3255
- https://github.com/refined-github/refined-github/issues/1864