### PR TITLE
Reduce `has` selector console noise in Firefox

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 import onElementRemoval from '../helpers/on-element-removal';
 import observe from '../helpers/selector-observer';
 import {removeTextNodeContaining} from '../helpers/dom-utils';
-import {noHasSelectorSupport} from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 
 const canEditSidebar = onetime((): boolean => select.exists('.discussion-sidebar-item [data-hotkey="l"]'));
 
@@ -129,11 +129,11 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isConversation,
-	],
-	exclude: [
-		noHasSelectorSupport,
 	],
 	awaitDomReady: true, // The sidebar is at the end of the page + it needs to be fully loaded
 	init,

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -8,6 +8,7 @@ import features from '../feature-manager';
 import onElementRemoval from '../helpers/on-element-removal';
 import observe from '../helpers/selector-observer';
 import {removeTextNodeContaining} from '../helpers/dom-utils';
+import {noHasSelectorSupport} from '../helpers/select-has';
 
 const canEditSidebar = onetime((): boolean => select.exists('.discussion-sidebar-item [data-hotkey="l"]'));
 
@@ -130,6 +131,9 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
+	],
+	exclude: [
+		noHasSelectorSupport,
 	],
 	awaitDomReady: true, // The sidebar is at the end of the page + it needs to be fully loaded
 	init,

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -2,7 +2,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
-import {noHasSelectorSupport} from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 import observe from '../helpers/selector-observer';
 
 function hide(item: HTMLElement): void {
@@ -21,11 +21,11 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isDashboard,
-	],
-	exclude: [
-		noHasSelectorSupport,
 	],
 	init,
 });

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -2,6 +2,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import {getUsername} from '../github-helpers';
+import {noHasSelectorSupport} from '../helpers/select-has';
 import observe from '../helpers/selector-observer';
 
 function hide(item: HTMLElement): void {
@@ -22,6 +23,9 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isDashboard,
+	],
+	exclude: [
+		noHasSelectorSupport,
 	],
 	init,
 });

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -7,7 +7,7 @@ import {objectEntries} from 'ts-extras';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
-import {noHasSelectorSupport} from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`
@@ -58,13 +58,13 @@ async function init(): Promise<void> {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isCommitList,
 		pageDetect.isPRConversation,
 		pageDetect.isCompare,
-	],
-	exclude: [
-		noHasSelectorSupport,
 	],
 	deduplicate: 'has-rgh-inner',
 	awaitDomReady: true, // TODO: Use `observe` + `batched-function`

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -7,6 +7,7 @@ import {objectEntries} from 'ts-extras';
 
 import features from '../feature-manager';
 import * as api from '../github-helpers/api';
+import {noHasSelectorSupport} from '../helpers/select-has';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`
@@ -61,6 +62,9 @@ void features.add(import.meta.url, {
 		pageDetect.isCommitList,
 		pageDetect.isPRConversation,
 		pageDetect.isCompare,
+	],
+	exclude: [
+		noHasSelectorSupport,
 	],
 	deduplicate: 'has-rgh-inner',
 	awaitDomReady: true, // TODO: Use `observe` + `batched-function`

--- a/source/features/quick-new-issue.tsx
+++ b/source/features/quick-new-issue.tsx
@@ -3,7 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import {buildRepoURL, getRepo, isArchivedRepoAsync} from '../github-helpers';
-import {noHasSelectorSupport} from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 import observe from '../helpers/selector-observer';
 
 function add(dropdownMenu: HTMLElement): void {
@@ -32,11 +32,11 @@ async function init(signal: AbortSignal): Promise<void | false> {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isRepo,
-	],
-	exclude: [
-		noHasSelectorSupport,
 	],
 	init,
 });

--- a/source/features/quick-new-issue.tsx
+++ b/source/features/quick-new-issue.tsx
@@ -3,6 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
 import {buildRepoURL, getRepo, isArchivedRepoAsync} from '../github-helpers';
