### PR TITLE
Correctly hide grouped "Follow" events in `hide-newsfeed-noise`

### DIFF
--- a/source/features/hide-newsfeed-noise.css
+++ b/source/features/hide-newsfeed-noise.css
@@ -16,6 +16,7 @@ edited a gollum (wiki)
 
 .rgh-hide-newsfeed-noise .body:has(
 [data-hydro-click*='"type":"PushEvent"'],
+[data-hydro-click*='"type":"FollowEvent"'],
 [data-hydro-click*='"type":"ReleaseEvent"']
 ) {
 	display: none !important;


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6232
- Fixes https://github.com/refined-github/refined-github/issues/6305


## Test URLs

https://github.com/

## Demo
<table>
<tr>
	<th>Before
	<td><img width="581" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/217328740-f6ad62de-7828-4b8b-94e7-95fc859a132e.png">
<tr>
	<th>After
	<td><img width="581" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/217328754-937d0837-1415-4643-ad0a-81199d648684.png">
</table>

