### PR TITLE
Add support for Firefox and Safari in options import/export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9688,9 +9688,9 @@
 			"integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
 		},
 		"node_modules/webext-options-sync": {
-			"version": "4.1.0-4",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-4.tgz",
-			"integrity": "sha512-mxCvPctBGtjHYLd89EY9JwvOMGon+3CnaIQ5NclWPB8S71QF6AmJtEO93f9+L+t49mq8n1eBxH5KfCcMX03Cjg==",
+			"version": "4.1.0-5",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-5.tgz",
+			"integrity": "sha512-hMqgGYqLi3poYOOO2N6hgMlDnHy6og9lXKLWmu02mJnvcLT8zKWvBSuNYAS1GX3z2Jf0biO/Ha/MVSJB1Uat5g==",
 			"dependencies": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18053,9 +18053,9 @@
 			}
 		},
 		"webext-options-sync": {
-			"version": "4.1.0-4",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-4.tgz",
-			"integrity": "sha512-mxCvPctBGtjHYLd89EY9JwvOMGon+3CnaIQ5NclWPB8S71QF6AmJtEO93f9+L+t49mq8n1eBxH5KfCcMX03Cjg==",
+			"version": "4.1.0-5",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-5.tgz",
+			"integrity": "sha512-hMqgGYqLi3poYOOO2N6hgMlDnHy6og9lXKLWmu02mJnvcLT8zKWvBSuNYAS1GX3z2Jf0biO/Ha/MVSJB1Uat5g==",
 			"requires": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18072,7 +18072,7 @@
 				"mem": "^9.0.2",
 				"webext-additional-permissions": "^2.4.0",
 				"webext-detect-page": "^4.0.1",
-				"webext-options-sync": "4.1.0-4",
+				"webext-options-sync": "4.1.0-5",
 				"webext-patterns": "^1.3.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9688,9 +9688,9 @@
 			"integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
 		},
 		"node_modules/webext-options-sync": {
-			"version": "4.1.0-5",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-5.tgz",
-			"integrity": "sha512-hMqgGYqLi3poYOOO2N6hgMlDnHy6og9lXKLWmu02mJnvcLT8zKWvBSuNYAS1GX3z2Jf0biO/Ha/MVSJB1Uat5g==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.1.tgz",
+			"integrity": "sha512-Wv/7C2iZx8VmGQ2CPkH3OzWb2nJvkY4M7Qc89VpLr8pYGKtT6xmh3ZXOQHLP72n0TjhpAcUxpQi8VOPPTHUU1A==",
 			"dependencies": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18053,9 +18053,9 @@
 			}
 		},
 		"webext-options-sync": {
-			"version": "4.1.0-5",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-5.tgz",
-			"integrity": "sha512-hMqgGYqLi3poYOOO2N6hgMlDnHy6og9lXKLWmu02mJnvcLT8zKWvBSuNYAS1GX3z2Jf0biO/Ha/MVSJB1Uat5g==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.1.tgz",
+			"integrity": "sha512-Wv/7C2iZx8VmGQ2CPkH3OzWb2nJvkY4M7Qc89VpLr8pYGKtT6xmh3ZXOQHLP72n0TjhpAcUxpQi8VOPPTHUU1A==",
 			"requires": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18072,7 +18072,7 @@
 				"mem": "^9.0.2",
 				"webext-additional-permissions": "^2.4.0",
 				"webext-detect-page": "^4.0.1",
-				"webext-options-sync": "4.1.0-5",
+				"webext-options-sync": "^4.0.1",
 				"webext-patterns": "^1.3.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9688,9 +9688,9 @@
 			"integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
 		},
 		"node_modules/webext-options-sync": {
-			"version": "4.1.0-3",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-3.tgz",
-			"integrity": "sha512-8Xmg5we/Dyp8O9e3adJsHsmlKXnB9Phf9Mr2w359rAf5joicMeI+efDAMjla1dF/azb6h7FYi1XpbCOfwNfkPA==",
+			"version": "4.1.0-4",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-4.tgz",
+			"integrity": "sha512-mxCvPctBGtjHYLd89EY9JwvOMGon+3CnaIQ5NclWPB8S71QF6AmJtEO93f9+L+t49mq8n1eBxH5KfCcMX03Cjg==",
 			"dependencies": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18053,8 +18053,9 @@
 			}
 		},
 		"webext-options-sync": {
-			"version": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-3.tgz",
-			"integrity": "sha512-8Xmg5we/Dyp8O9e3adJsHsmlKXnB9Phf9Mr2w359rAf5joicMeI+efDAMjla1dF/azb6h7FYi1XpbCOfwNfkPA==",
+			"version": "4.1.0-4",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-4.1.0-4.tgz",
+			"integrity": "sha512-mxCvPctBGtjHYLd89EY9JwvOMGon+3CnaIQ5NclWPB8S71QF6AmJtEO93f9+L+t49mq8n1eBxH5KfCcMX03Cjg==",
 			"requires": {
 				"dom-form-serializer": "^2.0.0",
 				"lz-string": "^1.4.4",
@@ -18071,7 +18072,7 @@
 				"mem": "^9.0.2",
 				"webext-additional-permissions": "^2.4.0",
 				"webext-detect-page": "^4.0.1",
-				"webext-options-sync": "^4.0.1",
+				"webext-options-sync": "4.1.0-4",
 				"webext-patterns": "^1.3.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 		"npm": ">= 7"
 	},
 	"overrides": {
-		"webext-options-sync": "4.1.0-3"
+		"webext-options-sync": "4.1.0-4"
 	},
 	"webExt": {
 		"sourceDir": "distribution",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 		"npm": ">= 7"
 	},
 	"overrides": {
-		"webext-options-sync": "4.1.0-4"
+		"webext-options-sync": "4.1.0-5"
 	},
 	"webExt": {
 		"sourceDir": "distribution",

--- a/package.json
+++ b/package.json
@@ -124,9 +124,6 @@
 		"node": ">= 16",
 		"npm": ">= 7"
 	},
-	"overrides": {
-		"webext-options-sync": "4.1.0-5"
-	},
 	"webExt": {
 		"sourceDir": "distribution",
 		"run": {


### PR DESCRIPTION
Follows:

-  #3981 
-  #6448 

Includes:

- https://github.com/fregante/webext-options-sync/pull/65/files/06fafa8a6f002908e2ef43683a4d8181baf612da..7cf1c25080528a177192d8563b68c5a68afb5f46

Working at first try 😍  I also tested importing a file from Chrome


https://user-images.githubusercontent.com/1402241/232036339-58584155-e802-4d0d-8d9c-4def47bf39f5.mov

