### PR TITLE
Avoid `show-names` on the wrong links in the For You dashboard

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -80,8 +80,10 @@ const usernameLinksSelector = [
 		[data-hovercard-type="organization"]
 	)`,
 
-	// On dashboard `.text-bold` is required to not fetch avatars
-	'#dashboard a.text-bold[data-hovercard-type="user"]',
+	// On dashboard
+	// `.Link--primary` excludes avatars
+	// `.color-shadow-medium` excludes links in cards #6530
+	'#dashboard a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
 ] as const;
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6530



## Test URLs

https://github.com

## Screenshots

<img width="273" alt="Screenshot 6" src="https://user-images.githubusercontent.com/1402241/234572910-6bbd4cb5-bb0f-4419-8215-d5f8498fd9b6.png">


<img width="273" alt="Screenshot 7" src="https://user-images.githubusercontent.com/1402241/234572904-a2240729-2b67-4466-8245-90e729218adc.png">


