### PR TITLE
Collapse sections in options page

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -47,6 +47,7 @@ summary {
 	padding: var(--summary-padding);
 	cursor: pointer;
 }
+
 summary:hover {
 	background: #aaa4;
 }

--- a/source/options.css
+++ b/source/options.css
@@ -42,10 +42,13 @@ details[open] {
 
 summary {
 	--summary-padding: 10px;
-	background: #aaa4;
+	background: #aaa1;
 	list-style: none;
 	padding: var(--summary-padding);
 	cursor: pointer;
+}
+summary:hover {
+	background: #aaa4;
 }
 
 details[open] summary {

--- a/source/options.css
+++ b/source/options.css
@@ -34,6 +34,29 @@ li[data-validation] {
 	margin-bottom: 0.3em;
 }
 
+details[open] {
+	--border-left: 4px;
+	border-left: solid var(--border-left) #aaa4;
+	padding-bottom: 1px;
+}
+
+summary {
+	--summary-padding: 10px;
+	background: #aaa4;
+	list-style: none;
+	padding: var(--summary-padding);
+	cursor: pointer;
+}
+
+details[open] summary {
+	margin-bottom: 10px;
+	padding-left: calc(var(--summary-padding) - var(--border-left));
+}
+
+details[open] > :not(summary) {
+	margin-left: 10px;
+}
+
 [data-validation]::before {
 	content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" fill="gray" d="M8 5.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM4 8a4 4 0 118 0 4 4 0 01-8 0z"></path></svg>');
 	width: 16px;

--- a/source/options.css
+++ b/source/options.css
@@ -154,10 +154,6 @@ details[open] > :not(summary) {
 	opacity: 50%;
 }
 
-#show-debugging ~ * {
-	display: none;
-}
-
 details {
 	margin-bottom: 1em;
 }

--- a/source/options.css
+++ b/source/options.css
@@ -15,12 +15,12 @@
 	--rgh-red: #cf222e;
 }
 
-html:after {
+html::after {
 	/* Add some extra scroll to the page to reduce section toggle jumps/scroll */
 	content: '';
 	display: block;
 	height: 50vh;
-	background: url(icon.png) center no-repeat;
+	background: url('icon.png') center no-repeat;
 	filter: opacity(0.1) saturate(0) brightness(1.2);
 }
 

--- a/source/options.css
+++ b/source/options.css
@@ -15,6 +15,15 @@
 	--rgh-red: #cf222e;
 }
 
+html:after {
+	/* Add some extra scroll to the page to reduce section toggle jumps/scroll */
+	content: '';
+	display: block;
+	height: 50vh;
+	background: url(icon.png) center no-repeat;
+	filter: opacity(0.1) saturate(0) brightness(1.2);
+}
+
 @media (prefers-color-scheme: dark) {
 	:root {
 		--rgh-red: #f85149;
@@ -32,6 +41,10 @@ ul {
 
 li[data-validation] {
 	margin-bottom: 0.3em;
+}
+
+details {
+	margin-bottom: 1em;
 }
 
 details[open] {
@@ -152,10 +165,6 @@ details[open] > :not(summary) {
 
 .feature-checkbox:disabled + .info > *:not(.hotfix-notice) {
 	opacity: 50%;
-}
-
-details {
-	margin-bottom: 1em;
 }
 
 .screenshot {

--- a/source/options.html
+++ b/source/options.html
@@ -49,6 +49,19 @@
 		<p><input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off"></p>
 	</details>
 
+	<details id="bisect">
+		<summary><strong>🔎 Identify feature</strong></summary>
+		<p>
+			This process will help you identify what Refined GitHub feature is making changes or causing issues on GitHub.
+		</p>
+		<p id="find-feature-message" hidden>
+			Visit the GitHub page where you want to find the feature and refresh it to see the instructions. You can navigate to any page, but don’t use multiple tabs.
+		</p>
+		<p>
+			<button id="find-feature">Start process to identify feature…</button>
+		</p>
+	</details>
+
 	<details id="debugging">
 		<summary><strong>🐛 Debugging</strong></summary>
 		<p>
@@ -67,20 +80,6 @@
 			<button id="clear-cache">Clear cache</button>
 		</p>
 
-		<hr>
-
-		<p>
-			<strong>🔎 Find a feature</strong>
-		</p>
-		<p>
-			This process will help you identify what Refined GitHub feature is making changes or causing issues on GitHub.
-		</p>
-		<p id="find-feature-message" hidden>
-			Visit the GitHub page where you want to find the feature and refresh it to see the instructions. You can navigate to any page, but don’t use multiple tabs.
-		</p>
-		<p>
-			<button id="find-feature">Start process to identify feature…</button>
-		</p>
 	</details>
 
 

--- a/source/options.html
+++ b/source/options.html
@@ -13,7 +13,7 @@
 		</p>
 	</details>
 
-	<details id="token" open>
+	<details id="token">
 		<summary><strong>🔑 Personal token</strong></summary>
 		<p>
 			Optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo">generate one</a><br>

--- a/source/options.html
+++ b/source/options.html
@@ -4,65 +4,62 @@
 <title>Refined GitHub options</title>
 <link rel="stylesheet" href="options.css">
 <form id="options-form" class="detail-view-container">
-	<p>
-		<strong>👋 Information</strong><br>
-		Visit the <a href="https://github.com/refined-github/refined-github/issues/3543">welcome page</a> to learn about updates, debugging, and GitHub Enterprise.
-		You can <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
-		Follow or sponsor <a href="https://github.com/sponsors/fregante">@fregante</a> or <a href="https://github.com/sponsors/cheap-glitch">@cheap-glitch</a> if Refined GitHub helps you work more efficiently. 🍻
-	</p>
+	<details id="info" open>
+		<summary><strong>👋 Information</strong></summary>
+		<p>
+			Visit the <a href="https://github.com/refined-github/refined-github/issues/3543">welcome page</a> to learn about updates, debugging, and GitHub Enterprise.
+			You can <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
+			Follow or sponsor <a href="https://github.com/sponsors/fregante">@fregante</a> or <a href="https://github.com/sponsors/cheap-glitch">@cheap-glitch</a> if Refined GitHub helps you work more efficiently. 🍻
+		</p>
+	</details>
 
 	<hr>
 
-	<p>
-		<label>
-			<strong>🔑 Personal token</strong> (optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo">generate one</a>)<br>
+	<details id="token" open>
+		<summary><strong>🔑 Personal token</strong></summary>
+		<p>
+			Optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo">generate one</a>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input type="text" name="personalToken" pattern="[\da-f]{40}|ghp_\w{36,251}" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
 			<span id="validation"></span>
-		</label>
-	</p>
-	<ul>
-		<li data-validation data-scope="valid_token">The token enables <a href="https://github.com/refined-github/refined-github/search?q=github-helpers+api">some features</a> to <strong>read</strong> data from public repositories
-		<li data-validation data-scope="public_repo">The <code>public_repo</code> scope lets them <strong>edit</strong> your public repositories
-		<li data-validation data-scope="repo">The <code>repo</code> scope lets them <strong>edit private</strong> repositories as well
-		<li data-validation data-scope="delete_repo">The <code>delete_repo</code> scope is only used by the <code>quick-repo-deletion</code> feature
-	</ul>
+		</p>
+		<ul>
+			<li data-validation data-scope="valid_token">The token enables <a href="https://github.com/refined-github/refined-github/search?q=github-helpers+api">some features</a> to <strong>read</strong> data from public repositories
+			<li data-validation data-scope="public_repo">The <code>public_repo</code> scope lets them <strong>edit</strong> your public repositories
+			<li data-validation data-scope="repo">The <code>repo</code> scope lets them <strong>edit private</strong> repositories as well
+			<li data-validation data-scope="delete_repo">The <code>delete_repo</code> scope is only used by the <code>quick-repo-deletion</code> feature
+		</ul>
+	</details>
 
 	<hr>
 
-	<p>
+	<details id="action">
+		<summary><strong>🔗 Refined GitHub link</strong></summary>
 		<label>
 			<strong>🔗 Refined GitHub link</strong><br>
 			This page will open when clicking the toolbar icon
 			<input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off">
 		</label>
-	</p>
+	</details>
 
 	<hr>
 
-	<p>
-		<label>
-			<strong>💅 Custom CSS</strong> (useful to undo unwanted styles)
-			<textarea name="customCSS" rows="2" spellcheck="false"></textarea>
-		</label>
-	</p>
+	<details id="css">
+		<summary><strong>💅 Custom CSS</strong> (useful to undo unwanted styles)</summary>
+		<textarea name="customCSS" rows="2" spellcheck="false"></textarea>
+	</details>
 
 	<hr>
 
-	<div>
-		<p id="show-debugging">
-			<button>Show debugging tools</button>
-		</p>
-		<p>
-			<strong>🐛 Debugging</strong>
-		</p>
+	<details id="debugging">
+		<summary><strong>🐛 Debugging</strong></summary>
 		<p>
 			<label>
 				<input type="checkbox" name="logging">
 				Show the features enabled on each page in the console
 			</label>
 		</p>
-		<p id="logHTTP-line" hidden>
+		<p>
 			<label>
 				<input type="checkbox" name="logHTTP"/>
 					Log API calls in the console
@@ -86,17 +83,17 @@
 		<p>
 			<button id="find-feature">Start process to identify feature…</button>
 		</p>
-	</div>
+	</details>
 
 	<hr>
 
-	<p>
-		<label>
-			<strong class="features-header">🔋 Features</strong>
-			<input id="filter-features" type="text" placeholder="Find features" spellcheck="false" autocomplete="off" autocapitalize="off">
-		</label>
-	</p>
-	<div class="js-features"></div>
+	<details id="features">
+		<summary><strong class="features-header">🔋 Features</strong></summary>
+		<p>
+				<input id="filter-features" type="text" placeholder="Find features" spellcheck="false" autocomplete="off" autocapitalize="off">
+		</p>
+		<div class="js-features"></div>
+	</details>
 
 </form>
 <script src="options.js"></script>

--- a/source/options.html
+++ b/source/options.html
@@ -13,12 +13,10 @@
 		</p>
 	</details>
 
-	<hr>
-
 	<details id="token" open>
 		<summary><strong>🔑 Personal token</strong></summary>
 		<p>
-			Optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo">generate one</a>
+			Optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo">generate one</a><br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input type="text" name="personalToken" pattern="[\da-f]{40}|ghp_\w{36,251}" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
 			<span id="validation"></span>
@@ -31,25 +29,17 @@
 		</ul>
 	</details>
 
-	<hr>
-
 	<details id="action">
 		<summary><strong>🔗 Refined GitHub link</strong></summary>
-		<label>
-			<strong>🔗 Refined GitHub link</strong><br>
-			This page will open when clicking the toolbar icon
-			<input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off">
-		</label>
+		<p>This page will open when clicking the toolbar icon</p>
+		<p><input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off"></p>
 	</details>
-
-	<hr>
 
 	<details id="css">
-		<summary><strong>💅 Custom CSS</strong> (useful to undo unwanted styles)</summary>
-		<textarea name="customCSS" rows="2" spellcheck="false"></textarea>
+		<summary><strong>💅 Custom CSS</strong></summary>
+		<p>Like a userstyle, useful to undo unwanted style changes</p>
+		<p><textarea name="customCSS" rows="2" spellcheck="false"></textarea></p>
 	</details>
-
-	<hr>
 
 	<details id="debugging">
 		<summary><strong>🐛 Debugging</strong></summary>
@@ -84,8 +74,6 @@
 			<button id="find-feature">Start process to identify feature…</button>
 		</p>
 	</details>
-
-	<hr>
 
 	<details id="features">
 		<summary><strong class="features-header">🔋 Features</strong></summary>

--- a/source/options.html
+++ b/source/options.html
@@ -29,16 +29,24 @@
 		</ul>
 	</details>
 
-	<details id="action">
-		<summary><strong>🔗 Refined GitHub link</strong></summary>
-		<p>This page will open when clicking the toolbar icon</p>
-		<p><input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off"></p>
+	<details id="features">
+		<summary><strong class="features-header">🔋 Features</strong></summary>
+		<p>
+				<input id="filter-features" type="text" placeholder="Find features" spellcheck="false" autocomplete="off" autocapitalize="off">
+		</p>
+		<div class="js-features"></div>
 	</details>
 
 	<details id="css">
 		<summary><strong>💅 Custom CSS</strong></summary>
 		<p>Like a userstyle, useful to undo unwanted style changes</p>
 		<p><textarea name="customCSS" rows="2" spellcheck="false"></textarea></p>
+	</details>
+
+	<details id="action">
+		<summary><strong>🔗 Refined GitHub link</strong></summary>
+		<p>This page will open when clicking the toolbar icon</p>
+		<p><input type="url" name="actionUrl" placeholder="https://github.com" spellcheck="false" autocomplete="off" autocapitalize="off"></p>
 	</details>
 
 	<details id="debugging">
@@ -51,7 +59,7 @@
 		</p>
 		<p>
 			<label>
-				<input type="checkbox" name="logHTTP"/>
+				<input type="checkbox" name="logHTTP">
 					Log API calls in the console
 			</label>
 		</p>
@@ -75,13 +83,6 @@
 		</p>
 	</details>
 
-	<details id="features">
-		<summary><strong class="features-header">🔋 Features</strong></summary>
-		<p>
-				<input id="filter-features" type="text" placeholder="Find features" spellcheck="false" autocomplete="off" autocapitalize="off">
-		</p>
-		<div class="js-features"></div>
-	</details>
 
 </form>
 <script src="options.js"></script>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -292,10 +292,6 @@ function addEventListeners(): void {
 			window.open(event.delegateTarget.href);
 		}
 	});
-
-	select('#show-debugging button')!.addEventListener('click', function () {
-		this.parentElement!.remove();
-	});
 }
 
 async function init(): Promise<void> {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -70,10 +70,15 @@ async function getTokenScopes(personalToken: string): Promise<string[]> {
 	return scopes;
 }
 
+function expandTokenSection(): void {
+	select('details#token')!.open = true;
+}
+
 async function validateToken(): Promise<void> {
 	reportStatus({});
 	const tokenField = select('input[name="personalToken"]')!;
 	if (!tokenField.validity.valid || tokenField.value.length === 0) {
+		expandTokenSection();
 		return;
 	}
 
@@ -86,6 +91,7 @@ async function validateToken(): Promise<void> {
 	} catch (error) {
 		assertError(error);
 		reportStatus({error: true, text: error.message});
+		expandTokenSection();
 		throw error;
 	}
 }

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -242,11 +242,6 @@ async function generateDom(): Promise<void> {
 	moveNewAndDisabledFeaturesToTop();
 	void validateToken();
 
-	// Allow HTTP logging on dev builds
-	if (process.env.NODE_ENV === 'development') {
-		select('#logHTTP-line')!.hidden = false;
-	}
-
 	// Add feature count. CSS-only features are added approximately
 	select('.features-header')!.append(` (${featuresMeta.length + 25})`);
 


### PR DESCRIPTION
- Includes https://github.com/refined-github/refined-github/issues/5222#issuecomment-1172237540
- In preparation for a future https://github.com/refined-github/refined-github/issues/6383

## Test URLs

Open the options page

<details>
<summary>Initial screenshots / demos </summary>


## Video


https://user-images.githubusercontent.com/1402241/220904136-ca1be78d-4b82-46b1-8faf-4277f5bfa4d7.mov



## First load

<img width="557" alt="Screenshot 8" src="https://user-images.githubusercontent.com/1402241/220904099-9e8044e2-2467-4a63-99e6-b9c079984d0f.png">


## Everything expanded
<img width="557" alt="Screenshot 9" src="https://user-images.githubusercontent.com/1402241/220904198-27c1be82-012e-47af-ad37-064b00682fc0.png">



## Firefox

<img width="680" alt="Screenshot 10" src="https://user-images.githubusercontent.com/1402241/220904280-8bb7cc92-f27b-4a58-af4c-cc5d6fd7f7d2.png">


</details>