### PR TITLE
Avoid console error in `html-preview-link`

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -7,6 +7,10 @@ import observe from '../helpers/selector-observer';
 const isSingleHTMLFile = (): boolean => pageDetect.isSingleFile() && /\.html?$/.test(location.pathname);
 
 function add(rawButton: HTMLAnchorElement): void {
+	if (!pageDetect.isPublicRepo()) {
+		return;
+	}
+
 	rawButton
 		.parentElement! // `BtnGroup`
 		.prepend(
@@ -25,9 +29,6 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
-	asLongAs: [
-		pageDetect.isPublicRepo,
-	],
 	include: [
 		isSingleHTMLFile,
 	],


### PR DESCRIPTION
- Due to https://github.com/refined-github/refined-github/pull/6357#discussion_r1111221239 


```
refined-github.js:24847 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'textContent')
    at isPublicRepo (refined-github.js:24847:88)
    at refined-github.js:17997:32
    at Array.every (<anonymous>)
    at shouldFeatureRun (refined-github.js:17997:19)
    at setupPageLoad (refined-github.js:3790:73)
    at Object.add (refined-github.js:3865:12)
```

### Test URLs

 https://github.com/OctoLinker/OctoLinker/commits/master
