### PR TITLE
Add `workflow-log-copy-paste` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -399,6 +399,7 @@ Thanks for contributing! 🦋🙌
 - [](# "submission-via-ctrl-enter-everywhere") Enables submission via <kbd>ctrl</kbd> <kbd>enter</kbd> on every page possible.
 - [](# "clean-repo-header") [Reduces repository name wrapping by hiding the fork and watch count (they're still on the repository’s home page)](https://user-images.githubusercontent.com/1402241/218252904-6a31a933-41a7-452e-b841-9484e67429a8.png)
 - [](# "clean-mergeability-box") [Removes extra information in the PR mergeability box.](https://user-images.githubusercontent.com/25914066/224525440-d1ae40d2-29a0-47f0-a256-31d5b4bbdb1e.png)
+- [](# "workflow-log-copy-paste") Hides line numbers when copying logs from GitHub Action workflow runs.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/workflow-log-copy-paste.tsx
+++ b/source/features/workflow-log-copy-paste.tsx
@@ -1,0 +1,28 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager';
+
+function temporarilyHideNumbers(): void {
+	const lines = select.all('.js-checks-log-details[open] .CheckStep-line-number');
+	for (const line of lines) {
+		line.hidden = true;
+	}
+
+	setTimeout(() => {
+		for (const line of lines) {
+			line.hidden = false;
+		}
+	});
+}
+
+function init(signal: AbortSignal): void {
+	document.addEventListener('copy', temporarilyHideNumbers, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isActionJobRun,
+	],
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -215,3 +215,4 @@ import './features/emphasize-draft-pr-label';
 import './features/file-age-color';
 import './features/netiquette';
 import './features/rgh-netiquette';
+import './features/workflow-log-copy-paste';


### PR DESCRIPTION
- Close https://github.com/refined-github/refined-github/issues/6317

So painful. Finally I did this.

## Test URLs

1. Open https://github.com/refined-github/refined-github/actions
2. Navigate to a log (they expire eventually)
