### PR TITLE
Fix `repo-avatars` rounding in orgs

### DIFF
--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -31,10 +31,8 @@ async function init(): Promise<void> {
 
 	link.append(avatar);
 	icon.replaceWith(link);
-	
-	await pageLoaded; // For `isOrganizationRepo`
 
-	if (!pageDetect.isOrganizationRepo()) {
+	if (link.dataset.hovercardType !== 'organization') {
 		avatar.classList.add('avatar-user');
 	}
 }
@@ -47,3 +45,12 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh',
 	init,
 });
+
+/*
+
+## Test URLs
+
+- org repo: https://github.com/refined-github/refined-github
+- user repo: https://github.com/fregante/GhostText
+
+*/

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -29,12 +29,14 @@ async function init(): Promise<void> {
 		/>
 	);
 
+	link.append(avatar);
+	icon.replaceWith(link);
+	
+	await pageLoaded; // For `isOrganizationRepo`
+
 	if (!pageDetect.isOrganizationRepo()) {
 		avatar.classList.add('avatar-user');
 	}
-
-	link.append(avatar);
-	icon.replaceWith(link);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- For https://github.com/refined-github/github-url-detection/issues/152

## Test URLs

- org repo: https://github.com/refined-github/refined-github
- user repo: https://github.com/fregante/GhostText

## Before


<img width="412" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/202376370-c5a61124-b065-472d-94d1-a9c1c3df9e2d.png">



## After


<img width="412" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/202376378-b541a9bc-4b39-4325-a72d-6bdaf3097c93.png">