### PR TITLE
Fix `table-input` position

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -68,7 +68,7 @@ function add(anchor: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('md-task-list', add, {signal});
+	observe('md-ref', add, {signal});
 	delegate(document, '.rgh-tic', 'click', addTable, {signal});
 	if (!isHasSelectorSupported) {
 		delegate(document, '.rgh-tic', 'mouseenter', highlightSquares, {capture: true, signal});


### PR DESCRIPTION
Fix #6514

Moved the table input button to the same position as `collapsible-content-button`

## Test URLs

Here

## Screenshot

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="693" alt="image" src="https://user-images.githubusercontent.com/44045911/232004756-29e5362d-c051-427f-854a-ed35ebda4f3b.png">
	<td><img width="676" alt="image" src="https://user-images.githubusercontent.com/44045911/232097015-c623d12a-e77c-4381-bce1-259f9df9263d.png">

</table>