### PR TITLE
Hide avatar entirely from comment form

### DIFF
--- a/source/features/clean-conversations.css
+++ b/source/features/clean-conversations.css
@@ -1,5 +1,6 @@
 /* Remove user avatar from new comment form */
-:is(.review-thread-reply, .timeline-new-comment) .timeline-comment-avatar {
+.timeline-new-comment .timeline-comment-avatar,
+.review-thread-reply .avatar {
 	display: none;
 }
 

--- a/source/features/clean-conversations.css
+++ b/source/features/clean-conversations.css
@@ -1,5 +1,5 @@
 /* Remove user avatar from new comment form */
-:is(.review-thread-reply, .timeline-new-comment) .avatar {
+:is(.review-thread-reply, .timeline-new-comment) .timeline-comment-avatar {
 	display: none;
 }
 


### PR DESCRIPTION
Previously we are just hiding the image, not the link. Therefore I can still tab to it, which doesn't seem right.

## Test URLs

Here

## Screenshot

https://github.com/refined-github/refined-github/pull/6490#issuecomment-1505002859