### PR TITLE
Remove style override that is no longer needed

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -53,11 +53,6 @@
 	vertical-align: baseline !important;
 }
 
-/* Fix spacing of repo header button icons #5620 */
-.pagehead-actions :is(.btn, summary) .octicon {
-	margin-right: 4px !important;
-}
-
 /* Make sticky left-side sidebar scrollable on the dashboard #6099 */
 .dashboard-sidebar {
 	overflow: auto;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

The custom style which applies margin-right to the header button icons is no longer needed as GitHub has these styles corrected itself, and moreover the custom style is slightly incorrect as it was applying both to the icon before the text as well as the dropdown icon which doesn't need the margin.

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

**Before**

<img width="531" alt="image" src="https://user-images.githubusercontent.com/25914066/223124503-b6dfd857-dbf7-48b3-b2fb-7230cfed6bb0.png">

**After**


<img width="546" alt="SCR-20230306-agp" src="https://user-images.githubusercontent.com/25914066/223124538-1367dfe8-0f31-4397-aed2-74c19e8e0b4e.png">


