### PR TITLE
Also `hide-low-quality-comments` containing "thanks"

### DIFF
--- a/source/helpers/is-low-quality-comment.test.ts
+++ b/source/helpers/is-low-quality-comment.test.ts
@@ -27,7 +27,9 @@ describe('isLowQualityComment', () => {
 		'+1 and thank you for your work',
 		'Same here, please update, thanks',
 		'Same here! Please update, thank you.',
-	])('%s', text => assert.isTrue(isLowQualityComment(text)));
+	])('%s', text => {
+		assert.isTrue(isLowQualityComment(text));
+	});
 
 	test.each([
 		'+1\n<some useful information>',
@@ -35,5 +37,7 @@ describe('isLowQualityComment', () => {
 		'Same here on v1.2',
 		'Thanks!',
 		'Thank you 👍',
-	])('%s', text => assert.isFalse(isLowQualityComment(text)));
+	])('%s', text => {
+		assert.isFalse(isLowQualityComment(text));
+	});
 });

--- a/source/helpers/is-low-quality-comment.test.ts
+++ b/source/helpers/is-low-quality-comment.test.ts
@@ -20,9 +20,16 @@ test('isLowQualityComment', () => {
 	assert.isTrue(isLowQualityComment('this same issues'));
 	assert.isTrue(isLowQualityComment('same question'));
 	assert.isTrue(isLowQualityComment('any updates there?'));
+	assert.isTrue(isLowQualityComment('any news?'));
+	assert.isTrue(isLowQualityComment('+++ !!!\nThanks !!!'));
+	assert.isTrue(isLowQualityComment('+1\nThx for your job!'));
+	assert.isTrue(isLowQualityComment('+1 and thank you for your work'));
+	assert.isTrue(isLowQualityComment('Same here, please update, thanks'));
+	assert.isTrue(isLowQualityComment('Same here! Please update, thank you.'));
 
 	assert.isFalse(isLowQualityComment('+1\n<some useful information>'));
 	assert.isFalse(isLowQualityComment('Same here. <some useful information>'));
-	assert.isFalse(isLowQualityComment('Same here, please update, thanks'));
-	assert.isFalse(isLowQualityComment('Same here! Please update, thank you.'));
+	assert.isFalse(isLowQualityComment('Same here on v1.2'));
+	assert.isFalse(isLowQualityComment('Thanks!'));
+	assert.isFalse(isLowQualityComment('Thank you 👍'));
 });

--- a/source/helpers/is-low-quality-comment.test.ts
+++ b/source/helpers/is-low-quality-comment.test.ts
@@ -1,35 +1,39 @@
-import {test, assert} from 'vitest';
+import {test, assert, describe} from 'vitest';
 
 import isLowQualityComment from './is-low-quality-comment';
 
