### PR TITLE
Improve `releases-tab` reliability

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -38,7 +38,7 @@ async function fetchFromApi(): Promise<number> {
 	return repository.releases.totalCount;
 }
 
-export const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi(), {
+export const getReleaseCount = cache.function(async () => await parseCountFromDom() || await fetchFromApi(), {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},
 	cacheKey: getCacheKey,

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -42,7 +42,7 @@ async function fetchFromApi(): Promise<number> {
 // - It is disabled by repository owner on the home page (release DOM element won't be there)
 // - It only contains pre-releases (count badge won't be shown)
 // For this reason, if we can't find a count from the DOM, we ask the API instead (see #6298)
-export const getReleaseCount = cache.function(async () => await parseCountFromDom() || await fetchFromApi(), {
+export const getReleaseCount = cache.function(async () => await parseCountFromDom() || fetchFromApi(), {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},
 	cacheKey: getCacheKey,
@@ -84,7 +84,7 @@ async function addReleasesTab(): Promise<false | void> {
 	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
 	window.dispatchEvent(new Event('resize'));
 
-	const dropdownMenu = await elementReady('.js-responsive-underlinenav .dropdown-menu ul')
+	const dropdownMenu = await elementReady('.js-responsive-underlinenav .dropdown-menu ul');
 
 	appendBefore(
 		dropdownMenu!,

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -80,8 +80,13 @@ async function addReleasesTab(): Promise<false | void> {
 	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
 	window.dispatchEvent(new Event('resize'));
 
+	const dropdownMenu = await elementReady('.js-responsive-underlinenav .dropdown-menu ul', {waitForChildren: false})
+	if (!dropdownMenu) {
+		return
+	}
+
 	appendBefore(
-		select('.js-responsive-underlinenav .dropdown-menu ul')!,
+		dropdownMenu,
 		'.dropdown-divider', // Won't exist if `more-dropdown` is disabled
 		createDropdownItem('Releases', buildRepoURL('releases'), {
 			'data-menu-item': 'rgh-releases-item',

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -84,13 +84,10 @@ async function addReleasesTab(): Promise<false | void> {
 	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
 	window.dispatchEvent(new Event('resize'));
 
-	const dropdownMenu = await elementReady('.js-responsive-underlinenav .dropdown-menu ul', {waitForChildren: false})
-	if (!dropdownMenu) {
-		return
-	}
+	const dropdownMenu = await elementReady('.js-responsive-underlinenav .dropdown-menu ul')
 
 	appendBefore(
-		dropdownMenu,
+		dropdownMenu!,
 		'.dropdown-divider', // Won't exist if `more-dropdown` is disabled
 		createDropdownItem('Releases', buildRepoURL('releases'), {
 			'data-menu-item': 'rgh-releases-item',

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -38,6 +38,10 @@ async function fetchFromApi(): Promise<number> {
 	return repository.releases.totalCount;
 }
 
+// Release count can be not found in DOM if:
+// - It is disabled by repository owner on the home page (release DOM element won't be there)
+// - It only contains pre-releases (count badge won't be shown)
+// For this reason, if we can't find a count from the DOM, we ask the API instead (see #6298)
 export const getReleaseCount = cache.function(async () => await parseCountFromDom() || await fetchFromApi(), {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},


### PR DESCRIPTION
This pull request fixes an issue with `releases-tab` where the tab would not be displayed if Refined GitHub could not find the release count from the DOM, which would be the case if a user disabled "releases" from the "show in the home page" setting.

![CleanShot 2023-02-04 at 15 43 35](https://user-images.githubusercontent.com/16060559/216773562-814853f9-eef3-4b59-ac2d-156bf7c83efa.png)

Example repositories:
- https://github.com/hybridly/hybridly
- https://github.com/vueuse/motion

Note: this change doesn't affect the fact that the release tab won't be displayed if there's no release at all.