### PR TITLE
Restore `quick-file-edit` on new directory views

### DIFF
--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -24,7 +24,6 @@ const cachedGetDefaultBranch = mem(getDefaultBranch, cachePerPage);
 
 async function linkifyIcon(fileIcon: Element): Promise<void> {
 	const isPermalink_ = await cachedIsPermalink();
-	debugger;
 	const fileLink = fileIcon.closest('.js-navigation-item, .react-directory-filename-column')!.querySelector('a.js-navigation-open, a.Link--primary')!;
 	const url = new GitHubURL(fileLink.href).assign({
 		route: 'edit',

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -1,3 +1,5 @@
+// TODO: Drop js-navigation-item. Pre-React makeover
+
 import './quick-file-edit.css';
 import mem from 'mem';
 import React from 'dom-chef';
@@ -22,7 +24,8 @@ const cachedGetDefaultBranch = mem(getDefaultBranch, cachePerPage);
 
 async function linkifyIcon(fileIcon: Element): Promise<void> {
 	const isPermalink_ = await cachedIsPermalink();
-	const fileLink = fileIcon.closest('.js-navigation-item')!.querySelector('a.js-navigation-open')!;
+	debugger;
+	const fileLink = fileIcon.closest('.js-navigation-item, .react-directory-filename-column')!.querySelector('a.js-navigation-open, a.Link--primary')!;
 	const url = new GitHubURL(fileLink.href).assign({
 		route: 'edit',
 	});
@@ -37,7 +40,10 @@ async function linkifyIcon(fileIcon: Element): Promise<void> {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.js-navigation-container :not(a) > .octicon-file', linkifyIcon, {signal});
+	observe([
+		'.react-directory-filename-column svg.color-fg-muted',
+		'.js-navigation-container .octicon-file',
+	], linkifyIcon, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Part of https://github.com/refined-github/refined-github/issues/6152



## Test URLs

- https://github.com/refined-github/refined-github/tree/lint/safari
- https://github.com/refined-github/refined-github


## Screenshot

![gif23](https://user-images.githubusercontent.com/1402241/202396477-d5ff0724-4717-443c-970e-b342107c3ffd.gif)

