### PR TITLE
Allow color customization via CSS in `file-age-color` and `release-download-count`

### DIFF
--- a/source/github-helpers/heat-map.css
+++ b/source/github-helpers/heat-map.css
@@ -4,46 +4,59 @@ Original file: https://github.githubassets.com/assets/code-d21b20a03009.css
 These colors are for normally-gray text.
 */
 
+/* stylelint-disable declaration-block-no-duplicate-properties */
+
 :root {
-	--rgh-heat-color-deg: 29deg;
+	--rgh-heat-color: #c24e00;
+	--rgh-gray: #6a737d;
 }
 
 :root [data-rgh-heat='1'] {
-	color: hsl(var(--rgh-heat-color-deg) 100% 38%) !important;
+	color: #c24e00 !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 100%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='2'] {
-	color: hsl(var(--rgh-heat-color-deg) 69% 40%) !important;
+	color: #ac571f !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 90%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='3'] {
-	color: hsl(var(--rgh-heat-color-deg) 57% 41%) !important;
+	color: #a35b2c !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 80%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='4'] {
-	color: hsl(var(--rgh-heat-color-deg) 47% 41%) !important;
+	color: #9a5f38 !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 70%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='5'] {
-	color: hsl(var(--rgh-heat-color-deg) 36% 42%) !important;
+	color: #926245 !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 60%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='6'] {
-	color: hsl(var(--rgh-heat-color-deg) 26% 43%) !important;
+	color: #896651 !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 50%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='7'] {
-	color: hsl(var(--rgh-heat-color-deg) 15% 44%) !important;
+	color: #806a5e !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 40%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='8'] {
-	color: hsl(var(--rgh-heat-color-deg) 6% 44%) !important;
+	color: #776d6a !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 30%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='9'] {
-	color: hsl(var(--rgh-heat-color-deg) 4% 45%) !important;
+	color: #6e7177 !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 20%, var(--rgh-gray)) !important;
 }
 
 :root [data-rgh-heat='10'] {
-	color: hsl(var(--rgh-heat-color-deg) 2% 45%) !important;
+	color: #6a737d !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 0%, var(--rgh-gray)) !important;
 }

--- a/source/github-helpers/heat-map.css
+++ b/source/github-helpers/heat-map.css
@@ -4,42 +4,56 @@ Original file: https://github.githubassets.com/assets/code-d21b20a03009.css
 These colors are for normally-gray text.
 */
 
+:root {
+	--rgh-heat-color-deg: 29deg;
+	--rgh-heat-color-1: hsl(var(--rgh-heat-color-deg) 100% 38%);
+	--rgh-heat-color-2: hsl(var(--rgh-heat-color-deg) 69% 40%);
+	--rgh-heat-color-3: hsl(var(--rgh-heat-color-deg) 57% 41%);
+	--rgh-heat-color-4: hsl(var(--rgh-heat-color-deg) 47% 41%);
+	--rgh-heat-color-5: hsl(var(--rgh-heat-color-deg) 36% 42%);
+	--rgh-heat-color-6: hsl(var(--rgh-heat-color-deg) 26% 43%);
+	--rgh-heat-color-7: hsl(var(--rgh-heat-color-deg) 15% 44%);
+	--rgh-heat-color-8: hsl(var(--rgh-heat-color-deg) 6% 44%);
+	--rgh-heat-color-9: hsl(var(--rgh-heat-color-deg) 4% 45%);
+	--rgh-heat-color-10: hsl(var(--rgh-heat-color-deg) 2% 45%);
+}
+
 :root [data-rgh-heat='1'] {
-	color: #c24e00 !important;
+	color: var(--rgh-heat-color-1) !important;
 }
 
 :root [data-rgh-heat='2'] {
-	color: #ac571f !important;
+	color: var(--rgh-heat-color-2) !important;
 }
 
 :root [data-rgh-heat='3'] {
-	color: #a35b2c !important;
+	color: var(--rgh-heat-color-3) !important;
 }
 
 :root [data-rgh-heat='4'] {
-	color: #9a5f38 !important;
+	color: var(--rgh-heat-color-4) !important;
 }
 
 :root [data-rgh-heat='5'] {
-	color: #926245 !important;
+	color: var(--rgh-heat-color-5) !important;
 }
 
 :root [data-rgh-heat='6'] {
-	color: #896651 !important;
+	color: var(--rgh-heat-color-6) !important;
 }
 
 :root [data-rgh-heat='7'] {
-	color: #806a5e !important;
+	color: var(--rgh-heat-color-7) !important;
 }
 
 :root [data-rgh-heat='8'] {
-	color: #776d6a !important;
+	color: var(--rgh-heat-color-8) !important;
 }
 
 :root [data-rgh-heat='9'] {
-	color: #6e7177 !important;
+	color: var(--rgh-heat-color-9) !important;
 }
 
 :root [data-rgh-heat='10'] {
-	color: #6a737d !important;
+	color: var(--rgh-heat-color-10) !important;
 }

