### PR TITLE
Restore `linkify-user-labels`

### DIFF
--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -30,7 +30,7 @@
 
 /* Removes on issues: [octocat] opened this issue on 1 Jan · 1 comments */
 /* Removes on PRs: [octocat] merged 1 commit into master from feature */
-.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author + .Label,
+.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author + .Label, /* #5832 */
 .rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author {
 	display: none;
 }

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -8,8 +8,8 @@ import getCommentAuthor from '../github-helpers/get-comment-author';
 import observe from '../helpers/selector-observer';
 
 const selectors = [
-	'.Label[aria-label*="a member of the"]',
-	'.Label[aria-label^="This user has previously committed"]',
+	'.tooltipped[aria-label*="a member of the"]',
+	'.tooltipped[aria-label^="This user has previously committed"]',
 ];
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
The `.Label` class is gone.

Also:

- [x]  Check https://github.com/refined-github/refined-github/blob/e123ad7e99ca0e5e1a20eddad8ce22dba7ac4326/source/features/clean-conversation-headers.css#L33


## Test URLs

https://github.com/refined-github/refined-github/issues/6263

## Screenshot

<img width="457" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/215565811-11419f27-ca8f-4b62-8d42-60ec2cae0050.png">

