### PR TITLE
Better search link in console issue reporter

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -70,7 +70,7 @@ const logError = (url: string, error: unknown): void => {
 	}
 
 	const searchIssueUrl = new URL('https://github.com/refined-github/refined-github/issues');
-	searchIssueUrl.searchParams.set('q', `is:issue is:open sort:updated-desc ${message}`);
+	searchIssueUrl.searchParams.set('q', `is:issue is:open label:bug ${id}`);
 
 	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
 	newIssueUrl.searchParams.set('template', '1_bug_report.yml');


### PR DESCRIPTION

## Before: [0 results](https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+Cannot+read+properties+of+undefined+%28reading+%27parentElement%27%29)

<img width="766" alt="Screenshot 11" src="https://user-images.githubusercontent.com/1402241/232390404-f191c5d3-9066-4f12-a9e8-0316d53249f0.png">


## After: [4 open issues for `ci-link`](https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+label%3Abug+ci-link)

<img width="766" alt="Screenshot 12" src="https://user-images.githubusercontent.com/1402241/232390367-3d2bcf47-505d-41b4-bfa1-8976b846a547.png">

