### PR TITLE
Add `unhide-reactions-on-mobile` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -258,6 +258,7 @@ Thanks for contributing! 🦋🙌
 - [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
 - [](# "linkify-user-labels") [Links the "Contributor" and "Member" labels on comments to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
 - [](# "jump-to-conversation-close-event") [Adds a link to jump to the latest close event of a conversation.](https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif)
+- [](# "unhide-reactions-on-mobile") [Unhides reactions button on mobile.](https://user-images.githubusercontent.com/38327267/205493629-14563105-eaa1-4885-9f07-8b3ee9214c86.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/unhide-reactions-on-mobile.css
+++ b/source/features/unhide-reactions-on-mobile.css
@@ -1,0 +1,3 @@
+.timeline-comment-actions > .d-none:has(.js-comment-header-reaction-button) {
+	display: inline-block !important;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -25,6 +25,7 @@ import './features/sticky-file-header.css';
 import './features/readable-title-change-events.css';
 import './features/clean-checks-list.css';
 import './features/sticky-csv-header.css';
+import './features/unhide-reactions-on-mobile.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
Closes https://github.com/refined-github/refined-github/issues/6161

## Test URLs
https://github.com/refined-github/refined-github/issues/6161

Firefox users have to set `layout.css.has-selector.enabled` to true in `about:config` (https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility).

## Screenshot
![demo](https://user-images.githubusercontent.com/38327267/205493629-14563105-eaa1-4885-9f07-8b3ee9214c86.png)


## Tested
On Google Play Store version of Firefox Nightly for Developers, version `109.0a1`.
With `npx web-ext run -t firefox-android --adb-device <use adb devices> --firefox-apk org.mozilla.fenix`