### PR TITLE
Meta: Fix hotfixes

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -83,6 +83,6 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 	}
 
 	// Hope that the feature was fixed in this version
-	await cache.delete('hotfixes');
-	await cache.delete('style-hotfixes');
+	await cache.delete('hotfixes:');
+	await cache.delete('style-hotfixes:');
 });

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -52,6 +52,7 @@ export const updateHotfixes = cache.function('hotfixes', async (version: string)
 }, {
 	maxAge: {hours: 6},
 	staleWhileRevalidate: {days: 30},
+	cacheKey: () => '',
 });
 
 export const getStyleHotfix = cache.function('style-hotfixes',
@@ -59,6 +60,7 @@ export const getStyleHotfix = cache.function('style-hotfixes',
 	{
 		maxAge: {hours: 6},
 		staleWhileRevalidate: {days: 300},
+		cacheKey: () => '',
 	},
 );
 
@@ -69,7 +71,7 @@ export async function getLocalHotfixes(): Promise<HotfixStorage> {
 		return [];
 	}
 
-	return await cache.get<HotfixStorage>('hotfixes') ?? [];
+	return await cache.get<HotfixStorage>('hotfixes:') ?? [];
 }
 
 export async function getLocalHotfixesAsOptions(): Promise<Partial<RGHOptions>> {
@@ -103,7 +105,7 @@ export async function getLocalStrings(): Promise<void> {
 		return;
 	}
 
-	localStrings = await cache.get<Record<string, string>>(stringHotfixesKey) ?? {};
+	localStrings = await cache.get<Record<string, string>>(stringHotfixesKey + ':') ?? {};
 }
 
 export const updateLocalStrings = cache.function(stringHotfixesKey, async (): Promise<Record<string, string>> => {


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/6376
- Precedes https://github.com/fregante/webext-storage-cache/issues/40

Before my PR, the key was static: `'hotfixes'`
After my PR, the key became dynamic: `'hotfixes:0.0.0'`

I had ignored this because the actual key doesn't really matter when using `cache.function`, but it does matter when accessing the same cached item via `cache.get`. 

Yet another reason to fix the API as described in https://github.com/fregante/webext-storage-cache/issues/40