### PR TITLE
Disable `ci-link` on new UI

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -40,7 +40,8 @@ function getCiDetails(commit: string): HTMLElement {
 
 async function init(): Promise<void | false> {
 	const head = await getHead();
-	const repoTitle = await elementReady('[itemprop="name"]');
+	// `.avatar` disables it on "Global navigation update" until #6454
+	const repoTitle = await elementReady('[itemprop="name"]:not(.avatar ~ [itemprop])');
 	if (!repoTitle) {
 		return false;
 	}


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6453

The feature currently only works on the repo root, which is exactly where it isn't needed. See screenshot.


## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<img width="510" alt="Screenshot 13" src="https://user-images.githubusercontent.com/1402241/234579787-143b911d-7a6c-424d-947d-b23047fff1ff.png">
