### PR TITLE
Add name and  "Copy name" button to `rgh-feature-descriptions`

### DIFF
--- a/source/features/rgh-feature-descriptions.css
+++ b/source/features/rgh-feature-descriptions.css
@@ -2,3 +2,8 @@
 	flex-basis: 300px !important;
 	flex-grow: 1;
 }
+
+.rgh-feature-description :is(code, kbd) {
+	font-size: 0.8em;
+	line-height: 0.8;
+}

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -1,6 +1,7 @@
 import './rgh-feature-descriptions.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
+import {CopyIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager';
 import {featuresMeta} from '../../readme.md';
@@ -24,8 +25,20 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 		<div className="Box mb-3">
 			<div className="Box-row d-flex gap-3 flex-wrap">
 				<div className="rgh-feature-description">
+					<h3 className="mb-2"><code>{feature.id}</code>
+						<clipboard-copy
+							aria-label="Copy"
+							data-copy-feedback="Copied!"
+							value={feature.id}
+							class="Link--onHover color-fg-muted d-inline-block ml-2"
+							tabindex="0"
+							role="button"
+						>
+							<CopyIcon className="v-align-baseline"/>
+						</clipboard-copy>
+					</h3>
 					{ /* eslint-disable-next-line react/no-danger */ }
-					<h3 dangerouslySetInnerHTML={{__html: feature.description}}/>
+					<div dangerouslySetInnerHTML={{__html: feature.description}} className="h3"/>
 					<div className="no-wrap" data-turbo-frame="repo-content-turbo-frame">
 						<a href={conversationsUrl.href}>Related issues</a>
 						{


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/6253

Why:

- the box looks weird without a title, it's not clear what it describes
- I find myself copying the name all the time

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="662" alt="Screenshot 4" src="https://user-images.githubusercontent.com/1402241/216768901-bf13ad0e-456b-491e-9d4d-5d1d1440f376.png">
	<td><img width="662" alt="Screenshot 3" src="https://user-images.githubusercontent.com/1402241/216768892-8b9c9e91-c9f9-436e-9b09-c4078e1372f9.png">
</table>