### PR TITLE
Fix pagination in `last-notification-page-buttons`

### DIFF
--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -7,7 +7,7 @@ import looseParseInt from '../helpers/loose-parse-int';
 import {assertNodeContent} from '../helpers/dom-utils';
 import observe from '../helpers/selector-observer';
 
-let itemsPerNotificationsPage = 25;
+const itemsPerNotificationsPage = 25;
 
 function linkify(nextButton: HTMLAnchorElement): void {
 	const lastNotificationPageNode = select('.js-notifications-list-paginator-counts')!.lastChild!;

--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -7,11 +7,13 @@ import looseParseInt from '../helpers/loose-parse-int';
 import {assertNodeContent} from '../helpers/dom-utils';
 import observe from '../helpers/selector-observer';
 
+let itemsPerNotificationsPage = 25;
+
 function linkify(nextButton: HTMLAnchorElement): void {
 	const lastNotificationPageNode = select('.js-notifications-list-paginator-counts')!.lastChild!;
 	assertNodeContent(lastNotificationPageNode, /^of \d+$/);
 	const lastNotificationPageNumber = looseParseInt(lastNotificationPageNode);
-	const lastCursor = Math.floor(lastNotificationPageNumber / 50) * 50;
+	const lastCursor = Math.floor(lastNotificationPageNumber / itemsPerNotificationsPage) * itemsPerNotificationsPage;
 	const nextButtonSearch = new URLSearchParams(nextButton.search);
 	nextButtonSearch.set('after', btoa(`cursor:${lastCursor}`));
 	lastNotificationPageNode.replaceWith(


### PR DESCRIPTION
fixes #6218

Tested via `npx web-ext run --target=chromium` and https://github.com/notifications?query=repo%3Aprisma%2Fprisma+is%3Aunread where the problem manifested for me.
