### PR TITLE
Better wrap 6 reactions in releases in `center-reactions-popup`

### DIFF
--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -1,7 +1,8 @@
 /* Restore two-line layout */
 :root .dropdown-menu-reactions {
 	display: grid !important;
-	grid-template: auto / repeat(4, auto);
+	grid-template-rows: 1fr 1fr; /* Keep two lines whether there are 6 or 8 reactions */
+	grid-auto-flow: column;
 }
 
 /* Move the popups */


### PR DESCRIPTION




## Test URLs

https://github.com/refined-github/refined-github/releases/tag/23.2.5

## Before
<img width="209" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/218244199-fd826cb6-ee1e-405a-9459-43ddac4c2c4a.png">

## After
<img width="175" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/218244207-020db123-c5c9-4fa6-a2fb-aad0b443071e.png">


