### PR TITLE
Open RGH links in current tab unless we're on a form

### DIFF
--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import {LinkExternalIcon} from '@primer/octicons-react';
+import {GlobeIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager';
 import {getRepo} from '../github-helpers';
@@ -12,7 +12,7 @@ function getLinkToGitHubIo(repoTitle: HTMLElement, className?: string): JSX.Elem
 			href={`https://${repoTitle.textContent!.trim()}`}
 			className={className}
 		>
-			<LinkExternalIcon className="v-align-middle"/>
+			<GlobeIcon className="v-align-middle"/>
 		</a>
 	);
 }

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -10,8 +10,6 @@ function getLinkToGitHubIo(repoTitle: HTMLElement, className?: string): JSX.Elem
 	return (
 		<a
 			href={`https://${repoTitle.textContent!.trim()}`}
-			target="_blank"
-			rel="noopener noreferrer"
 			className={className}
 		>
 			<LinkExternalIcon className="v-align-middle"/>

--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -35,7 +35,7 @@ async function init(): Promise<void | false> {
 function createBannerLink(): JSX.Element {
 	// It must return an element for `attachElement`. It includes a space
 	return (
-		<span> You can use <a href={getUrl()} target="_blank" rel="noreferrer">useful-forks.github.io</a></span>
+		<span> You can use <a href={getUrl()}>useful-forks.github.io</a></span>
 	);
 }
 

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -18,8 +18,6 @@ function init(): void {
 		<a
 			className="rgh-last-deployment btn btn-sm d-none d-md-block mr-1"
 			href={href}
-			target="_blank"
-			rel="noreferrer"
 		>
 			<LinkExternalIcon className="mr-1"/> View deployment
 		</a>,

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import {LinkExternalIcon} from '@primer/octicons-react';
+import {GlobeIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
@@ -19,7 +19,7 @@ function init(): void {
 			className="rgh-last-deployment btn btn-sm d-none d-md-block mr-1"
 			href={href}
 		>
-			<LinkExternalIcon className="mr-1"/> View deployment
+			<GlobeIcon className="mr-1"/> View deployment
 		</a>,
 	);
 }


### PR DESCRIPTION
GitHub always opens links in the current tab. The only exception should be for situations where following a link results in loss of data (comments, WIP commits, etc)