### PR TITLE
Enable `reaction-avatars` on organization discussions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^1.0.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^6.1.0",
+				"github-url-detection": "^7.0.1-0",
 				"image-promise": "^7.0.1",
 				"indent-textarea": "^2.1.1",
 				"js-abbreviation-number": "^1.4.0",
@@ -4141,11 +4141,11 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-6.1.0.tgz",
-			"integrity": "sha512-Z2z3WmR38cbHegKHN3jiyo2wDBEPRlEn/8HHK05iidiHtNF8KltmjKiaNzB3QdGU+OxF2QhgwT1q4rLT15Z08w==",
+			"version": "7.0.1-0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.0.1-0.tgz",
+			"integrity": "sha512-umFshV+FkdsRjR6TKo0senmCep5h9JGqV6TmajRgUI+adF+SWSIledRMkKy9zO7n2Y+GwnNIixrXi3tPm2xGpw==",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
@@ -13184,9 +13184,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"github-url-detection": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-6.1.0.tgz",
-			"integrity": "sha512-Z2z3WmR38cbHegKHN3jiyo2wDBEPRlEn/8HHK05iidiHtNF8KltmjKiaNzB3QdGU+OxF2QhgwT1q4rLT15Z08w=="
+			"version": "7.0.1-0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.0.1-0.tgz",
+			"integrity": "sha512-umFshV+FkdsRjR6TKo0senmCep5h9JGqV6TmajRgUI+adF+SWSIledRMkKy9zO7n2Y+GwnNIixrXi3tPm2xGpw=="
 		},
 		"glob": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"filter-altered-clicks": "^1.0.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^6.1.0",
+		"github-url-detection": "^7.0.1-0",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.1.1",
 		"js-abbreviation-number": "^1.4.0",

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -92,3 +92,12 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	init,
 });
+
+/*
+Test URLs
+
+https://github.com/parcel-bundler/parcel/discussions/6490
+https://github.com/orgs/community/discussions/11202
+https://github.com/refined-github/refined-github/pull/6316
+
+*/

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -74,21 +74,12 @@ function showAvatarsOn(commentReactions: Element): void {
 	}
 }
 
-// TODO [2022-12-18]: Drop `.comment-reactions-options` (GHE)
-const reactionsSelector = '.has-reactions :is(.js-comment-reactions-options, .comment-reactions-options):not(.rgh-reactions)';
-
 function observeCommentReactions(commentReactions: Element): void {
-	commentReactions.classList.add('rgh-reactions');
 	viewportObserver.observe(commentReactions);
 }
 
 function init(signal: AbortSignal): void {
-	observe(reactionsSelector, observeCommentReactions, {signal});
-	onAbort(signal, viewportObserver);
-}
-
-function discussionInit(signal: AbortSignal): void {
-	observe(reactionsSelector, observeCommentReactions, {signal});
+	observe('.has-reactions .js-comment-reactions-options', observeCommentReactions, {signal});
 	onAbort(signal, viewportObserver);
 }
 
@@ -96,13 +87,8 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 		pageDetect.isReleasesOrTags,
-	],
-	awaitDomReady: false,
-	init,
-}, {
-	include: [
 		pageDetect.isDiscussion,
 	],
 	awaitDomReady: false,
-	init: discussionInit,
+	init,
 });

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -97,7 +97,7 @@ void features.add(import.meta.url, {
 /*
 Test URLs
 
-https://github.com/refined-github/refined-github/pull/6316
+https://github.com/refined-github/refined-github/pull/4119
 https://github.com/parcel-bundler/parcel/discussions/6490
 https://github.com/orgs/community/discussions/11202
 

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -58,7 +58,8 @@ const viewportObserver = new IntersectionObserver(changes => {
 });
 
 function showAvatarsOn(commentReactions: Element): void {
-	const avatarLimit = arbitraryAvatarLimit - (commentReactions.children.length * approximateHeaderLength);
+	const reactionTypes = select.all('.social-reaction-summary-item', commentReactions).length;
+	const avatarLimit = arbitraryAvatarLimit - (reactionTypes * approximateHeaderLength);
 
 	const participantByReaction = select
 		.all(':scope > button.social-reaction-summary-item', commentReactions)
@@ -96,8 +97,8 @@ void features.add(import.meta.url, {
 /*
 Test URLs
 
+https://github.com/refined-github/refined-github/pull/6316
 https://github.com/parcel-bundler/parcel/discussions/6490
 https://github.com/orgs/community/discussions/11202
-https://github.com/refined-github/refined-github/pull/6316
 
 */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5485
- Includes https://github.com/refined-github/github-url-detection/pull/158




## Org discussions

https://github.com/orgs/community/discussions/11202


<img width="988" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/217811267-6cc2db97-729c-4447-83ea-c72cae0fd4c3.png">


## Regular discussions


https://github.com/parcel-bundler/parcel/discussions/6490

<img width="513" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/217811411-aa25563d-40cc-4590-a27f-d84596fda3b9.png">

## PRs 

https://github.com/refined-github/refined-github/pull/4119

<img width="617" alt="Screenshot 3" src="https://user-images.githubusercontent.com/1402241/217811924-80d755e0-301a-46dc-b004-3300f330a4a4.png">