--- a/source/github-helpers/heat-map.css
+++ b/source/github-helpers/heat-map.css
@@ -6,54 +6,44 @@ These colors are for normally-gray text.
 
 :root {
 	--rgh-heat-color-deg: 29deg;
-	--rgh-heat-color-1: hsl(var(--rgh-heat-color-deg) 100% 38%);
-	--rgh-heat-color-2: hsl(var(--rgh-heat-color-deg) 69% 40%);
-	--rgh-heat-color-3: hsl(var(--rgh-heat-color-deg) 57% 41%);
-	--rgh-heat-color-4: hsl(var(--rgh-heat-color-deg) 47% 41%);
-	--rgh-heat-color-5: hsl(var(--rgh-heat-color-deg) 36% 42%);
-	--rgh-heat-color-6: hsl(var(--rgh-heat-color-deg) 26% 43%);
-	--rgh-heat-color-7: hsl(var(--rgh-heat-color-deg) 15% 44%);
-	--rgh-heat-color-8: hsl(var(--rgh-heat-color-deg) 6% 44%);
-	--rgh-heat-color-9: hsl(var(--rgh-heat-color-deg) 4% 45%);
-	--rgh-heat-color-10: hsl(var(--rgh-heat-color-deg) 2% 45%);
 }
 
 :root [data-rgh-heat='1'] {
-	color: var(--rgh-heat-color-1) !important;
+	color: hsl(var(--rgh-heat-color-deg) 100% 38%) !important;
 }
 
 :root [data-rgh-heat='2'] {
-	color: var(--rgh-heat-color-2) !important;
+	color: hsl(var(--rgh-heat-color-deg) 69% 40%) !important;
 }
 
 :root [data-rgh-heat='3'] {
-	color: var(--rgh-heat-color-3) !important;
+	color: hsl(var(--rgh-heat-color-deg) 57% 41%) !important;
 }
 
 :root [data-rgh-heat='4'] {
-	color: var(--rgh-heat-color-4) !important;
+	color: hsl(var(--rgh-heat-color-deg) 47% 41%) !important;
 }
 
 :root [data-rgh-heat='5'] {
-	color: var(--rgh-heat-color-5) !important;
+	color: hsl(var(--rgh-heat-color-deg) 36% 42%) !important;
 }
 
 :root [data-rgh-heat='6'] {
-	color: var(--rgh-heat-color-6) !important;
+	color: hsl(var(--rgh-heat-color-deg) 26% 43%) !important;
 }
 
 :root [data-rgh-heat='7'] {
-	color: var(--rgh-heat-color-7) !important;
+	color: hsl(var(--rgh-heat-color-deg) 15% 44%) !important;
 }
 
 :root [data-rgh-heat='8'] {
-	color: var(--rgh-heat-color-8) !important;
+	color: hsl(var(--rgh-heat-color-deg) 6% 44%) !important;
 }
 
 :root [data-rgh-heat='9'] {
-	color: var(--rgh-heat-color-9) !important;
+	color: hsl(var(--rgh-heat-color-deg) 4% 45%) !important;
 }
 
 :root [data-rgh-heat='10'] {
-	color: var(--rgh-heat-color-10) !important;
+	color: hsl(var(--rgh-heat-color-deg) 2% 45%) !important;
 }

--- a/source/github-helpers/heat-map.css
+++ b/source/github-helpers/heat-map.css
@@ -1,62 +1,55 @@
-/*
-Heatmap colors copied from GH, because GH does not load them on every page #5637
-Original file: https://github.githubassets.com/assets/code-d21b20a03009.css
-These colors are for normally-gray text.
-*/
-
-/* stylelint-disable declaration-block-no-duplicate-properties */
+/* stylelint-disable declaration-block-no-duplicate-properties -- Used as fallback */
 
 :root {
 	--rgh-heat-color: #c24e00;
-	--rgh-gray: #6a737d;
 }
 
 :root [data-rgh-heat='1'] {
 	color: #c24e00 !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 100%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 100%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='2'] {
 	color: #ac571f !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 90%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 90%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='3'] {
 	color: #a35b2c !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 80%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 80%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='4'] {
 	color: #9a5f38 !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 70%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 70%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='5'] {
 	color: #926245 !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 60%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 60%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='6'] {
 	color: #896651 !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 50%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 50%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='7'] {
 	color: #806a5e !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 40%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 40%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='8'] {
 	color: #776d6a !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 30%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 30%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='9'] {
 	color: #6e7177 !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 20%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 20%, var(--color-fg-muted)) !important;
 }
 
 :root [data-rgh-heat='10'] {
 	color: #6a737d !important;
-	color: color-mix(in srgb, var(--rgh-heat-color) 0%, var(--rgh-gray)) !important;
+	color: color-mix(in srgb, var(--rgh-heat-color) 0%, var(--color-fg-muted)) !important;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #6369

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

My preferred green (75deg)
<img width="800" alt="image" src="https://user-images.githubusercontent.com/7195563/229576792-8dfff4a6-acb6-4672-ae58-188da45595ee.png">

The default current palette (29deg)
<img width="800" alt="image" src="https://user-images.githubusercontent.com/7195563/229576966-83e3b61d-a061-4ea1-b665-cba4509ccd86.png">

