### PR TITLE
Restore `scheduled-and-manual-workflow-indicators` again

### DIFF
--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -109,6 +109,7 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
+	// Do it as soon as possible, before the page loads
 	const workflows = await getWorkflowsDetails();
 	if (!workflows) {
 		return false;
@@ -122,7 +123,6 @@ void features.add(import.meta.url, {
 		pageDetect.isRepositoryActions,
 	],
 	awaitDomReady: false,
-	deduplicate: 'has-rgh-inner',
 	init,
 });
 

--- a/source/features/scheduled-and-manual-workflow-indicators.tsx
+++ b/source/features/scheduled-and-manual-workflow-indicators.tsx
@@ -3,12 +3,12 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import {PlayIcon} from '@primer/octicons-react';
 import {parseCron} from '@cheap-glitch/mi-cron';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
 type WorkflowDetails = {
 	schedule?: string;
@@ -65,47 +65,56 @@ const getWorkflowsDetails = cache.function(async (): Promise<Record<string, Work
 	cacheKey: () => 'workflows:' + getRepo()!.nameWithOwner,
 });
 
-async function init(): Promise<false | void> {
+async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void> {
+	// Memoized above
+	const workflows = await getWorkflowsDetails();
+	if (!workflows) {
+		return; // Impossibru, for types only
+	}
+
+	if (select.exists('.octicon-stop', workflowListItem)) {
+		return;
+	}
+
+	const workflowName = workflowListItem.href.split('/').pop()!;
+	const workflow = workflows[workflowName];
+	if (!workflow) {
+		return;
+	}
+
+	if (workflow.manuallyDispatchable) {
+		workflowListItem.append(<PlayIcon className="ActionListItem-visual--trailing m-auto"/>);
+		addTooltip(workflowListItem, 'This workflow can be triggered manually');
+	}
+
+	if (!workflow.schedule) {
+		return;
+	}
+
+	const nextTime = parseCron.nextDate(workflow.schedule);
+	if (!nextTime) {
+		return;
+	}
+
+	const relativeTime = <relative-time datetime={String(nextTime)}/>;
+	select('.ActionList-item-label', workflowListItem)!.append(
+		<em>
+			(next {relativeTime})
+		</em>,
+	);
+	setTimeout(() => {
+		// The content of `relative-time` might not be immediately available
+		addTooltip(workflowListItem, 'Next run in ' + relativeTime.textContent!);
+	}, 500);
+}
+
+async function init(signal: AbortSignal): Promise<false | void> {
 	const workflows = await getWorkflowsDetails();
 	if (!workflows) {
 		return false;
 	}
 
-	const workflowsSidebar = await elementReady('.ActionList');
-	for (const workflowListItem of select.all('a.ActionList-content[href*="/workflows/"]', workflowsSidebar)) {
-		if (select.exists('.octicon-stop', workflowListItem)) {
-			continue;
-		}
-
-		const workflowName = workflowListItem.href.split('/').pop()!;
-		const workflow = workflows[workflowName];
-		if (!workflow) {
-			continue;
-		}
-
-		if (workflow.manuallyDispatchable) {
-			workflowListItem.append(<PlayIcon className="ActionListItem-visual--trailing m-auto"/>);
-			addTooltip(workflowListItem, 'This workflow can be triggered manually');
-		}
-
-		if (workflow.schedule) {
-			const nextTime = parseCron.nextDate(workflow.schedule);
-			if (!nextTime) {
-				continue;
-			}
-
-			const relativeTime = <relative-time datetime={String(nextTime)}/>;
-			select('.ActionList-item-label', workflowListItem)!.append(
-				<em>
-					(next {relativeTime})
-				</em>,
-			);
-			setTimeout(() => {
-				// The content of `relative-time` might not be immediately available
-				addTooltip(workflowListItem, 'Next run in ' + relativeTime.textContent!);
-			}, 500);
-		}
-	}
+	observe('a.ActionList-content', addIndicators, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
The most annoying thing is that I wrote and tested this just last month 

- https://github.com/refined-github/refined-github/pull/6137


## Test URLs

https://github.com/refined-github/refined-github/actions

## Screenshot

<img width="323" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/202392287-1462b350-0c51-4f8a-a763-4c5265150ce7.png">


