### PR TITLE
More ergonomic `table-input` HTML

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -19,7 +19,7 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	const rows = Number(square.dataset.y);
 	const row = columns === 1
 		? '<tr><td>\n'
-		: '<tr>\n' + '<td>\n\n'.repeat(columns);
+		: '<tr>\n' + ' <td>\n'.repeat(columns);
 	field.focus();
 	const table = '<table>\n' + row.repeat(rows) + '</table>';
 	textFieldEdit.insert(field, smartBlockWrap(table, field));

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -15,13 +15,13 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	const field = square.form!.querySelector('textarea.js-comment-field')!;
 	const cursorPosition = field.selectionStart;
 
+	const columns = Number(square.dataset.x);
+	const rows = Number(square.dataset.y);
+	const row = columns === 1
+		? '<tr><td>\n'
+		: '<tr>\n' + '<td>\n\n'.repeat(columns);
 	field.focus();
-	const table
-		= '<table>\n'
-			+ ('<tr>\n'
-				+ '\t<td>\n'.repeat(Number(square.dataset.x))
-			).repeat(Number(square.dataset.y))
-		+ '</table>';
+	const table = '<table>\n' + row.repeat(rows) + '</table>';
 	textFieldEdit.insert(field, smartBlockWrap(table, field));
 
 	// Move caret to first cell

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -18,7 +18,11 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	const columns = Number(square.dataset.x);
 	const rows = Number(square.dataset.y);
 	const row = columns === 1
+		// One HTML line per row
 		? '<tr><td>\n'
+
+		// <tr> on its own line
+		// "1 space" indents without causing unwanted Markdown code blocks that 4 spaces would cause
 		: '<tr>\n' + ' <td>\n'.repeat(columns);
 	field.focus();
 	const table = '<table>\n' + row.repeat(rows) + '</table>';


### PR DESCRIPTION
I think this generates a slightly more usable HTML:

- if there's only one column, print one HTML line per table row
- reduce the indentation because it can issues in Markdown, like:

```html
<table>
<tr>
	<td> 

	<td>

<tr>
	<td>

	<td>

</table>
```

Causes:


<table>
<tr>
	<td> 

	<td>

<tr>
	<td>

	<td>

</table>

The extra line breaks are used sometimes to re-enable markdown parsing in the table, like:

```md
<table>
<tr>
	<td>

[link](/file)

</table>
```

<table>
<tr>
	<td>

[link](/file)

</table>


## Test URLs

Here

## Screenshot

![fixed](https://user-images.githubusercontent.com/1402241/232011975-55dfb5a9-b0a5-40d6-b5be-cab5feef5006.gif)

