### PR TITLE
Fix global search dropdown overlap caused by `sticky-sidebar`

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -43,6 +43,7 @@ Exclusively use simple sums and use `0px` instead of `0`
 html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .search-with-dialog {
 	z-index: 95; /* Native: 35 */
 }
+
 html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .dark-backdrop {
 	z-index: 92; /* Native: 32 */
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -38,3 +38,11 @@ Exclusively use simple sums and use `0px` instead of `0`
 .rgh-sticky-sidebar-enabled .pagehead-actions .js-user-list-menu {
 	z-index: unset;
 }
+
+/* z-index fights 🥲 This is the search dropdown on the repo root #6151 */
+html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .search-with-dialog {
+	z-index: 95; /* Native: 35 */
+}
+html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .dark-backdrop {
+	z-index: 92; /* Native: 32 */
+}


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6151


Side note: `sticky-sidebar` is broken on the repo root, likely due to https://github.com/refined-github/refined-github/pull/5961 and specifically due to the lack of this variable outside the conversations

https://github.com/refined-github/refined-github/blob/c0c48c4290b4ae38e3f10b60e93a84a7174e0d13/source/features/sticky-sidebar.css#L10-L11

## Test URLs

https://github.com/refined-github/refined-github

## Before

<img width="662" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/215503519-db5ab035-56ca-4c57-8408-a3079a32e05a.png">

## After

<img width="662" alt="Screenshot 33" src="https://user-images.githubusercontent.com/1402241/215503274-ef2ff54e-c531-4d66-b01c-29329188f24c.png">


