### PR TITLE
Enable `fit-textareas` sooner, don't wait for focus

### DIFF
--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -1,41 +1,29 @@
 import './fit-textareas.css';
-import select from 'select-dom';
-import delegate, {DelegateEvent} from 'delegate-it';
 import {isSafari} from 'webext-detect-page';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager';
-import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
+import observe from '../helpers/selector-observer';
 
 function inputListener({target}: Event): void {
 	fitTextarea(target as HTMLTextAreaElement);
 }
 
-function watchTextarea(textarea: HTMLTextAreaElement): void {
-	textarea.addEventListener('input', inputListener); // The user triggers `input` event
-	textarea.addEventListener('change', inputListener); // File uploads trigger `change` events
+function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
+	textarea.addEventListener('input', inputListener, {signal}); // The user triggers `input` event
+	textarea.addEventListener('change', inputListener, {signal}); // File uploads trigger `change` events
+	textarea.form?.addEventListener('reset', inputListener, {signal});
 	fitTextarea(textarea);
 
 	// Disable constrained native feature
 	textarea.classList.replace('js-size-to-fit', 'rgh-fit-textareas');
 }
 
-function focusListener({delegateTarget: textarea}: DelegateEvent<Event, HTMLTextAreaElement>): void {
-	watchTextarea(textarea);
-}
-
-function fitPrCommitMessageBox(): void {
-	watchTextarea(select('textarea[name="commit_message"]')!);
-}
-
 function init(signal: AbortSignal): void {
-	// Exclude PR review box because it's in a `position:fixed` container; The scroll HAS to appear within the fixed element.
-	delegate('textarea:not(#pull_request_review_body)', 'focusin', focusListener, {signal});
-
-	for (const textArea of select.all('textarea')) {
-		watchTextarea(textArea);
-	}
+	// Exclude PR review box because it's in a `position:fixed` container;
+	// The scroll HAS to appear within the fixed element.
+	observe('textarea:not(#pull_request_review_body)', watchTextarea, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -45,18 +33,5 @@ void features.add(import.meta.url, {
 	exclude: [
 		isSafari,
 	],
-	awaitDomReady: true, // TODO: Probably doesn't have to
 	init,
-}, {
-	include: [
-		pageDetect.isPRConversation,
-	],
-	exclude: [
-		isSafari,
-	],
-	additionalListeners: [
-		onPrMergePanelOpen,
-	],
-	onlyAdditionalListeners: true,
-	init: fitPrCommitMessageBox,
 });


### PR DESCRIPTION
Testable here. It works.

Ideal testing:

1. Find a tall message you wrote
2. Click edit