### PR TITLE
Highlight RGH features on the page

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -192,3 +192,13 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 .rgh-bg-none {
 	background: none !important;
 }
+
+[class*="rgh-"]:not([class*="rgh-seen"]) {
+	outline: solid 3px violet;
+	outline-offset: 3px;
+}
+
+[class*="rgh-seen"] {
+	outline: solid 3px rgb(238, 204, 130);
+	outline-offset: 3px;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -193,12 +193,12 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	background: none !important;
 }
 
-[class*="rgh-"]:not([class*="rgh-seen"]) {
-	outline: solid 3px violet;
+[class*="rgh-seen"] {
+	outline: solid 3px rgb(238, 204, 130);
 	outline-offset: 3px;
 }
 
-[class*="rgh-seen"] {
-	outline: solid 3px rgb(238, 204, 130);
+[class*="rgh-"]:not([class*="rgh-seen"]) {
+	outline: solid 3px violet;
 	outline-offset: 3px;
 }


### PR DESCRIPTION
I thought about this for a while, this can help us see through Refined GitHub a bit. It's not perfect but I don’t think we should focus too much on ensuring every generated/altered element has an `rgh` class.

This would be hidden behind a "debugging" toggle.

<img width="1053" alt="Screenshot 9" src="https://user-images.githubusercontent.com/1402241/234471842-6a8ba9eb-6003-493e-b423-2ee9ecab7b05.png">
