### PR TITLE
Exclude mannequins from `show-names`

### DIFF
--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -7,15 +7,6 @@ import {buildRepoURL} from '../github-helpers';
 import getCommentAuthor from '../github-helpers/get-comment-author';
 import observe from '../helpers/selector-observer';
 
-const selectors = [
-	'.tooltipped[aria-label*="a member of the"]',
-	'.tooltipped[aria-label^="This user has previously committed"]',
-];
-
-function init(signal: AbortSignal): void {
-	observe(selectors, linkify, {signal});
-}
-
 function linkify(label: Element): void {
 	if (label.closest('a')) {
 		features.log.error(import.meta.url, 'Already linkified, feature needs to be updated');
@@ -25,6 +16,13 @@ function linkify(label: Element): void {
 	const url = new URL(buildRepoURL('commits'));
 	url.searchParams.set('author', getCommentAuthor(label));
 	wrap(label, <a className="Link--secondary" href={url.href}/>);
+}
+
+function init(signal: AbortSignal): void {
+	observe([
+		'.tooltipped[aria-label*="a member of the"]',
+		'.tooltipped[aria-label^="This user has previously committed"]',
+	], linkify, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -68,7 +68,17 @@ const batchUpdateLinks = batchedFunction(async (batchedUsernameElements: HTMLAnc
 
 const usernameLinksSelector = [
 	// `a` selector needed to skip commits by non-GitHub users
-	':is(.js-discussion, .inline-comments) a.author:not([href*="/apps/"], [href*="/marketplace/"], [data-hovercard-type="organization"])',
+	// # and `show_full_name` target mannequins #6504
+	`:is(
+		.js-discussion,
+		.inline-comments
+	) a.author:not(
+		[show_full_name="false"],
+		[href="#"],
+		[href*="/apps/"],
+		[href*="/marketplace/"],
+		[data-hovercard-type="organization"]
+	)`,
 
 	// On dashboard `.text-bold` is required to not fetch avatars
 	'#dashboard a.text-bold[data-hovercard-type="user"]',


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6504


## Test URLs

https://github.com/python/cpython/issues/67591

## Before


<img width="407" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/231664072-d3fcbcf8-7a10-4b17-bb42-19bbd15228e9.png">

## After

<img width="407" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/231664098-0ee8468c-e163-48ef-8854-04abe313c5a7.png">

