### PR TITLE
Sort Refined GitHub shortcuts in Shortcut Help dialog

### DIFF
--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -17,14 +17,16 @@ function improveShortcutHelp(dialog: Element): void {
 			</div>
 
 			<ul>
-				{[...features.shortcutMap].map(([hotkey, description]) => (
-					<li className="Box-row d-flex flex-row">
-						<div className="flex-auto">{description}</div>
-						<div className="ml-2 no-wrap">
-							{splitKeys(hotkey)}
-						</div>
-					</li>
-				))}
+				{[...features.shortcutMap]
+					.sort(([, a], [, b]) => a.localeCompare(b))
+					.map(([hotkey, description]) => (
+						<li className="Box-row d-flex flex-row">
+							<div className="flex-auto">{description}</div>
+							<div className="ml-2 no-wrap">
+								{splitKeys(hotkey)}
+							</div>
+						</li>
+					))}
 			</ul>
 		</div>,
 	);

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -24,10 +24,7 @@ async function init(): Promise<void> {
 
 void features.add(import.meta.url, {
 	shortcuts: {
-		'g 1': 'Go to Conversation',
-		'g 2': 'Go to Commits',
-		'g 3': 'Go to Checks',
-		'g 4': 'Go to Files changed',
+		'g <number>': 'Go to PR tab <number>',
 		'g →': 'Go to next PR tab',
 		'g ←': 'Go to previous PR tab',
 	},


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5439

## Test URLs

This page, press the `?` key

## Screenshot

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="308" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/220908958-09387e02-989c-4e75-bff9-594b5e9a29b1.png">
	<td><img width="308" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/220908935-fc2461ad-bf34-4b9b-8fd6-ef798f4be715.png">
</table>





