### PR TITLE
Fix navigation issues in file explorer

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -274,11 +274,13 @@ const add = async (url: string, ...loaders: FeatureLoader[]): Promise<void> => {
 			void setupPageLoad(id, details);
 		}
 
-		document.addEventListener('turbo:render', () => {
-			if (!deduplicate || !select.exists(deduplicate)) {
-				void setupPageLoad(id, details);
-			}
-		});
+		for (const eventType of ['turbo:render', 'soft-nav:render']) {
+			document.addEventListener(eventType, () => {
+				if (!deduplicate || !select.exists(deduplicate)) {
+					void setupPageLoad(id, details);
+				}
+			});
+		}
 	}
 };
 

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function add(folderDropdown: HTMLElement): void {
-	folderDropdown.parentElement!.querySelector('a.rgh-download-folder-button')?.remove()
+	folderDropdown.parentElement!.querySelector('a.rgh-download-folder-button')?.remove();
 
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
@@ -26,8 +26,8 @@ function add(folderDropdown: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe([
-		'[title="More options"]',	// pageDetect.isRepoTree
-		'[title="More file actions"]', // pageDetect.isSingleFile
+		'[title="More options"]',	// PageDetect.isRepoTree
+		'[title="More file actions"]', // PageDetect.isSingleFile
 		'[aria-label="Add file"] + details', // TODO: Drop in mid 2023. Old file view #6154
 	], add, {signal});
 }

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -8,6 +8,8 @@ import features from '../feature-manager';
 import observe from '../helpers/selector-observer';
 
 function add(folderDropdown: HTMLElement): void {
+	folderDropdown.parentElement!.querySelector('a.rgh-download-folder-button')?.remove()
+
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 
@@ -24,7 +26,8 @@ function add(folderDropdown: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe([
-		'[title="More options"]',
+		'[title="More options"]',	// pageDetect.isRepoTree
+		'[title="More file actions"]', // pageDetect.isSingleFile
 		'[aria-label="Add file"] + details', // TODO: Drop in mid 2023. Old file view #6154
 	], add, {signal});
 }
@@ -32,6 +35,7 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoTree,
+		pageDetect.isSingleFile,
 	],
 	exclude: [
 		pageDetect.isRepoRoot, // Already has an native download ZIP button


### PR DESCRIPTION
## Description
- Closes #6414
- Reproducing route
	- Enter a file tree of repository.
	- Enter some file of the tree.
	- Pop to back page (I don't know the correct word of this)
	- Enter some file of the tree.

## Test URLs
https://github.com/refined-github/refined-github/tree/main/source/features

## Screenshot
### Before
The button is duplicating and get pushed out to left
<img width="1723" alt="image" src="https://user-images.githubusercontent.com/50487467/234012679-7bf2852f-b30c-492d-9f9d-f6b331095b4e.png">

### After
Remove previous button and stay the button right position.
Also, create button when accessing not only `repo-tree` but also `single-file`
<img width="1311" alt="image" src="https://user-images.githubusercontent.com/50487467/234012761-23e8a69d-e5bd-48e3-b8b7-6f3528360232.png">


