### PR TITLE
Disable `quick-comment-edit` on non-editable issues

### DIFF
--- a/source/features/quick-comment-edit.css
+++ b/source/features/quick-comment-edit.css
@@ -1,0 +1,6 @@
+/* Re-hide buttons when you can't leave a new comment (locked conversation or user blocked you) */
+html:has(
+.previewable-comment-form .octicon-lock.blankslate-icon
+) .rgh-quick-comment-edit-button {
+	display: none;
+}

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -1,3 +1,4 @@
+import './quick-comment-edit.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import {PencilIcon} from '@primer/octicons-react';
@@ -59,5 +60,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 	],
+	// The feature is "disabled" via CSS selector when the conversation is locked.
+	// We want the edit buttons to appear while the conversation is loading, but we only know it's locked when the page has finished.
 	init,
 });


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6390

Note this fix is `has` selector-based: #5797 

## Test URLs

A conversation:

- you commented on in the past
- you can't edit or comment on anymore (locked or user blocked you)

## Screenshot

<img width="523" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/222110125-85993419-6ca8-497a-93af-d94ae3999897.png">
