### PR TITLE
Avoid duplicate `user-profile-follower-badge`

### DIFF
--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -1,6 +1,5 @@
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6053

## Repro

1. Visit https://github.com/YOUR_NAME?tab=followers
2. Open any profile
3. Go back 
4. Go forward