### PR TITLE
Change `closing-remarks` style

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -7,8 +7,6 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager';
 import fetchDom from '../helpers/fetch-dom';
 import onPrMerge from '../github-events/on-pr-merge';
-import createBanner from '../github-helpers/banner';
-import TimelineItem from '../github-helpers/timeline-item';
 import attachElement from '../helpers/attach-element';
 import {canEditEveryComment} from './quick-comment-edit';
 import onConversationHeaderUpdate from '../github-events/on-conversation-header-update';
@@ -61,16 +59,17 @@ function addExistingTagLink(tagName: string): void {
 		);
 	}
 
-	attachElement('#issue-comment-box', {
-		before: () => (
-			<TimelineItem>
-				{createBanner({
-					text: <>This pull request first appeared in <span className="text-mono text-small">{tagName}</span></>,
-					classes: ['flash-success'],
-					action: tagUrl,
-					buttonLabel: <><TagIcon/> See release</>,
-				})}
-			</TimelineItem>
+	attachElement('.js-discussion', {
+		append: () => (
+			<div className="TimelineItem">
+				<div className="TimelineItem-badge color-bg-accent-emphasis color-fg-on-emphasis">
+					<TagIcon/>
+				</div>
+				<div className="TimelineItem-body">
+					This pull request first appeared in <strong>{tagName}</strong>
+					<a href={tagUrl} className="btn btn-sm btn-outline float-right">See release</a>
+				</div>
+			</div>
 		),
 	});
 }
@@ -85,15 +84,17 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 			? 'https://github.com/refined-github/refined-github/actions/workflows/release.yml'
 			: buildRepoURL('releases/new')
 	) : undefined;
-	attachElement('#issue-comment-box', {
-		before: () => (
-			<TimelineItem>
-				{createBanner(url ? {
-					text,
-					action: url,
-					buttonLabel: <><TagIcon/> Draft a new release</>,
-				} : {text})}
-			</TimelineItem>
+	attachElement('.js-discussion', {
+		append: () => (
+			<div className="TimelineItem">
+				<div className="TimelineItem-badge color-bg-accent-emphasis color-fg-on-emphasis">
+					<TagIcon/>
+				</div>
+				<div className="TimelineItem-body">
+					{text}
+					<a href={url} className="btn btn-sm btn-outline float-right">Draft a new release</a>
+				</div>
+			</div>
 		),
 	});
 }

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -84,16 +84,13 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 			? 'https://github.com/refined-github/refined-github/actions/workflows/release.yml'
 			: buildRepoURL('releases/new')
 	) : undefined;
-	attachElement('.js-discussion', {
-		append: () => (
-			<div className="TimelineItem">
-				<div className="TimelineItem-badge color-bg-accent-emphasis color-fg-on-emphasis">
-					<TagIcon/>
-				</div>
-				<div className="TimelineItem-body">
-					{text}
-					<a href={url} className="btn btn-sm btn-outline float-right">Draft a new release</a>
-				</div>
+	attachElement('#issue-comment-box', {
+		before: () => (
+			<div className="mt-3 ml-md-6 pl-md-3 color-fg-muted">
+				{text}
+				<a href={url} className="btn btn-sm ml-2">
+					<TagIcon className="mr-1"/> Draft a new release
+				</a>
 			</div>
 		),
 	});


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Resolve #6482

- Chose blue icon because other colors are associated with their own meanings
- Unfortunately no alternative tag icon
- Write a helper to create timeline item?
- Our `conversation-activity-filter` won't filter it

## Test URLs

- "See release": https://github.com//refined-github/refined-github/pull/6427#ref-pullrequest-1640816674
- "Draft a new release": 🤷‍♂️

## Screenshot

<img width="867" alt="image" src="https://user-images.githubusercontent.com/44045911/230907777-d62f9dd0-1226-4212-add7-bccd80f43c2b.png">