### PR TITLE
Improve `rgh-feature-descriptions` links

### DIFF
--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -1,4 +1,5 @@
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {isFeaturePrivate} from '../source/options-storage.js';
 
 import {getImportedFeatures, getFeaturesMeta} from './readme-parser.js'; // Must import as `.js`
 
@@ -48,7 +49,7 @@ function findError(filename: string): string | void {
 	}
 
 	// The previous checks apply to RGH features, but the next ones don't
-	if (filename.startsWith('rgh-')) {
+	if (isFeaturePrivate(filename)) {
 		return;
 	}
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -1,7 +1,7 @@
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
-import {isFeaturePrivate} from '../source/options-storage.js';
 
-import {getImportedFeatures, getFeaturesMeta} from './readme-parser.js'; // Must import as `.js`
+import {isFeaturePrivate} from '../source/helpers/feature-utils.js';
+import {getImportedFeatures, getFeaturesMeta} from './readme-parser.js';
 
 const featuresDirContents = readdirSync('source/features/');
 const entryPoint = 'source/refined-github.ts';

--- a/source/background.ts
+++ b/source/background.ts
@@ -6,10 +6,11 @@ import {isSafari} from 'webext-detect-page';
 import {objectKeys} from 'ts-extras';
 import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 
-import optionsStorage, {isBrowserActionAPopup} from './options-storage.js';
+import optionsStorage from './options-storage.js';
 import {getRghIssueUrl} from './helpers/rgh-issue-link.js';
 import isDevelopmentVersion from './helpers/is-development-version.js';
 import getStorageBytesInUse from './helpers/used-storage.js';
+import {isBrowserActionAPopup} from './helpers/feature-utils.js';
 
 // GHE support
 addDomainPermissionToggle();

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -10,7 +10,8 @@ import onAbort from './helpers/abort-controller.js';
 import ArrayMap from './helpers/map-of-arrays.js';
 import bisectFeatures from './helpers/bisect.js';
 import {shouldFeatureRun} from './github-helpers/index.js';
-import optionsStorage, {isFeatureDisabled, isFeaturePrivate, RGHOptions} from './options-storage.js';
+import {isFeaturePrivate} from './helpers/feature-utils.js';
+import optionsStorage, {isFeatureDisabled, RGHOptions} from './options-storage.js';
 import {
 	applyStyleHotfixes,
 	getStyleHotfix,

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -10,7 +10,7 @@ import onAbort from './helpers/abort-controller.js';
 import ArrayMap from './helpers/map-of-arrays.js';
 import bisectFeatures from './helpers/bisect.js';
 import {shouldFeatureRun} from './github-helpers/index.js';
-import optionsStorage, {RGHOptions} from './options-storage.js';
+import optionsStorage, {isFeatureDisabled, isFeaturePrivate, RGHOptions} from './options-storage.js';
 import {
 	applyStyleHotfixes,
 	getStyleHotfix,
@@ -173,7 +173,7 @@ async function setupPageLoad(id: FeatureID, config: InternalRunConfig): Promise<
 		try {
 			result = await init(featureController.signal);
 			// Features can return `false` when they decide not to run on the current page
-			if (result !== false && !id?.startsWith('rgh')) {
+			if (result !== false && !isFeaturePrivate(id)) {
 				log.info('✅', id);
 			}
 		} catch (error) {
@@ -228,9 +228,7 @@ async function add(url: string, ...loaders: FeatureLoader[]): Promise<void> {
 	/* Feature filtering and running */
 	const options = await globalReady;
 	// Skip disabled features, unless the feature is private
-	// Must check if it's specifically `false`: It could be undefined if not yet in the readme or if misread from the entry point #6606
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
-	if (options[`feature:${id}`] === false && !id.startsWith('rgh')) {
+	if (isFeatureDisabled(options, id) && !isFeaturePrivate(id)) {
 		log.info('↩️', 'Skipping', id);
 		return;
 	}

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -21,6 +21,20 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 	// This ID exists whether the feature is documented or not
 	const id = feature?.id ?? currentFeature;
 
+	const isCss = location.pathname.endsWith('.css');
+	const isPrivateFeature = id.startsWith('rgh-');
+
+	const description = feature?.description // Regular feature?
+	?? (
+		isPrivateFeature
+			? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled'
+			: (
+				isCss
+					? 'This feature is CSS-only cannot be disabled'
+					: undefined // The heck!?
+			)
+	);
+
 	const conversationsUrl = new URL('https://github.com/refined-github/refined-github/issues');
 	conversationsUrl.searchParams.set('q', `sort:updated-desc is:open "${id}"`);
 
@@ -47,13 +61,13 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 						</clipboard-copy>
 					</h3>
 					{ /* eslint-disable-next-line react/no-danger */ }
-					{feature && <div dangerouslySetInnerHTML={{__html: feature.description}} className="h3"/>}
+					{description && <div dangerouslySetInnerHTML={{__html: description}} className="h3"/>}
 					<div className="no-wrap">
 						<a href={conversationsUrl.href} data-turbo-frame="repo-content-turbo-frame">Related issues</a>
 						{' • '}
 						<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>
 						{
-							location.pathname.endsWith('css')
+							feature && isCss
 								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
 								: undefined
 						}
@@ -110,7 +124,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
-- https://github.com/refined-github/refined-github/blob/main/source/features/clean-conversation-sidebar.css
-- https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
+- Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
+- CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.css
+- RGH feature: https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
+- CSS-only feature: https://github.com/refined-github/refined-github/blob/main/source/features/center-reactions-popup.css
 */

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -17,27 +17,28 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 	// Enable link even on past commits
 	const currentFeatureName = getNewFeatureName(currentFeature);
 	const feature = featuresMeta.find(feature => feature.id === currentFeatureName);
-	if (!feature) {
-		return;
-	}
+
+	// This ID exists whether the feature is documented or not
+	const id = feature?.id ?? currentFeature;
 
 	const conversationsUrl = new URL('https://github.com/refined-github/refined-github/issues');
-	conversationsUrl.searchParams.set('q', `sort:updated-desc is:open "${feature.id}"`);
+	conversationsUrl.searchParams.set('q', `sort:updated-desc is:open "${id}"`);
 
 	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
 	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-	newIssueUrl.searchParams.set('title', `\`${feature.id}\`: `);
+	newIssueUrl.searchParams.set('title', `\`${id}\`: `);
 
 	infoBanner.before(
 		// Block and width classes required to avoid margin collapse
 		<div className="Box mb-3 d-inline-block width-full">
 			<div className="Box-row d-flex gap-3 flex-wrap">
 				<div className="rgh-feature-description d-flex flex-column gap-2">
-					<h3><code>{feature.id}</code>
+					<h3>
+						<code>{id}</code>
 						<clipboard-copy
 							aria-label="Copy"
 							data-copy-feedback="Copied!"
-							value={feature.id}
+							value={id}
 							class="Link--onHover color-fg-muted d-inline-block ml-2"
 							tabindex="0"
 							role="button"
@@ -46,7 +47,7 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 						</clipboard-copy>
 					</h3>
 					{ /* eslint-disable-next-line react/no-danger */ }
-					<div dangerouslySetInnerHTML={{__html: feature.description}} className="h3"/>
+					{feature && <div dangerouslySetInnerHTML={{__html: feature.description}} className="h3"/>}
 					<div className="no-wrap">
 						<a href={conversationsUrl.href} data-turbo-frame="repo-content-turbo-frame">Related issues</a>
 						{' • '}
@@ -58,7 +59,7 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 						}
 					</div>
 				</div>
-				{feature.screenshot && (
+				{feature?.screenshot && (
 					<a href={feature.screenshot} className="flex-self-center">
 						<img
 							src={feature.screenshot}
@@ -111,5 +112,5 @@ Test URLs:
 
 - https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
 - https://github.com/refined-github/refined-github/blob/main/source/features/clean-conversation-sidebar.css
-
+- https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
 */

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -6,13 +6,14 @@ import cache from 'webext-storage-cache';
 
 import features from '../feature-manager.js';
 import {featuresMeta} from '../../readme.md';
-import optionsStorage, {getNewFeatureName, isFeatureDisabled, isFeaturePrivate} from '../options-storage.js';
+import optionsStorage, {getNewFeatureName, isFeatureDisabled} from '../options-storage.js';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {HotfixStorage} from '../helpers/hotfix.js';
 import {createRghIssueLink} from '../helpers/rgh-issue-link.js';
 import openOptions from '../helpers/open-options.js';
 import createBanner from '../github-helpers/banner.js';
+import {isFeaturePrivate} from '../helpers/feature-utils.js';
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
 	const isCss = location.pathname.endsWith('.css');

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -22,14 +22,18 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 	}
 
 	const conversationsUrl = new URL('https://github.com/refined-github/refined-github/issues');
-	conversationsUrl.searchParams.set('q', `sort:updated-desc "${feature.id}"`);
+	conversationsUrl.searchParams.set('q', `sort:updated-desc is:open "${feature.id}"`);
+
+	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
+	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
+	newIssueUrl.searchParams.set('title', `\`${feature.id}\`: `);
 
 	infoBanner.before(
 		// Block and width classes required to avoid margin collapse
 		<div className="Box mb-3 d-inline-block width-full">
 			<div className="Box-row d-flex gap-3 flex-wrap">
-				<div className="rgh-feature-description">
-					<h3 className="mb-2"><code>{feature.id}</code>
+				<div className="rgh-feature-description d-flex flex-column gap-2">
+					<h3><code>{feature.id}</code>
 						<clipboard-copy
 							aria-label="Copy"
 							data-copy-feedback="Copied!"
@@ -43,11 +47,13 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 					</h3>
 					{ /* eslint-disable-next-line react/no-danger */ }
 					<div dangerouslySetInnerHTML={{__html: feature.description}} className="h3"/>
-					<div className="no-wrap" data-turbo-frame="repo-content-turbo-frame">
-						<a href={conversationsUrl.href}>Related issues</a>
+					<div className="no-wrap">
+						<a href={conversationsUrl.href} data-turbo-frame="repo-content-turbo-frame">Related issues</a>
+						{' • '}
+						<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>
 						{
 							location.pathname.endsWith('css')
-								? <> • <a href={location.pathname.replace('.css', '.tsx')}>See JavaScript</a></>
+								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
 								: undefined
 						}
 					</div>

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -1,0 +1,7 @@
+import {isMobileSafari} from 'webext-detect-page';
+
+export function isFeaturePrivate(id: string): boolean {
+	return id.startsWith('rgh-');
+}
+
+export const isBrowserActionAPopup = isMobileSafari();

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -52,6 +52,16 @@ export const renamedFeatures = new Map<string, string>([
 	['set-default-repositories-type-to-sources', 'hide-user-forks'],
 ]);
 
+export function isFeaturePrivate(id: string): boolean {
+	return id.startsWith('rgh-');
+}
+
+export function isFeatureDisabled(options: RGHOptions, id: string): boolean {
+	// Must check if it's specifically `false`: It could be undefined if not yet in the readme or if misread from the entry point #6606
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+	return options[`feature:${id}`] === false;
+}
+
 export function getNewFeatureName(possibleFeatureName: string): FeatureID | undefined {
 	let newFeatureName = possibleFeatureName;
 	while (renamedFeatures.has(newFeatureName)) {

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -1,11 +1,8 @@
-import {isMobileSafari} from 'webext-detect-page';
 import OptionsSyncPerDomain from 'webext-options-sync-per-domain';
 
 import {importedFeatures} from '../readme.md';
 
 export type RGHOptions = typeof defaults;
-
-export const isBrowserActionAPopup = isMobileSafari();
 
 // eslint-disable-next-line prefer-object-spread -- TypeScript doesn't merge the definitions so `...` is not equivalent.
 const defaults = Object.assign({
@@ -51,10 +48,6 @@ export const renamedFeatures = new Map<string, string>([
 	['useful-forks', 'fork-notice'],
 	['set-default-repositories-type-to-sources', 'hide-user-forks'],
 ]);
-
-export function isFeaturePrivate(id: string): boolean {
-	return id.startsWith('rgh-');
-}
 
 export function isFeatureDisabled(options: RGHOptions, id: string): boolean {
 	// Must check if it's specifically `false`: It could be undefined if not yet in the readme or if misread from the entry point #6606

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -19,8 +19,9 @@ import {getLocalHotfixes} from './helpers/hotfix.js';
 import {createRghIssueLink} from './helpers/rgh-issue-link.js';
 import {importedFeatures, featuresMeta} from '../readme.md';
 import getStorageBytesInUse from './helpers/used-storage.js';
-import {isBrowserActionAPopup, perDomainOptions} from './options-storage.js';
+import {perDomainOptions} from './options-storage.js';
 import isDevelopmentVersion from './helpers/is-development-version.js';
+import {isBrowserActionAPopup} from './helpers/feature-utils.js';
 
 type Status = {
 	error?: true;


### PR DESCRIPTION
- Closes #6600 

#### Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
<img width="543" alt="Screenshot 11" src="https://github.com/refined-github/refined-github/assets/1402241/d8a324f3-f4fe-4125-9483-b98bb8e68c7c">

#### CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.css
<img width="543" alt="Screenshot 12" src="https://github.com/refined-github/refined-github/assets/1402241/37ad0c5e-59e5-4cd0-a30f-09df83f88475">

#### RGH feature: https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
<img width="543" alt="Screenshot 13" src="https://github.com/refined-github/refined-github/assets/1402241/7008195f-8fef-4c2d-a9ec-3832dfd0c512">

#### CSS-only feature: https://github.com/refined-github/refined-github/blob/main/source/features/center-reactions-popup.css

<img width="543" alt="Screenshot 14" src="https://github.com/refined-github/refined-github/assets/1402241/a4b55eef-a6c2-4308-a652-23834e8f7e88">

