### PR TITLE
Fix `release-download-count` spacing

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -83,6 +83,6 @@
 }
 
 /* Add margin to release download icon #6510 */
-:is(.octicon-package, .octicon-file-zip):has(+ a[rel='nofollow']) {
+.Box-row :is(.octicon-package, .octicon-file-zip):has(+ a[rel='nofollow']) {
 	margin-right: 4px;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -81,3 +81,8 @@
 		display: none;
 	}
 }
+
+/* Add margin to release download icon #6510 */
+:is(.octicon-package, .octicon-file-zip):has(+ a[rel="nofollow"]) {
+	margin-right: 4px;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -83,6 +83,6 @@
 }
 
 /* Add margin to release download icon #6510 */
-:is(.octicon-package, .octicon-file-zip):has(+ a[rel="nofollow"]) {
+:is(.octicon-package, .octicon-file-zip):has(+ a[rel='nofollow']) {
 	margin-right: 4px;
 }

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,17 +1,10 @@
-/* Simulates fixed columns. "*" doesn't work */
-.rgh-release-download-count > :is(span, small) {
-	flex-grow: 0 !important;
+/* Simulates fixed columns */
+.rgh-release-download-count > span {
+	flex-basis: 0 !important;
 	min-width: 6em;
 }
 
-@media (max-width: 767px) {
-	/* Uses smaller width for download count */
-	.rgh-release-download-count [data-rgh-heat] {
-		min-width: 5em;
-	}
-
-	/* Restores flex-grow to center align asset size */
-	.rgh-release-download-count [data-rgh-heat] + span {
-		flex-grow: 1 !important;
-	}
+/* Makes space for right aligning download count */
+.rgh-release-download-count [data-rgh-heat] {
+	min-width: 5em;
 }

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -5,10 +5,12 @@
 }
 
 @media (max-width: 767px) {
+	/* Uses smaller width for download count */
 	.rgh-release-download-count [data-rgh-heat] {
 		min-width: 5em;
 	}
 
+	/* Restores flex-grow to center align asset size */
 	.rgh-release-download-count [data-rgh-heat] + span {
 		flex-grow: 1 !important;
 	}

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,13 +1,15 @@
-/* Improve spacing on mobile. "*" doesn't work */
+/* Simulates fixed columns. "*" doesn't work */
 .rgh-release-download-count > :is(span, small) {
-	flex: 0 0 auto !important;
+	flex-grow: 0 !important;
+	min-width: 6em;
 }
 
-/* Simulates fixed columns: Size  */
-.rgh-release-download-count .text-sm-left {
-	min-width: 5em;
-}
-/* Simulates fixed columns: Date */
-.rgh-release-download-count .text-right {
-	min-width: 6em;
+@media (max-width: 767px) {
+	.rgh-release-download-count [data-rgh-heat] {
+		min-width: 5em;
+	}
+
+	.rgh-release-download-count [data-rgh-heat] + span {
+		flex-grow: 1 !important;
+	}
 }

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -70,10 +70,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		const calculateHeatIndex = createHeatIndexFunction([...downloadCounts.values()]);
 		for (const assetName of select.all('.octicon-package ~ a .text-bold', release)) {
 			// Match the asset in the DOM to the asset in the API response
-			const downloadCount = downloadCounts.get(assetName.textContent!);
-			if (!downloadCount) {
-				continue;
-			}
+			const downloadCount = downloadCounts.get(assetName.textContent!) ?? 0;
 
 			// Place next to asset size
 			const assetSize = assetName
@@ -82,11 +79,16 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 
 			assetSize.parentElement!.classList.add('rgh-release-download-count');
 			assetSize.classList.remove('text-sm-left');
+			assetSize.classList.add('text-center');
 
 			const classes = new Set(assetSize.classList);
-			assetSize.classList.add('text-center');
+			classes.delete('text-center');
 			classes.add('text-right');
 			classes.add('no-wrap');
+
+			if (downloadCount === 0) {
+				classes.add('v-hidden');
+			}
 
 			assetSize.before(
 				<small

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -78,26 +78,24 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 				.querySelector(':scope > .flex-justify-end > :first-child')!;
 
 			assetSize.parentElement!.classList.add('rgh-release-download-count');
-			assetSize.classList.remove('text-sm-left');
-			assetSize.classList.add('text-center');
 
 			const classes = new Set(assetSize.classList);
-			classes.delete('text-center');
-			classes.add('text-right');
-			classes.add('no-wrap');
+			classes.delete('text-sm-left');
 
 			if (downloadCount === 0) {
 				classes.add('v-hidden');
 			}
 
 			assetSize.before(
-				<small
-					className={[...classes].join(' ')}
-					title={`${downloadCount} downloads`}
-					data-rgh-heat={calculateHeatIndex(downloadCount)}
-				>
-					{abbreviateNumber(downloadCount)} <DownloadIcon/>
-				</small>,
+				<span className={[...classes].join(' ')}>
+					<small
+						className="d-inline-block text-right"
+						title={`${downloadCount} downloads`}
+						data-rgh-heat={calculateHeatIndex(downloadCount)}
+					>
+						{abbreviateNumber(downloadCount)} <DownloadIcon/>
+					</small>
+				</span>,
 			);
 		}
 	}

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -81,13 +81,12 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 				.querySelector(':scope > .flex-justify-end > :first-child')!;
 
 			assetSize.parentElement!.classList.add('rgh-release-download-count');
+			assetSize.classList.remove('text-sm-left');
 
 			const classes = new Set(assetSize.classList);
-			classes.delete('text-sm-left');
+			assetSize.classList.add('text-center');
 			classes.add('text-right');
 			classes.add('no-wrap');
-			classes.add('ml-auto');
-			classes.add('mr-2');
 
 			assetSize.before(
 				<small

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -87,7 +87,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 			classes.add('text-right');
 			classes.add('no-wrap');
 			classes.add('ml-auto');
-			classes.add('mr-sm-2');
+			classes.add('mr-2');
 
 			assetSize.before(
 				<small

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -88,13 +88,13 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 
 			assetSize.before(
 				<span className={[...classes].join(' ')}>
-					<small
+					<span
 						className="d-inline-block text-right"
 						title={`${downloadCount} downloads`}
 						data-rgh-heat={calculateHeatIndex(downloadCount)}
 					>
 						{abbreviateNumber(downloadCount)} <DownloadIcon/>
-					</small>
+					</span>
 				</span>,
 			);
 		}


### PR DESCRIPTION
Fix #6509
Fix #6150

## Test URLs

https://github.com/veracrypt/VeraCrypt/releases/tag/VeraCrypt_1.25.9

## Screenshot

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="376" alt="image" src="https://user-images.githubusercontent.com/44045911/231974877-fe37aa0d-f14a-4d60-8323-2a9b5078e8dd.png">
	<td>

[See comment](https://github.com/refined-github/refined-github/pull/6510#issuecomment-1508788214)

</table>