### PR TITLE
Fix `more-conversation-filters` subscription link

### DIFF
--- a/source/features/more-conversation-filters.tsx
+++ b/source/features/more-conversation-filters.tsx
@@ -16,8 +16,9 @@ function init(): void {
 
 	sourceItem.after(commentsLink);
 
-	// "Subscribed" link
-	const subscriptionsLink = select('#filters-select-menu a:last-child')!.cloneNode(true);
+	// "Subscribed" external link
+	const searchSyntaxLink = select('#filters-select-menu a:last-child')!;
+	const subscriptionsLink = searchSyntaxLink.cloneNode(true);
 	subscriptionsLink.lastElementChild!.textContent = 'Everything you subscribed to';
 
 	const subscriptionsUrl = new URL('https://github.com/notifications/subscriptions');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #6501

## Test URLs

https://github.com/refined-github/refined-github/issues

## Screenshot

I took the chance to make some slight visual changes:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/44045911/231478503-a26c9781-347a-4808-bdae-1dfe3a763913.png">

Because previously when pressing back button you see this:

<img width="321" alt="image" src="https://user-images.githubusercontent.com/44045911/231478660-96d7f186-5551-4218-8d84-1595fb1e2655.png">
