### PR TITLE
Fix GitHub bug: header overflow on homepage on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -68,3 +68,17 @@
 .dashboard-sidebar .loading-context {
 	min-height: initial !important;
 }
+
+/* Hide elements that are stretching the whole viewport #6159 */
+/* .full-width sort of limits it to the homepage. Other pages aren't affected */
+@media (max-width: 920px) {
+	.full-width .Header-link[href="/marketplace"] {
+		display: none
+	}
+}
+
+@media (max-width: 820px) {
+	.full-width .Header-link[href="/explore"] {
+		display: none
+	}
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -72,13 +72,13 @@
 /* Hide elements that are stretching the whole viewport #6159 */
 /* .full-width sort of limits it to the homepage. Other pages aren't affected */
 @media (max-width: 920px) {
-	.full-width .Header-link[href="/marketplace"] {
+	.full-width .Header-link[href='/marketplace'] {
 		display: none
 	}
 }
 
 @media (max-width: 820px) {
-	.full-width .Header-link[href="/explore"] {
+	.full-width .Header-link[href='/explore'] {
 		display: none
 	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -73,12 +73,12 @@
 /* .full-width sort of limits it to the homepage. Other pages aren't affected */
 @media (max-width: 920px) {
 	.full-width .Header-link[href='/marketplace'] {
-		display: none
+		display: none;
 	}
 }
 
 @media (max-width: 820px) {
 	.full-width .Header-link[href='/explore'] {
-		display: none
+		display: none;
 	}
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6159

Months later, bug still there. The hotfix wasn't enough https://github.com/refined-github/yolo/commit/f038ff814d194a101fb51ab2a3068c7387906b64

## Test URLs

https://github.com/

## Before


https://user-images.githubusercontent.com/1402241/215964724-31325882-16a2-4c94-8c13-76add2000aa1.mov

## After

https://user-images.githubusercontent.com/1402241/215964785-b7296a9e-10e1-4573-bd43-34ad7bdada7d.mov



