### PR TITLE
Restore `copy-on-y` and enable it on every page

### DIFF
--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -1,29 +1,18 @@
-import select from 'select-dom';
-import * as pageDetect from 'github-url-detection';
-
 import features from '../feature-manager';
 import {isEditable} from '../helpers/dom-utils';
 
-const handler = ({key, target}: KeyboardEvent): void => {
+async function handler({key, target}: KeyboardEvent): Promise<void> {
 	if (key === 'y' && !isEditable(target)) {
-		const permalink = select('a.js-permalink-shortcut')!.href;
-		void navigator.clipboard.writeText(permalink + location.hash);
+		await navigator.clipboard.writeText(location.href);
+		console.log('Copied URL to the clipboard', location.href);
 	}
-};
+}
 
 function init(signal: AbortSignal): void {
 	window.addEventListener('keyup', handler, {signal});
 }
 
 void features.add(import.meta.url, {
-	include: [
-		pageDetect.isBlame,
-		pageDetect.isCompare,
-		pageDetect.isRepoTree,
-		pageDetect.isRepoCommitList,
-		pageDetect.isSingleCommit,
-		pageDetect.isSingleFile,
-	],
 	awaitDomReady: false,
 	init,
 });

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -3,8 +3,10 @@ import {isEditable} from '../helpers/dom-utils';
 
 async function handler({key, target}: KeyboardEvent): Promise<void> {
 	if (key === 'y' && !isEditable(target)) {
-		await navigator.clipboard.writeText(location.href);
-		console.log('Copied URL to the clipboard', location.href);
+		const url = location.href;
+		await navigator.clipboard.writeText(url);
+		// Log to ensure we're coping the new URL
+		console.log('Copied URL to the clipboard', url);
 	}
 }
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6210
- Part of #6152

Over the years I've come to expect "copy on y" on any page so I think it wouldn't be too bad to actually enable it site-wide.

Thoughts?

![download](https://user-images.githubusercontent.com/1402241/215467247-e9637a2f-18c3-4a5b-8953-81b7bb83d2d7.png)


￼

## Test URLs

Literally any page, including:

https://github.com/refined-github/refined-github/blob/main/source/features/hide-diff-signs.css

