### PR TITLE
Fix unified diff bug caused by `no-unnecessary-split-diff-view`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -26,8 +26,8 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: How to replicate the issue
-      description: Include the steps to reproduce and A REAL URL where the bug appears. If it happens on a private repo, find an equivalent public URL, even if it doesn't happen there.
+      label: How to replicate the issue + URL
+      description: ‼️‼️‼️ Every bug report MUST include A REAL URL where the bug appears. If it happens on a private repo, find an equivalent public URL, even if it doesn't happen there.
     validations:
       required: true
   - type: input

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -24,7 +24,7 @@
 	display: var(--rgh-only-deletions, table-cell) !important;
 }
 
-/* Any applicable situation: Re-align annotations, which are always on the left */
-.rgh-no-unnecessary-split-diff-view :is(.inline-comments, .js-inline-annotations) td:nth-child(2) {
+/* Any applicable situation: Re-align annotations */
+.rgh-no-unnecessary-split-diff-view :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
 	display: var(--rgh-only-additions, var(--rgh-only-deletions, table-cell)) !important;
 }

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,13 +1,13 @@
 /* The selector looks for diff tables WITHOUT changes on the left XOR on the right */
 /* Instead of duplicating this selector for each rule, we set a variable and pick it up where needed */
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+.rgh-no-unnecessary-split-diff-view .js-diff-table:has([data-split-side]):not(
 :has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
 ) {
 	--rgh-only-additions: none;
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:not(
+.rgh-no-unnecessary-split-diff-view .js-diff-table:has([data-split-side]):not(
 :has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
 ) {
 	--rgh-only-deletions: none;


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6061
- Fixes #6064
- Caused by https://github.com/refined-github/refined-github/pull/6023


## Demo

### PR files

https://github.com/refined-github/sandbox/pull/50/files?diff=split
https://github.com/refined-github/sandbox/pull/50/files?diff=unified



### Compare page

https://github.com/refined-github/sandbox/compare/no-unnecessary-split-diff-view?expand=1&diff=split
https://github.com/refined-github/sandbox/compare/no-unnecessary-split-diff-view?expand=1&diff=unified


### Single commit

https://github.com/refined-github/sandbox/commit/c28cc8e5271452b5b4c347d46a63f717c29417d6?diff=split
https://github.com/refined-github/sandbox/commit/c28cc8e5271452b5b4c347d46a63f717c29417d6?diff=unified
