### PR TITLE
Restore `release-download-count` on single releases

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -48,7 +48,7 @@ async function getAssetsForTag(tags: string[]): Promise<Tag> {
 async function addCounts(assetsList: HTMLElement): Promise<void> {
 	const releaseName = assetsList
 		.closest('[data-test-selector="release-card"]')!
-		.previousElementSibling!
+		.parentElement!
 		.querySelector('.octicon-tag ~ span')!
 		.textContent!
 		.trim();


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6014 again


## Test URLs

https://github.com/TigerBeanst/TigerInTheWall/releases
https://github.com/TigerBeanst/TigerInTheWall/releases/tag/v1.0.6

## Screenshot

### Releases list
<img width="877" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/194828210-cb2c86c3-b537-44b6-9451-7d0162a36713.png">



### Single release

<img width="939" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/194828224-5b317819-65fa-48d8-a908-5b5998ab739c.png">

