### PR TITLE
Restore `download-folder-button` for non-beta users

### DIFF
--- a/source/features/download-folder-button.css
+++ b/source/features/download-folder-button.css
@@ -1,0 +1,4 @@
+/* Sometimes it's spaced via gap, sometimes via margin 🤦‍♂️  */
+:not(.gap-2) > .rgh-download-folder-button {
+	margin-inline: 8px;
+}

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -1,3 +1,5 @@
+import './download-folder-button.css';
+
 import React from 'dom-chef';
 import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
@@ -10,9 +12,8 @@ function add(folderDropdown: HTMLElement): void {
 	downloadUrl.searchParams.set('url', location.href);
 
 	folderDropdown.before(
-		// The buttons are spaced via `gap` on `md+` resolutions, and via `margin` at `sm`
 		<a
-			className="btn tooltipped tooltipped-nw mr-2 mr-md-0"
+			className="rgh-download-folder-button btn tooltipped tooltipped-nw"
 			aria-label="Download directory"
 			href={downloadUrl.href}
 		>
@@ -22,7 +23,10 @@ function add(folderDropdown: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('[title="More options"]', add, {signal});
+	observe([
+		'[title="More options"]',
+		'[aria-label="Add file"] + details', // TODO: Drop in mid 2023. Old file view #6154
+	], add, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Re-fixes https://github.com/refined-github/refined-github/issues/6154

## Test URLs


- https://github.com/VoronDesign/VoronUsers/tree/master/orphaned_mods/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_%26_Nozzle_Scrubber

## Beta view

<img width="718" alt="Screenshot 5" src="https://user-images.githubusercontent.com/1402241/217766289-70cec0ca-902e-46cd-89ec-c68816a1ac1a.png">

## Old view

<img width="718" alt="Screenshot 6" src="https://user-images.githubusercontent.com/1402241/217766247-c045c4cd-c493-4fd6-b7a0-37f92e04a320.png">

