### PR TITLE
Show whether feature is hotfixed in `rgh-feature-descriptions`

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -98,3 +98,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+- https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
+- https://github.com/refined-github/refined-github/blob/main/source/features/clean-conversation-sidebar.css
+
+*/

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -2,12 +2,15 @@ import './rgh-feature-descriptions.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import {CopyIcon} from '@primer/octicons-react';
+import cache from 'webext-storage-cache';
 
 import features from '../feature-manager';
 import {featuresMeta} from '../../readme.md';
 import {getNewFeatureName} from '../options-storage';
 import {isRefinedGitHubRepo} from '../github-helpers';
 import observe from '../helpers/selector-observer';
+import {HotfixStorage} from '../helpers/hotfix';
+import {createRghIssueLink} from '../helpers/rgh-issue-link';
 
 async function add(infoBanner: HTMLElement): Promise<void> {
 	const [, currentFeature] = /source\/features\/([^.]+)/.exec(location.pathname) ?? [];
@@ -61,6 +64,23 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 					</a>
 				)}
 			</div>
+		</div>,
+	);
+
+	// Skip dev check present in `getLocalHotfixes`, we want to see this even when developing
+	const hotfixes = await cache.get<HotfixStorage>('hotfixes:') ?? [];
+
+	const hotfixed = hotfixes.find(([feature]) => feature === currentFeatureName);
+	if (!hotfixed) {
+		return;
+	}
+
+	const [_name, issue, unaffectedVersion] = hotfixed;
+
+	infoBanner.before(
+		<div className="mb-3 d-inline-block width-full flash flash-warn mb-2">
+			<strong>Note:</strong> This feature is disabled due to {createRghIssueLink(issue)}
+			{unaffectedVersion && ` until version ${unaffectedVersion}`}
 		</div>,
 	);
 }

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -33,7 +33,7 @@ async function fetchHotfix(path: string): Promise<string> {
 	return '';
 }
 
-export type HotfixStorage = Array<[FeatureID, string]>;
+export type HotfixStorage = Array<[FeatureID, string, string]>;
 
 export const updateHotfixes = cache.function('hotfixes', async (version: string): Promise<HotfixStorage> => {
 	const content = await fetchHotfix('broken-features.csv');
@@ -44,7 +44,7 @@ export const updateHotfixes = cache.function('hotfixes', async (version: string)
 	const storage: HotfixStorage = [];
 	for (const [featureID, relatedIssue, unaffectedVersion] of parseCsv(content)) {
 		if (featureID && relatedIssue && (!unaffectedVersion || compareVersions(unaffectedVersion, version) > 0)) {
-			storage.push([featureID as FeatureID, relatedIssue]);
+			storage.push([featureID as FeatureID, relatedIssue, unaffectedVersion]);
 		}
 	}
 


### PR DESCRIPTION


## Still disabled: `clean-conversation-sidebar`

<img width="400" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/222129918-35662f58-821b-4ad7-8319-e20aeb7bdc61.png">



## Already re-enabled (shows a "until version"): `sync-pr-commit-title`

<img width="370" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/222129935-72639a68-d47f-4b7b-81b6-0c98e2a817d2.png">
