### PR TITLE
Avoid `link-to-github-io` duplicates

### DIFF
--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -1,5 +1,4 @@
 import React from 'dom-chef';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {LinkExternalIcon} from '@primer/octicons-react';
 
@@ -7,32 +6,34 @@ import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 
-function getLinkToGitHubIo(repoTitle: HTMLElement): JSX.Element {
+function getLinkToGitHubIo(repoTitle: HTMLElement, className?: string): JSX.Element {
 	return (
 		<a
 			href={`https://${repoTitle.textContent!.trim()}`}
 			target="_blank"
 			rel="noopener noreferrer"
+			className={className}
 		>
 			<LinkExternalIcon className="v-align-middle"/>
 		</a>
 	);
 }
 
-async function initRepo(): Promise<void> {
-	const repoTitle = (await elementReady('[itemprop="name"]'))!;
-	const link = getLinkToGitHubIo(repoTitle);
 
-	link.classList.add('mr-2');
-	repoTitle.after(link);
-}
-
-function addLink(repoTitle: HTMLAnchorElement): void {
+function addRepoListLink(repoTitle: HTMLAnchorElement): void {
 	repoTitle.after(' ', getLinkToGitHubIo(repoTitle));
 }
 
+function addRepoHeaderLink(repoTitle: HTMLAnchorElement): void {
+	repoTitle.after(getLinkToGitHubIo(repoTitle, 'mr-2'));
+}
+
+ function initRepo(signal: AbortSignal): void {
+	observe('a[itemprop="name"]', addRepoHeaderLink, {signal});
+}
+
 function initRepoList(signal: AbortSignal): void {
-	observe('a[href$=".github.io"][itemprop="name codeRepository"]', addLink, {signal});
+	observe('a[href$=".github.io"][itemprop="name codeRepository"]', addRepoListLink, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Fixes #6026


## Repro

1. Visit https://github.com/KatsuteDev/katsutedev.github.io
2. Click the Code tab

## Before


![gif](https://user-images.githubusercontent.com/1402241/195306259-ff037bf0-d349-44a1-beaf-7c7470bd7691.gif)



## After

![gif](https://user-images.githubusercontent.com/1402241/195307219-d5c85db8-f4d2-45c3-bbdf-5a53f976e8ff.gif)

