### PR TITLE
Add `rgh-netiquette` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -210,7 +210,6 @@ Thanks for contributing! 🦋🙌
 - [](# "wait-for-attachments") [Wait for the attachments to finish uploading before allowing to post a comment.](https://user-images.githubusercontent.com/46634000/104294547-9b8b0c80-54bf-11eb-93e5-65ae158353b3.gif)
 - [](# "quick-review-comment-deletion") [Adds a button to delete review comments in one click when editing them.](https://user-images.githubusercontent.com/46634000/115445792-9fdd6900-a216-11eb-9ba3-6dab4d2f9d32.png)
 - [](# "avoid-accidental-submissions") [Disables the <kbd>enter</kbd>-to-submit shortcut in some commit/PR/issue title fields to avoid accidental submissions. Use <kbd>ctrl</kbd> <kbd>enter</kbd> instead.](https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif)
-- [](# "comment-on-draft-pr-indicator") [Reminds you you’re commenting on a draft PR by changing the submit button’s label.](https://user-images.githubusercontent.com/34235681/152473140-22b6eb86-3ef4-4104-af10-4a659d878f91.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -255,7 +254,6 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-user-labels") [Links the "Contributor" and "Member" labels on comments to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
 - [](# "jump-to-conversation-close-event") [Adds a link to jump to the latest close event of a conversation.](https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif)
 - [](# "unhide-reactions-on-mobile") [Restores reactions button on mobile.](https://user-images.githubusercontent.com/38327267/205493629-14563105-eaa1-4885-9f07-8b3ee9214c86.png)
-- [](# "netiquette") [Adds unobtrusive netiquette reminders.](https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -288,8 +286,6 @@ Thanks for contributing! 🦋🙌
 - [](# "sync-pr-commit-title") 🔥 [Uses the PR’s title as the default squash commit title](https://github.com/refined-github/refined-github/issues/276) and [updates the PR’s title to match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
 - [](# "update-pr-from-base-branch") [Adds a button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/106494023-816d9a00-647f-11eb-8cb1-7c97aa8a5546.png) GitHub only adds it when the base branch is "protected".
 - [](# "one-click-review-submission") [Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
-- [](# "warn-pr-from-master") [Warns you when creating a pull request from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
-- [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [](# "pull-request-hotkeys") [Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>](https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png).
 - [](# "pr-branch-auto-delete") [Automatically deletes the branch right after merging a PR, if possible.](https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png)
 - [](# "one-click-pr-or-gist") [Lets you create draft pull requests and public gists in one click.](https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png)
@@ -372,6 +368,15 @@ Thanks for contributing! 🦋🙌
 - [](# "pagination-hotkey") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
+
+### Netiquette
+
+- [](# "netiquette") [Adds unobtrusive netiquette reminders.](https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png)
+- [](# "warn-pr-from-master") [Warns you when creating a pull request from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
+- [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
+- [](# "comment-on-draft-pr-indicator") [Reminds you you’re commenting on a draft PR by changing the submit button’s label.](https://user-images.githubusercontent.com/34235681/152473140-22b6eb86-3ef4-4104-af10-4a659d878f91.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -65,9 +65,9 @@ function addExistingTagLink(tagName: string): void {
 		before: () => (
 			<TimelineItem>
 				{createBanner({
-					text: <>The pull request first appeared in <span className="text-mono text-small">{tagName}</span></>,
+					text: <>This pull request first appeared in <span className="text-mono text-small">{tagName}</span></>,
 					classes: ['flash-success'],
-					url: tagUrl,
+					action: tagUrl,
 					buttonLabel: <><TagIcon/> See release</>,
 				})}
 			</TimelineItem>
@@ -90,7 +90,7 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 			<TimelineItem>
 				{createBanner(url ? {
 					text,
-					url,
+					action: url,
 					buttonLabel: <><TagIcon/> Draft a new release</>,
 				} : {text})}
 			</TimelineItem>

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -49,7 +49,7 @@ export function getNoticeText(): JSX.Element {
 function addConversationBanner(newCommentField: HTMLElement): void {
 	newCommentField.before(
 		createBanner({
-			icon: <InfoIcon/>,
+			icon: <InfoIcon className="m-0"/>,
 			classes: 'p-2 m-2 text-small color-fg-muted border-0'.split(' '),
 			text: getNoticeText(),
 		}),

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -50,7 +50,7 @@ function addConversationBanner(newCommentField: HTMLElement): void {
 	newCommentField.before(
 		createBanner({
 			icon: <InfoIcon className="m-0"/>,
-			classes: 'p-2 m-2 text-small color-fg-muted border-0'.split(' '),
+			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
 			text: getNoticeText(),
 		}),
 	);

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -62,7 +62,7 @@ function init(signal: AbortSignal): void | false {
 		return false;
 	}
 
-	observe('#issue-comment-box file-attachment', addConversationBanner, {signal});
+	observe('#issuecomment-new file-attachment', addConversationBanner, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -80,7 +80,7 @@ void features.add(import.meta.url, {
 
 Test URLs
 
-- Old issue: https://github.com/refined-github/refined-github/issues/3076
-- Old PR: https://github.com/refined-github/refined-github/pull/159
+- Old issue: https://github.com/facebook/react/issues/227
+- Old PR: https://github.com/facebook/react/pull/209
 
 */

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -1,0 +1,63 @@
+import React from 'dom-chef';
+import {InfoIcon} from '@primer/octicons-react';
+import * as pageDetect from 'github-url-detection';
+
+import createBanner from '../github-helpers/banner';
+import features from '../feature-manager';
+import observe from '../helpers/selector-observer';
+import {isAnyRefinedGitHubRepo} from '../github-helpers';
+import {getNoticeText, shouldDisplayNotice} from './netiquette';
+import TimelineItem from '../github-helpers/timeline-item';
+
+function addConversationBanner(newCommentBox: HTMLElement): void {
+	const button = (
+		<button
+			type="button"
+			className="btn-link"
+			onClick={() => {
+				banner.remove();
+				newCommentBox.hidden = false;
+			}}
+		>leave a comment
+		</button>
+	);
+	const banner = (
+		<TimelineItem>
+			{createBanner({
+				icon: <InfoIcon/>,
+				text: <>{getNoticeText()} If it must really be here, you can {button}.</>,
+			})}
+		</TimelineItem>
+	);
+	newCommentBox.before(banner);
+	newCommentBox.hidden = true;
+}
+
+function init(signal: AbortSignal): void | false {
+	// Do not move to `asLongAs` because those conditions are run before `isConversation`
+	if (!shouldDisplayNotice()) {
+		return false;
+	}
+
+	observe('#issuecomment-new:has(file-attachment)', addConversationBanner, {signal});
+}
+
+void features.add(import.meta.url, {
+	asLongAs: [
+		isAnyRefinedGitHubRepo,
+	],
+	include: [
+		pageDetect.isConversation,
+	],
+	awaitDomReady: true, // We're specifically looking for the last event
+	init,
+});
+
+/*
+
+Test URLs
+
+- Old issue: https://github.com/refined-github/refined-github/issues/3076
+- Old PR: https://github.com/refined-github/refined-github/pull/159
+
+*/

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -24,7 +24,7 @@ function addConversationBanner(newCommentBox: HTMLElement): void {
 	const banner = (
 		<TimelineItem>
 			{createBanner({
-				icon: <InfoIcon/>,
+				icon: <InfoIcon className="mr-1"/>,
 				text: <>{getNoticeText()} If it must really be here, you can {button}.</>,
 			})}
 		</TimelineItem>

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -34,9 +34,11 @@ export default function createBanner(props: BannerProps): JSX.Element {
 	return (
 		<div className={['flash', ...props.classes ?? ''].join(' ')}>
 			<div className="d-sm-flex flex-items-center gap-2">
-				{props.icon}
-				{/* TODO: Drop `any` after https://github.com/frenic/csstype/issues/177 */}
-				<div className="flex-auto flex-self-center" style={{textWrap: 'balance'} as any}>{props.text}</div>
+				<div className="d-flex flex-auto flex-self-center flex-items-center gap-2">
+					{props.icon}
+					{/* TODO: Drop `any` after https://github.com/frenic/csstype/issues/177 */}
+					<span style={{textWrap: 'balance'} as any}>{props.text}</span>
+				</div>
 				{button}
 			</div>
 		</div>

--- a/source/github-helpers/banner.tsx
+++ b/source/github-helpers/banner.tsx
@@ -1,25 +1,43 @@
 import React from 'dom-chef';
 import {RequireAllOrNone} from 'type-fest';
 
-type BannerProps = RequireAllOrNone<{
+export type BannerProps = RequireAllOrNone<{
+	icon?: JSX.Element;
 	text: Array<string | JSX.Element> | string | JSX.Element;
 	classes?: string[];
-	url: string;
+	action: string | (() => void);
 	buttonLabel: JSX.Element | string;
-}, 'url' | 'buttonLabel'>;
+}, 'action' | 'buttonLabel'>;
+
+// Classes copied from "had recent pushes" banner from repo home
+const classes = 'flex-shrink-0 btn btn-sm ml-sm-3 mt-2 mt-sm-n2 mb-sm-n2 mr-sm-n1 flex-self-center';
 
 // This could be a `<Banner/>` element but dom-chef doesn't pass props
 // https://github.com/vadimdemedes/dom-chef/issues/77
 export default function createBanner(props: BannerProps): JSX.Element {
-	// Classes copied from "had recent pushes" banner from repo home
+	let button: JSX.Element | undefined;
+
+	if (typeof props.action === 'string') {
+		button = (
+			<a href={props.action} className={classes}>
+				{props.buttonLabel}
+			</a>
+		);
+	} else if (typeof props.action === 'function') {
+		button = (
+			<button type="button" className={classes} onClick={props.action}>
+				{props.buttonLabel}
+			</button>
+		);
+	}
+
 	return (
 		<div className={['flash', ...props.classes ?? ''].join(' ')}>
-			<div className="d-sm-flex">
-				<div className="flex-auto">{props.text}</div>
-				{props.url && (
-					<a href={props.url} className="flex-shrink-0 btn btn-sm ml-sm-3 mt-2 mt-sm-n2 mb-sm-n2 mr-sm-n1 flex-self-center">
-						{props.buttonLabel}
-					</a>)}
+			<div className="d-sm-flex flex-items-center gap-2">
+				{props.icon}
+				{/* TODO: Drop `any` after https://github.com/frenic/csstype/issues/177 */}
+				<div className="flex-auto flex-self-center" style={{textWrap: 'balance'} as any}>{props.text}</div>
+				{button}
 			</div>
 		</div>
 	);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -217,3 +217,4 @@ import './features/clean-repo-header';
 import './features/emphasize-draft-pr-label';
 import './features/file-age-color';
 import './features/netiquette';
+import './features/rgh-netiquette';


### PR DESCRIPTION
- Continues from #6427 
- Part of #5934 

## Why

I don't want to lock issues, but also I don't want comments on years-old issues.

I think the only comments allowed there would be "GitHub implemented this" or "I extracted this code into its own extension". That is: actually-useful comments, not just disagreements or bug reports.

## Possible additional changes

- [ ] Completely block comments for old issues (>6mo)
- [ ] Keep comment box visible to us maintainers


👆 maybe not, because of the aforementioned _useful_ comments.

## Test URLs



- Old issue: https://github.com/refined-github/refined-github/issues/3076
- Old PR: https://github.com/refined-github/refined-github/pull/159



## Demo

![fixed](https://user-images.githubusercontent.com/1402241/227763707-3a54536c-f0a5-4332-ac74-37189fa0ebd5.gif)

