### PR TITLE
Move "Report repository" link to bottom of sidebar in `clean-repo-sidebar`

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -53,6 +53,13 @@ async function hideEmptyMeta(): Promise<void> {
 	}
 }
 
+async function moveReportLink(): Promise<void> {
+	await domLoaded;
+
+	const reportLink = select('.Layout-sidebar a[href^="/contact/report-content"]')!.parentElement!;
+	select('.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell')!.append(reportLink);
+}
+
 async function init(): Promise<void> {
 	document.documentElement.classList.add('rgh-clean-repo-sidebar');
 
@@ -61,6 +68,7 @@ async function init(): Promise<void> {
 		hideEmptyPackages(),
 		hideLanguageHeader(),
 		hideEmptyMeta(),
+		moveReportLink(),
 	]);
 }
 


### PR DESCRIPTION
Resolve #6498

I'm tagging as "bug" per original issue but this seems to be "enhancement"?

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<table>
<tr>
	<td>Desktop
	<td>Mobile
<tr>
	<td><img width="321" alt="image" src="https://user-images.githubusercontent.com/44045911/231465345-32c2208d-c6a5-47fe-a9d5-7632b984095e.png">
	<td><img width="481" alt="image" src="https://user-images.githubusercontent.com/44045911/231465333-2b37b8cf-81af-4d89-9e73-d5c731285e1a.png">
</table>