### PR TITLE
Fix GitHub header overflow bug on every page

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -70,15 +70,14 @@
 }
 
 /* Hide elements that are stretching the whole viewport #6159 */
-/* .full-width sort of limits it to the homepage. Other pages aren't affected */
 @media (max-width: 920px) {
-	.full-width .Header-link[href='/marketplace'] {
+	.Header-link[href='/marketplace'] {
 		display: none;
 	}
 }
 
 @media (max-width: 820px) {
-	.full-width .Header-link[href='/explore'] {
+	.Header-link[href='/explore'] {
 		display: none;
 	}
 }


### PR DESCRIPTION
- Extends https://github.com/refined-github/refined-github/pull/6278
- For https://github.com/refined-github/refined-github/issues/6159

## Test URLs

- https://github.com/VoronDesign/VoronUsers/tree/master/orphaned_mods/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_%26_Nozzle_Scrubber

## Before

<img width="796" alt="Screenshot 7" src="https://user-images.githubusercontent.com/1402241/217766667-2ec92215-fbde-4c10-b0a7-40e6b0210578.png">


## After

<img width="796" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/217766722-b713fe4e-e15c-4e69-b870-b60ffc074863.png">


