### PR TITLE
Preserve `toggle-files-button` after navigation

### DIFF
--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -74,7 +74,7 @@ async function updateView(anchor: HTMLHeadingElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	// TODO: Use `.Box:has(> #files)` instead
-	observe('.Box > h2#files', updateView, {signal});
+	observe('.Box h2#files', updateView, {signal});
 	delegate(document, `.${toggleButtonClass}, .${noticeClass}`, 'click', toggleHandler, {signal});
 }
 

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -4,6 +4,7 @@ import onetime from 'onetime';
 import {ParseSelector} from 'typed-query-selector/parser';
 
 import getCallerID from './caller-id';
+import isDevelopmentVersion from './is-development-version';
 
 const animation = 'rgh-selector-observer';
 const getListener = <ExpectedElement extends HTMLElement>(seenMark: string, selector: string, callback: (element: ExpectedElement) => void) => function (event: AnimationEvent) {
@@ -40,12 +41,17 @@ export default function observe<
 	registerAnimation();
 
 	const rule = document.createElement('style');
+	if (isDevelopmentVersion()) {
+		// For debuggability
+		rule.setAttribute('s', selector);
+	}
+
 	rule.textContent = css`
 		:where(${String(selector)}):not(.${seenMark}) {
 			animation: 1ms ${animation};
 		}
 	`;
-	document.head.append(rule);
+	document.body.prepend(rule);
 	signal?.addEventListener('abort', () => {
 		rule.remove();
 	});


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6077

## Test URLs

1. From this issue
1. Open https://github.com/refined-github/refined-github

## Demo

![gif](https://user-images.githubusercontent.com/1402241/195377877-95869247-376d-43c9-a0d3-cef767bd2e77.gif)

