### PR TITLE
Meta: Update `webext-storage-cache`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"webext-domain-permission-toggle": "^4.0.0-0",
 				"webext-dynamic-content-scripts": "^9.2.0",
 				"webext-options-sync-per-domain": "^3.0.0",
-				"webext-storage-cache": "^6.0.0-1",
+				"webext-storage-cache": "^6.0.0-2",
 				"webextension-polyfill": "^0.10.0",
 				"zip-text-nodes": "^1.0.0"
 			},
@@ -9716,22 +9716,14 @@
 			}
 		},
 		"node_modules/webext-storage-cache": {
-			"version": "6.0.0-1",
-			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-6.0.0-1.tgz",
-			"integrity": "sha512-4B6fs+nTp7QC1YbNZCVPYUDe6CenpDTPo7hynAwQv71/zScO91iYN9DH8qVMD79mpM+kHBSUvIPUY9/dGaTyAQ==",
+			"version": "6.0.0-2",
+			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-6.0.0-2.tgz",
+			"integrity": "sha512-fez9KD5dhx7KNi9CumHlZnLcTkn1i6h1hc+fUHKC4w8s2PnEINJOXR+jHeuu/EyCkZrW7dpzahDWLKjX9+tPZw==",
 			"dependencies": {
 				"@sindresorhus/to-milliseconds": "^2.0.0",
 				"webext-detect-page": "^4.0.1",
 				"webext-polyfill-kinda": "^1.0.0"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/fregante"
-			}
-		},
-		"node_modules/webext-storage-cache/node_modules/webext-polyfill-kinda": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.0.tgz",
-			"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw==",
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
 			}
@@ -18054,20 +18046,13 @@
 			"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw=="
 		},
 		"webext-storage-cache": {
-			"version": "6.0.0-1",
-			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-6.0.0-1.tgz",
-			"integrity": "sha512-4B6fs+nTp7QC1YbNZCVPYUDe6CenpDTPo7hynAwQv71/zScO91iYN9DH8qVMD79mpM+kHBSUvIPUY9/dGaTyAQ==",
+			"version": "6.0.0-2",
+			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-6.0.0-2.tgz",
+			"integrity": "sha512-fez9KD5dhx7KNi9CumHlZnLcTkn1i6h1hc+fUHKC4w8s2PnEINJOXR+jHeuu/EyCkZrW7dpzahDWLKjX9+tPZw==",
 			"requires": {
 				"@sindresorhus/to-milliseconds": "^2.0.0",
 				"webext-detect-page": "^4.0.1",
 				"webext-polyfill-kinda": "^1.0.0"
-			},
-			"dependencies": {
-				"webext-polyfill-kinda": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.0.tgz",
-					"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw=="
-				}
 			}
 		},
 		"webext-tools": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"webext-domain-permission-toggle": "^4.0.0-0",
 		"webext-dynamic-content-scripts": "^9.2.0",
 		"webext-options-sync-per-domain": "^3.0.0",
-		"webext-storage-cache": "^6.0.0-1",
+		"webext-storage-cache": "^6.0.0-2",
 		"webextension-polyfill": "^0.10.0",
 		"zip-text-nodes": "^1.0.0"
 	},

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -55,7 +55,7 @@ async function countIssuesWithLabel(label: string): Promise<number> {
 	return repository.label?.issues.totalCount ?? 0;
 }
 
