### PR TITLE
Don't run `html-preview-link` on private repos

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -22,6 +22,9 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		pageDetect.isPublicRepo,
+	],
 	include: [
 		isSingleHTMLFile,
 	],


### PR DESCRIPTION
- Related to https://github.com/refined-github/refined-github/pull/3305#issuecomment-1277193028


## Test URLs

- HTML file on a private repo, e.g. https://github.com/refined-github/refined-github/blob/main/source/options.html 
