### PR TITLE
Drop duplicate hotfix notice in the options page

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -72,17 +72,6 @@ li[data-validation] {
 	display: flex;
 }
 
-.js-hotfixes:not(:empty) {
-	margin-bottom: 15px;
-	padding: 10px 15px;
-	border: 1px solid var(--rgh-red);
-	border-radius: 0.2em;
-}
-
-.js-hotfixes p {
-	margin-bottom: 0;
-}
-
 .js-features input[type='checkbox'] {
 	flex-shrink: 0;
 }

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -203,14 +203,9 @@ async function highlightNewFeatures(): Promise<void> {
 	void browser.storage.local.set({featuresAlreadySeen});
 }
 
-async function getLocalHotfixesAsNotice(): Promise<HTMLElement> {
-	const disabledFeatures = <div className="js-hotfixes"/>;
-
+async function markLocalHotfixes(): Promise<void> {
 	for (const [feature, relatedIssue] of await getLocalHotfixes()) {
 		if (importedFeatures.includes(feature)) {
-			disabledFeatures.append(
-				<p><code>{feature}</code> has been temporarily disabled due to {createRghIssueLink(relatedIssue)}.</p>,
-			);
 			const input = select<HTMLInputElement>('#' + feature)!;
 			input.disabled = true;
 			input.removeAttribute('name');
@@ -219,8 +214,6 @@ async function getLocalHotfixesAsNotice(): Promise<HTMLElement> {
 			);
 		}
 	}
-
-	return disabledFeatures;
 }
 
 function updateRateLink(): void {
@@ -239,7 +232,7 @@ async function generateDom(): Promise<void> {
 	);
 
 	// Add notice for features disabled via hotfix
-	select('.js-features')!.before(await getLocalHotfixesAsNotice());
+	await markLocalHotfixes();
 
 	// Update list from saved options
 	await perDomainOptions.syncForm('form');


### PR DESCRIPTION
The notice is useful when the user has disabled a lot of features, because they're pushed down, but it's not essential, we already show when each feature has been disabled inline.

## Before

<img width="553" alt="Screenshot 8" src="https://user-images.githubusercontent.com/1402241/215963065-6f97b6c3-58e4-42c6-a07a-c096e8fb764b.png">

## After



<img width="553" alt="Screenshot 7" src="https://user-images.githubusercontent.com/1402241/215963087-638e7bdb-4898-4e67-aa03-6a7024e9a668.png">