### PR TITLE
Restore `download-folder-button`

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -1,42 +1,28 @@
 import React from 'dom-chef';
-import select from 'select-dom';
 import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
-import {getRepo} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
-function getDropdownItem(downloadUrl: URL): JSX.Element {
-	return (
-		<a className="dropdown-item rgh-download-folder" href={downloadUrl.href}>
-			Download directory
-		</a>
-	);
-}
-
-function init(): void {
+function add(folderDropdown: HTMLElement): void {
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 
-	const deleteButtons = select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`);
-	if (deleteButtons.length > 0) { // There are no buttons to delete the folder on "commit tree" pages #5335
-		for (const deleteButton of deleteButtons) {
-			deleteButton.before(getDropdownItem(downloadUrl));
-		}
-
-		return;
-	}
-
-	select('a.dropdown-item[data-hotkey="t"]')!.after(getDropdownItem(downloadUrl));
-	select('a.btn[data-hotkey="t"]')!.after(
+	folderDropdown.before(
+		// The buttons are spaced via `gap` on `md+` resolutions, and via `margin` at `sm`
 		<a
-			className="btn d-none d-md-block tooltipped tooltipped-ne rgh-download-folder"
+			className="btn tooltipped tooltipped-nw rgh-download-folder mr-2 mr-md-0"
 			aria-label="Download directory"
 			href={downloadUrl.href}
 		>
 			<DownloadIcon/>
 		</a>,
 	);
+}
+
+function init(signal: AbortSignal): void {
+	observe('[title="More options"]', add, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -46,6 +32,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isRepoRoot, // Already has an native download ZIP button
 	],
-	deduplicate: '.rgh-download-folder', // #3945
 	init,
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -12,7 +12,7 @@ function add(folderDropdown: HTMLElement): void {
 	folderDropdown.before(
 		// The buttons are spaced via `gap` on `md+` resolutions, and via `margin` at `sm`
 		<a
-			className="btn tooltipped tooltipped-nw rgh-download-folder mr-2 mr-md-0"
+			className="btn tooltipped tooltipped-nw mr-2 mr-md-0"
 			aria-label="Download directory"
 			href={downloadUrl.href}
 		>

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -34,3 +34,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs
+
+- Own repo: https://github.com/refined-github/refined-github/tree/main/.github
+- Archived repo: https://github.com/fregante/object-fit-images/tree/master/demo
+
+*/


### PR DESCRIPTION
- Finally fixes https://github.com/refined-github/refined-github/issues/6154



## Test URLs

- Own repo: https://github.com/refined-github/refined-github/tree/main/.github
- Archived repo: https://github.com/fregante/object-fit-images/tree/master/demo


## Screenshot

Seen in both desktop and mobile resolutions.

<img width="523" alt="Screenshot 4" src="https://user-images.githubusercontent.com/1402241/215564128-63343f6e-fd84-4b82-b3e8-1d0a5b0154e9.png">


<img width="661" alt="Screenshot 5" src="https://user-images.githubusercontent.com/1402241/215564115-84955f66-f3ba-4914-adec-77291e156cc1.png">



