### PR TITLE
Default branch and current branch detector improvements

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -29,7 +29,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 
 	const defaultLink = (
 		<a
-			className="btn tooltipped tooltipped-s px-2"
+			className="btn tooltipped tooltipped-ne px-2"
 			href={url.href}
 			data-turbo-frame="repo-content-turbo-frame"
 			aria-label="See this view on the default branch"

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -35,6 +35,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isRepoRoot, // Already has an native download ZIP button
+		pageDetect.isEnterprise,
 	],
 	init,
 });

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import doesFileExist from '../github-helpers/does-file-exist.js';
-import getDefaultBranch from '../github-helpers/get-default-branch.js';
+import {getDefaultBranchOfRepo} from '../github-helpers/get-default-branch.js';
 import {getRepo, getForkedRepo} from '../github-helpers/index.js';
 
 const isFilePath = (): boolean =>
@@ -34,7 +34,7 @@ async function getEquivalentURL(): Promise<string> {
 	});
 
 	if (isFilePath()) {
-		sameViewUrl.branch = await getDefaultBranch(forkedRepository);
+		sameViewUrl.branch = await getDefaultBranchOfRepo(forkedRepository);
 		if (!await doesFileExist(sameViewUrl)) {
 			return defaultUrl;
 		}

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -3,14 +3,14 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import getDefaultBranch from '../github-helpers/get-default-branch.js';
+import getDefaultBranch, {getDefaultBranchOfRepo} from '../github-helpers/get-default-branch.js';
 import {getRepo} from '../github-helpers/index.js';
 
 async function init(): Promise<false | void> {
 	let defaultBranch;
 	if (select.exists('.is-cross-repo')) {
-		const forkedRepository = getRepo(select('[title^="head: "]')!.textContent!);
-		defaultBranch = await getDefaultBranch(forkedRepository);
+		const forkedRepository = getRepo(select('[title^="head: "]')!.textContent!)!;
+		defaultBranch = await getDefaultBranchOfRepo(forkedRepository);
 	} else {
 		defaultBranch = await getDefaultBranch();
 	}

--- a/source/github-helpers/get-current-git-ref.test.ts
+++ b/source/github-helpers/get-current-git-ref.test.ts
@@ -2,112 +2,112 @@ import {assert, test} from 'vitest';
 
 // @ts-expect-error JS only
 import {navigateToBranch} from '../../test/fixtures/globals.js';
-import getCurrentGitRef from './get-current-git-ref.js';
+import {getGitRef} from './get-current-git-ref.js';
 
 // The titles supplied here listed here are real, not guessed, except the error tester
-test('getCurrentGitRef', () => {
+test('getGitRef', () => {
 	// Error testing
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/',
 		'some page title',
 	), undefined, 'It should never throw with valid input');
-	assert.throws(() => getCurrentGitRef(
+	assert.throws(() => getGitRef(
 		'https://github.com',
 		'github.com',
 	));
 
 	// Root
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint',
 		'typescript-eslint/typescript-eslint: Monorepo for all the tooling which enables ESLint to support TypeScript',
 	), undefined);
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/tree/chore/lerna-4',
 		'typescript-eslint/typescript-eslint at chore/lerna-4',
 	), 'chore/lerna-4');
 
 	// Sub folder
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/tree/master/docs',
 		'typescript-eslint/docs at master · typescript-eslint/typescript-eslint',
 	), 'master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/tree/chore/lerna-4/docs',
 		'typescript-eslint/docs at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	// Sub sub folder
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/tree/master/docs/getting-started',
 		'typescript-eslint/docs/getting-started at master · typescript-eslint/typescript-eslint',
 	), 'master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/tree/chore/lerna-4/docs/getting-started',
 		'typescript-eslint/docs/getting-started at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	// File
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/README.md',
 		'typescript-eslint/README.md at master · typescript-eslint/typescript-eslint',
 	), 'master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/blob/chore/lerna-4/docs/getting-started/README.md',
 		'typescript-eslint/README.md at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	// Editing file
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/edit/master/docs/getting-started/README.md',
 		'Editing typescript-eslint/README.md at master · typescript-eslint/typescript-eslint',
 	), 'master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/edit/chore/lerna-4/docs/getting-started/README.md',
 		'Editing typescript-eslint/README.md at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	// Blame
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/blame/master/docs/getting-started/README.md',
 		'typescript-eslint/docs/getting-started/README.md at master · typescript-eslint/typescript-eslint',
 	), 'master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/blame/chore/lerna-4/docs/getting-started/README.md',
 		'typescript-eslint/docs/getting-started/README.md at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	// Commits
 	navigateToBranch('master');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/commits/master/docs/getting-started/README.md',
 		'History for docs/getting-started/README.md - typescript-eslint/typescript-eslint',
 	), 'master');
 
 	navigateToBranch('chore/lerna-4');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/commits/chore/lerna-4/docs/getting-started/README.md',
 		'History for docs/getting-started/README.md - typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
 	navigateToBranch('this/branch/has/many/slashes');
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/yakov116/TestR/commits/this/branch/has/many/slashes',
 		'Commits · yakov116/TestR',
 	), 'this/branch/has/many/slashes');
 
 	// Single commit
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/commit/795fd1c529ee58e97283c9ddf8463703517b50ab',
 		'chore: add markdownlint (#1889) · typescript-eslint/typescript-eslint@795fd1c',
 	), '795fd1c529ee58e97283c9ddf8463703517b50ab');
 
 	// Branch includes period
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/anggrayudi/SimpleStorage/tree/release/0.8.0',
 		'anggrayudi/SimpleStorage at release/0.8.0',
 	), 'release/0.8.0');
 
