### PR TITLE
Less eye-catching `rgh-netiquette`

### DIFF
--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -24,6 +24,7 @@ function addConversationBanner(newCommentBox: HTMLElement): void {
 	const banner = (
 		<TimelineItem>
 			{createBanner({
+				classes: ['rgh-bg-transparent'],
 				icon: <InfoIcon className="mr-1"/>,
 				text: <>{getNoticeText()} If it must really be here, you can {button}.</>,
 			})}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -188,3 +188,7 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
+
+.rgh-bg-transparent {
+	background: transparent !important;
+}


### PR DESCRIPTION
- fixes #6484 

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs

https://github.com/refined-github/sandbox/pull/17
https://github.com/refined-github/sandbox/pull/1

## Before

<img width="898" alt="Screenshot 25" src="https://user-images.githubusercontent.com/1402241/230873321-5d0f5b2e-5189-4ca8-b091-0722f977fe6a.png">



## After

<img width="898" alt="Screenshot 24" src="https://user-images.githubusercontent.com/1402241/230873350-fe01c6a5-2f9d-48f9-bbe8-4f635426e1c2.png">


### Dark

<img width="898" alt="Screenshot 26" src="https://user-images.githubusercontent.com/1402241/230873375-8da5bea7-1f1a-4187-9ec1-b7e36cda9f28.png">