-const countBugs = cache.function(async (): Promise<number> => {
+const countBugs = cache.function('bugs', async (): Promise<number> => {
 	const bugLabel = await getBugLabel();
 	return bugLabel
 		? countIssuesWithLabel(bugLabel)
@@ -63,7 +63,7 @@ const countBugs = cache.function(async (): Promise<number> => {
 }, {
 	maxAge: {minutes: 30},
 	staleWhileRevalidate: {days: 4},
-	cacheKey: (): string => 'bugs:' + getRepo()!.nameWithOwner,
+	cacheKey: (): string => getRepo()!.nameWithOwner,
 });
 
 async function getSearchQueryBugLabel(): Promise<string> {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
+import {cacheByRepo, getRepo} from '../github-helpers';
 import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils';
@@ -63,7 +63,7 @@ const countBugs = cache.function('bugs', async (): Promise<number> => {
 }, {
 	maxAge: {minutes: 30},
 	staleWhileRevalidate: {days: 4},
-	cacheKey: (): string => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function getSearchQueryBugLabel(): Promise<string> {

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
+import {cacheByRepo, getRepo} from '../github-helpers';
 
 const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean> => {
 	const {repository, organization} = await api.v4(`
@@ -23,7 +23,7 @@ const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean>
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 function getCount(element: HTMLElement): number {

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -7,7 +7,7 @@ import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 
-const hasAnyProjects = cache.function(async (): Promise<boolean> => {
+const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean> => {
 	const {repository, organization} = await api.v4(`
 		repository() {
 			projects { totalCount }
@@ -23,7 +23,7 @@ const hasAnyProjects = cache.function(async (): Promise<boolean> => {
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: () => 'has-projects:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 function getCount(element: HTMLElement): number {

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -9,7 +9,7 @@ import * as api from '../github-helpers/api';
 import getTabCount from '../github-helpers/get-tab-count';
 import looseParseInt from '../helpers/loose-parse-int';
 import abbreviateNumber from '../helpers/abbreviate-number';
-import {buildRepoURL, getRepo} from '../github-helpers';
+import {buildRepoURL, cacheByRepo} from '../github-helpers';
 import {unhideOverflowDropdown} from './more-dropdown-links';
 
 async function canUserEditOrganization(): Promise<boolean> {
@@ -58,7 +58,7 @@ const getWikiPageCount = cache.function('wiki-page-count', async (): Promise<num
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 const getWorkflowsCount = cache.function('workflows-count', async (): Promise<number> => {
@@ -74,7 +74,7 @@ const getWorkflowsCount = cache.function('workflows-count', async (): Promise<nu
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 10},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function initWiki(): Promise<void | false> {

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -46,7 +46,7 @@ function onlyShowInDropdown(id: string): void {
 	select('.UnderlineNav-actions ul')!.append(menuItem);
 }
 
-const getWikiPageCount = cache.function(async (): Promise<number> => {
+const getWikiPageCount = cache.function('wiki-page-count', async (): Promise<number> => {
 	const dom = await fetchDom(buildRepoURL('wiki'));
 	const counter = dom.querySelector('#wiki-pages-box .Counter');
 
@@ -58,10 +58,10 @@ const getWikiPageCount = cache.function(async (): Promise<number> => {
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},
-	cacheKey: () => 'wiki-page-count:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
-const getWorkflowsCount = cache.function(async (): Promise<number> => {
+const getWorkflowsCount = cache.function('workflows-count', async (): Promise<number> => {
 	const {repository: {workflowFiles}} = await api.v4(`
 		repository() {
 			workflowFiles: object(expression: "HEAD:.github/workflows") {
@@ -74,7 +74,7 @@ const getWorkflowsCount = cache.function(async (): Promise<number> => {
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 10},
-	cacheKey: () => 'workflows-count:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function initWiki(): Promise<void | false> {

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -18,7 +18,7 @@ import {getReleaseCount} from './releases-tab';
 // TODO: Not an exact match; Moderators can edit comments but not create releases
 const canCreateRelease = canEditEveryComment;
 
-const getFirstTag = cache.function(async (commit: string): Promise<string | undefined> => {
+const getFirstTag = cache.function('first-tag', async (commit: string): Promise<string | undefined> => {
 	const firstTag = await fetchDom(
 		buildRepoURL('branch_commits', commit),
 		'ul.branches-tag-list li:last-child a',
@@ -26,7 +26,7 @@ const getFirstTag = cache.function(async (commit: string): Promise<string | unde
 
 	return firstTag?.textContent ?? undefined;
 }, {
-	cacheKey: ([commit]) => `first-tag:${getRepo()!.nameWithOwner}:${commit}`,
+	cacheKey: ([commit]) => [getRepo()!.nameWithOwner, commit].join(':'),
 });
 
 async function init(): Promise<void> {

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -25,7 +25,7 @@ function addTooltip(element: HTMLElement, tooltip: string): void {
 	}
 }
 
-const getWorkflowsDetails = cache.function(async (): Promise<Record<string, WorkflowDetails> | false> => {
+const getWorkflowsDetails = cache.function('workflows', async (): Promise<Record<string, WorkflowDetails> | false> => {
 	const {repository: {workflowFiles}} = await api.v4(`
 		repository() {
 			workflowFiles: object(expression: "HEAD:.github/workflows") {
@@ -62,7 +62,7 @@ const getWorkflowsDetails = cache.function(async (): Promise<Record<string, Work
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 10},
-	cacheKey: () => 'workflows:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void> {

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
+import {cacheByRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
 
 type WorkflowDetails = {
@@ -62,7 +62,7 @@ const getWorkflowsDetails = cache.function('workflows', async (): Promise<Record
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 10},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void> {

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import {buildRepoURL, getRepo, getUsername} from '../github-helpers';
 
-const getCollaborators = cache.function(async (): Promise<string[]> => {
+const getCollaborators = cache.function('repo-collaborators', async (): Promise<string[]> => {
 	const dom = await fetchDom(buildRepoURL('issues/show_menu_content?partial=issues/filters/authors_content'));
 	return select
 		.all('.SelectMenu-item img[alt]', dom)
@@ -16,7 +16,7 @@ const getCollaborators = cache.function(async (): Promise<string[]> => {
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: () => 'repo-collaborators:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function highlightCollaborators(): Promise<void> {

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
-import {buildRepoURL, getRepo, getUsername} from '../github-helpers';
+import {buildRepoURL, cacheByRepo, getUsername} from '../github-helpers';
 
 const getCollaborators = cache.function('repo-collaborators', async (): Promise<string[]> => {
 	const dom = await fetchDom(buildRepoURL('issues/show_menu_content?partial=issues/filters/authors_content'));
@@ -16,7 +16,7 @@ const getCollaborators = cache.function('repo-collaborators', async (): Promise<
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function highlightCollaborators(): Promise<void> {

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -11,7 +11,7 @@ import GitHubURL from '../github-helpers/github-url';
 import {groupButtons} from '../github-helpers/group-buttons';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';
-import {buildRepoURL, getCurrentCommittish, getLatestVersionTag, getRepo} from '../github-helpers';
+import {buildRepoURL, cacheByRepo, getCurrentCommittish, getLatestVersionTag} from '../github-helpers';
 
 type RepoPublishState = {
 	latestTag: string | false;
@@ -86,7 +86,7 @@ const getRepoPublishState = cache.function('tag-ahead-by', async (): Promise<Rep
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 2},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function init(): Promise<false | void> {

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -30,7 +30,7 @@ type Tags = {
 
 const undeterminableAheadBy = Number.MAX_SAFE_INTEGER; // For when the branch is ahead by more than 20 commits #5505
 
-const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> => {
+const getRepoPublishState = cache.function('tag-ahead-by', async (): Promise<RepoPublishState> => {
 	const {repository} = await api.v4(`
 		repository() {
 			refs(first: 20, refPrefix: "refs/tags/", orderBy: {
@@ -86,7 +86,7 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 2},
-	cacheKey: () => 'tag-ahead-by:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function init(): Promise<false | void> {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -15,7 +15,8 @@ type FileType = {
 	type: string;
 };
 
-const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
+const cacheName = 'changelog';
+const getCacheKey = (): string => getRepo()!.nameWithOwner;
 
 const changelogFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
 function findChangelogName(files: string[]): string | false {
@@ -24,11 +25,11 @@ function findChangelogName(files: string[]): string | false {
 
 function parseFromDom(): false {
 	const files = select.all('[aria-labelledby="files"] .js-navigation-open[href*="/blob/"').map(file => file.title);
-	void cache.set(getCacheKey(), findChangelogName(files));
+	void cache.set(cacheName + ':' + getCacheKey(), findChangelogName(files));
 	return false;
 }
 
-const getChangelogName = cache.function(async (): Promise<string | false> => {
+const getChangelogName = cache.function(cacheName, async (): Promise<string | false> => {
 	const {repository} = await api.v4(`
 		repository() {
 			object(expression: "HEAD:") {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {wrapAll} from '../helpers/dom-utils';
-import {buildRepoURL, getRepo} from '../github-helpers';
+import {buildRepoURL, cacheByRepo} from '../github-helpers';
 
 type FileType = {
 	name: string;
@@ -16,7 +16,6 @@ type FileType = {
 };
 
 const cacheName = 'changelog';
-const getCacheKey = (): string => getRepo()!.nameWithOwner;
 
 const changelogFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
 function findChangelogName(files: string[]): string | false {
@@ -25,7 +24,7 @@ function findChangelogName(files: string[]): string | false {
 
 function parseFromDom(): false {
 	const files = select.all('[aria-labelledby="files"] .js-navigation-open[href*="/blob/"').map(file => file.title);
-	void cache.set(cacheName + ':' + getCacheKey(), findChangelogName(files));
+	void cache.set(cacheName + ':' + cacheByRepo(), findChangelogName(files));
 	return false;
 }
 
@@ -52,7 +51,7 @@ const getChangelogName = cache.function(cacheName, async (): Promise<string | fa
 
 	return findChangelogName(files);
 }, {
-	cacheKey: getCacheKey,
+	cacheKey: cacheByRepo,
 });
 
 async function init(): Promise<void | false> {

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -9,7 +9,7 @@ import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';
-import {buildRepoURL, getRepo} from '../github-helpers';
+import {buildRepoURL, cacheByRepo} from '../github-helpers';
 
 function getPRUrl(prNumber: number): string {
 	return buildRepoURL('pull', prNumber, 'files');
@@ -102,7 +102,7 @@ const getPrsByFile = cache.function('files-with-prs', async (): Promise<Record<s
 }, {
 	maxAge: {hours: 2},
 	staleWhileRevalidate: {days: 9},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function getCurrentPath(): Promise<string> {

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -63,7 +63,7 @@ function getSingleButton(prNumber: number): HTMLElement {
 /**
 @returns prsByFile {"filename1": [10, 3], "filename2": [2]}
 */
-const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> => {
+const getPrsByFile = cache.function('files-with-prs', async (): Promise<Record<string, number[]>> => {
 	const {repository} = await api.v4(`
 		repository() {
 			pullRequests(
@@ -102,7 +102,7 @@ const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> 
 }, {
 	maxAge: {hours: 2},
 	staleWhileRevalidate: {days: 9},
-	cacheKey: () => 'files-with-prs:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function getCurrentPath(): Promise<string> {

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -9,7 +9,7 @@ import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import {getUsername} from '../github-helpers';
 
-const getPublicOrganizationsNames = cache.function(async (username: string): Promise<string[]> => {
+const getPublicOrganizationsNames = cache.function('public-organizations', async (username: string): Promise<string[]> => {
 	// API v4 seems to *require* `org:read` permission AND it includes private organizations as well, which defeats the purpose. There's no way to filter them.
 	// GitHub's API explorer inexplicably only includes public organizations.
 	const response = await api.v3(`/users/${username}/orgs`);
@@ -17,7 +17,6 @@ const getPublicOrganizationsNames = cache.function(async (username: string): Pro
 }, {
 	maxAge: {hours: 6},
 	staleWhileRevalidate: {days: 10},
-	cacheKey: ([username]) => 'public-organizations:' + username,
 });
 
 async function init(): Promise<false | void> {

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -12,7 +12,7 @@ type IssueInfo = {
 	updatedAt: string;
 };
 
-const getLastUpdated = cache.function(async (issueNumbers: number[]): Promise<Record<string, IssueInfo>> => {
+const getLastUpdated = cache.function('last-updated', async (issueNumbers: number[]): Promise<Record<string, IssueInfo>> => {
 	const {repository} = await api.v4(`
 		repository() {
 			${issueNumbers.map(number => `
@@ -26,7 +26,7 @@ const getLastUpdated = cache.function(async (issueNumbers: number[]): Promise<Re
 	return repository;
 }, {
 	maxAge: {minutes: 30},
-	cacheKey: ([issues]) => `pinned-issues:${getRepo()!.nameWithOwner}:${String(issues)}`,
+	cacheKey: ([issues]) => `${getRepo()!.nameWithOwner}:${String(issues)}`,
 });
 
 function getPinnedIssueNumber(pinnedIssue: HTMLElement): number {

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -7,7 +7,7 @@ import features from '../feature-manager';
 import * as api from '../github-helpers/api';
 import pluralize from '../helpers/pluralize';
 
-const getCommitChanges = cache.function(async (commit: string): Promise<[additions: number, deletions: number]> => {
+const getCommitChanges = cache.function('commit-changes', async (commit: string): Promise<[additions: number, deletions: number]> => {
 	const {repository} = await api.v4(`
 		repository() {
 			object(expression: "${commit}") {
@@ -20,8 +20,6 @@ const getCommitChanges = cache.function(async (commit: string): Promise<[additio
 	`);
 
 	return [repository.object.additions, repository.object.deletions];
-}, {
-	cacheKey: ([commit]) => 'commit-changes:' + commit,
 });
 
 async function init(): Promise<void> {

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -52,7 +52,7 @@ function addDraftFilter(dropdown: HTMLElement): void {
 	addDropdownItem(dropdown, 'Not ready for review (Draft PR)', 'draft', 'true');
 }
 
-const hasChecks = cache.function(async (): Promise<boolean> => {
+const hasChecks = cache.function('has-checks', async (): Promise<boolean> => {
 	const {repository} = await api.v4(`
 		repository() {
 			head: object(expression: "HEAD") {
@@ -72,7 +72,7 @@ const hasChecks = cache.function(async (): Promise<boolean> => {
 	return repository.head.history.nodes.some((commit: AnyObject) => commit.statusCheckRollup);
 }, {
 	maxAge: {days: 3},
-	cacheKey: () => 'has-checks:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function addChecksFilter(reviewsFilter: HTMLElement): Promise<void> {

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -6,8 +6,8 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
+import {cacheByRepo} from '../github-helpers';
 
 const reviewsFilterSelector = '#reviews-select-menu';
 
@@ -72,7 +72,7 @@ const hasChecks = cache.function('has-checks', async (): Promise<boolean> => {
 	return repository.head.history.nodes.some((commit: AnyObject) => commit.statusCheckRollup);
 }, {
 	maxAge: {days: 3},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function addChecksFilter(reviewsFilter: HTMLElement): Promise<void> {

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -10,7 +10,7 @@ import {getCleanPathname} from '../github-helpers';
 import createDropdownItem from '../github-helpers/create-dropdown-item';
 import observe from '../helpers/selector-observer';
 
-const getGistCount = cache.function(async (username: string): Promise<number> => {
+const getGistCount = cache.function('gist-count', async (username: string): Promise<number> => {
 	const {user} = await api.v4(`
 		user(login: "${username}") {
 			gists(first: 0) {
@@ -22,7 +22,6 @@ const getGistCount = cache.function(async (username: string): Promise<number> =>
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 3},
-	cacheKey: ([username]) => 'gist-count:' + username,
 });
 
 function getUser(): {url: string; name: string} {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -51,7 +51,7 @@ export const getReleaseCount = cache.function(cacheName, async () => await parse
 async function addReleasesTab(): Promise<false | void> {
 	// Always prefer the information in the DOM
 	if (pageDetect.isRepoRoot()) {
-		await cache.delete(cacheName + cacheByRepo());
+		await cache.delete(cacheName + ':' + cacheByRepo());
 	}
 
 	const count = await getReleaseCount();

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -11,12 +11,11 @@ import * as api from '../github-helpers/api';
 import looseParseInt from '../helpers/loose-parse-int';
 import abbreviateNumber from '../helpers/abbreviate-number';
 import createDropdownItem from '../github-helpers/create-dropdown-item';
-import {buildRepoURL, getRepo} from '../github-helpers';
+import {buildRepoURL, cacheByRepo} from '../github-helpers';
 import {releasesSidebarSelector} from './clean-repo-sidebar';
 import {appendBefore, highlightTab, unhighlightTab} from '../helpers/dom-utils';
 
 const cacheName = 'releases-count';
-const getCacheKey = (): string => getRepo()!.nameWithOwner;
 
 async function parseCountFromDom(): Promise<number> {
 	const moreReleasesCountElement = await elementReady(releasesSidebarSelector + ' .Counter');
@@ -46,13 +45,13 @@ async function fetchFromApi(): Promise<number> {
 export const getReleaseCount = cache.function(cacheName, async () => await parseCountFromDom() || fetchFromApi(), {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},
-	cacheKey: getCacheKey,
+	cacheKey: cacheByRepo,
 });
 
 async function addReleasesTab(): Promise<false | void> {
 	// Always prefer the information in the DOM
 	if (pageDetect.isRepoRoot()) {
-		await cache.delete(cacheName + getCacheKey());
+		await cache.delete(cacheName + cacheByRepo());
 	}
 
 	const count = await getReleaseCount();

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo} from '../github-helpers';
+import {cacheByRepo} from '../github-helpers';
 
 type CommitTarget = {
 	oid: string;
@@ -92,7 +92,7 @@ const getFirstCommit = cache.function('first-commit', async (): Promise<[committ
 
 	return getRepoAge(commitSha, commitsCount);
 }, {
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 async function init(): Promise<void> {

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -66,7 +66,7 @@ const getRepoAge = async (commitSha: string, commitsCount: number): Promise<[com
 	return [committedDate, resourcePath];
 };
 
-const getFirstCommit = cache.function(async (): Promise<[committedDate: string, resourcePath: string]> => {
+const getFirstCommit = cache.function('first-commit', async (): Promise<[committedDate: string, resourcePath: string]> => {
 	const {repository} = await api.v4(`
 		repository() {
 			defaultBranchRef {
@@ -92,7 +92,7 @@ const getFirstCommit = cache.function(async (): Promise<[committedDate: string, 
 
 	return getRepoAge(commitSha, commitsCount);
 }, {
-	cacheKey: () => 'first-commit:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 async function init(): Promise<void> {

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -18,7 +18,7 @@ type PullRequest = {
 	url: string;
 };
 
-export const getPullRequestsAssociatedWithBranch = cache.function(async (): Promise<Record<string, PullRequest>> => {
+export const getPullRequestsAssociatedWithBranch = cache.function('associatedBranchPullRequests', async (): Promise<Record<string, PullRequest>> => {
 	const {repository} = await api.v4(`
 		repository() {
 			refs(refPrefix: "refs/heads/", last: 100) {
@@ -57,7 +57,7 @@ export const getPullRequestsAssociatedWithBranch = cache.function(async (): Prom
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 4},
-	cacheKey: () => 'associatedBranchPullRequests:' + getRepo()!.nameWithOwner,
+	cacheKey: () => getRepo()!.nameWithOwner,
 });
 
 export const stateIcon = {

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -6,7 +6,7 @@ import {GitMergeIcon, GitPullRequestIcon, GitPullRequestClosedIcon, GitPullReque
 import observe from '../helpers/selector-observer';
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {getRepo, upperCaseFirst} from '../github-helpers';
+import {cacheByRepo, upperCaseFirst} from '../github-helpers';
 
 type PullRequest = {
 	timelineItems: {
@@ -57,7 +57,7 @@ export const getPullRequestsAssociatedWithBranch = cache.function('associatedBra
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 4},
-	cacheKey: () => getRepo()!.nameWithOwner,
+	cacheKey: cacheByRepo,
 });
 
 export const stateIcon = {

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -13,7 +13,7 @@ function getLinkCopy(count: number): string {
 	return pluralize(count, 'one open pull request', 'at least $$ open pull requests');
 }
 
-const countPRs = cache.function(async (forkedRepo: string): Promise<[prCount: number, singlePrNumber?: number]> => {
+const countPRs = cache.function('prs-on-forked-repo', async (forkedRepo: string): Promise<[prCount: number, singlePrNumber?: number]> => {
 	const {search} = await api.v4(`
 		search(
 			first: 100,
@@ -43,7 +43,7 @@ const countPRs = cache.function(async (forkedRepo: string): Promise<[prCount: nu
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 2},
-	cacheKey: ([forkedRepo]): string => `prs-on-forked-repo:${forkedRepo}:${getRepo()!.nameWithOwner}`,
+	cacheKey: ([forkedRepo]): string => `${forkedRepo}:${getRepo()!.nameWithOwner}`,
 });
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -28,7 +28,7 @@ async function loadCommitPatch(commitUrl: string): Promise<string> {
 	return textContent;
 }
 
-const getLastCommitDate = cache.function(async (login: string): Promise<string | false> => {
+const getLastCommitDate = cache.function('last-commit', async (login: string): Promise<string | false> => {
 	for await (const page of api.v3paginated(`/users/${login}/events`)) {
 		for (const event of page as any) {
 			if (event.type !== 'PushEvent') {
@@ -66,7 +66,6 @@ const getLastCommitDate = cache.function(async (login: string): Promise<string |
 }, {
 	maxAge: {days: 10},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: ([login]) => 'last-commit:' + login,
 });
 
 function parseOffset(date: string): number {

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -8,15 +8,13 @@ import * as api from '../github-helpers/api';
 import {getUsername, getCleanPathname} from '../github-helpers';
 import attachElement from '../helpers/attach-element';
 
-const doesUserFollow = cache.function(async (userA: string, userB: string): Promise<boolean> => {
+const doesUserFollow = cache.function('user-follows', async (userA: string, userB: string): Promise<boolean> => {
 	const {httpStatus} = await api.v3(`/users/${userA}/following/${userB}`, {
 		json: false,
 		ignoreHTTPStatus: true,
 	});
 
 	return httpStatus === 204;
-}, {
-	cacheKey: ([userA, userB]) => `user-follows:${userA}:${userB}`,
 });
 
 async function init(): Promise<void> {

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -15,7 +15,7 @@ const branchInfoRegex = /([^ ]+)\.$/;
 
 // DO NOT use optional arguments/defaults in "cached functions" because they can't be memoized effectively
 // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864
-const _getDefaultBranch = cache.function(async function (repository: pageDetect.RepositoryInfo): Promise<string> {
+const _getDefaultBranch = cache.function('default-branch', async function (repository: pageDetect.RepositoryInfo): Promise<string> {
 	if (arguments.length === 0 || JSON.stringify(repository) === JSON.stringify(getRepo())) {
 		if (pageDetect.isRepoHome()) {
 			const branchSelector = await elementReady('[data-hotkey="w"]');
@@ -53,7 +53,7 @@ const _getDefaultBranch = cache.function(async function (repository: pageDetect.
 }, {
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 20},
-	cacheKey: ([repository]) => 'default-branch:' + repository.nameWithOwner,
+	cacheKey: ([repository]) => repository.nameWithOwner,
 });
 
 export default async function getDefaultBranch(repository: pageDetect.RepositoryInfo | undefined = getRepo()): Promise<string> {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -182,3 +182,5 @@ export async function isArchivedRepoAsync(): Promise<boolean> {
 	// DOM-based detection, we want awaitDomReady: false, so it needs to be here
 	return pageDetect.isArchivedRepo();
 }
+
+export const cacheByRepo = (): string => getRepo()!.nameWithOwner;

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -35,7 +35,7 @@ async function fetchHotfix(path: string): Promise<string> {
 
 export type HotfixStorage = Array<[FeatureID, string]>;
 
-export const updateHotfixes = cache.function(async (version: string): Promise<HotfixStorage> => {
+export const updateHotfixes = cache.function('hotfixes', async (version: string): Promise<HotfixStorage> => {
 	const content = await fetchHotfix('broken-features.csv');
 	if (!content) {
 		return [];
@@ -52,15 +52,13 @@ export const updateHotfixes = cache.function(async (version: string): Promise<Ho
 }, {
 	maxAge: {hours: 6},
 	staleWhileRevalidate: {days: 30},
-	cacheKey: () => 'hotfixes',
 });
 
-export const getStyleHotfix = cache.function(
+export const getStyleHotfix = cache.function('style-hotfixes',
 	async (version: string): Promise<string> => fetchHotfix(`style/${version}.css`),
 	{
 		maxAge: {hours: 6},
 		staleWhileRevalidate: {days: 300},
-		cacheKey: () => 'style-hotfixes',
 	},
 );
 
@@ -108,11 +106,10 @@ export async function getLocalStrings(): Promise<void> {
 	localStrings = await cache.get<Record<string, string>>(stringHotfixesKey) ?? {};
 }
 
-export const updateLocalStrings = cache.function(async (): Promise<Record<string, string>> => {
+export const updateLocalStrings = cache.function(stringHotfixesKey, async (): Promise<Record<string, string>> => {
 	const json = await fetchHotfix('strings.json');
 	return json ? JSON.parse(json) : {};
 }, {
 	maxAge: {hours: 6},
 	staleWhileRevalidate: {days: 30},
-	cacheKey: () => stringHotfixesKey,
 });


### PR DESCRIPTION
- Includes https://github.com/fregante/webext-storage-cache/pull/39

It looks pretty smooth, no great improvement though since many functions silently depend on a global (`user/repo`). This should help on that front:

- https://github.com/refined-github/refined-github/issues/5848