-test('isLowQualityComment', () => {
-	assert.isTrue(isLowQualityComment('+1'));
-	assert.isTrue(isLowQualityComment('+1!'));
-	assert.isTrue(isLowQualityComment('+10'));
-	assert.isTrue(isLowQualityComment('+9000'));
-	assert.isTrue(isLowQualityComment('-1'));
-	assert.isTrue(isLowQualityComment('👍'));
-	assert.isTrue(isLowQualityComment('👍🏾'));
-	assert.isTrue(isLowQualityComment('me too'));
-	assert.isTrue(isLowQualityComment('ditto'));
-	assert.isTrue(isLowQualityComment('Dito'));
-	assert.isTrue(isLowQualityComment('following'));
-	assert.isTrue(isLowQualityComment('please update!'));
-	assert.isTrue(isLowQualityComment('please update 🙏🏻'));
-	assert.isTrue(isLowQualityComment('same issue'));
-	assert.isTrue(isLowQualityComment('this same issues'));
-	assert.isTrue(isLowQualityComment('same question'));
-	assert.isTrue(isLowQualityComment('any updates there?'));
-	assert.isTrue(isLowQualityComment('any news?'));
-	assert.isTrue(isLowQualityComment('+++ !!!\nThanks !!!'));
-	assert.isTrue(isLowQualityComment('+1\nThx for your job!'));
-	assert.isTrue(isLowQualityComment('+1 and thank you for your work'));
-	assert.isTrue(isLowQualityComment('Same here, please update, thanks'));
-	assert.isTrue(isLowQualityComment('Same here! Please update, thank you.'));
+describe('isLowQualityComment', () => {
+	test.each([
+		'+1',
+		'+1!',
+		'+10',
+		'+9000',
+		'-1',
+		'👍',
+		'👍🏾',
+		'me too',
+		'ditto',
+		'Dito',
+		'following',
+		'please update!',
+		'please update 🙏🏻',
+		'same issue',
+		'this same issues',
+		'same question',
+		'any updates there?',
+		'any news?',
+		'+++ !!!\nThanks !!!',
+		'+1\nThx for your job!',
+		'+1 and thank you for your work',
+		'Same here, please update, thanks',
+		'Same here! Please update, thank you.',
+	])('%s', text => assert.isTrue(isLowQualityComment(text)));
 
-	assert.isFalse(isLowQualityComment('+1\n<some useful information>'));
-	assert.isFalse(isLowQualityComment('Same here. <some useful information>'));
-	assert.isFalse(isLowQualityComment('Same here on v1.2'));
-	assert.isFalse(isLowQualityComment('Thanks!'));
-	assert.isFalse(isLowQualityComment('Thank you 👍'));
+	test.each([
+		'+1\n<some useful information>',
+		'Same here. <some useful information>',
+		'Same here on v1.2',
+		'Thanks!',
+		'Thank you 👍',
+	])('%s', text => assert.isFalse(isLowQualityComment(text)));
 });

--- a/source/helpers/is-low-quality-comment.ts
+++ b/source/helpers/is-low-quality-comment.ts
@@ -1,4 +1,17 @@
+import regexJoin from 'regex-join';
+
+// Note: the unicode range targets skin color modifiers for the hand emojis
+const fillerRegex = /[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]/gui;
+const thanksRegex = /and|thanks?|thx|for|your?|job|work/gi;
+const unhelpfulRegex = /[+-]\d+|\+|⬆️|ditt?o|me|too|t?here|on|same|this|issues?|please|pl[sz]|any|news|updates?|bump|question|solution|following/gui;
+
+const thanksWithFillerRegex = regexJoin(fillerRegex, /|/, thanksRegex);
+const lowQualityRegex = regexJoin(fillerRegex, /|/, thanksRegex, /|/, unhelpfulRegex);
+
 export default function isLowQualityComment(text: string): boolean {
-	// Note: the unicode range targets skin color modifiers for the hand emojis
-	return text.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditt?o|me|too|t?here|on|same|this|issues?|please|pl[sz]|any|updates?|bump|question|solution|following/gui, '') === '';
+	if (thanksRegex.test(text) && text.replace(thanksWithFillerRegex, '') === '') {
+		return false;
+	}
+
+	return text.replace(lowQualityRegex, '') === '';
 }

--- a/source/helpers/is-low-quality-comment.ts
+++ b/source/helpers/is-low-quality-comment.ts
@@ -5,7 +5,9 @@ const fillerRegex = /[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]/gui;
 const thanksRegex = /and|thanks?|thx|for|your?|job|work/gi;
 const unhelpfulRegex = /[+-]\d+|\+|⬆️|ditt?o|me|too|t?here|on|same|this|issues?|please|pl[sz]|any|news|updates?|bump|question|solution|following/gui;
 
+// eslint-disable-next-line unicorn/better-regex -- it doesn't know how regexJoin works
 const thanksWithFillerRegex = regexJoin(fillerRegex, /|/, thanksRegex);
+// eslint-disable-next-line unicorn/better-regex -- it does not know indeed
 const lowQualityRegex = regexJoin(fillerRegex, /|/, thanksRegex, /|/, unhelpfulRegex);
 
 export default function isLowQualityComment(text: string): boolean {


### PR DESCRIPTION
Otherwise low quality comments that contain "thanks" or "thank you for your work" are still low quality.
Comments that only contain "thanks" or similar are still shown.

## Test URLs
https://github.com/Etar-Group/Etar-Calendar/issues/62#issuecomment-513282994
