### PR TITLE
Restore `scheduled-and-manual-workflow-indicators`

### DIFF
--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -61,8 +61,8 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
-	const workflowsSidebar = await elementReady('.Layout-sidebar');
-	for (const workflowListItem of select.all('a.filter-item[href*="/workflows/"]', workflowsSidebar)) {
+	const workflowsSidebar = await elementReady('.ActionList');
+	for (const workflowListItem of select.all('a.ActionList-content[href*="/workflows/"]', workflowsSidebar)) {
 		if (select.exists('.octicon-stop', workflowListItem)) {
 			continue;
 		}
@@ -75,10 +75,10 @@ async function init(): Promise<false | void> {
 
 		const tooltip: string[] = [];
 		if (workflow.manuallyDispatchable) {
-			workflowListItem.append(<PlayIcon className="ml-1"/>);
+			workflowListItem.append(<PlayIcon className="ActionListItem-visual--trailing m-auto"/>);
+			workflowListItem.classList.add('tooltipped', 'tooltipped-s');
+			workflowListItem.setAttribute('aria-label', tooltip.join('\n'));
 			tooltip.push('This workflow can be triggered manually');
-			workflowListItem.parentElement!.classList.add('tooltipped', 'tooltipped-e');
-			workflowListItem.parentElement!.setAttribute('aria-label', tooltip.join('\n'));
 		}
 
 		if (workflow.schedule) {

--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -116,3 +116,15 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+## Test URLs
+
+Manual:
+https://github.com/fregante/browser-extension-template/actions
+
+Manual + scheduled:
+https://github.com/fregante/eslint-formatters/actions
+
+*/


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6111



## Test URLs

Manual:
https://github.com/fregante/browser-extension-template/actions

Manual + scheduled:
https://github.com/fregante/eslint-formatters/actions 

## Screenshot
<img width="244" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/200111187-7c72e0f1-a765-4342-8fb4-c5c6a96d08c7.png"> <img width="303" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/200111899-fe97f58b-826a-48b9-8d9d-a166db22e448.png">

