### PR TITLE
Add `releases-dropdown` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,7 @@ Thanks for contributing! 🦋🙌
 
 - [](# "release-download-count") [Adds a download count next to release assets.](https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png)
 - [](# "releases-tab") [Adds a `Releases` tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
+- [](# "tags-dropdown") [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png)
 - [](# "create-release-shortcut") Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
 - [](# "tag-changes-link") 🔥 [Adds a link to changes since last tag/release for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/44045911/155496122-6267c45d-21d4-45c9-adf7-94c9e41cc652.png)

--- a/readme.md
+++ b/readme.md
@@ -314,7 +314,7 @@ Thanks for contributing! 🦋🙌
 
 - [](# "release-download-count") [Adds a download count next to release assets.](https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png)
 - [](# "releases-tab") [Adds a `Releases` tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
-- [](# "tags-dropdown") [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png)
+- [](# "releases-dropdown") [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png)
 - [](# "create-release-shortcut") Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
 - [](# "tag-changes-link") 🔥 [Adds a link to changes since last tag/release for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/44045911/155496122-6267c45d-21d4-45c9-adf7-94c9e41cc652.png)

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -81,3 +81,13 @@
 		display: none;
 	}
 }
+
+/* Align icons in the release search field #6506 */
+/* Test: https://github.com/refined-github/refined-github/releases */
+[action$="/releases"] .subnav-search-icon {
+	margin-top: -1px;
+}
+
+#release-filter::-webkit-calendar-picker-indicator {
+	margin-top: -4px;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -84,7 +84,7 @@
 
 /* Align icons in the release search field #6506 */
 /* Test: https://github.com/refined-github/refined-github/releases */
-[action$="/releases"] .subnav-search-icon {
+[action$='/releases'] .subnav-search-icon {
 	margin-top: -1px;
 }
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -54,7 +54,7 @@ async function init(): Promise<false | void> {
 			continue;
 		}
 
-		const branch = pr.baseRef && buildRepoURL(`tree/${pr.baseRefName}`);
+		const branch = pr.baseRef && buildRepoURL('tree', pr.baseRefName);
 
 		prLink.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!.append(
 			<span className="issue-meta-section ml-2">

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -144,7 +144,7 @@ async function init(): Promise<false | void> {
 			const compareLink = (
 				<a
 					className="btn btn-sm tooltipped tooltipped-ne"
-					href={buildRepoURL(`compare/${latestTag}...${defaultBranch}`)}
+					href={buildRepoURL('compare', `${latestTag}...${defaultBranch}`)}
 					data-turbo-frame="repo-content-turbo-frame"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>

--- a/source/features/releases-dropdown.tsx
+++ b/source/features/releases-dropdown.tsx
@@ -11,7 +11,7 @@ let latestTags: string[] | undefined;
 
 const gql = `
 	repository() {
-		refs(refPrefix: "refs/tags/", last: 100) {
+		releases(last: 100) {
 			nodes {
 				name
 			}
@@ -39,9 +39,9 @@ async function addList(searchField: HTMLInputElement): Promise<void> {
 		return;
 	}
 
-	searchField.setAttribute('list', 'rgh-tags-dropdown');
+	searchField.setAttribute('list', 'rgh-releases-dropdown');
 	searchField.after(
-		<datalist id="rgh-tags-dropdown">
+		<datalist id="rgh-releases-dropdown">
 			{latestTags!.map(tag => <option value={tag}/>)}
 		</datalist>,
 	);

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -1,0 +1,41 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+
+import select from 'select-dom';
+
+import * as api from '../github-helpers/api';
+
+import features from '../feature-manager';
+
+const gql = `
+	repository() {
+		refs(refPrefix: "refs/tags/", last: 100) {
+			nodes {
+				name
+			}
+		}
+	}
+`;
+
+async function init(): Promise<false | void> {
+	const {repository} = await api.v4(gql);
+	const tags = repository.refs.nodes as Array<{name: string}>;
+	if (tags.length === 0) {
+		return false;
+	}
+
+	const searchField = select('input#release-filter')!;
+	searchField.after(
+		<datalist id="rgh-tags-dropdown">
+			{tags.reverse().map(tag => <option value={tag.name}/>)}
+		</datalist>,
+	);
+	searchField.setAttribute('list', 'rgh-tags-dropdown');
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isReleasesOrTags,
+	],
+	init,
+});

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -59,3 +59,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+## Test URLs
+
+https://github.com/refined-github/refined-github/tags
+https://github.com/refined-github/sandbox/releases
+
+*/

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -24,7 +24,7 @@ function selectionHandler(event: DelegateEvent<Event, HTMLInputElement>): void {
 	const field = event.delegateTarget;
 	const selectedTag = field.value;
 	if (!('inputType' in event) && latestTags!.includes(selectedTag)) {
-		location.href = buildRepoURL('releases/tag', selectedTag);
+		location.href = buildRepoURL('releases/tag', encodeURIComponent(selectedTag));
 		field.value = '';
 	}
 }

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -37,11 +37,11 @@ async function addList(searchField: HTMLInputElement): Promise<void> {
 	}
 
 	// Save globally
-	latestTags = nodes.map(({name}) => name);
+	latestTags = nodes.map(({name}) => name).reverse();
 
 	searchField.after(
 		<datalist id="rgh-tags-dropdown">
-			{latestTags.reverse().map(tag => <option value={tag}/>)}
+			{latestTags.map(tag => <option value={tag}/>)}
 		</datalist>,
 	);
 	searchField.setAttribute('list', 'rgh-tags-dropdown');

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -31,20 +31,20 @@ function selectionHandler(event: DelegateEvent<Event, HTMLInputElement>): void {
 
 async function addList(searchField: HTMLInputElement): Promise<void> {
 	const {repository} = await api.v4(gql);
-	const nodes = repository.refs.nodes as Array<{name: string}>;
-	if (nodes.length === 0) {
+	// Save globally
+	latestTags = repository.refs.nodes
+		.map(({name}: {name: string}) => name)
+		.reverse();
+	if (latestTags!.length === 0) {
 		return;
 	}
 
-	// Save globally
-	latestTags = nodes.map(({name}) => name).reverse();
-
+	searchField.setAttribute('list', 'rgh-tags-dropdown');
 	searchField.after(
 		<datalist id="rgh-tags-dropdown">
-			{latestTags.map(tag => <option value={tag}/>)}
+			{latestTags!.map(tag => <option value={tag}/>)}
 		</datalist>,
 	);
-	searchField.setAttribute('list', 'rgh-tags-dropdown');
 }
 
 const searchFieldSelector = 'input#release-filter';
@@ -55,7 +55,7 @@ async function init(signal: AbortSignal): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isReleasesOrTags,
+		pageDetect.isReleases,
 	],
 	init,
 });

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -32,6 +32,8 @@ interface GlobalEventHandlersEventMap {
 	'page:loaded': CustomEvent;
 	'turbo:visit': CustomEvent;
 	'session:resume': CustomEvent;
+	// No input:InputEvent match
+	// https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1174#issuecomment-933042088
 }
 
 declare namespace JSX {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -214,3 +214,4 @@ import './features/file-age-color';
 import './features/netiquette';
 import './features/rgh-netiquette';
 import './features/small-user-avatars';
+import './features/tags-dropdown';

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -214,4 +214,4 @@ import './features/file-age-color';
 import './features/netiquette';
 import './features/rgh-netiquette';
 import './features/small-user-avatars';
-import './features/tags-dropdown';
+import './features/releases-dropdown';


### PR DESCRIPTION
Follows:
- https://github.com/refined-github/refined-github/issues/6257
- https://github.com/refined-github/refined-github/pull/6438

Super easy, barely an inconvenience. The only issue is that it's technically misusing the `datalist` for navigation (just like mobile websites have done with `select` from 2007 until recently)

## Test URLs

https://github.com/refined-github/refined-github/releases

## Screenshot

<img width="381" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/231668903-7ccfb60b-ab78-4066-a716-9fed46250498.png">


