### PR TITLE
Fix overflow caused by `patch-diff-links`

### DIFF
--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -13,7 +13,9 @@ function init(): void {
 		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
 	}
 
-	select('.commit-meta > :last-child')!.append(
+	const commitMeta = select('.commit-meta')!;
+	commitMeta.classList.remove('no-wrap'); // #5987
+	commitMeta.lastElementChild!.append(
 		<span className="sha-block" data-turbo="false">
 			<a href={`${commitUrl}.patch`} className="sha">patch</a>
 			{' '}


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5987

## Test URLs

[`05b7ccd` (#5807)](https://github.com/refined-github/refined-github/pull/5807/commits/05b7ccda4335b5927531d3c58a535548bbd74b64)

## Screenshot



<img width="307" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/200114832-5a3f31fc-a902-4ddd-9cbb-d1ee7a3f698e.png">
