### PR TITLE
Cleanup and extend `pagination-hotkey`

### DIFF
--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -4,26 +4,22 @@ import observe from '../helpers/selector-observer';
 import features from '../feature-manager';
 import {addHotkey} from '../github-helpers/hotkey';
 
-const nextPageButtonSelectors = [
-	'a.next_page', // Issue/PR list, Search, Releases
-	'a.paginate-container [aria-label="Next"]', // Notifications
-	'a.paginate-container > .BtnGroup > :last-child', // Commits
-	'a.prh-commit > .BtnGroup > :last-child', // PR Commits
+const previous = [
+	'a[rel="prev"]', // `isIssueOrPRList`, `isGlobalSearchResults`, `isReleases`, `isUserProfileRepoTab`, `isDiscussionList`
+	'.paginate-container a.BtnGroup-item:first-child', // `isRepoCommitList`, `isNotifications`
+	'.prh-commit a.BtnGroup-item:first-child', // `isPRCommit`
 ] as const;
 
-const previousPageButtonSelectors = [
-	'a.previous_page', // Issue/PR list, Search, Releases
-	'a.paginate-container [aria-label="Previous"]', // Notifications
-	'a.paginate-container > .BtnGroup > :first-child', // Commits
-	'a.prh-commit > .BtnGroup > :first-child', // PR Commits
-] as const;
+const next = previous.join(',')
+	.replaceAll('"prev"', '"next"')
+	.replaceAll(':first', ':last') as 'a';
 
 function init(signal: AbortSignal): void {
-	observe(nextPageButtonSelectors, button => {
-		addHotkey(button, 'ArrowRight');
-	}, {signal});
-	observe(previousPageButtonSelectors, button => {
+	observe(previous, button => {
 		addHotkey(button, 'ArrowLeft');
+	}, {signal});
+	observe(next, button => {
+		addHotkey(button, 'ArrowRight');
 	}, {signal});
 }
 
@@ -32,7 +28,6 @@ void features.add(import.meta.url, {
 		'→': 'Go to the next page',
 		'←': 'Go to the previous page',
 	},
-	// TODO: enable for isDiscussionList after #4695 is fixed
 	include: [
 		pageDetect.isIssueOrPRList,
 		pageDetect.isGlobalSearchResults,
@@ -40,6 +35,8 @@ void features.add(import.meta.url, {
 		pageDetect.isNotifications,
 		pageDetect.isRepoCommitList,
 		pageDetect.isPRCommit,
+		pageDetect.isDiscussionList,
+		pageDetect.isReleases,
 		pageDetect.isUserProfileRepoTab,
 	],
 	init,
@@ -51,6 +48,7 @@ void features.add(import.meta.url, {
 
 PR Commit: https://github.com/refined-github/refined-github/pull/4677/commits/1e1e0707ac58d1a40543a92651c3bbfd113481bf
 Releases: https://github.com/refined-github/refined-github/releases
-Search: https://github.com/refined-github/refined-github/search?q=pull
 Issues: https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+Repo Search: https://github.com/refined-github/refined-github/search?q=pull
+Global search: https://github.com/search?q=wonder&type=repositories
 */

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -1,28 +1,30 @@
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
+import observe from '../helpers/selector-observer';
 import features from '../feature-manager';
 import {addHotkey} from '../github-helpers/hotkey';
 
 const nextPageButtonSelectors = [
-	'a.next_page', // Issue/PR list, Search
-	'.paginate-container.BtnGroup > :last-child', // Notifications
-	'.paginate-container > .BtnGroup > :last-child', // Commits
-	'.paginate-container > .pagination > :last-child', // Releases
-	'.prh-commit > .BtnGroup > :last-child', // PR Commits
-];
+	'a.next_page', // Issue/PR list, Search, Releases
+	'a.paginate-container [aria-label="Next"]', // Notifications
+	'a.paginate-container > .BtnGroup > :last-child', // Commits
+	'a.prh-commit > .BtnGroup > :last-child', // PR Commits
+] as const;
 
 const previousPageButtonSelectors = [
-	'a.previous_page', // Issue/PR list, Search
-	'.paginate-container.BtnGroup > :first-child', // Notifications
-	'.paginate-container > .BtnGroup > :first-child', // Commits
-	'.paginate-container > .pagination > :first-child', // Releases
-	'.prh-commit > .BtnGroup > :first-child', // PR Commits
-];
+	'a.previous_page', // Issue/PR list, Search, Releases
+	'a.paginate-container [aria-label="Previous"]', // Notifications
+	'a.paginate-container > .BtnGroup > :first-child', // Commits
+	'a.prh-commit > .BtnGroup > :first-child', // PR Commits
+] as const;
 
-function init(): void {
-	addHotkey(select(nextPageButtonSelectors), 'ArrowRight');
-	addHotkey(select(previousPageButtonSelectors), 'ArrowLeft');
+function init(signal: AbortSignal): void {
+	observe(nextPageButtonSelectors, button => {
+		addHotkey(button, 'ArrowRight');
+	}, {signal});
+	observe(previousPageButtonSelectors, button => {
+		addHotkey(button, 'ArrowLeft');
+	}, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -42,3 +44,13 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+# Test URLs
+
+PR Commit: https://github.com/refined-github/refined-github/pull/4677/commits/1e1e0707ac58d1a40543a92651c3bbfd113481bf
+Releases: https://github.com/refined-github/refined-github/releases
+Search: https://github.com/refined-github/refined-github/search?q=pull
+Issues: https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+*/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,12 @@
 		"declaration": false,
 		"esModuleInterop": true,
 		"noUncheckedIndexedAccess": false,
-		"noPropertyAccessFromIndexSignature": false
+		"noPropertyAccessFromIndexSignature": false,
+		"lib": [
+			"DOM",
+			"DOM.Iterable",
+			"ES2021"
+		],
 	},
 	"include": [
 		"source",


### PR DESCRIPTION
- Fixes #6146 
- Includes #6147


# Test URLs

PR Commit: [`1e1e070` (#4677)](https://github.com/refined-github/refined-github/pull/4677/commits/1e1e0707ac58d1a40543a92651c3bbfd113481bf)
Releases: https://github.com/refined-github/refined-github/releases
Issues: https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
Repo Search: https://github.com/refined-github/refined-github/search?q=pull
Global search: https://github.com/search?q=wonder&type=repositories

