### PR TITLE
Make sticky left-side sidebar scrollable on the dashboard

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -15,11 +15,9 @@
 
 #merge_title_field,
 #commit-summary-input, /* Restore monospace font in commit/merge title fields #5188 */
-:is(.new_public_key, .new_gpg_key) textarea {
-	/* Monospace textareas for new SSH/GPG keys #4917 */
+:is(.new_public_key, .new_gpg_key) textarea { /* Monospace textareas for new SSH/GPG keys #4917 */
 	/* Same as GitHub style for `code` */
-	font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-		"Liberation Mono", monospace !important;
+	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace !important;
 }
 
 /* Limit width of comment form on commit pages #5032 */
@@ -43,14 +41,11 @@
 }
 
 /* Fix alignment of "Allow edits by maintainers" checkbox label and icons #5510 */
-#partial-discussion-sidebar
-	.discussion-sidebar-item:last-child
-	> .d-inline-flex {
+#partial-discussion-sidebar .discussion-sidebar-item:last-child > .d-inline-flex {
 	align-items: center !important;
 }
 
-#partial-discussion-sidebar
-	:is(.js-collab-option input, .js-collab-form + details summary) {
+#partial-discussion-sidebar :is(.js-collab-option input, .js-collab-form + details summary) {
 	margin-top: 0 !important;
 }
 
@@ -67,6 +62,7 @@
 .dashboard-sidebar {
 	overflow: auto;
 }
+
 #dashboard-user-teams {
 	padding-bottom: 32px;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -58,7 +58,7 @@
 	margin-right: 4px !important;
 }
 
-/* Add scrollbar to show cut-off content in left side section of homepage */
+/* Add scrollbar to show cut-off content in left side section of homepage #6099 */
 .dashboard-sidebar {
 	overflow: auto;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -15,9 +15,11 @@
 
 #merge_title_field,
 #commit-summary-input, /* Restore monospace font in commit/merge title fields #5188 */
-:is(.new_public_key, .new_gpg_key) textarea { /* Monospace textareas for new SSH/GPG keys #4917 */
+:is(.new_public_key, .new_gpg_key) textarea {
+	/* Monospace textareas for new SSH/GPG keys #4917 */
 	/* Same as GitHub style for `code` */
-	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace !important;
+	font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+		"Liberation Mono", monospace !important;
 }
 
 /* Limit width of comment form on commit pages #5032 */
@@ -41,11 +43,14 @@
 }
 
 /* Fix alignment of "Allow edits by maintainers" checkbox label and icons #5510 */
-#partial-discussion-sidebar .discussion-sidebar-item:last-child > .d-inline-flex {
+#partial-discussion-sidebar
+	.discussion-sidebar-item:last-child
+	> .d-inline-flex {
 	align-items: center !important;
 }
 
-#partial-discussion-sidebar :is(.js-collab-option input, .js-collab-form + details summary) {
+#partial-discussion-sidebar
+	:is(.js-collab-option input, .js-collab-form + details summary) {
 	margin-top: 0 !important;
 }
 
@@ -56,4 +61,12 @@
 /* Fix spacing of repo header button icons #5620 */
 .pagehead-actions :is(.btn, summary) .octicon {
 	margin-right: 4px !important;
+}
+
+/* Add scrollbar to show cut-off content in left side section of homepage */
+.dashboard-sidebar {
+	overflow: auto;
+}
+#dashboard-user-teams {
+	padding-bottom: 32px;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -58,11 +58,13 @@
 	margin-right: 4px !important;
 }
 
-/* Add scrollbar to show cut-off content in left side section of homepage #6099 */
+/* Make sticky left-side sidebar scrollable on the dashboard #6099 */
 .dashboard-sidebar {
 	overflow: auto;
+	padding-bottom: 32px;
 }
 
-#dashboard-user-teams {
-	padding-bottom: 32px;
+/* Make sticky left-side sidebar scrollable on the dashboard: Also enables padding-bottom */
+.dashboard-sidebar .loading-context {
+	min-height: initial !important;
 }


### PR DESCRIPTION
Fixes #6099 
- Added scrollbar
![image](https://user-images.githubusercontent.com/54069197/197395421-be32ec49-f032-44c3-a8da-5541be2e7bc5.png)

- Added some padding at the bottom of the sidebar to match the padding at top of sidebar
![image](https://user-images.githubusercontent.com/54069197/197395451-20c4826e-5ff4-4e30-8f47-fb966faf1540.png)
