### PR TITLE
Reduce `table-input` CPU usage thanks to :has selector

### DIFF
--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -6,6 +6,10 @@
 	grid-template: repeat(5, 20px) / repeat(5, 20px);
 }
 
+.rgh-table-input .sentinel { /* 🤷‍♂️ */
+	display: none;
+}
+
 :root .rgh-tic {
 	padding: 1px;
 }
@@ -24,11 +28,11 @@
 }
 
 .rgh-tic:hover div,
-.rgh-tic:is(:nth-child(5n+1)):has(~ :hover:nth-child(5n+1)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2)):has(~ :hover:nth-child(5n+2)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3)):has(~ :hover:nth-child(5n+3)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4)):has(~ :hover:nth-child(5n+4)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4), :nth-child(5n+5)):has(~ :hover:nth-child(5n+5)) div {
+.rgh-tic:is(:nth-of-type(5n+1)):has(~ :hover:nth-of-type(5n+1)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2)):has(~ :hover:nth-of-type(5n+2)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3)):has(~ :hover:nth-of-type(5n+3)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4)):has(~ :hover:nth-of-type(5n+4)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4), :nth-of-type(5n+5)):has(~ :hover:nth-of-type(5n+5)) div {
 	border-color: #79b8ff;
 	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
 }

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -6,18 +6,29 @@
 	grid-template: repeat(5, 20px) / repeat(5, 20px);
 }
 
-:root .rgh-table-input-cell {
+:root .rgh-tic {
 	padding: 1px;
 }
 
-.rgh-table-input-cell div {
+.rgh-tic div {
 	width: 18px;
 	height: 18px;
 	border: 2px solid var(--rgh-border-color);
 	border-radius: 2px;
 }
 
+/** TODO: Drop JS-based version after :has() has full support */
 .rgh-table-input:hover .selected div {
+	border-color: #79b8ff;
+	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
+}
+
+.rgh-tic:hover div,
+.rgh-tic:is(:nth-child(5n+1)):has(~ :hover:nth-child(5n+1)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2)):has(~ :hover:nth-child(5n+2)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3)):has(~ :hover:nth-child(5n+3)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4)):has(~ :hover:nth-child(5n+4)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4), :nth-child(5n+5)):has(~ :hover:nth-child(5n+5)) div {
 	border-color: #79b8ff;
 	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
 }

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -6,10 +6,6 @@
 	grid-template: repeat(5, 20px) / repeat(5, 20px);
 }
 
-.rgh-table-input .sentinel { /* 🤷‍♂️ */
-	display: none;
-}
-
 :root .rgh-tic {
 	padding: 1px;
 }
@@ -28,11 +24,11 @@
 }
 
 .rgh-tic:hover div,
-.rgh-tic:is(:nth-of-type(5n+1)):has(~ :hover:nth-of-type(5n+1)) div,
-.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2)):has(~ :hover:nth-of-type(5n+2)) div,
-.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3)):has(~ :hover:nth-of-type(5n+3)) div,
-.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4)):has(~ :hover:nth-of-type(5n+4)) div,
-.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4), :nth-of-type(5n+5)):has(~ :hover:nth-of-type(5n+5)) div {
+.rgh-tic:is(:nth-child(5n+1)):has(~ :hover:nth-child(5n+1)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2)):has(~ :hover:nth-child(5n+2)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3)):has(~ :hover:nth-child(5n+3)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4)):has(~ :hover:nth-child(5n+4)) div,
+.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4), :nth-child(5n+5)):has(~ :hover:nth-child(5n+5)) div {
 	border-color: #79b8ff;
 	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
 }

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -8,6 +8,7 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../feature-manager';
 import smartBlockWrap from '../helpers/smart-block-wrap';
 import observe from '../helpers/selector-observer';
+import { isHasSelectorSupported } from '../helpers/select-has';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #5303 */
@@ -55,7 +56,7 @@ function addButtons(signal: AbortSignal): void {
 						<button
 							type="button"
 							role="menuitem"
-							className="rgh-table-input-cell btn-link"
+							className="rgh-tic btn-link"
 							data-x={(index % 5) + 1}
 							data-y={Math.floor(index / 5) + 1}
 						>
@@ -70,8 +71,10 @@ function addButtons(signal: AbortSignal): void {
 
 function init(signal: AbortSignal): void {
 	addButtons(signal);
-	delegate(document, '.rgh-table-input-cell', 'click', addTable, {signal});
-	delegate(document, '.rgh-table-input-cell', 'mouseenter', highlightSquares, {capture: true, signal});
+	delegate(document, '.rgh-tic', 'click', addTable, {signal});
+	if (!isHasSelectorSupported) {
+		delegate(document, '.rgh-tic', 'mouseenter', highlightSquares, {capture: true, signal});
+	}
 }
 
 void features.add(import.meta.url, {

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -8,7 +8,7 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../feature-manager';
 import smartBlockWrap from '../helpers/smart-block-wrap';
 import observe from '../helpers/selector-observer';
-import { isHasSelectorSupported } from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #5303 */

--- a/source/helpers/select-has.ts
+++ b/source/helpers/select-has.ts
@@ -1,6 +1,6 @@
 import {ParseSelector} from 'typed-query-selector/parser';
 
-export const isHasSelectorSupported = CSS.supports('selector(:has(a))');
+export const isHasSelectorSupported = globalThis.CSS?.supports('selector(:has(a))');
 
 // Adapted from https://stackoverflow.com/a/35271017/288906
 const hasSelectorRegex = /:has\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/;

--- a/source/helpers/select-has.ts
+++ b/source/helpers/select-has.ts
@@ -1,5 +1,7 @@
 import {ParseSelector} from 'typed-query-selector/parser';
 
+export const isHasSelectorSupported = CSS.supports('selector(:has(a))');
+
 // Adapted from https://stackoverflow.com/a/35271017/288906
 const hasSelectorRegex = /:has\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/;
 


### PR DESCRIPTION
- Related to #5797 

`mouseenter` events are triggered hundreds of times just by moving the mouse across the page, whether you’re using `table-input` or not; `delegate` will call `querySelector` in each event to determine whether to call our callback on the specific events we want.


Thankfully `:has` again comes to the rescue, even though the code is awful. I implemented this in a way to preserve backwards compatibility.


## Test URLs

This page

## Screenshot

![gif](https://user-images.githubusercontent.com/1402241/196026786-6a0c1f28-52cc-401c-ad1f-bd78b2342dd4.gif)