-	assert.equal(getCurrentGitRef(
+	assert.equal(getGitRef(
 		'/ksh-code/repository/tree/h.l.o.o',
 		'ksh-code/repository at h.l.o.o',
 	), 'h.l.o.o');

--- a/source/github-helpers/get-current-git-ref.test.ts
+++ b/source/github-helpers/get-current-git-ref.test.ts
@@ -1,8 +1,8 @@
 import {assert, test} from 'vitest';
 
 // @ts-expect-error JS only
-import {navigateToBranch} from '../../test/fixtures/globals.js';
-import {getGitRef} from './get-current-git-ref.js';
+import {navigateToCommits} from '../../test/fixtures/globals.js';
+import getCurrentGitRef, {getGitRef} from './get-current-git-ref.js';
 
 // The titles supplied here listed here are real, not guessed, except the error tester
 test('getGitRef', () => {
@@ -76,25 +76,6 @@ test('getGitRef', () => {
 		'typescript-eslint/docs/getting-started/README.md at chore/lerna-4 · typescript-eslint/typescript-eslint',
 	), 'chore/lerna-4');
 
-	// Commits
-	navigateToBranch('master');
-	assert.equal(getGitRef(
-		'/typescript-eslint/typescript-eslint/commits/master/docs/getting-started/README.md',
-		'History for docs/getting-started/README.md - typescript-eslint/typescript-eslint',
-	), 'master');
-
-	navigateToBranch('chore/lerna-4');
-	assert.equal(getGitRef(
-		'/typescript-eslint/typescript-eslint/commits/chore/lerna-4/docs/getting-started/README.md',
-		'History for docs/getting-started/README.md - typescript-eslint/typescript-eslint',
-	), 'chore/lerna-4');
-
-	navigateToBranch('this/branch/has/many/slashes');
-	assert.equal(getGitRef(
-		'/yakov116/TestR/commits/this/branch/has/many/slashes',
-		'Commits · yakov116/TestR',
-	), 'this/branch/has/many/slashes');
-
 	// Single commit
 	assert.equal(getGitRef(
 		'/typescript-eslint/typescript-eslint/commit/795fd1c529ee58e97283c9ddf8463703517b50ab',
@@ -111,4 +92,26 @@ test('getGitRef', () => {
 		'/ksh-code/repository/tree/h.l.o.o',
 		'ksh-code/repository at h.l.o.o',
 	), 'h.l.o.o');
+});
+
+// The titles supplied here listed here are real, not guessed, except the error tester
+test('getCurrentGitRef', () => {
+	// Commits
+	navigateToCommits(
+		'master',
+		'/typescript-eslint/typescript-eslint/commits/master/docs/getting-started/README.md',
+	);
+	assert.equal(getCurrentGitRef(), 'master');
+
+	navigateToCommits(
+		'chore/lerna-4',
+		'/typescript-eslint/typescript-eslint/commits/chore/lerna-4/docs/getting-started/README.md',
+	);
+	assert.equal(getCurrentGitRef(), 'chore/lerna-4');
+
+	navigateToCommits(
+		'this/branch/has/many/slashes',
+		'/yakov116/TestR/commits/this/branch/has/many/slashes',
+	);
+	assert.equal(getCurrentGitRef(), 'this/branch/has/many/slashes');
 });

--- a/source/github-helpers/get-current-git-ref.ts
+++ b/source/github-helpers/get-current-git-ref.ts
@@ -1,3 +1,4 @@
+import {isRepoCommitList} from 'github-url-detection';
 import select from 'select-dom';
 
 import {branchSelector} from './selectors.js';
@@ -14,6 +15,12 @@ export default function getCurrentGitRef(): string | undefined {
 		return refViaPicker;
 	}
 
+	// Slashed branches on `commits`, including pages without a branch picker
+	const branchFromFeed = getCurrentBranchFromFeed();
+	if (branchFromFeed) {
+		return branchFromFeed;
+	}
+
 	return getGitRef(location.pathname, document.title);
 }
 
@@ -28,12 +35,6 @@ export function getGitRef(pathname: string, title: string): string | undefined {
 		return;
 	}
 
-	// Slashed branches on `commits`
-	const branchFromFeed = getCurrentBranchFromFeed(type);
-	if (branchFromFeed) {
-		return branchFromFeed;
-	}
-
 	// Slashed branches on `blob` and `tree`
 	const parsedTitle = titleWithGitRef.exec(title);
 	if (parsedTitle) {
@@ -45,10 +46,10 @@ export function getGitRef(pathname: string, title: string): string | undefined {
 }
 
 // In <head>, but not reliable https://github.com/refined-github/refined-github/assets/1402241/50357d94-505f-48dc-bd54-74e86b19d642
-function getCurrentBranchFromFeed(type: string): string | undefined {
-	const feedLink = type === 'commits' && select('link[type="application/atom+xml"]');
+function getCurrentBranchFromFeed(): string | undefined {
+	const feedLink = isRepoCommitList() && select('link[type="application/atom+xml"]');
 	if (!feedLink) {
-		// Do not throw errors, the element may be missing after AJAX navigation
+		// Do not throw errors, the element may be missing after AJAX navigation even if on the right page
 		return;
 	}
 

--- a/source/github-helpers/get-current-git-ref.ts
+++ b/source/github-helpers/get-current-git-ref.ts
@@ -1,13 +1,15 @@
 import select from 'select-dom';
 
+import {branchSelector} from './selectors.js';
+
 const typesWithGitRef = new Set(['tree', 'blob', 'blame', 'edit', 'commit', 'commits', 'compare']);
 const titleWithGitRef = / at (?<branch>[.\w-/]+)( · [\w-]+\/[\w-]+)?$/i;
 
 /** Must not be async because it's used by GitHubURL. May return different results depending on whether it's called before or after DOM ready */
 export default function getCurrentGitRef(): string | undefined {
-	// There are usually 2 elements on the page; 4 on the compare page.
 	// Note: This is not in the <head> so it's only available on AJAXed loads.
-	const refViaPicker = select('ref-selector')?.getAttribute('current-committish');
+	// It appears on every Code page except `commits` on folders/files
+	const refViaPicker = select(branchSelector)?.textContent!.trim();
 	if (refViaPicker) {
 		return refViaPicker;
 	}
@@ -26,6 +28,12 @@ export function getGitRef(pathname: string, title: string): string | undefined {
 		return;
 	}
 
+	// Slashed branches on `commits`
+	const branchFromFeed = getCurrentBranchFromFeed(type);
+	if (branchFromFeed) {
+		return branchFromFeed;
+	}
+
 	// Slashed branches on `blob` and `tree`
 	const parsedTitle = titleWithGitRef.exec(title);
 	if (parsedTitle) {
@@ -34,4 +42,20 @@ export function getGitRef(pathname: string, title: string): string | undefined {
 
 	// Couldn't ensure it's not slashed, so we'll return the first piece whether correct or not
 	return gitRefIfNonSlashed;
+}
+
+// In <head>, but not reliable https://github.com/refined-github/refined-github/assets/1402241/50357d94-505f-48dc-bd54-74e86b19d642
+function getCurrentBranchFromFeed(type: string): string | undefined {
+	const feedLink = type === 'commits' && select('link[type="application/atom+xml"]');
+	if (!feedLink) {
+		// Do not throw errors, the element may be missing after AJAX navigation
+		return;
+	}
+
+	return new URL(feedLink.href)
+		.pathname
+		.split('/')
+		.slice(4) // Drops the initial /user/repo/route/ part
+		.join('/')
+		.replace(/\.atom$/, '');
 }

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -1,27 +1,40 @@
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing -- Wrong, the type is `false | undefined` */
 import cache from 'webext-storage-cache';
 import elementReady from 'element-ready';
-import * as pageDetect from 'github-url-detection';
+import {type RepositoryInfo} from 'github-url-detection';
 
 import * as api from './api.js';
 import {getRepo} from './index.js';
 import {branchSelector} from './selectors.js';
 
-const isCurrentRepo = ({nameWithOwner}: pageDetect.RepositoryInfo): boolean => Boolean(getRepo()?.nameWithOwner === nameWithOwner);
+const typesWithRefSelector = new Set(['tree', 'blob', 'blame', 'compare']);
 
-// DO NOT use optional arguments/defaults in "cached functions" because they can't be memoized effectively
-// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864
-const _getDefaultBranch = cache.function('default-branch', async (repository: pageDetect.RepositoryInfo): Promise<string> => {
-	// TODO: extract from `ref-selector` if available https://github.com/refined-github/refined-github/issues/6557
-	if (isCurrentRepo(repository) && ['', 'commits'].includes(repository.path)) {
-		// We're on the default branch, so we can extract it from the current page. This usually happens on the pages:
-		// @example /user/repo
-		// @example /user/repo/commits (without further path)
+const isCurrentRepo = ({nameWithOwner}: RepositoryInfo): boolean => Boolean(getRepo()?.nameWithOwner === nameWithOwner);
+
+async function fromDOM(): Promise<string | undefined> {
+	if (['', 'commits'].includes(getRepo()!.path)) {
+		// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
+		// /user/repo
+		// /user/repo/commits (without further path)
 		const branchPicker = await elementReady(branchSelector);
 		if (branchPicker) {
 			return branchPicker.textContent!.trim();
 		}
 	}
 
+	// Use explicit list to avoid uselessly waiting for the the `ref-selector` to appear
+	const type = location.pathname.split('/')[3];
+	if (typesWithRefSelector.has(type)) {
+		const branchPicker = await elementReady('ref-selector', {waitForChildren: false});
+		if (branchPicker) {
+			return branchPicker.getAttribute('default-branch')!;
+		}
+	}
+
+	return undefined;
+}
+
+async function fromAPI(repository: RepositoryInfo): Promise<string> {
 	const response = await api.v4(`
 		repository(owner: "${repository.owner}", name: "${repository.name}") {
 			defaultBranchRef {
@@ -31,13 +44,20 @@ const _getDefaultBranch = cache.function('default-branch', async (repository: pa
 	`);
 
 	return response.repository.defaultBranchRef.name;
-}, {
-	maxAge: {hours: 1},
-	staleWhileRevalidate: {days: 20},
-	cacheKey: ([repository]) => repository.nameWithOwner,
-});
+}
 
-export default async function getDefaultBranch(repository: pageDetect.RepositoryInfo | undefined = getRepo()): Promise<string> {
+// DO NOT use optional arguments/defaults in "cached functions" because they can't be memoized effectively
+// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864
+const _getDefaultBranch = cache.function('default-branch',
+	async (repository: RepositoryInfo): Promise<string> => (isCurrentRepo(repository) && await fromDOM()) || fromAPI(repository),
+	{
+		maxAge: {hours: 1},
+		staleWhileRevalidate: {days: 20},
+		cacheKey: ([repository]) => repository.nameWithOwner,
+	},
+);
+
+export default async function getDefaultBranch(repository: RepositoryInfo | undefined = getRepo()): Promise<string> {
 	if (!repository) {
 		throw new Error('getDefaultBranch was called on a non-repository page');
 	}

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -10,17 +10,15 @@ const isCurrentRepo = ({nameWithOwner}: RepositoryInfo): boolean => Boolean(getR
 
 // Do not make this function complicated. We're only optimizing for the repo root.
 async function fromDOM(): Promise<string | undefined> {
-	if (['', 'commits'].includes(getRepo()!.path)) {
-		// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
-		// /user/repo
-		// /user/repo/commits (without further path)
-		const branchPicker = await elementReady(branchSelector);
-		if (branchPicker) {
-			return branchPicker.textContent!.trim();
-		}
+	if (!['', 'commits'].includes(getRepo()!.path)) {
+		return undefined;
 	}
 
-	return undefined;
+	// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
+	// /user/repo
+	// /user/repo/commits (without further path)
+	const branchPicker = await elementReady(branchSelector);
+	return branchPicker!.textContent!.trim();
 }
 
 async function fromAPI(repository: RepositoryInfo): Promise<string> {

--- a/source/github-helpers/github-url.ts
+++ b/source/github-helpers/github-url.ts
@@ -1,3 +1,5 @@
+import {isRepoRoot} from 'github-url-detection';
+
 import getCurrentGitRef from './get-current-git-ref.js';
 
 export default class GitHubURL {
@@ -24,6 +26,7 @@ export default class GitHubURL {
 		return this;
 	}
 
+	// Handle branch names containing multiple slashes #4492
 	private disambiguateReference(
 		ambiguousReference: string[],
 	): {branch: string; filePath: string} {
@@ -37,6 +40,7 @@ export default class GitHubURL {
 
 		const filePath = ambiguousReference.slice(1).join('/');
 
+		// TODO: `getCurrentGitRef` uses global state https://github.com/refined-github/refined-github/issues/6637
 		const currentBranch = getCurrentGitRef();
 		const currentBranchSections = currentBranch?.split('/');
 		if (
@@ -68,8 +72,8 @@ export default class GitHubURL {
 
 	set pathname(pathname: string) {
 		const [user, repository, route, ...ambiguousReference] = pathname.replace(/^\/|\/$/g, '').split('/');
-		// Handle branch names containing multiple slashes #4492
-		if (ambiguousReference.length === 2 && ambiguousReference[1].includes('%2F')) {
+		// TODO: `isRepoRoot` uses global state https://github.com/refined-github/refined-github/issues/6637
+		if (isRepoRoot() || (ambiguousReference.length === 2 && ambiguousReference[1].includes('%2F'))) {
 			const branch = ambiguousReference.join('/').replace(/%2F/g, '/');
 			this.assign({user, repository, route, branch, filePath: ''});
 			return;

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -20,20 +20,6 @@ export function getConversationNumber(): number | undefined {
 	return undefined;
 }
 
-export function getCurrentBranchFromFeed(): string {
-	const feedLink = select('link[type="application/atom+xml"]');
-	if (!feedLink) {
-		throw new Error('getCurrentBranchFromFeed() is only available on commit lists');
-	}
-
-	return new URL(feedLink.href)
-		.pathname
-		.split('/')
-		.slice(4) // Drops the initial /user/repo/route/ part
-		.join('/')
-		.replace(/\.atom$/, '');
-}
-
 export const isMac = navigator.userAgent.includes('Macintosh');
 
 type Not<Yes, Not> = Yes extends Not ? never : Yes;

--- a/source/github-helpers/prevent-link-loss.ts
+++ b/source/github-helpers/prevent-link-loss.ts
@@ -1,9 +1,10 @@
 /* eslint-disable max-params */
+import {RepositoryInfo} from 'github-url-detection';
+
 import {getRepo} from './index.js';
 
-const currentRepo = getRepo() ?? {nameWithOwner: 'refined-github/refined-github'};
-function getRepoReference(repoNameWithOwner: string, delemiter = ''): string {
-	return repoNameWithOwner === currentRepo.nameWithOwner ? '' : repoNameWithOwner + delemiter;
+function getRepoReference(currentRepo: RepositoryInfo | undefined, repoNameWithOwner: string, delimiter = ''): string {
+	return repoNameWithOwner === currentRepo!.nameWithOwner ? '' : repoNameWithOwner + delimiter;
 }
 
 const escapeRegex = (string: string): string => string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
@@ -22,7 +23,7 @@ export function preventPrCommitLinkLoss(url: string, repoNameWithOwner: string, 
 		return url;
 	}
 
-	return `[${getRepoReference(repoNameWithOwner, '@')}\`${commit}\` (#${pr})](${url})`;
+	return `[${getRepoReference(getRepo(), repoNameWithOwner, '@')}\`${commit}\` (#${pr})](${url})`;
 }
 
 // To be used as replacer callback in string.replace() for compare links
@@ -31,7 +32,7 @@ export function preventPrCompareLinkLoss(url: string, repoNameWithOwner: string,
 		return url;
 	}
 
-	return `[${getRepoReference(repoNameWithOwner, '@')}\`${compare}\`${hash.slice(0, 16)}](${url})`;
+	return `[${getRepoReference(getRepo(), repoNameWithOwner, '@')}\`${compare}\`${hash.slice(0, 16)}](${url})`;
 }
 
 // To be used as replacer callback in string.replace() for discussion links
@@ -40,5 +41,5 @@ export function preventDiscussionLinkLoss(url: string, repoNameWithOwner: string
 		return url;
 	}
 
-	return `[${getRepoReference(repoNameWithOwner)}#${discussion}${comment ? ' (comment)' : ''}](${url})`;
+	return `[${getRepoReference(getRepo(), repoNameWithOwner)}#${discussion}${comment ? ' (comment)' : ''}](${url})`;
 }

--- a/source/github-helpers/selectors.test.ts
+++ b/source/github-helpers/selectors.test.ts
@@ -24,5 +24,5 @@ describe.concurrent('selectors', () => {
 			const {window} = await fetchDocument(url);
 			assert.isDefined(window.document.querySelector(selector));
 		}));
-	});
+	}, {timeout: 9999});
 });

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -8,7 +8,11 @@ export const branchSelector = '[data-hotkey="w"]';
 export const branchSelector_ = [
 	'https://github.com/refined-github/refined-github',
 	'https://github.com/refined-github/refined-github/blob/main/readme.md',
+	'https://github.com/refined-github/refined-github/blame/main/readme.md',
 	'https://github.com/refined-github/refined-github/tree/main/source',
+	'https://github.com/refined-github/sandbox/tree/branch/with/slashes',
+	'https://github.com/refined-github/sandbox/commits/branch/with/slashes',
+	'https://github.com/refined-github/sandbox/commits',
 ];
 
 export const directoryListingFileIcon = [

--- a/test/fixtures/globals.js
+++ b/test/fixtures/globals.js
@@ -23,11 +23,12 @@ for (const property of globals) {
 const link = document.createElement('link');
 link.rel = 'alternate';
 link.type = 'application/atom+xml';
-navigateToBranch('master');
+navigateToCommits('master', '/refined-github/refined-github/commits');
 document.head.append(link);
 
 // eslint-disable-next-line import/prefer-default-export
-export function navigateToBranch(branch) {
-	link.href = `https://github.com/avajs/ava/commits/${branch}.atom`;
+export function navigateToCommits(branch, pathname) {
+	link.href = `https://github.com/refined-github/refined-github/commits/${branch}.atom`;
 	link.title = `Recent Commits to ava:${branch}`;
+	location.pathname = pathname;
 }


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6557
- Fixes issue introduced by https://github.com/refined-github/refined-github/pull/6629



A mistake that we keep making is mixing parameterized functions which then ignore the parameters and use the DOM. This must either be made clear by the function name (e.g. "current") or by verifying that the arguments match the current page. Default parameters are the worst because they make us forget this important distinction.

Related:

- https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864#issuecomment-1413182933