### PR TITLE
Update CSS color names

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,6 +1,6 @@
 :root {
-	--rgh-green: var(--color-fg-success, #1a7f37);
-	--rgh-red: var(--color-fg-danger, #cf222e);
+	--rgh-green: var(--color-success-fg, #1a7f37);
+	--rgh-red: var(--color-danger-fg, #cf222e);
 	--rgh-border-color: var(--color-border-muted, #d8dee4);
 	--rgh-background: var(--color-canvas-default, #fff);
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

It seems like GitHub have changed the css variables `--color-fg-success` and `--color-fg-danger` to `--color-success-fg` and `--color-danger-fg`, respectively. This fixes that so that the refined-github changes align better with the rest of the colors on the webpage. 



## Test URLs

https://github.com/cypress-io/cypress/pulls seems to have quite a few examples where this change can be seen 


## Screenshot

**Before**
<img alt="Before" src="https://user-images.githubusercontent.com/10176195/208440188-571f3dc6-918c-4a1c-997f-4b6e99ab9980.png">


**After**
<img alt="After" src="https://user-images.githubusercontent.com/10176195/208440160-a38f8bdb-36dd-448b-ae3f-3eef58f5e06d.png">


