### PR TITLE
Adjust `table-input` size on mobile

### DIFF
--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -1,9 +1,9 @@
-:root{
+:root {
 	--rgh-table-input-size: 40px;
 }
+
 :root:root:root:root .rgh-table-input {
 	font-size: var(--rgh-table-input-size);
-	width: auto;
 	padding: 3px;
 	z-index: 99;
 	display: grid !important;

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -1,9 +1,16 @@
-:root .rgh-table-input {
+:root{
+	--rgh-table-input-size: 40px;
+}
+:root:root:root:root .rgh-table-input {
+	font-size: var(--rgh-table-input-size);
 	width: auto;
 	padding: 3px;
 	z-index: 99;
 	display: grid !important;
-	grid-template: repeat(5, 20px) / repeat(5, 20px);
+	grid-template: repeat(5, 1em) / repeat(5, 1em);
+	width: fit-content;
+	height: fit-content;
+	margin: auto;
 }
 
 :root .rgh-tic {
@@ -11,10 +18,16 @@
 }
 
 .rgh-tic div {
-	width: 18px;
-	height: 18px;
+	height: 100%;
 	border: 2px solid var(--rgh-border-color);
 	border-radius: 2px;
+}
+
+@media screen and (min-width: 768px) {
+	:root {
+		/* #6511 */
+		--rgh-table-input-size: 20px;
+	}
 }
 
 /** TODO: Drop JS-based version after :has() has full support */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6511


## Test


In a comment box below

## Demo mobile

![fixed](https://user-images.githubusercontent.com/1402241/234565874-33666167-28e2-48e4-8d65-83e82324d3fb.gif)

## Screenshots

<img width="428" src="https://user-images.githubusercontent.com/1402241/234566271-bac79e29-30a3-44e4-a379-a2e34a784716.png">


<img width="446" alt="Screenshot 2" src="https://user-images.githubusercontent.com/1402241/234565865-4ad1096e-bfaa-4aeb-9c63-6ccf9ee61967.png">
