### PR TITLE
Fixed partially broken `tag-changes-link` 

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -34,7 +34,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 
 function parseTags(element: HTMLElement): TagDetails {
 	// Safari doesn't correctly parse links if they're loaded via AJAX #3899
-	const {pathname: tagUrl} = new URL(select('a[href*="/tree/"]', element)!.href);
+	const {pathname: tagUrl} = new URL(select(['a[href*="/tree/"]', 'a[href*="/tag/"]'], element)!.href);
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 
 	return {

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -149,3 +149,13 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs:
+
+- https://github.com/refined-github/refined-github/releases
+- https://github.com/refined-github/refined-github/tags
+- https://github.com/refined-github/refined-github/releases/tag/23.2.5
+
+*/


### PR DESCRIPTION
- Fixes #6080 

Fixes the tag-changes-link not visible on the tags list and single release pages.

## Test URLs
- https://github.com/refined-github/refined-github/releases
- https://github.com/refined-github/refined-github/tags
- https://github.com/refined-github/refined-github/releases/tag/23.2.5


## Screenshot
![tag changes -1](https://user-images.githubusercontent.com/11196460/217819031-0c8c1f09-dc5b-45d2-878b-cc4bd6739147.png)
![tag changes -2](https://user-images.githubusercontent.com/11196460/217819035-dc7ef282-cb51-4ef9-816e-b007a5132e2c.png)
![tag changes -3](https://user-images.githubusercontent.com/11196460/217819051-b058d485-a739-42f2-ae95-b363babd33c6.png)

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->




