### PR TITLE
Drop discussion support from `quick-comment-edit`

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -19,7 +19,7 @@ function addQuickEditButton(commentForm: Element): void {
 			<button
 				type="button"
 				role="menuitem"
-				className={'timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button' + (pageDetect.isDiscussion() ? ' js-discussions-comment-edit-button' : '')}
+				className="timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button"
 				aria-label="Edit comment"
 			>
 				<PencilIcon/>
@@ -53,7 +53,6 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
-		pageDetect.isDiscussion,
 	],
 	exclude: [
 		pageDetect.isArchivedRepo,


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/6029

Sorry discussions have a completely different DOM so at this point they're not worth supporting (also because relatively rare).

I can accept PRs to add support, if they don't require complex logic, but otherwise I won't treat this as a bug and won't keep it as a feature request. 