### PR TITLE
Meta: use `hasRepoHeader`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -182,7 +182,7 @@ async function init(): Promise<void | false> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	init,
 });

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -51,7 +51,7 @@ async function init(): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	exclude: [
 		pageDetect.isEmptyRepo,

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -77,7 +77,7 @@ const getWorkflowsCount = cache.function(async (): Promise<number> => {
 	cacheKey: () => 'workflows-count:' + getRepo()!.nameWithOwner,
 });
 
-async function initWiki(): Promise<void | false> {
+async function updateWikiTab(): Promise<void | false> {
 	const wikiTab = await elementReady('[data-hotkey="g w"]');
 	if (!wikiTab) {
 		return false;
@@ -91,7 +91,7 @@ async function initWiki(): Promise<void | false> {
 	}
 }
 
-async function initActions(): Promise<void | false> {
+async function updateActionsTab(): Promise<void | false> {
 	const actionsTab = await elementReady('[data-hotkey="g a"]');
 	if (!actionsTab) {
 		return false;
@@ -105,7 +105,7 @@ async function initActions(): Promise<void | false> {
 	onlyShowInDropdown('actions-tab');
 }
 
-async function initProjects(): Promise<void | false> {
+async function updateProjectsTab(): Promise<void | false> {
 	const projectsTab = await elementReady('[data-hotkey="g b"]');
 	if (await getTabCount(projectsTab!) > 0 || mustKeepTab(projectsTab)) {
 		return false;
@@ -124,7 +124,7 @@ async function initProjects(): Promise<void | false> {
 	projectsTab!.remove();
 }
 
-async function init(): Promise<void | false> {
+async function moveRareTabs(): Promise<void | false> {
 	// The user may have disabled `more-dropdown-links` so un-hide it
 	if (!await unhideOverflowDropdown()) {
 		return false;
@@ -136,29 +136,25 @@ async function init(): Promise<void | false> {
 	onlyShowInDropdown('insights-tab');
 }
 
+async function init(): Promise<void> {
+	await Promise.all([
+		moveRareTabs(),
+		updateActionsTab(),
+		updateWikiTab(),
+		updateProjectsTab()
+	]);
+}
+
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	deduplicate: 'has-rgh',
 	init,
 }, {
 	include: [
-		pageDetect.isRepo,
 		pageDetect.isOrganizationProfile,
 	],
 	deduplicate: 'has-rgh',
-	init: initProjects,
-}, {
-	include: [
-		pageDetect.isRepo,
-	],
-	deduplicate: 'has-rgh',
-	init: initActions,
-}, {
-	include: [
-		pageDetect.isRepo,
-	],
-	deduplicate: 'has-rgh',
-	init: initWiki,
+	init: updateProjectsTab,
 });

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -141,7 +141,7 @@ async function init(): Promise<void> {
 		moveRareTabs(),
 		updateActionsTab(),
 		updateWikiTab(),
-		updateProjectsTab()
+		updateProjectsTab(),
 	]);
 }
 

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -43,7 +43,7 @@ async function init(): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	exclude: [
 		pageDetect.isEmptyRepo,
@@ -52,5 +52,6 @@ void features.add(import.meta.url, {
 		() => !select.exists('.js-responsive-underlinenav'),
 	],
 	deduplicate: 'has-rgh',
+	awaitDomReady: true, // DOM-based filter
 	init,
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -115,7 +115,7 @@ void features.add(import.meta.url, {
 		'g r': 'Go to Releases',
 	},
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	init,
 });

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -39,7 +39,7 @@ async function init(): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 	],
 	deduplicate: 'has-rgh',
 	init,

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -107,7 +107,7 @@ void features.add(import.meta.url, {
 	init: handleNewIssue,
 }, {
 	include: [
-		pageDetect.isRepo,
+		pageDetect.hasRepoHeader,
 		pageDetect.isUserProfile,
 		pageDetect.isOrganizationProfile,
 	],


### PR DESCRIPTION
- Follows https://github.com/refined-github/github-url-detection/pull/131
- For https://github.com/refined-github/refined-github/issues/5222#issuecomment-1245728297


## Test URLs

### `clean-repo-tabs`

This feature was slightly refactored.

- Org with 0 projects: https://github.com/babel
- Repo with 0 projects: https://github.com/babel/flavortown
- Repo with 0 wiki: https://github.com/babel/babel-sublime-snippets
