### PR TITLE
Wrap `tags-on-commits-list`

### DIFF
--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -136,9 +136,9 @@ async function init(): Promise<void | false> {
 			// There was no tags for this commit, save that info to the cache
 			commitsWithNoTags.push(targetCommit);
 		} else if (targetTags.length > 0) {
-			const meta = select('.flex-auto .d-flex.mt-1', commit)!;
-			meta.classList.add('flex-wrap');
-			meta.append(
+			const commitMeta = select('.flex-auto .d-flex.mt-1', commit)!;
+			commitMeta.classList.add('flex-wrap');
+			commitMeta.append(
 				<span>
 					<TagIcon className="ml-1"/>
 					{...targetTags.map(tag => (


### PR DESCRIPTION
Fix #6495

Can also be fixed via CSS, current solution doesn't need to create and sync selectors

## Test URLs

https://github.com/refined-github/refined-github/commits/main

## Screenshot

https://user-images.githubusercontent.com/44045911/231249240-024ac46d-8096-49df-9fb9-c9ce380db180.mov

