### PR TITLE
`preview-hidden-comments` even if reason is missing

### DIFF
--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -16,7 +16,7 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	if (commentText.length === 0) {
 		return;
 	}
-	
+
 	const commentHeader = hiddenCommentHeader.textContent!;
 	if (/disruptive|spam/.test(commentHeader)) {
 		return;

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -16,13 +16,14 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	if (commentText.length === 0) {
 		return;
 	}
-
-	const reason = /duplicate|outdated|off-topic|hidden/.exec(hiddenCommentHeader.textContent!)?.[0];
-	const hide = /disruptive|spam/.exec(hiddenCommentHeader.textContent!)?.[0];
-	if (hide) {
+	
+	const commentHeader = hiddenCommentHeader.textContent!;
+	if (/disruptive|spam/.test(commentHeader)) {
 		return;
 	}
 
+	// The reason is missing/lost in some cases
+	const reason = /duplicate|outdated|off-topic|hidden/.exec(commentHeader)?.[0];
 	hiddenCommentHeader.classList.add('css-truncate', 'css-truncate-overflow', 'mr-2');
 	hiddenCommentHeader.append(
 		<span className="Details-content--open">{hiddenCommentHeader.firstChild}</span>,

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -18,15 +18,12 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	}
 
 	const reason = /duplicate|outdated|off-topic|hidden/.exec(hiddenCommentHeader.textContent!)?.[0];
-	if (!reason) {
-		return;
-	}
 
 	hiddenCommentHeader.classList.add('css-truncate', 'css-truncate-overflow', 'mr-2');
 	hiddenCommentHeader.append(
 		<span className="Details-content--open">{hiddenCommentHeader.firstChild}</span>,
 		<span className="Details-content--closed">
-			<span className="Label mr-2">{upperCaseFirst(reason)}</span>{commentText.slice(0, 100)}
+			{reason && <span className="Label mr-2">{upperCaseFirst(reason)}</span>}{commentText.slice(0, 100)}
 		</span>,
 	);
 }

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -18,6 +18,10 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	}
 
 	const reason = /duplicate|outdated|off-topic|hidden/.exec(hiddenCommentHeader.textContent!)?.[0];
+	const hide = /disruptive|spam/.exec(hiddenCommentHeader.textContent!)?.[0];
+	if (hide) {
+        return;
+	}
 
 	hiddenCommentHeader.classList.add('css-truncate', 'css-truncate-overflow', 'mr-2');
 	hiddenCommentHeader.append(

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -20,7 +20,7 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	const reason = /duplicate|outdated|off-topic|hidden/.exec(hiddenCommentHeader.textContent!)?.[0];
 	const hide = /disruptive|spam/.exec(hiddenCommentHeader.textContent!)?.[0];
 	if (hide) {
-        return;
+		return;
 	}
 
 	hiddenCommentHeader.classList.add('css-truncate', 'css-truncate-overflow', 'mr-2');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #6098

* Write label only if reason exists
* Write comment in all cases (previously would only write if a reason existed)
* Keep comment hidden if disruptive or spam (only if reason exists)

## Test URLs

https://github.com/refined-github/refined-github/issues/3647

https://github.com/refined-github/sandbox/pull/47

## Screenshot

Comment with missing reason:

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/58778985/198177000-644c1b94-042e-4c24-a137-5be801f0b5dd.png)|![image](https://user-images.githubusercontent.com/58778985/198408331-14fb93f9-47c7-4ff8-a176-bf5ec55c5c7d.png)|

Comment with reason:

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/58778985/198177262-3cc097bc-e774-4c16-ba36-2e3280ab6559.png)|![image](https://user-images.githubusercontent.com/58778985/198408903-a034439f-4382-4bb7-a310-066e61faedba.png)|