### PR TITLE
Minor correction in `feature.add` examples in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -19,7 +19,7 @@ The simplest usage of `feature.add` is the following. This will be run instantly
 
 ```ts
 import * as pageDetect from 'github-url-detection';
-import features from '.';
+import features from '../feature-manager';
 
 function init(): void {
 	console.log('✨');
@@ -42,7 +42,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
-import features from '.';
+import features from '../feature-manager';
 
 function append(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	event.delegateTarget.after('✨', <div className="rgh-jsx-element">Button clicked!</div>);


### PR DESCRIPTION
- Since Each JavaScript feature lives in its own file under [source/features](https://github.com/refined-github/refined-github/tree/main/source/features), the import mentioned in [contributing.md](https://github.com/refined-github/refined-github/commit/89143fa5a0a57be34cceada6f158a7eb0d708863) gives error: `Cannot find module`. 

