### PR TITLE
Fix `sticky-sidebar` on repo's "Code" tab 

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -18,7 +18,7 @@ Exclusively use simple sums and use `0px` instead of `0`
 
 .rgh-sticky-sidebar {
 	position: sticky;
-	top: var(--rgh-sticky-sidebar-offset) !important;
+	top: var(--rgh-sticky-sidebar-offset, 0px) !important;
 
 	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
 	/* Higher than sticky readme header #4192 */

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -18,7 +18,7 @@ Exclusively use simple sums and use `0px` instead of `0`
 
 .rgh-sticky-sidebar {
 	position: sticky;
-	top: var(--rgh-sticky-sidebar-offset, 0px) !important;
+	top: var(--rgh-sticky-sidebar-offset, 0) !important;
 
 	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
 	/* Higher than sticky readme header #4192 */


### PR DESCRIPTION
- Fixes #6307
 
## Test URLs
https://github.com/refined-github/refined-github

## Screenshots
![Sticky Sidebar](https://user-images.githubusercontent.com/11196460/217795454-3d7ce670-b1d2-455b-9545-4da462bfff64.gif)

