### PR TITLE
`restore-file` UX improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ GitHub Enterprise is also supported: [How to enable it](https://fregante.github.
 			<p><img src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">
 	<tr>
 		<th width="50%">
-			<p><a title="restore-file"></a> Adds a button to revert all the changes to a file in a PR
+			<p><a title="restore-file"></a> Adds a button to discard all the changes to a file in a PR
 			<p><img src="https://user-images.githubusercontent.com/50487467/236245182-afc97200-2634-4f82-9e9c-1f605fb04565.gif">
 		<th width="50%">
 			<p><a title="select-notifications"></a> Select notifications by type and status

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ GitHub Enterprise is also supported: [How to enable it](https://fregante.github.
 	<tr>
 		<th width="50%">
 			<p><a title="restore-file"></a> Adds a button to discard all the changes to a file in a PR
-			<p><img src="https://user-images.githubusercontent.com/50487467/236245182-afc97200-2634-4f82-9e9c-1f605fb04565.gif">
+			<p><img src="https://user-images.githubusercontent.com/1402241/236630610-e11a64f6-5e70-4353-89b8-39aae830dd16.gif">
 		<th width="50%">
 			<p><a title="select-notifications"></a> Select notifications by type and status
 			<p><img src="https://user-images.githubusercontent.com/1402241/152119039-4ea8333f-a744-4106-b56f-cf09f50678be.gif">

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -115,7 +115,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	}
 
 	if (editFile.closest('.file-header')!.querySelector('[aria-label="File added"]')) {
-		// The file is new. "Removing from PR" it means deleting it, which is already possible.
+		// The file is new. "Discarding changes" means deleting it, which is already possible.
 		// Depends on `highlight-deleted-and-added-files-in-diffs`.
 		return;
 	}

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -42,23 +42,34 @@ async function getFile(filePath: string): Promise<{isTruncated: boolean; text: s
 	return repository.file;
 }
 
-async function dropFile(progress: (message: string) => void, menuItem: Element, filePath: string): Promise<void> {
+async function removeFile(progress: (message: string) => void, filePath: string): Promise<void> {
 	const file = await getFile(filePath);
 
-	if (!file) {
-		// The file was created by this PR.
-		// This code won’t be reached if `highlight-deleted-and-added-files-in-diffs` works.
-		throw new Error('Nothing to drop. Delete file instead');
+	if (file?.isTruncated) {
+		throw new Error('File too big, you’ll have to use git');
 	}
 
-	if (file.isTruncated) {
-		throw new Error('Drop failed: File too big');
-	}
+	// Only possible if `highlight-deleted-and-added-files-in-diffs` is broken or disabled
+	const isNewFile = !file;
+
+	const change = isNewFile ? `
+		deletions: [
+			{
+				path: "${filePath}"
+			}
+		]
+	` : `
+		additions: [
+			{
+				path: "${filePath}",
+				contents: "${btoa(unescape(encodeURIComponent(file.text)))}"
+			}
+		]
+	`;
 
 	const {nameWithOwner, branch: prBranch} = getBranches().head;
-	progress(menuItem.closest('[data-file-deleted="true"]') ? 'Undeleting…' : 'Committing…');
+	progress('Committing…');
 
-	const content = file.text;
 	await api.v4(`mutation {
 		createCommitOnBranch(input: {
 			branch: {
@@ -67,15 +78,10 @@ async function dropFile(progress: (message: string) => void, menuItem: Element, 
 			},
 			expectedHeadOid: "${await getHeadReference()}",
 			fileChanges: {
-				additions: [
-					{
-						path: "${filePath}",
-						contents: "${btoa(unescape(encodeURIComponent(content)))}"
-					}
-				]
+				${change}
 			},
 			message: {
-				headline: "Drop ${filePath}"
+				headline: "Remove ${filePath} from PR"
 			}
 		}) {
 			commit {
@@ -85,14 +91,14 @@ async function dropFile(progress: (message: string) => void, menuItem: Element, 
 	}`);
 }
 
-async function handleDropFileClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): Promise<void> {
+async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): Promise<void> {
 	const menuItem = event.delegateTarget;
 
 	try {
 		const filePath = menuItem.closest<HTMLDivElement>('[data-path]')!.dataset.path!;
-		await showToast(async progress => dropFile(progress!, menuItem, filePath), {
-			message: 'Dropping…',
-			doneMessage: 'Dropped!',
+		await showToast(async progress => removeFile(progress!, filePath), {
+			message: 'Fetching info…',
+			doneMessage: 'File removed from PR',
 		});
 
 		// Hide file from view
@@ -109,7 +115,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	}
 
 	if (editFile.closest('.file-header')!.querySelector('[aria-label="File added"]')) {
-		// The file is new. "Dropping from PR" it means deleting it, which is already possible.
+		// The file is new. "Removing from PR" it means deleting it, which is already possible.
 		// Depends on `highlight-deleted-and-added-files-in-diffs`.
 		return;
 	}
@@ -121,7 +127,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 			role="menuitem"
 			type="button"
 		>
-			Drop from PR
+			Remove from PR
 		</button>,
 	);
 }
@@ -129,7 +135,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 function init(signal: AbortSignal): void {
 	// `capture: true` required to be fired before GitHub's handlers
 	delegate('.file-header .js-file-header-dropdown', 'toggle', handleMenuOpening, {capture: true, signal});
-	delegate('.rgh-restore-file', 'click', handleDropFileClick, {capture: true, signal});
+	delegate('.rgh-restore-file', 'click', handleClick, {capture: true, signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -42,7 +42,7 @@ async function getFile(filePath: string): Promise<{isTruncated: boolean; text: s
 	return repository.file;
 }
 
-async function removeFile(progress: (message: string) => void, filePath: string): Promise<void> {
+async function discardChanges(progress: (message: string) => void, filePath: string): Promise<void> {
 	const file = await getFile(filePath);
 
 	if (file?.isTruncated) {
@@ -81,7 +81,7 @@ async function removeFile(progress: (message: string) => void, filePath: string)
 				${change}
 			},
 			message: {
-				headline: "Remove ${filePath} from PR"
+				headline: "Discard changes to ${filePath}"
 			}
 		}) {
 			commit {
@@ -96,9 +96,9 @@ async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>):
 
 	try {
 		const filePath = menuItem.closest<HTMLDivElement>('[data-path]')!.dataset.path!;
-		await showToast(async progress => removeFile(progress!, filePath), {
-			message: 'Fetching info…',
-			doneMessage: 'File removed from PR',
+		await showToast(async progress => discardChanges(progress!, filePath), {
+			message: 'Loading info…',
+			doneMessage: 'Changes discarded',
 		});
 
 		// Hide file from view
@@ -127,7 +127,7 @@ function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 			role="menuitem"
 			type="button"
 		>
-			Remove from PR
+			Discard changes
 		</button>,
 	);
 }
@@ -145,3 +145,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/sandbox/pull/16/files
+
+*/


### PR DESCRIPTION
- Continues #6596 

## Changes

- Allow deletion via API
- "Drop" was a bit awkward, I replaced with with "Remove from PR"

## Test URLs

https://github.com/refined-github/sandbox/pull/16/files

## Screenshot

![2](https://user-images.githubusercontent.com/1402241/236630610-e11a64f6-5e70-4353-89b8-39aae830dd16.gif)

## Prior art

### GitHub Desktop

<img width="459" alt="Screenshot 9" src="https://user-images.githubusercontent.com/1402241/236630893-fa8ba271-ed1c-4985-9dd6-f0a1e1266fc9.png">

### VS Code

<img width="371" alt="Screenshot 10" src="https://user-images.githubusercontent.com/1402241/236630942-477a5ebb-2f93-4f02-8cfb-152bec759eba.png">



cc @134130 