### PR TITLE
Restore `clean-header-search-field`

### DIFF
--- a/source/features/clean-header-search-field.tsx
+++ b/source/features/clean-header-search-field.tsx
@@ -1,10 +1,13 @@
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
+import select from 'select-dom';
 
 import features from '../feature-manager';
 
 async function init(): Promise<void> {
-	(await elementReady('input.header-search-input'))!.value = '';
+	const headerSearchButton = await elementReady('button.header-search-button');
+	headerSearchButton!.classList.add('placeholder');
+	select('[data-target="search-input.inputButtonText"]', headerSearchButton)!.textContent = headerSearchButton!.getAttribute('placeholder');
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION




## Test URLs

https://github.com/fregante/GhostText/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc


## Before

<img width="426" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/215724362-4eaed02c-4744-4c7f-b023-777c7b0cd956.png">



## After

<img width="426" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/215724166-babbf699-2473-4bf6-9718-34544938400c.png">
