### PR TITLE
Improve `select-notifications` style

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -18,7 +18,6 @@ import {
 
 import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
-import attachElement from '../helpers/attach-element';
 
 const filters = {
 	'Pull requests': ':is(.octicon-git-pull-request, .octicon-git-pull-request-closed, .octicon-git-pull-request-draft, .octicon-git-merge)',
@@ -124,11 +123,11 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 
 const createDropdown = onetime(() => (
 	<details
-		className="details-reset details-overlay position-relative rgh-select-notifications ml-2"
+		className="details-reset details-overlay position-relative rgh-select-notifications mx-2"
 		onToggle={resetFilters}
 	>
 		<summary
-			className="btn btn-sm"
+			className="h6" // Match "Select all" style
 			data-hotkey="S"
 			aria-haspopup="menu"
 			role="button"
@@ -157,9 +156,7 @@ function closeDropdown(): void {
 }
 
 function addDropdown(markAllPrompt: Element): void {
-	attachElement(markAllPrompt.closest('label'), {
-		after: createDropdown,
-	});
+	markAllPrompt.closest('label')!.after(createDropdown());
 }
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
The button style feels more appropriate for actions in this case, rather than for selections. This is more clear when a notification is selected and you can tell the two types apart (select vs act)


## Test URLs

https://github.com/notifications

## Before


<img width="499" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/202380556-e195d779-2cc6-4a2b-87db-0f6609f7ec5d.png">

## After


<img width="499" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/202380550-2ae7643f-d2aa-4561-b730-ca08cb1b1896.png">

### After, open


<img width="499" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/202380527-e341175b-b0e9-4b06-b8c4-ab92af502ab8.png">

