### PR TITLE
Restore `clean-header-search-field` for some users

### DIFF
--- a/source/features/clean-header-search-field.tsx
+++ b/source/features/clean-header-search-field.tsx
@@ -5,7 +5,14 @@ import select from 'select-dom';
 import features from '../feature-manager';
 
 async function init(): Promise<void> {
-	const headerSearchButton = await elementReady('button.header-search-button');
+	const headerSearchButton = await elementReady('button.header-search-button, input.header-search-input');
+	if (headerSearchButton instanceof HTMLInputElement) {
+		// Previous version #6310
+		// TODO: Remove in mid 2023
+		headerSearchButton.value = '';
+		return;
+	}
+
 	headerSearchButton!.classList.add('placeholder');
 	select('[data-target="search-input.inputButtonText"]', headerSearchButton)!.textContent = headerSearchButton!.getAttribute('placeholder');
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6310

## Test URLs

https://github.com/fregante/GhostText/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

## Screenshot

Untested, depends on the user

cc @kaste