### PR TITLE
Less flashy `closing-remarks`

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -73,7 +73,7 @@ function addExistingTagLink(tagName: string): void {
 		);
 	}
 
-	const linkedTag = <a href={tagUrl} className="text-mono text-small">{tagName}</a>;
+	const linkedTag = <a href={tagUrl} className="Link--primary text-bold">{tagName}</a>;
 	attachElement('#issue-comment-box', {
 		before: () => (
 			<TimelineItem>

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -36,7 +36,7 @@ async function init(): Promise<void> {
 	if (tagName) {
 		addExistingTagLink(tagName);
 	} else {
-		void addReleaseBanner('The merge commit doesn’t appear in any tags');
+		void addReleaseBanner('This PR’s merge commit doesn’t appear in any tags');
 	}
 }
 
@@ -61,14 +61,14 @@ function addExistingTagLink(tagName: string): void {
 		);
 	}
 
+	const linkedTag = <a href={tagUrl} className="text-mono text-small">{tagName}</a>;
 	attachElement('#issue-comment-box', {
 		before: () => (
 			<TimelineItem>
 				{createBanner({
-					text: <>This pull request first appeared in <span className="text-mono text-small">{tagName}</span></>,
+					icon: <TagIcon className="m-0"/>,
+					text: <>This pull request first appeared in {linkedTag}</>,
 					classes: ['flash-success', 'rgh-bg-none'],
-					action: tagUrl,
-					buttonLabel: <><TagIcon/> See release</>,
 				})}
 			</TimelineItem>
 		),

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -147,4 +147,6 @@ Test URLs
 - PR: https://github.com/refined-github/refined-github/pull/5600
 - Locked PR: https://github.com/eslint/eslint/pull/17
 - Archived repo: https://github.com/fregante/iphone-inline-video/pull/130
+- RGH tagged PR: https://github.com/refined-github/sandbox/pull/1
+
 */

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -66,7 +66,7 @@ function addExistingTagLink(tagName: string): void {
 			<TimelineItem>
 				{createBanner({
 					text: <>This pull request first appeared in <span className="text-mono text-small">{tagName}</span></>,
-					classes: ['flash-success'],
+					classes: ['flash-success', 'rgh-bg-none'],
 					action: tagUrl,
 					buttonLabel: <><TagIcon/> See release</>,
 				})}
@@ -89,9 +89,10 @@ async function addReleaseBanner(text = 'Now you can release this change'): Promi
 		before: () => (
 			<TimelineItem>
 				{createBanner(url ? {
+					classes: ['rgh-bg-none'],
 					text,
 					action: url,
-					buttonLabel: <><TagIcon/> Draft a new release</>,
+					buttonLabel: 'Draft a new release',
 				} : {text})}
 			</TimelineItem>
 		),

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -24,7 +24,7 @@ function addConversationBanner(newCommentBox: HTMLElement): void {
 	const banner = (
 		<TimelineItem>
 			{createBanner({
-				classes: ['rgh-bg-transparent'],
+				classes: ['rgh-bg-none'],
 				icon: <InfoIcon className="mr-1"/>,
 				text: <>{getNoticeText()} If it must really be here, you can {button}.</>,
 			})}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -189,6 +189,6 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	border-bottom-left-radius: 0;
 }
 
-.rgh-bg-transparent {
-	background: transparent !important;
+.rgh-bg-none {
+	background: none !important;
 }


### PR DESCRIPTION
- Fixes #6482 
- Addresses https://github.com/refined-github/refined-github/issues/5851#issuecomment-1195289714
- May replace #6489 

## Test URLs

- PR: https://github.com/refined-github/refined-github/pull/5600
- Locked PR: https://github.com/eslint/eslint/pull/17
- Archived repo: https://github.com/fregante/iphone-inline-video/pull/130
- RGH tagged PR: https://github.com/refined-github/sandbox/pull/1

## Released

<img width="724" alt="Screenshot 9" src="https://user-images.githubusercontent.com/1402241/231418641-c34d1265-aac8-43a6-88c7-ef2f208255eb.png">

## Unreleased

<img width="724" alt="Screenshot 8" src="https://user-images.githubusercontent.com/1402241/231418659-7ebfd302-55aa-4cc7-abf4-5aeff95410e5.png">
