### PR TITLE
`fit-textareas` after `clear-pr-merge-commit-message`

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -24,6 +24,10 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void | false> {
 
 	// Do not use `text-field-edit` #6348
 	messageField.value = cleanedMessage ? cleanedMessage + '\n' : '';
+
+	// Trigger `fit-textareas` if enabled
+	messageField.dispatchEvent(new Event('input', {bubbles: true}));
+
 	messageField.after(
 		<div>
 			<p className="note">

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -67,6 +67,9 @@ async function updateCommitTitle(): Promise<void> {
 	if (field) {
 		// Do not use `text-field-edit` #6348
 		field.value = createCommitTitle();
+
+		// There might be listeners that need to be notified
+		field.dispatchEvent(new Event('input', {bubbles: true}));
 	}
 }
 


### PR DESCRIPTION
- Due to https://github.com/refined-github/refined-github/pull/6584

## Test URLs

This page (if not yet merged)

## Before

![before](https://github.com/refined-github/refined-github/assets/1402241/dc8d626e-1ff8-449e-aed9-0209b5f5b7e1)

## After

![after](https://github.com/refined-github/refined-github/assets/1402241/d938d9e0-0bc0-4d5f-825a-ed7c70a8c762)

