### PR TITLE
Restore `mark-merge-commits-in-list` in PRs

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -40,8 +40,13 @@ export function getCommitHash(commit: HTMLElement): string {
 async function init(): Promise<void> {
 	const pageCommits = select.all([
 		'.js-commits-list-item', // `isCommitList`
-		'[data-test-selector="pr-timeline-commits-list"] .TimelineItem', // `isPRConversation`
+		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`, "js-timeline-item" to exclude "isCommitList"
 	].join(','));
+
+	if (pageCommits.length === 0) {
+		throw new Error('No commits found, selector likely out of date');
+	}
+
 	const mergeCommits = await filterMergeCommits(pageCommits.map(commit => getCommitHash(commit)));
 	for (const commit of pageCommits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
@@ -60,3 +65,14 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs
+
+- isPRConversation: https://github.com/refined-github/refined-github/pull/6194
+- isPRCommitList: https://github.com/refined-github/refined-github/pull/6194/commits
+- isCommitList: https://github.com/babel/babel/commits/master?after=ddd40bf5c7ad8565fc990f26142f85613958a329+104
+- isCompare: https://github.com/refined-github/sandbox/compare/e8b25d3e...b3d0d992
+
+*/


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/6235

<img width="461" alt="Screenshot 3" src="https://user-images.githubusercontent.com/1402241/215415308-b535841e-d8c8-4275-882f-0a4d38055bbb.png">



## Test URLs

- isPRConversation: https://github.com/refined-github/refined-github/pull/6194
- isPRCommitList: https://github.com/refined-github/refined-github/pull/6194/commits
- isCommitList: https://github.com/babel/babel/commits/master?after=ddd40bf5c7ad8565fc990f26142f85613958a329+104
- isCompare: https://github.com/refined-github/sandbox/compare/e8b25d3e...b3d0d992


## Screenshot

<img width="447" alt="Screenshot 4" src="https://user-images.githubusercontent.com/1402241/215415295-3e6c990a-6190-46f7-b409-9cf66e64271b.png">


