### PR TITLE
Refactor `tab-size` /2

### DIFF
--- a/source/features/tab-size.css
+++ b/source/features/tab-size.css
@@ -8,7 +8,7 @@ There’s also one place where GitHub incorrectly uses the "user configuration" 
 */
 
 :root,
-.tab-size[data-tab-size='8'] {
+.comment-body .tab-size[data-tab-size='8'] {
 	--tab-size: 4;
 	tab-size: var(--tab-size);
 }


### PR DESCRIPTION
The selector is not specific enough after previous refactor PR.

https://github.com/refined-github/refined-github/pull/6480#discussion_r1161521663

I'm leaving out https://github.com/refined-github/refined-github/pull/6480#discussion_r1161516959 fot the moment.

## Test URLs

https://github.com/refined-github/sandbox/pull/19

## Screenshot

As mentioned in https://github.com/refined-github/refined-github/pull/6480#pullrequestreview-1377199124 GitHub has some weird render bug so I think this is probably clearer:

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="326" alt="image" src="https://user-images.githubusercontent.com/44045911/230856944-bf69d108-4988-4ade-9f16-2aa4188b1c4d.png">
	<td><img width="321" alt="image" src="https://user-images.githubusercontent.com/44045911/230856956-377454bb-f09e-48f7-9400-c2f0a84525ac.png">

</table>