### PR TITLE
Add `quick-new-issue` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ Thanks for contributing! 🦋🙌
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
 - [](# "repo-avatars") [Adds the profile picture to the header of public repositories.](https://user-images.githubusercontent.com/44045911/177211845-c9b0fa37-c157-4449-890e-af2602c312e3.png)
-- [](# "quick-new-issue") [Adds a link to create an issue from anywhere in a repo]()
+- [](# "quick-new-issue") [Adds a link to create an issue from anywhere in a repo](https://user-images.githubusercontent.com/1402241/218251057-b94b62dd-a944-4763-b78a-fc233f7c9fd3.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ Thanks for contributing! 🦋🙌
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
 - [](# "repo-avatars") [Adds the profile picture to the header of public repositories.](https://user-images.githubusercontent.com/44045911/177211845-c9b0fa37-c157-4449-890e-af2602c312e3.png)
+- [](# "quick-new-issue") [Adds a link to create an issue from anywhere in a repo]()
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ Thanks for contributing! 🦋🙌
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
 - [](# "clean-repo-tabs") [Moves the "Security" and "Insights"  to the repository navigation dropdown. Also moves the "Projects", "Actions" and "Wiki" tabs if they're empty/unused.](https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png)
 - [](# "repo-avatars") [Adds the profile picture to the header of public repositories.](https://user-images.githubusercontent.com/44045911/177211845-c9b0fa37-c157-4449-890e-af2602c312e3.png)
-- [](# "quick-new-issue") [Adds a link to create an issue from anywhere in a repo](https://user-images.githubusercontent.com/1402241/218251057-b94b62dd-a944-4763-b78a-fc233f7c9fd3.png)
+- [](# "quick-new-issue") [Adds a link to create issues from anywhere in a repository.](https://user-images.githubusercontent.com/1402241/218251057-b94b62dd-a944-4763-b78a-fc233f7c9fd3.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/quick-new-issue.tsx
+++ b/source/features/quick-new-issue.tsx
@@ -1,0 +1,34 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager';
+import {buildRepoURL, getRepo, isArchivedRepoAsync} from '../github-helpers';
+import observe from '../helpers/selector-observer';
+
+function add(dropdownMenu: HTMLElement): void {
+	dropdownMenu.append(
+		<div role="none" className="dropdown-divider"/>,
+		<div className="dropdown-header">
+			<span title={getRepo()?.name}>This repository</span>
+		</div>,
+		<a role="menuitem" className="dropdown-item" href={buildRepoURL('issues/new/choose')}>
+			New issue
+		</a>,
+	);
+}
+
+async function init(signal: AbortSignal): Promise<void | false> {
+	if (await isArchivedRepoAsync()) {
+		return false;
+	}
+
+	observe('.Header-item .dropdown-menu:has(> [data-ga-click="Header, create new repository"])', add, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepo,
+	],
+	awaitDomReady: false,
+	init,
+});

--- a/source/features/quick-new-issue.tsx
+++ b/source/features/quick-new-issue.tsx
@@ -32,3 +32,18 @@ void features.add(import.meta.url, {
 	awaitDomReady: false,
 	init,
 });
+
+/*
+
+Test URLs:
+
+Repo home:
+https://github.com/fregante/webext-storage-cache
+
+Wiki, template picker:
+https://github.com/refined-github/refined-github/wiki
+
+Archived repo (feature disabled):
+https://github.com/fregante/iphone-inline-video
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -217,3 +217,4 @@ import './features/repo-avatars';
 import './features/jump-to-conversation-close-event';
 import './features/last-notification-page-button';
 import './features/rgh-linkify-yolo-issues';
+import './features/quick-new-issue';


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6294



## Test URLs


Known issues: it still appears on repos that have issues disabled 🤷‍♂️ 


Repo home:
https://github.com/fregante/webext-storage-cache

Wiki, template picker:
https://github.com/refined-github/refined-github/wiki

Archived repo (feature disabled):
https://github.com/fregante/iphone-inline-video

## Screenshot

![Screenshot 9 2](https://user-images.githubusercontent.com/1402241/218251057-b94b62dd-a944-4763-b78a-fc233f7c9fd3.png)

