### PR TITLE
Safari: Restore migrations and the actions button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9731,9 +9731,9 @@
 			}
 		},
 		"node_modules/webext-polyfill-kinda": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.0.tgz",
-			"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.2.tgz",
+			"integrity": "sha512-rqQUKeBTOicej0tjDJWDQlOTnDcm9yYJTzgI+7rMdyYV4QHmYMRm+yjkcVgECkg/Wu9MboZ4lYeBPdp1Ep9WgQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
 			}
@@ -18078,9 +18078,9 @@
 			}
 		},
 		"webext-polyfill-kinda": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.0.tgz",
-			"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.2.tgz",
+			"integrity": "sha512-rqQUKeBTOicej0tjDJWDQlOTnDcm9yYJTzgI+7rMdyYV4QHmYMRm+yjkcVgECkg/Wu9MboZ4lYeBPdp1Ep9WgQ=="
 		},
 		"webext-storage-cache": {
 			"version": "6.0.0-2",


### PR DESCRIPTION
Includes https://github.com/fregante/webext-polyfill-kinda/commit/8438cd88f245ca9a5bcfc7ced18a9d03a191e516

## Timeline

1. `webext-polyfill-kinda` always threw an error when accessing a missing property
2. `webext-options-sync` started using `webext-polyfill-kinda` in v4, including a call to `chromeP.management.getSelf()`
3. [#6448](https://github.com/refined-github/refined-github/pull/6448) started using `webext-options-sync` v4
4. 23.4.15 is the first Safari version that includes the above changes
5. Safari doesn't support `chrome.management`
6. Today: the RG icon doesn't nothing in Safari

```
TypeError: A Proxy's 'target' should be an Object
```