### PR TITLE
Ensure `hide-user-forks` works coming from anywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"filter-altered-clicks": "^2.0.0",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^7.1.1",
+				"github-url-detection": "^7.1.2",
 				"image-promise": "^7.0.1",
 				"indent-textarea": "^2.1.1",
 				"js-abbreviation-number": "^1.4.0",
@@ -4812,9 +4812,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.1.1.tgz",
-			"integrity": "sha512-0WsM1jxEIVUGKyGlLcOkUz3paZlHohtcqZNri8//nd0BKdnVUuXtp0AYWxJ3WTL461l+VRK371Esd8+b6qEXqg==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.1.2.tgz",
+			"integrity": "sha512-GBQTPWpHYKmg97sRssyX9IFFCJzWt1IMaHLBJxPw9AZDq6Ole/t15b4Nie9di20LIo+SCfUVKuGrhzzPjlP2aw==",
 			"engines": {
 				"node": ">=18"
 			},
@@ -14549,9 +14549,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"github-url-detection": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.1.1.tgz",
-			"integrity": "sha512-0WsM1jxEIVUGKyGlLcOkUz3paZlHohtcqZNri8//nd0BKdnVUuXtp0AYWxJ3WTL461l+VRK371Esd8+b6qEXqg=="
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-7.1.2.tgz",
+			"integrity": "sha512-GBQTPWpHYKmg97sRssyX9IFFCJzWt1IMaHLBJxPw9AZDq6Ole/t15b4Nie9di20LIo+SCfUVKuGrhzzPjlP2aw=="
 		},
 		"glob": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"filter-altered-clicks": "^2.0.0",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^7.1.1",
+		"github-url-detection": "^7.1.2",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.1.1",
 		"js-abbreviation-number": "^1.4.0",

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -3,12 +3,12 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
-const isProfileRepos = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+const isProfileRepoList = (url: URL | HTMLAnchorElement | Location = location): boolean =>
 	pageDetect.isUserProfileRepoTab(url) || pageDetect.utils.getOrg(url)?.path === 'repositories';
 
 function addSourceTypeToLink(link: HTMLAnchorElement): void {
-	if (!isProfileRepos(link)) {
-		return
+	if (!isProfileRepoList(link)) {
+		return;
 	}
 
 	const search = new URLSearchParams(link.search);
@@ -36,6 +36,7 @@ void features.add(import.meta.url, {
 /*
 
 ## Test
+
 - https://github.com/fregante?tab=repositories
 - https://github.com/orgs/refined-github/repositories
 - The "Your repositories" link in the user dropdown in the header

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -16,12 +16,14 @@ function addSourceTypeToLink(link: HTMLAnchorElement): void {
 	link.search = String(search);
 }
 
+const skipUrlsWithType = ':not([href*="&type="])';
+
 const selectors = [
 	// User repos
-	`a[href$="?tab=repositories"]:is([href^="/"], [href^="${location.origin}/"])`,
+	`a[href$="?tab=repositories"]:is([href^="/"], [href^="${location.origin}/"])${skipUrlsWithType}`,
 
 	// Organization repos
-	`a[href$="/repositories"]:is([href^="/orgs/"], [href^="${location.origin}/orgs/"])`,
+	`a[href$="/repositories"]:is([href^="/orgs/"], [href^="${location.origin}/orgs/"])${skipUrlsWithType}`,
 ] as const;
 
 // No `include`, no `signal` necessary

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -14,7 +14,7 @@ const selectors = [
 	`a[href*="?tab=repositories"]:is([href^="/"], [href^="${location.origin}/"])${skipUrlsWithType}`,
 
 	// Organization repos
-	`a[href$="/repositories"]:is([href^="/orgs/"], [href^="${location.origin}/orgs/"])${skipUrlsWithType}`,
+	`a[href*="/repositories"]:is([href^="/orgs/"], [href^="${location.origin}/orgs/"])${skipUrlsWithType}`,
 ] as const;
 
 // No `include`, no `signal` necessary

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -1,16 +1,7 @@
-import * as pageDetect from 'github-url-detection';
-
 import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
-const isProfileRepoList = (url: URL | HTMLAnchorElement | Location = location): boolean =>
-	pageDetect.isUserProfileRepoTab(url) || pageDetect.utils.getOrg(url)?.path === 'repositories';
-
 function addSourceTypeToLink(link: HTMLAnchorElement): void {
-	if (!isProfileRepoList(link)) {
-		return;
-	}
-
 	const search = new URLSearchParams(link.search);
 	search.set('type', 'source');
 	link.search = String(search);

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -11,7 +11,7 @@ const skipUrlsWithType = ':not([href*="&type="])';
 
 const selectors = [
 	// User repos
-	`a[href$="?tab=repositories"]:is([href^="/"], [href^="${location.origin}/"])${skipUrlsWithType}`,
+	`a[href*="?tab=repositories"]:is([href^="/"], [href^="${location.origin}/"])${skipUrlsWithType}`,
 
 	// Organization repos
 	`a[href$="/repositories"]:is([href^="/orgs/"], [href^="${location.origin}/orgs/"])${skipUrlsWithType}`,


### PR DESCRIPTION
- Fixes #6464
- Replaces and closes https://github.com/refined-github/refined-github/pull/6466

## Test URLs

- https://github.com/fregante?tab=repositories
- https://github.com/orgs/refined-github/repositories
- The "Your repositories" link in the user dropdown in the header
- The "Repositories" tab in
	- https://github.com/fregante
	- https://github.com/refined-github

## Screenshot

<img width="519" alt="Screenshot 7" src="https://user-images.githubusercontent.com/1402241/232291168-e40d5452-bbd0-478a-9142-bffdd9b9e692.png">