+import {noHasSelectorSupport} from '../helpers/select-has';
 import observe from '../helpers/selector-observer';
 
 function add(dropdownMenu: HTMLElement): void {
@@ -33,6 +34,9 @@ async function init(signal: AbortSignal): Promise<void | false> {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
+	],
+	exclude: [
+		noHasSelectorSupport,
 	],
 	init,
 });

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer';
 import {isAnyRefinedGitHubRepo} from '../github-helpers';
 import {getNoticeText, shouldDisplayNotice} from './netiquette';
 import TimelineItem from '../github-helpers/timeline-item';
-import {noHasSelectorSupport} from '../helpers/select-has';
+import {isHasSelectorSupported} from '../helpers/select-has';
 
 function addConversationBanner(newCommentBox: HTMLElement): void {
 	const button = (
@@ -47,12 +47,10 @@ function init(signal: AbortSignal): void | false {
 void features.add(import.meta.url, {
 	asLongAs: [
 		isAnyRefinedGitHubRepo,
+		isHasSelectorSupported,
 	],
 	include: [
 		pageDetect.isConversation,
-	],
-	exclude: [
-		noHasSelectorSupport,
 	],
 	awaitDomReady: true, // We're specifically looking for the last event
 	init,

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -8,6 +8,7 @@ import observe from '../helpers/selector-observer';
 import {isAnyRefinedGitHubRepo} from '../github-helpers';
 import {getNoticeText, shouldDisplayNotice} from './netiquette';
 import TimelineItem from '../github-helpers/timeline-item';
+import {noHasSelectorSupport} from '../helpers/select-has';
 
 function addConversationBanner(newCommentBox: HTMLElement): void {
 	const button = (
@@ -49,6 +50,9 @@ void features.add(import.meta.url, {
 	],
 	include: [
 		pageDetect.isConversation,
+	],
+	exclude: [
+		noHasSelectorSupport,
 	],
 	awaitDomReady: true, // We're specifically looking for the last event
 	init,

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -74,7 +74,7 @@ function add(anchor: HTMLElement): void {
 function init(signal: AbortSignal): void {
 	observe('md-ref', add, {signal});
 	delegate(document, '.rgh-tic', 'click', addTable, {signal});
-	if (!isHasSelectorSupported) {
+	if (!isHasSelectorSupported()) {
 		delegate(document, '.rgh-tic', 'mouseenter', highlightSquares, {capture: true, signal});
 	}
 }

--- a/source/helpers/select-has.ts
+++ b/source/helpers/select-has.ts
@@ -1,6 +1,7 @@
 import {ParseSelector} from 'typed-query-selector/parser';
 
 export const isHasSelectorSupported = globalThis.CSS?.supports('selector(:has(a))');
+export const noHasSelectorSupport = (): boolean => !isHasSelectorSupported;
 
 // Adapted from https://stackoverflow.com/a/35271017/288906
 const hasSelectorRegex = /:has\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/;

--- a/source/helpers/select-has.ts
+++ b/source/helpers/select-has.ts
@@ -1,7 +1,7 @@
 import {ParseSelector} from 'typed-query-selector/parser';
 
-export const isHasSelectorSupported = globalThis.CSS?.supports('selector(:has(a))');
-export const noHasSelectorSupport = (): boolean => !isHasSelectorSupported;
+const _isHasSelectorSupported = globalThis.CSS?.supports('selector(:has(a))');
+export const isHasSelectorSupported = (): boolean => _isHasSelectorSupported;
 
 // Adapted from https://stackoverflow.com/a/35271017/288906
 const hasSelectorRegex = /:has\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/;


### PR DESCRIPTION
- Closes #6508 

As seen in https://github.com/refined-github/refined-github/issues/6533

This should explicitly skip features that rely on the `has` selector.

May be incomplete but better than nothing.

Related:

- #5797 