### PR TITLE
Expand all PR/issue comments

### DIFF
--- a/source/features/pr-expand-comments.tsx
+++ b/source/features/pr-expand-comments.tsx
@@ -1,0 +1,39 @@
+import * as pageDetect from 'github-url-detection';
+import select from 'select-dom';
+import features from '../feature-manager';
+
+async function selectAndClickLoadMoreBtns(): Promise<boolean> {
+    const buttons: HTMLButtonElement[] = select.all('.ajax-pagination-btn[data-disable-with="Loading…"]');
+    if(!buttons || buttons.length === 0) {
+        return false; // no more buttons
+    }
+
+    await Promise.all(buttons.map(async (button) => {
+        button.click();
+
+        while (button.disabled) {
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+    }));
+
+    return true; // more buttons
+}
+
+async function loadComments(): Promise<void> {
+    let loadMoreBtns = true;
+    while (loadMoreBtns) {
+        loadMoreBtns = await selectAndClickLoadMoreBtns();
+    }
+}
+
+function init(): void {
+    loadComments();
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPR,
+        pageDetect.isIssue,
+	],
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -217,3 +217,4 @@ import './features/submission-via-ctrl-enter-everywhere';
 import './features/linkify-user-labels';
 import './features/repo-avatars';
 import './features/jump-to-conversation-close-event';
+import './features/pr-expand-comments';


### PR DESCRIPTION
This PR adds a feature to expand all the comments of a PR or an issue by clicking repeatedly on the "Load more..." buttons.

![image](https://user-images.githubusercontent.com/22493292/196756522-be9afe1f-b975-4906-8244-312959cc063e.png)

This is very annoying to do manually on large pulls because the "Load more..." button's position jumps when clicked.

Can be tested on large PRs or issues.
https://github.com/bitcoin/bitcoin/pulls?q=is%3Apr+sort%3Acomments-desc+
https://github.com/bitcoin/bitcoin/issues?q=is%3Aissue+sort%3Acomments-desc+

