### PR TITLE
Add `status-subscription` feature (WIP)

### DIFF
--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -1,0 +1,57 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import {BellIcon, BellSlashIcon, IssueReopenedIcon} from '@primer/octicons-react';
+
+import features from '../feature-manager';
+import observe from '../helpers/selector-observer';
+
+function addButton(subscriptionButton: HTMLButtonElement): void {
+	subscriptionButton.before(
+		<div className="BtnGroup d-flex width-full">
+			<button
+				type="button"
+				className="btn btn-sm flex-grow-1 BtnGroup-item tooltipped tooltipped-s"
+				aria-label="Unsubscribe"
+			>
+				<BellSlashIcon/> None
+			</button>
+			<button
+				aria-selected
+				type="button"
+				className="btn btn-sm flex-grow-1 BtnGroup-item tooltipped tooltipped-s selected"
+				aria-label="Subscribe"
+			>
+				<BellIcon/> All
+			</button>
+			<button
+				type="button"
+				className="btn btn-sm flex-grow-1 BtnGroup-item tooltipped tooltipped-s"
+				aria-label="Subscribe just to close event"
+			>
+				<IssueReopenedIcon/> Status
+			</button>
+		</div>,
+	);
+	subscriptionButton.hidden = true;
+}
+
+function init(signal: AbortSignal): void | false {
+	observe('button[data-thread-subscribe-button]', addButton, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isConversation,
+	],
+	awaitDomReady: true, // The sidebar is at the end of the page
+	init,
+});
+
+/*
+
+Test URLs
+
+- Issue: https://github.com/refined-github/sandbox/issues/3
+- PR: https://github.com/refined-github/sandbox/pull/4
+
+*/

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -188,3 +188,7 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
+
+.flex-grow-1 {
+	flex-grow: 1 !important;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -215,3 +215,4 @@ import './features/emphasize-draft-pr-label';
 import './features/file-age-color';
 import './features/netiquette';
 import './features/rgh-netiquette';
+import './features/status-subscription';


### PR DESCRIPTION
- If finalized, closes https://github.com/refined-github/refined-github/issues/3005

Findings:

- The DOM doesn't include information regarding the exact current subscription state, but it does mention "custom state" (which could be either one or both "closed" and "reopened")

	<img width="278" alt="Screenshot 11" src="https://user-images.githubusercontent.com/1402241/230738361-84eee8d8-1d35-44fd-a89d-7c926df8f8f9.png">



- GraphQL doesn't include information regarding custom subscriptions states nor allows setting it: 
	- https://docs.github.com/en/graphql/reference/enums#subscriptionstate
	- https://docs.github.com/en/graphql/reference/mutations#updatesubscription
- I don't see any way to get or set subscription state to a specific issue via Rest API
	- https://docs.github.com/en/rest/issues
- Both the "unsubscribe" and "custom" forms point to `/notifications/thread` 👍 

That means:

- we can use that "reason" paragraph to detect the current state
- we we have to submit GitHub’s own form to make changes

UI-wise, none of the options mentioned so far work that well together with the current "subscribe/unsubscribe" button, because it acts as a "single action that also shows the (partial) status" and it's hard to combine it with "subscribe, but only to status events"

This is the best I could come up with: replacing the native button and sometimes hiding the reason:

<img width="278" alt="Screenshot 14" src="https://user-images.githubusercontent.com/1402241/230738614-56d56679-00c0-4de0-bbee-e1b6796b6028.png">

here's how it compares to the native one:

<img width="314" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/230738640-f85bd319-21f7-474a-9194-438aafb52521.png">

