### PR TITLE
Fix `align-issue-labels` on milestones

### DIFF
--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -4,7 +4,7 @@
 	flex-wrap: wrap;
 }
 
-.rgh-align-issue-labels .js-issue-row .lh-default.d-block.d-md-inline { /* Labels */
+.rgh-align-issue-labels .js-issue-row .min-width-0 > .lh-default { /* Labels */
 	order: 1;
 }
 
@@ -28,3 +28,14 @@
 	margin-top: 4px;
 	font-size: 11px !important;
 }
+
+/*
+
+# Test URLs
+
+https://github.com/pulls
+https://github.com/bmish/eslint-doc-generator/pulls
+https://github.com/bmish/eslint-doc-generator/issues
+https://github.com/bmish/eslint-doc-generator/milestone/1
+
+*/


### PR DESCRIPTION
- Fixes #6056



## Test URLs

https://github.com/bmish/eslint-doc-generator/milestone/1

## Screenshot

<img width="753" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/194829005-59d0ce95-9b77-4f43-b5c1-25e2b0c2e23c.png">

cc @tyrann0us 
