### PR TITLE
Drop outdated references to PJAX

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -322,7 +322,7 @@ void add('rgh-deduplicator' as FeatureID, {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();
 		select(_`#js-repo-pjax-container, #js-pjax-container`)?.append(<has-rgh/>);
-		select(_`#repo-content-pjax-container, turbo-frame`)?.append(<has-rgh-inner/>); // #4567
+		select(_`turbo-frame`)?.append(<has-rgh-inner/>); // #4567
 	},
 });
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -66,7 +66,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 	}
 
 	const link = (
-		<a className="rgh-link-date" href={url.href}>
+		<a className="rgh-link-date" href={url.href} data-turbo-frame="repo-content-turbo-frame">
 			view this object as it appeared at the time of the comment
 		</a>
 	);

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -51,7 +51,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time', {waitForChildren: false});
+		const lastCommitDate = await elementReady('.Box.Box--condensed relative-time', {waitForChildren: false});
 		if (lastCommitDate && date > lastCommitDate.getAttribute('datetime')!) {
 			return false;
 		}
@@ -65,7 +65,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 	}
 
 	const link = (
-		<a className="rgh-link-date" href={url.href} data-pjax="#repo-content-pjax-container">
+		<a className="rgh-link-date" href={url.href}>
 			view this object as it appeared at the time of the comment
 		</a>
 	);

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -51,7 +51,8 @@ async function showTimeMachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		const lastCommitDate = await elementReady('.Box.Box--condensed relative-time', {waitForChildren: false});
+		// Selector note: isRepoFile and isRepoTree have different DOM for this element
+		const lastCommitDate = await elementReady('.Box-header relative-time', {waitForChildren: false});
 		if (lastCommitDate && date > lastCommitDate.getAttribute('datetime')!) {
 			return false;
 		}

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -37,6 +37,7 @@ async function init(): Promise<false | void> {
 		<a
 			className="btn tooltipped tooltipped-ne rgh-default-branch-button"
 			href={url.href}
+			data-turbo-frame="repo-content-turbo-frame"
 			aria-label="See this view on the default branch"
 		>
 			<ChevronLeftIcon/>

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -37,7 +37,6 @@ async function init(): Promise<false | void> {
 		<a
 			className="btn tooltipped tooltipped-ne rgh-default-branch-button"
 			href={url.href}
-			data-pjax="#repo-content-pjax-container"
 			aria-label="See this view on the default branch"
 		>
 			<ChevronLeftIcon/>

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -45,7 +45,7 @@ function init(): void {
 
 	// Delay collapsing, but only after they're collapsed on load #5158
 	requestAnimationFrame(() => {
-		select('turbo-frame .js-navigation-container')!.classList.add('rgh-dim-bots--after-hover');
+		select('#repo-content-turbo-frame .js-navigation-container')!.classList.add('rgh-dim-bots--after-hover');
 	});
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -45,7 +45,7 @@ function init(): void {
 
 	// Delay collapsing, but only after they're collapsed on load #5158
 	requestAnimationFrame(() => {
-		select(':is(#repo-content-pjax-container, turbo-frame) .js-navigation-container')!.classList.add('rgh-dim-bots--after-hover');
+		select('turbo-frame .js-navigation-container')!.classList.add('rgh-dim-bots--after-hover');
 	});
 }
 

--- a/source/features/easier-pr-sha-copy.css
+++ b/source/features/easier-pr-sha-copy.css
@@ -1,4 +1,0 @@
-/* Add margin to commit SHA to reduce likelihood of selection overflow #2508 */
-.js-commit .text-right code .Link--secondary {
-	margin-right: 16px;
-}

--- a/source/features/easier-pr-sha-copy.css
+++ b/source/features/easier-pr-sha-copy.css
@@ -1,4 +1,4 @@
 /* Add margin to commit SHA to reduce likelihood of selection overflow #2508 */
-.repository-content .js-commit .text-right code .Link--secondary {
+.js-commit .text-right code .Link--secondary {
 	margin-right: 16px;
 }

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -50,6 +50,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isGlobalIssueOrPRList,
 	],
-	deduplicate: 'has-rgh',
 	init,
 });

--- a/source/features/global-search-filters.tsx
+++ b/source/features/global-search-filters.tsx
@@ -37,7 +37,7 @@ async function init(): Promise<void> {
 			<h2 className="d-inline-block f5 mb-2">
 				Filters
 			</h2>
-			<ul data-pjax className="filter-list small">
+			<ul className="filter-list small">
 				{items}
 			</ul>
 		</div>,

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -104,6 +104,7 @@ async function init(): Promise<false | void> {
 	const link = (
 		<a
 			className="btn btn-sm ml-0 flex-self-center css-truncate rgh-latest-tag-button"
+			data-turbo-frame="repo-content-turbo-frame"
 			href={url.href}
 		>
 			<TagIcon className="v-align-middle"/>
@@ -144,6 +145,7 @@ async function init(): Promise<false | void> {
 				<a
 					className="btn btn-sm tooltipped tooltipped-ne"
 					href={buildRepoURL(`compare/${latestTag}...${defaultBranch}`)}
+					data-turbo-frame="repo-content-turbo-frame"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>
 					<GitCompareIcon className="v-align-middle"/>

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -105,7 +105,6 @@ async function init(): Promise<false | void> {
 		<a
 			className="btn btn-sm ml-0 flex-self-center css-truncate rgh-latest-tag-button"
 			href={url.href}
-			data-pjax="#repo-content-pjax-container"
 		>
 			<TagIcon className="v-align-middle"/>
 		</a>
@@ -145,7 +144,6 @@ async function init(): Promise<false | void> {
 				<a
 					className="btn btn-sm tooltipped tooltipped-ne"
 					href={buildRepoURL(`compare/${latestTag}...${defaultBranch}`)}
-					data-pjax="#repo-content-pjax-container"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>
 					<GitCompareIcon className="v-align-middle"/>

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import {GlobeIcon} from '@primer/octicons-react';
+import {LinkIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
@@ -12,7 +12,7 @@ function getLinkToGitHubIo(repoTitle: HTMLElement, className?: string): JSX.Elem
 			href={`https://${repoTitle.textContent!.trim()}`}
 			className={className}
 		>
-			<GlobeIcon className="v-align-middle"/>
+			<LinkIcon className="v-align-middle"/>
 		</a>
 	);
 }

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<void | false> {
 	const branchUrl = buildRepoURL('tree', element.textContent!);
 	element.replaceWith(
 		<span className="commit-ref">
-			<a className="no-underline" href={branchUrl} data-pjax="#repo-content-pjax-container">
+			<a className="no-underline" href={branchUrl}>
 				{element.textContent}
 			</a>
 		</span>,

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<void | false> {
 	const branchUrl = buildRepoURL('tree', element.textContent!);
 	element.replaceWith(
 		<span className="commit-ref">
-			<a className="no-underline" href={branchUrl}>
+			<a className="no-underline" href={branchUrl} data-turbo-frame="repo-content-turbo-frame">
 				{element.textContent}
 			</a>
 		</span>,

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -43,7 +43,7 @@ const hovercardObserver = new MutationObserver(([mutation]) => {
 		}
 
 		reference.replaceChildren(
-			<a className="no-underline" href={url.href}>
+			<a className="no-underline" href={url.href} data-turbo-frame="repo-content-turbo-frame">
 				{[...reference.childNodes]}
 			</a>,
 		);

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 function init(): void {
 	if (select('.file-mode')?.textContent === 'symbolic link') {
 		const line = select('.js-file-line')!;
-		wrap(line.firstChild!, <a href={line.textContent!} data-pjax="#repo-content-pjax-container"/>);
+		wrap(line.firstChild!, <a href={line.textContent!}/>);
 	}
 }
 

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 function init(): void {
 	if (select('.file-mode')?.textContent === 'symbolic link') {
 		const line = select('.js-file-line')!;
-		wrap(line.firstChild!, <a href={line.textContent!}/>);
+		wrap(line.firstChild!, <a href={line.textContent!} data-turbo-frame="repo-content-turbo-frame"/>);
 	}
 }
 

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -37,7 +37,6 @@ function getDropdown(prs: number[]): HTMLElement {
 					<a
 						className="dropdown-item"
 						href={getPRUrl(prNumber)}
-						data-pjax="#js-repo-pjax-container"
 						data-hovercard-url={getHovercardUrl(prNumber)}
 					>
 						#{prNumber}
@@ -126,10 +125,6 @@ async function init(): Promise<void> {
 	const [prNumber] = prs; // First one or only one
 
 	const button = prs.length === 1 ? getSingleButton(prNumber) : getDropdown(prs);
-
-	if (prs.length === 1) {
-		button.dataset.pjax = '#js-repo-pjax-container';
-	}
 
 	await addAfterBranchSelector(button);
 }

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -13,7 +13,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	const getDropdownLink = (name: string, route: string): JSX.Element => {
 		const {href} = new GitHubURL(viewFile.href).assign({route});
 		return (
-			<a href={href} className="pl-5 dropdown-item btn-link" role="menuitem">
+			<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 dropdown-item btn-link" role="menuitem">
 				View {name}
 			</a>
 		);

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -13,7 +13,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	const getDropdownLink = (name: string, route: string): JSX.Element => {
 		const {href} = new GitHubURL(viewFile.href).assign({route});
 		return (
-			<a href={href} data-skip-pjax={route === 'raw'} className="pl-5 dropdown-item btn-link" role="menuitem">
+			<a href={href} className="pl-5 dropdown-item btn-link" role="menuitem">
 				View {name}
 			</a>
 		);

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -15,9 +15,9 @@ function init(): void {
 
 	select('.commit-meta > :last-child')!.append(
 		<span className="sha-block">
-			<a data-skip-pjax href={`${commitUrl}.patch`} className="sha">patch</a>
+			<a href={`${commitUrl}.patch`} className="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }
-			<a data-skip-pjax href={`${commitUrl}.diff`} className="sha">diff</a>
+			<a href={`${commitUrl}.diff`} className="sha">diff</a>
 		</span>,
 	);
 }

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -14,9 +14,9 @@ function init(): void {
 	}
 
 	select('.commit-meta > :last-child')!.append(
-		<span className="sha-block">
+		<span className="sha-block" data-turbo="false">
 			<a href={`${commitUrl}.patch`} className="sha">patch</a>
-			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }
+			{' '}
 			<a href={`${commitUrl}.diff`} className="sha">diff</a>
 		</span>,
 	);

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -32,7 +32,7 @@ async function linkifyIcon(fileIcon: Element): Promise<void> {
 		url.branch = await cachedGetDefaultBranch();
 	}
 
-	wrap(fileIcon, <a data-skip-pjax href={url.href} className="rgh-quick-file-edit"/>);
+	wrap(fileIcon, <a href={url.href} className="rgh-quick-file-edit"/>);
 	fileIcon.after(<PencilIcon/>);
 }
 

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -15,7 +15,7 @@ function createReviewLink(): Element {
 
 	return (
 		<span className="text-normal">
-			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v" data-pjax="#repo-content-pjax-container">review now</a>
+			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v">review now</a>
 		</span>
 	);
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -15,7 +15,7 @@ function createReviewLink(): Element {
 
 	return (
 		<span className="text-normal">
-			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v">review now</a>
+			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v" data-turbo-frame="repo-content-turbo-frame">review now</a>
 		</span>
 	);
 }

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -17,7 +17,7 @@ import {appendBefore, highlightTab, unhighlightTab} from '../helpers/dom-utils';
 const getCacheKey = (): string => `releases-count:${getRepo()!.nameWithOwner}`;
 
 async function parseCountFromDom(): Promise<number> {
-	const moreReleasesCountElement = await elementReady('.repository-content .file-navigation [href$="/tags"] strong');
+	const moreReleasesCountElement = await elementReady('.file-navigation [href$="/tags"] strong');
 	if (moreReleasesCountElement) {
 		return looseParseInt(moreReleasesCountElement);
 	}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -17,7 +17,7 @@ import {appendBefore, highlightTab, unhighlightTab} from '../helpers/dom-utils';
 const getCacheKey = (): string => `releases-count:${getRepo()!.nameWithOwner}`;
 
 async function parseCountFromDom(): Promise<number> {
-	const moreReleasesCountElement = await elementReady('.file-navigation [href$="/tags"] strong');
+	const moreReleasesCountElement = await elementReady('.file-navigation .octicon-tag + strong');
 	if (moreReleasesCountElement) {
 		return looseParseInt(moreReleasesCountElement);
 	}

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -110,8 +110,8 @@ async function init(): Promise<void> {
 		? fresh[Math.floor(Math.random() * fresh.length)]
 		: <><strong>{value}</strong> {unit} old</>;
 
-	const sidebarAboutSection = await elementReady('.repository-content .BorderGrid-cell');
-	sidebarAboutSection!.append(
+	const sidebarForksLinkIcon = await elementReady('.BorderGrid .octicon-repo-forked');
+	sidebarForksLinkIcon!.closest('.mt-2')!.append(
 		<h3 className="sr-only">Repository age</h3>,
 		<div className="mt-2">
 			<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -11,6 +11,7 @@ async function init(): Promise<void> {
 		<a
 			hidden
 			data-hotkey="t"
+			data-turbo-frame="repo-content-turbo-frame"
 			href={buildRepoURL('find', getCurrentCommittish() ?? await getDefaultBranch())}
 		/>,
 	);

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -11,7 +11,6 @@ async function init(): Promise<void> {
 		<a
 			hidden
 			data-hotkey="t"
-			data-pjax="#js-repo-pjax-container"
 			href={buildRepoURL('find', getCurrentCommittish() ?? await getDefaultBranch())}
 		/>,
 	);

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -48,10 +48,10 @@ async function init(): Promise<void | false> {
 					{ /* eslint-disable-next-line react/no-danger */ }
 					<div dangerouslySetInnerHTML={{__html: feature.description}} className="text-bold"/>
 					<div className="no-wrap">
-						<a href={conversationsUrl.href} data-pjax="#repo-content-pjax-container">Conversations</a>
+						<a href={conversationsUrl.href}>Conversations</a>
 						{
 							location.pathname.endsWith('css')
-								? <> • <a href={location.pathname.replace('.css', '.tsx')} data-pjax="#repo-content-pjax-container">See JavaScript</a></>
+								? <> • <a href={location.pathname.replace('.css', '.tsx')}>See JavaScript</a></>
 								: undefined
 						}
 					</div>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -47,8 +47,8 @@ async function init(): Promise<void | false> {
 				<div className={'flex-auto' + (feature.screenshot ? ' ml-3' : '')}>
 					{ /* eslint-disable-next-line react/no-danger */ }
 					<div dangerouslySetInnerHTML={{__html: feature.description}} className="text-bold"/>
-					<div className="no-wrap">
-						<a href={conversationsUrl.href}>Conversations</a>
+					<div className="no-wrap" data-turbo-frame="repo-content-turbo-frame">
+						<a href={conversationsUrl.href}>Related issues</a>
 						{
 							location.pathname.endsWith('css')
 								? <> • <a href={location.pathname.replace('.css', '.tsx')}>See JavaScript</a></>

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -31,7 +31,6 @@ function linkifyFeature(possibleFeature: HTMLElement): void {
 			<a
 				className="color-fg-accent"
 				href={href}
-				data-pjax="#repo-content-pjax-container"
 			/>,
 		);
 	}

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -30,6 +30,7 @@ function linkifyFeature(possibleFeature: HTMLElement): void {
 			possibleFeature,
 			<a
 				className="color-fg-accent"
+				data-turbo-frame="repo-content-turbo-frame"
 				href={href}
 			/>,
 		);

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -3,10 +3,9 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 
-function init(): void | false {
-	for (const author of select.all('#repo-content-pjax-container .js-navigation-container a.commit-author')) {
+function init(): void {
+	for (const author of select.all('.js-navigation-container a.commit-author')) {
 		author.pathname = location.pathname;
-		author.dataset.pjax = '#repo-content-pjax-container';
 	}
 }
 
@@ -14,6 +13,5 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoCommitList,
 	],
-	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/submission-via-ctrl-enter-everywhere.tsx
+++ b/source/features/submission-via-ctrl-enter-everywhere.tsx
@@ -20,6 +20,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isBlank,
 	],
-	deduplicate: 'has-rgh',
 	init: addQuickSubmit,
 });

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -20,7 +20,7 @@ function init(): void {
 
 	const icon = select('.range-editor .octicon-arrow-left')!;
 	icon.parentElement!.attributes['aria-label'].value += '.\nClick to swap.';
-	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
+	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))} data-turbo-frame="repo-content-turbo-frame"/>);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -20,7 +20,7 @@ function init(): void {
 
 	const icon = select('.range-editor .octicon-arrow-left')!;
 	icon.parentElement!.attributes['aria-label'].value += '.\nClick to swap.';
-	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))} data-pjax="#repo-content-pjax-container"/>);
+	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -38,7 +38,7 @@ async function init(): Promise<void | false> {
 function createBannerLink(): JSX.Element {
 	// It must return an element for `attachElement`. It includes a space
 	return (
-		<span> You can use <a href={getUrl()} target="_blank" rel="noreferrer">useful-forks.github.io</a></span>
+		<span> You can use <a href={getUrl()}>useful-forks.github.io</a></span>
 	);
 }
 

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -22,10 +22,13 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const selector = pageDetect.isRepoForksList() ? '#network' : '#repo-content-pjax-container h2';
+	const selector = [
+		'#network', // `isRepoForksList`
+		'.Subhead-heading', // `isRepoNetworkGraph`
+	].join(', ');
 	const container = await elementReady(selector, {waitForChildren: false});
 	container!.prepend(
-		<a className="btn mb-2 float-right" href={getUrl()} target="_blank" rel="noreferrer">
+		<a className="btn mb-2 float-right" href={getUrl()}>
 			<RepoForkedIcon className="mr-2"/>
 			Find useful forks
 		</a>,

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import {GlobeIcon} from '@primer/octicons-react';
+import {LinkIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
@@ -19,7 +19,7 @@ function init(): void {
 			className="rgh-last-deployment btn btn-sm d-none d-md-block mr-1"
 			href={href}
 		>
-			<GlobeIcon className="mr-1"/> View deployment
+			<LinkIcon className="mr-1"/> View deployment
 		</a>,
 	);
 }

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -12,7 +12,6 @@ import './features/pr-approvals-count.css';
 import './features/clean-conversations.css';
 import './features/sticky-conversation-list-toolbar.css';
 import './features/always-show-branch-delete-buttons.css';
-import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
 import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5751#issuecomment-1275907968

The `#js-repo-pjax-container` continues to exist though

Untested