### PR TITLE
Fix: `profile-gists-link` appears in status selection on profile

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -34,7 +34,8 @@ function getUser(): {url: string; name: string} {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe('.UnderlineNav-body', appendTab, {signal});
+	// `.Layout-main` needed for specificity #6162
+	observe('.Layout-main .UnderlineNav-body', appendTab, {signal});
 }
 
 async function appendTab(navigationBar: Element): Promise<void> {


### PR DESCRIPTION
- Fixes #6162 



## Test URLs

- your own profile, e.g. https://github.com/fregante

## Screenshot

<img width="746" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/202390065-27ef5543-e2a8-47bf-b004-069255765572.png">

