### PR TITLE
Restore `rgh-feature-descriptions`

### DIFF
--- a/source/features/rgh-feature-descriptions.css
+++ b/source/features/rgh-feature-descriptions.css
@@ -1,0 +1,4 @@
+.rgh-feature-description {
+	flex-basis: 300px !important;
+	flex-grow: 1;
+}

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -9,7 +9,6 @@ import {isRefinedGitHubRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 
 async function add(infoBanner: HTMLElement): Promise<void> {
-	console.log(infoBanner);
 
 	const [, currentFeature] = /source\/features\/([^.]+)/.exec(location.pathname) ?? [];
 	// Enable link even on past commits

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -9,7 +9,6 @@ import {isRefinedGitHubRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 
 async function add(infoBanner: HTMLElement): Promise<void> {
-
 	const [, currentFeature] = /source\/features\/([^.]+)/.exec(location.pathname) ?? [];
 	// Enable link even on past commits
 	const currentFeatureName = getNewFeatureName(currentFeature);

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -1,14 +1,16 @@
+import './rgh-feature-descriptions.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
-import {wrapAll} from '../helpers/dom-utils';
 import {featuresMeta} from '../../readme.md';
 import {getNewFeatureName} from '../options-storage';
 import {isRefinedGitHubRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 
-async function add(commit: HTMLElement): Promise<void> {
+async function add(infoBanner: HTMLElement): Promise<void> {
+	console.log(infoBanner);
+
 	const [, currentFeature] = /source\/features\/([^.]+)/.exec(location.pathname) ?? [];
 	// Enable link even on past commits
 	const currentFeatureName = getNewFeatureName(currentFeature);
@@ -17,17 +19,24 @@ async function add(commit: HTMLElement): Promise<void> {
 		return;
 	}
 
-	const commitInfoBox = commit.parentElement!;
-
 	const conversationsUrl = new URL('https://github.com/refined-github/refined-github/issues');
 	conversationsUrl.searchParams.set('q', `sort:updated-desc "${feature.id}"`);
 
-	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
-	commitInfoBox.classList.remove('flex-shrink-0');
-
-	const featureInfoBox = (
-		<div className="Box" style={{flex: '0 1 544px'}}>
-			<div className="Box-row d-flex height-full">
+	infoBanner.before(
+		<div className="Box mb-3">
+			<div className="Box-row d-flex gap-3 flex-wrap">
+				<div className="rgh-feature-description">
+					{ /* eslint-disable-next-line react/no-danger */ }
+					<h3 dangerouslySetInnerHTML={{__html: feature.description}}/>
+					<div className="no-wrap" data-turbo-frame="repo-content-turbo-frame">
+						<a href={conversationsUrl.href}>Related issues</a>
+						{
+							location.pathname.endsWith('css')
+								? <> • <a href={location.pathname.replace('.css', '.tsx')}>See JavaScript</a></>
+								: undefined
+						}
+					</div>
+				</div>
 				{feature.screenshot && (
 					<a href={feature.screenshot} className="flex-self-center">
 						<img
@@ -39,27 +48,13 @@ async function add(commit: HTMLElement): Promise<void> {
 							}}/>
 					</a>
 				)}
-				<div className={'flex-auto' + (feature.screenshot ? ' ml-3' : '')}>
-					{ /* eslint-disable-next-line react/no-danger */ }
-					<div dangerouslySetInnerHTML={{__html: feature.description}} className="text-bold"/>
-					<div className="no-wrap" data-turbo-frame="repo-content-turbo-frame">
-						<a href={conversationsUrl.href}>Related issues</a>
-						{
-							location.pathname.endsWith('css')
-								? <> • <a href={location.pathname.replace('.css', '.tsx')}>See JavaScript</a></>
-								: undefined
-						}
-					</div>
-				</div>
 			</div>
-		</div>
+		</div>,
 	);
-
-	wrapAll([commitInfoBox, featureInfoBox], <div className="d-lg-flex mb-4"/>);
 }
 
 function init(signal: AbortSignal): void {
-	observe('[data-testid="latest-commit"]', add, {signal});
+	observe('#repos-sticky-header', add, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- finally fixes https://github.com/refined-github/refined-github/issues/6211

## Test URLs

- https://github.com/refined-github/refined-github/blob/main/source/features/avoid-accidental-submissions.tsx
- https://github.com/refined-github/refined-github/blob/main/source/features/copy-on-y.tsx


## Screenshot

At three different resolutions. Zoom in or open in a new window:

<table>
<tr>
	<td><img width="1029" alt="Screenshot 25" src="https://user-images.githubusercontent.com/1402241/215476515-35c9865c-29e1-4777-8399-4144a37dc804.png">
	<td>
<img width="564" alt="Screenshot 24" src="https://user-images.githubusercontent.com/1402241/215476533-d122641f-2d5a-4715-88b4-f043a8e0ef1d.png">
	<td><img width="479" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/215476577-c0188b2e-8d15-4d32-8bfc-451b3483cd93.png">
</table>