### PR TITLE
Run `clear-pr-merge-commit-message` only once per load

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -10,6 +10,9 @@ import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 import attachElement from '../helpers/attach-element';
 
 async function init(): Promise<void | false> {
+	// Only run once so that it doesn't clear the field every time it's opened
+	features.unload(import.meta.url);
+
 	const messageField = select('textarea#merge_message_field')!;
 	const originalMessage = messageField.value;
 	const preservedContent = new Set();

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -7,6 +7,7 @@ import features from '../feature-manager';
 import {getBranches} from './update-pr-from-base-branch';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
+import attachElement from '../helpers/attach-element';
 
 async function init(): Promise<void | false> {
 	const messageField = select('textarea#merge_message_field')!;
@@ -33,12 +34,16 @@ async function init(): Promise<void | false> {
 	}
 
 	set(messageField, cleanedMessage);
-	messageField.after(
-		<p className="note">
-			The description field was cleared by <a target="_blank" href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message" rel="noreferrer">Refined GitHub</a>.
-		</p>,
-		<hr/>,
-	);
+	attachElement(messageField, {
+		after: () => (
+			<div>
+				<p className="note">
+					The description field was cleared by <a target="_blank" href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message" rel="noreferrer">Refined GitHub</a>.
+				</p>
+				<hr/>
+			</div>
+		),
+	});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Opening the merge box multiple times could cause multiple notes to be injected. The field also lost any user-customized content every time the form was opened.

 
<img width="442" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/218244898-543520e5-9a50-4bfd-a770-7d0dd2aba754.png">


## Test URLs

https://github.com/refined-github/sandbox/pull/55
<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td> 

https://user-images.githubusercontent.com/1402241/218244742-f049e627-4ce4-4894-bbbd-928c9d045600.mov

<td> 

https://user-images.githubusercontent.com/1402241/218244820-e01cb99a-5318-452d-9074-12aa0d7e9059.mov

</table>




