### PR TITLE
Correctly escape tags in the tooltip of `tag-changes-link`

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -106,7 +106,7 @@ async function init(): Promise<void> {
 			const compareLink = (
 				<a
 					className="Link--muted tooltipped tooltipped-n"
-					aria-label={`See commits between ${decodeURIComponent(previousTag)} and ${currentTag}`}
+					aria-label={`See commits between ${decodeURIComponent(previousTag)} and ${decodeURIComponent(currentTag)}`}
 					href={buildRepoURL(`compare/${previousTag}...${currentTag}`)}
 				>
 					<DiffIcon/> {pageDetect.isEnterprise() ? 'Commits' : <span className="ml-1 wb-break-all">Commits</span>}


### PR DESCRIPTION
- Fixes #5884 

## Test URLs
https://github.com/parcel-bundler/parcel/tags?after=%40parcel%2Fintegration-tests%401.12.5

## Screenshot
![decode-uri](https://user-images.githubusercontent.com/11196460/218259816-2f46c059-f44c-431e-bec3-6039762aacf3.png)


