### PR TITLE
Add `rgh-linkify-yolo-issues` feature

### DIFF
--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -1,14 +1,14 @@
-import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
-import {wrap} from '../helpers/dom-utils';
 import features from '../feature-manager';
-import {getRghIssueUrl} from '../helpers/rgh-issue-link';
 import {isRefinedGitHubYoloRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
+import {linkifyIssues} from '../github-helpers/dom-formatters';
 
+// Linkify with hovercards
 function linkify(issueCell: HTMLElement): void {
-	wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
+	issueCell.textContent = '#' + issueCell.textContent!;
+	linkifyIssues({owner: 'refined-github', name: 'refined-github'}, issueCell);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -1,0 +1,27 @@
+import * as pageDetect from 'github-url-detection';
+
+import React from 'dom-chef';
+
+import select from 'select-dom';
+
+import features from '../feature-manager';
+
+import {wrap} from '../helpers/dom-utils';
+
+import {getRghIssueUrl} from '../helpers/rgh-issue-link';
+
+function init(): void {
+	for (const issueCell of select.all('td:nth-child(3)')) {
+		wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
+	}
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepo,
+		pageDetect.hasCode,
+		pageDetect.isSingleFile,
+	],
+	awaitDomReady: false,
+	init,
+});

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -9,6 +9,7 @@ import features from '../feature-manager';
 import {wrap} from '../helpers/dom-utils';
 
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
+import {isAnyRefinedGitHubRepo} from '../github-helpers';
 
 function init(): void {
 	for (const issueCell of select.all('.js-csv-data td:nth-child(3)')) {
@@ -17,8 +18,12 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isAnyRefinedGitHubRepo,
+	],
 	include: [
 		pageDetect.isRepo,
+		pageDetect.isSingleFile,
 		() => new URLSearchParams(location.pathname).has('broken-features.csv'),
 	],
 	awaitDomReady: false,

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -1,17 +1,19 @@
 import React from 'dom-chef';
-import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils';
 import features from '../feature-manager';
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
 import {isRefinedGitHubYoloRepo} from '../github-helpers';
+import observe from '../helpers/selector-observer';
 
-function init(): void {
+function linkify(issueCell: HTMLElement): void {
+	wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
+}
+
+function init(signal: AbortSignal): void {
 	// .js-csv-data is the old selector
-	for (const issueCell of select.all(':is(.js-csv-data, .react-csv-row) td:nth-child(3)')) {
-		wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
-	}
+	observe(':is(.js-csv-data, .react-csv-row) td:nth-child(3)', linkify, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -20,5 +22,6 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 		() => location.pathname.endsWith('broken-features.csv'),
 	],
+	awaitDomReady: false,
 	init,
 });

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -9,7 +9,7 @@ import features from '../feature-manager';
 import {wrap} from '../helpers/dom-utils';
 
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
-import {isAnyRefinedGitHubRepo} from '../github-helpers';
+import {isRefinedGitHubYoloRepo} from '../github-helpers';
 
 function init(): void {
 	for (const issueCell of select.all('.js-csv-data td:nth-child(3)')) {
@@ -19,12 +19,9 @@ function init(): void {
 
 void features.add(import.meta.url, {
 	asLongAs: [
-		isAnyRefinedGitHubRepo,
-	],
-	include: [
-		pageDetect.isRepo,
+		isRefinedGitHubYoloRepo,
 		pageDetect.isSingleFile,
-		() => new URLSearchParams(location.pathname).has('broken-features.csv'),
+		() => location.pathname.endsWith('broken-features.csv'),
 	],
 	awaitDomReady: false,
 	init,

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -11,7 +11,7 @@ import {wrap} from '../helpers/dom-utils';
 import {getRghIssueUrl} from '../helpers/rgh-issue-link';
 
 function init(): void {
-	for (const issueCell of select.all('td:nth-child(3)')) {
+	for (const issueCell of select.all('.js-csv-data td:nth-child(3)')) {
 		wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
 	}
 }
@@ -19,8 +19,7 @@ function init(): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
-		pageDetect.hasCode,
-		pageDetect.isSingleFile,
+		() => new URLSearchParams(location.pathname).has('broken-features.csv'),
 	],
 	awaitDomReady: false,
 	init,

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -19,6 +19,5 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 		() => location.pathname.endsWith('broken-features.csv'),
 	],
-	awaitDomReady: false,
 	init,
 });

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -8,7 +8,8 @@ import {getRghIssueUrl} from '../helpers/rgh-issue-link';
 import {isRefinedGitHubYoloRepo} from '../github-helpers';
 
 function init(): void {
-	for (const issueCell of select.all('.js-csv-data td:nth-child(3)')) {
+	// .js-csv-data is the old selector
+	for (const issueCell of select.all(':is(.js-csv-data, .react-csv-row) td:nth-child(3)')) {
 		wrap(issueCell.firstChild!, <a href={getRghIssueUrl(issueCell.textContent!)}/>);
 	}
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -158,6 +158,10 @@ export function isAnyRefinedGitHubRepo(): boolean {
 	return /^\/refined-github\/.+/.test(location.pathname);
 }
 
+export function isRefinedGitHubYoloRepo(): boolean {
+	return location.pathname.startsWith('/refined-github/yolo');
+}
+
 export function shouldFeatureRun({
 	/** Every condition must be true */
 	asLongAs = [() => true],

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -217,3 +217,4 @@ import './features/linkify-user-labels';
 import './features/repo-avatars';
 import './features/jump-to-conversation-close-event';
 import './features/last-notification-page-button';
+import './features/rgh-linkify-yolo-issues';


### PR DESCRIPTION
- closes [#6258](https://github.com/refined-github/refined-github/issues/6258)
- Affects the page:  [refined-github/yolo@main/broken-features.csv](https://github.com/refined-github/yolo/blob/main/broken-features.csv?rgh-link-date=2023-01-30T13%3A28%3A41Z).
- This change in this pr continues the work which was done on [#6269](https://github.com/refined-github/refined-github/pull/6269) pr.

## Screenshot

![rgh-linkify-yolo-issues-screenshot](https://user-images.githubusercontent.com/118078892/216033122-51256231-5155-4529-8709-b0c653ba63f0.png)
