### PR TITLE
Meta: Use existing variable in `profile-gists-link`

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -56,7 +56,7 @@ async function appendTab(navigationBar: Element): Promise<void> {
 	navigationBar.replaceWith(navigationBar);
 
 	select('.js-responsive-underlinenav .dropdown-menu ul')!.append(
-		createDropdownItem('Gists', getUser().url),
+		createDropdownItem('Gists', user.url),
 	);
 
 	const count = await getGistCount(user.name);


### PR DESCRIPTION
use variable `user` which is introduced in line 41 - no need to call again `getUser()`

```javascript
41: const user = getUser();
```

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs


## Screenshot

