### PR TITLE
Restore `list-prs-for-file` 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ Thanks for contributing! 🦋🙌
 
 - [](# "copy-on-y") Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
 - [](# "linkify-symbolic-links") [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
-- [](# "list-prs-for-file") [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
+- [](# "list-prs-for-file") [Alerts you if the current file is altered by an open PR.](https://user-images.githubusercontent.com/1402241/234559302-b9911ac2-a1bb-4f8a-8e88-078d631cde18.png)
 - [](# "refined-github.css") [Reduces tabs’ size to 4 spaces instead of 8](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png) where GitHub doesn't follow [the user’s preferences.](https://github.com/settings/appearance)
 - [](# "esc-to-deselect-line") [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/refined-github/refined-github/issues/1590)
 - [](# "vertical-front-matter") [Shows Markdown front matter as vertical table.](https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png)

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -28,7 +28,7 @@ function getDropdown(prs: number[]): HTMLElement {
 		: <GitPullRequestIcon className="v-align-middle"/>;
 	// Markup copied from https://primer.style/css/components/dropdown
 	return (
-		<details className={`dropdown details-reset details-overlay flex-self-center ${isEditing ? 'mr-2' : ''}`}>
+		<details className="dropdown details-reset details-overlay flex-self-center">
 			<summary className="btn btn-sm">
 				{icon}
 				<span className="v-align-middle"> {prs.length} </span>
@@ -104,7 +104,12 @@ async function addToSingleFile(moreFileActionsDropdown: HTMLElement): Promise<vo
 	const prs = prsByFile[path];
 
 	if (prs) {
-		moreFileActionsDropdown.before(getDropdown(prs));
+		const dropdown = getDropdown(prs);
+		if (!moreFileActionsDropdown.parentElement!.matches('.gap-2')) {
+			dropdown.classList.add('mr-2');
+		}
+
+		moreFileActionsDropdown.before(dropdown);
 	}
 }
 
@@ -125,7 +130,9 @@ async function addToEditingFile(saveButton: HTMLElement): Promise<false | void> 
 		}
 	}
 
-	saveButton.parentElement!.prepend(getDropdown(prs));
+	const dropdown = getDropdown(prs);
+	dropdown.classList.add('mr-2');
+	saveButton.parentElement!.prepend(dropdown);
 }
 
 function initSingleFile(signal: AbortSignal): void {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6299

For brevity and consistency, this now always uses a dropdown when displaying the PRs, regardless of count. This was also done in order to always have a small widget on `isEditingFile` and show the description inside.

## Test URLs

- isSingleFile: One PR https://github.com/refined-github/sandbox/blob/default-a/4679

<img width="378" alt="Screenshot 35" src="https://user-images.githubusercontent.com/1402241/234552420-48d76725-76fe-4829-8ca8-65b9c7ee50cb.png">

- isSingleFile: Multiple PRs https://github.com/refined-github/sandbox/blob/default-a/README.md

<img width="490" alt="Screenshot 34" src="https://user-images.githubusercontent.com/1402241/234552458-e5aa7fa9-3cba-4f2d-af8c-83b8857df694.png">



- isEditingFile: One PR https://github.com/refined-github/sandbox/edit/default-a/4679


<img width="501" alt="Screenshot 37" src="https://user-images.githubusercontent.com/1402241/234552494-9f86ef4f-d89a-4079-b324-ae50668c7e10.png">

- isEditingFile: Multiple PRs https://github.com/refined-github/sandbox/edit/default-a/README.md



<img width="501" alt="Screenshot 36" src="https://user-images.githubusercontent.com/1402241/234552515-e07d80cc-fabb-40bd-bd04-7b06a077cb7a.png">
