### PR TITLE
Drop incorrect link added by `infinite-scroll`

### DIFF
--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -35,8 +35,7 @@ function init(signal: AbortSignal): void {
 		inView.observe(button);
 	}, {signal});
 
-	// Use cloneNode to keep the original ones for responsive layout
-	const feedLink = select('.news a.f6')!.cloneNode(true);
+	// Copy the footer links to the sidebar to make them more accessible. Also keep a copy in the footer.
 	const footer = select('.footer > .d-flex')!.cloneNode(true);
 
 	for (const child of footer.children) {
@@ -45,9 +44,6 @@ function init(signal: AbortSignal): void {
 
 	select('[aria-label="Explore"]')!.append(
 		<div className="footer">
-			<div>
-				{feedLink}
-			</div>
 			{footer}
 		</div>,
 	);


### PR DESCRIPTION
 - Fixes https://github.com/refined-github/refined-github/issues/6100

The intent of https://github.com/refined-github/refined-github/pull/5319 was to copy the RSS feed link, but the broad selector sometimes picked the wrong link (I even saw an issue link appear there)

This is what it looks like when it works correctly:

<img width="497" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/200112245-841f9149-6696-4eb0-ad51-3c5fa1ae15c7.png">


Since the RSS isn't something people generally look for at every load, it's ok to leave it at the bottom of the feed.

## Test URLs

https://github.com