### PR TITLE
Hide wiki events in `hide-newsfeed-noise`

### DIFF
--- a/source/features/hide-newsfeed-noise.css
+++ b/source/features/hide-newsfeed-noise.css
@@ -6,6 +6,7 @@ added someone as a collaborator
 forked a repo
 followed someone
 published a release
+edited a gollum (wiki)
 */
 
 /* TODO: Revert `classes` #6072 */

--- a/source/features/hide-newsfeed-noise.css
+++ b/source/features/hide-newsfeed-noise.css
@@ -14,8 +14,9 @@ published a release
 [classes~='fork'],
 [classes~='delete'],
 [classes~='follow'],
-[classes~='release']
+[classes~='release'],
+[classes~='gollum']
 ),
-.rgh-hide-newsfeed-noise .news :is(.push, .fork, .delete, .follow, .release) {
+.rgh-hide-newsfeed-noise .news :is(.push, .fork, .delete, .follow, .release, .gollum) {
 	display: none !important;
 }


### PR DESCRIPTION
Closes #5809

This PR adds gollum (wiki)  to hide target on newsfeed.
GitHub uses [gollum](https://github.com/gollum/gollum) for wiki. 


## Test URLs
https://github.com (newsfeed)

## Screenshot
I took a screenshot almost same time.

### Before
There are edited wiki events on feed.
![Screen Shot 2022-10-15 at 14 03 02](https://user-images.githubusercontent.com/38400669/195970081-87490180-a730-487b-9326-7a13b67236ce.png)


### After
This PR hides the edited wiki events.
![Screen Shot 2022-10-15 at 14 02 27](https://user-images.githubusercontent.com/38400669/195970065-0be1b41f-3eae-4c57-a55e-6cb4a5dbb222.png)
