### PR TITLE
Fix `clean-dashboard` style for multiple commits

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -22,8 +22,10 @@
 /* Add "box" style to each event group */
 /* This exact `>` sequence ensures it works on ajaxed-in events */
 .rgh-clean-dashboard [role='tabpanel'] [data-repository-hovercards-enabled] > [class] > .body,
+.rgh-clean-dashboard [role='tabpanel'] [data-repository-hovercards-enabled] > [classes] > .body,
 /* The organization newsfeed doesn't yet support the new style */
-.rgh-clean-dashboard .news > [data-repository-hovercards-enabled] > [class] > .body {
+.rgh-clean-dashboard .news > [data-repository-hovercards-enabled] > [class] > .body,
+.rgh-clean-dashboard .news > [data-repository-hovercards-enabled] > [classes] > .body {
 	background-color: var(--color-canvas-default);
 	border: 1px solid var(--color-border-muted);
 	border-radius: 4px;


### PR DESCRIPTION
## Test URLs

Dashboard: https://github.com/
Hovercards are broken when more than one commit gets listed in a single hovercard.

The reason for this is that some hovercards now appear to have the `classes` attribute instead of the `class` attribute, which breaks the existing CSS selector in the `clean-dashboard`:

![image](https://user-images.githubusercontent.com/467294/194682967-1f476f24-7690-405c-810d-9a202396ec47.png)

## Screenshot

Before:
![image](https://user-images.githubusercontent.com/467294/194682885-e70f020d-92ea-422a-87ac-e0b1ecbfc208.png)

After:
![image](https://user-images.githubusercontent.com/467294/194683051-b933854c-e33d-4dd6-9623-336091dd40ce.png)
