### PR TITLE
Update links in `sticky-file-header`

### DIFF
--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -2,13 +2,3 @@
 .rgh-hide-diff-signs .blob-code-marker-cell::before { /* Commit page */
 	visibility: hidden;
 }
-
-/*
-
-File URLs
-
-Any commits on https://github.com/sindresorhus/refined-github/commits/main
-Any reviewed block on https://github.com/sindresorhus/refined-github/pull/1783
-Full diff on https://github.com/sindresorhus/refined-github/pull/1783/files
-
-*/

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -2,3 +2,13 @@
 .rgh-hide-diff-signs .blob-code-marker-cell::before { /* Commit page */
 	visibility: hidden;
 }
+
+/*
+
+File URLs
+
+Any commits on https://github.com/sindresorhus/refined-github/commits/main
+Any reviewed block on https://github.com/sindresorhus/refined-github/pull/1783
+Full diff on https://github.com/sindresorhus/refined-github/pull/1783/files
+
+*/

--- a/source/features/sticky-file-header.css
+++ b/source/features/sticky-file-header.css
@@ -24,9 +24,10 @@ Test URLs
 https://github.com/refined-github/refined-github/commit/1d9dd9f0208c327351512beb6d6a22279bc47807
 https://github.com//refined-github/refined-github/compare/22.2.13...22.2.22#files_bucket
 https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
-https://github.com/refined-github/refined-github/edit/main/readme.md
-https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327
 
 Exclude:
 https://github.com/refined-github/refined-github/pull/5460/files
+https://github.com/refined-github/refined-github/blob/main/source/features/default-branch-button.tsx
+https://github.com/refined-github/refined-github/blame/243e51d786e4771d313091b94cec826ff86becc9/source/features/index.tsx#L326-L327
+
 */


### PR DESCRIPTION
This updates the links following a report in https://github.com/refined-github/refined-github/issues/6152#issuecomment-1376541166

Everything seems to still work, with the exception that GitHub now does this natively almost everywhere.

@kema-dev where do you see the issue? Please include URLs, your browser and the version you're using