### PR TITLE
Restore `default-branch-button`

### DIFF
--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,4 +1,4 @@
 /* Reduce excessive width on long branch names, this is also a GitHub bug */
-.rgh-default-branch-button-group [data-component="text"] {
+.rgh-default-branch-button-group [data-component='text'] {
 	max-width: 80px;
 }

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,0 +1,4 @@
+/* Reduce excessive width on long branch names, this is also a GitHub bug */
+.rgh-default-branch-button-group [data-component="text"] {
+	max-width: 80px;
+}

--- a/source/github-helpers/group-buttons.tsx
+++ b/source/github-helpers/group-buttons.tsx
@@ -6,7 +6,7 @@ import {wrapAll} from '../helpers/dom-utils';
 export const groupButtons = (buttons: Element[]): Element => {
 	// Ensure every button has this class
 	for (let button of buttons) {
-		if (!button.matches('.btn')) {
+		if (!button.matches('button, .btn')) {
 			button.classList.add('BtnGroup-parent');
 			button = button.querySelector('.btn')!;
 		}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -192,7 +192,7 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	margin-right: 20px; /* Push the text farther away from the text so it's cropped out */
 }
 
-/* Add override for CSS-in-JSS components that don't use regular .btn styles */
+/* Add override for CSS-in-JS components that don't use regular .btn styles */
 .BtnGroup-item:last-child {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -191,3 +191,9 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 [data-selected-links^='repo_milestones ']:has([title='0']) svg {
 	margin-right: 20px; /* Push the text farther away from the text so it's cropped out */
 }
+
+/* Add override for CSS-in-JSS components that don't use regular .btn styles */
+.BtnGroup-item:last-child {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}


### PR DESCRIPTION
- Part of #6152 




## Test URLs


Branch, subfolder: https://github.com/refined-github/refined-github/tree/better-ajax-detection/safari

<img width="445" alt="Screenshot 14" src="https://user-images.githubusercontent.com/1402241/215426336-a5b3aa87-600c-4db1-a286-09602f2c1bb6.png">

Commit, home page: https://github.com/refined-github/refined-github/tree/2ce3317eba7d01d0c728605ad7730b4ee067835d

<img width="445" alt="Screenshot 13" src="https://user-images.githubusercontent.com/1402241/215426489-c8144668-99a6-4530-a6e7-3b82240da24b.png">

