### PR TITLE
Avoid misplacement of `useful-forks`

### DIFF
--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -1,4 +1,5 @@
 import React from 'dom-chef';
+import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {RepoForkedIcon} from '@primer/octicons-react';
@@ -7,7 +8,6 @@ import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';
 import attachElement from '../helpers/attach-element';
-import select from 'select-dom';
 import { assertNodeContent } from '../helpers/dom-utils';
 
 function getUrl(): string {

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -7,6 +7,8 @@ import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';
 import attachElement from '../helpers/attach-element';
+import select from 'select-dom';
+import { assertNodeContent } from '../helpers/dom-utils';
 
 function getUrl(): string {
 	const url = new URL('https://useful-forks.github.io');
@@ -33,12 +35,14 @@ async function init(): Promise<void | false> {
 function createBannerLink(): JSX.Element {
 	// It must return an element for `attachElement`. It includes a space
 	return (
-		<span> You can find <a href={getUrl()} target="_blank" rel="noreferrer">useful-forks.github.io</a></span>
+		<span> You can use <a href={getUrl()} target="_blank" rel="noreferrer">useful-forks.github.io</a></span>
 	);
 }
 
 function initArchivedRepoBanner(): void {
-	attachElement('.flash-full', {
+	const banner = select('#js-repo-pjax-container > .flash-warn:first-child')!;
+	assertNodeContent(banner, 'repository has been archived');
+	attachElement(banner, {
 		append: createBannerLink,
 	});
 }
@@ -61,7 +65,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isArchivedRepo,
 	],
-	// Can't because `isArchivedRepo` is DOM-based
+	// Can't because `isArchivedRepo` and `isPublicRepo` are DOM-based
 	// awaitDomReady: false,
 	init: initArchivedRepoBanner,
 });

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import looseParseInt from '../helpers/loose-parse-int';
 import attachElement from '../helpers/attach-element';
-import { assertNodeContent } from '../helpers/dom-utils';
+import {assertNodeContent} from '../helpers/dom-utils';
 
 function getUrl(): string {
 	const url = new URL('https://useful-forks.github.io');

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -72,3 +72,9 @@ export const unhighlightTab = (tabElement: Element): void => {
 	tabElement.classList.remove('selected');
 	tabElement.removeAttribute('aria-current');
 };
+
+export const assertNodeContent = ({textContent}: Node, includes: string): void  => {
+	if (!textContent!.includes(includes)) {
+		throw new TypeError(`Expected node including "${includes}", found ${textContent!.trim()}`);
+	}
+};

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -73,7 +73,7 @@ export const unhighlightTab = (tabElement: Element): void => {
 	tabElement.removeAttribute('aria-current');
 };
 
-export const assertNodeContent = ({textContent}: Node, includes: string): void  => {
+export const assertNodeContent = ({textContent}: Node, includes: string): void => {
 	if (!textContent!.includes(includes)) {
 		throw new TypeError(`Expected node including "${includes}", found ${textContent!.trim()}`);
 	}


### PR DESCRIPTION
- Closes #6049

## Test URLs

https://github.com/probot/template/blob/master/CODE_OF_CONDUCT.md?rgh-link-date=2022-10-07T05%3A16%3A38Z

## Before / After

<img width="626" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/195287556-3cb5e416-0301-4386-834a-9b05f2fdafa9.png">
<img width="626" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/195287569-90d830e1-e3ab-4f72-96c3-f76d41a8896b.png">


