### PR TITLE
Add pr-files-commit-range-not-found feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,7 @@ Thanks for contributing! 🦋🙌
 - [](# "view-last-pr-deployment") [Adds a link to open the latest deployment from the header of a PR.](https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png)
 - [](# "no-unnecessary-split-diff-view") [Always uses unified diffs on files where split diffs aren’t useful.](https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png)
 - [](# "emphasize-draft-pr-label") [Makes it easier to distinguish draft PR in lists.](https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png)
+- [](# "pr-files-commit-range-not-found") [Redirect to all changes if commit range not found.](https://user-images.githubusercontent.com/8899636/237991799-2fec2f38-7311-4e7d-9050-9449f75a5317.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/pr-files-commit-range-not-found.tsx
+++ b/source/features/pr-files-commit-range-not-found.tsx
@@ -1,0 +1,21 @@
+import * as pageDetect from 'github-url-detection';
+import select from 'select-dom';
+
+import features from '../feature-manager.js';
+
+function init(): void {
+	// Link to navigate to all changes is nested in a paragraph of a blankslate div
+	// The link only exists if not changes where found
+	const latestChangesLink = select.last('.blankslate > p > a');
+	if (latestChangesLink) {
+		latestChangesLink.click();
+	}
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRFiles,
+	],
+	awaitDomReady: true,
+	init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -215,3 +215,4 @@ import './features/releases-dropdown.js';
 import './features/pr-base-commit.js';
 import './features/unreleased-commits.js';
 import './features/previous-version.js';
+import './features/pr-files-commit-range-not-found.js';


### PR DESCRIPTION
This adds a new feature that automatically redirects the user from a "Commit range not found" PR files page to the latest changes.
To check for whether no commit range was found, the existence of a link in a `blankslate` div is checked. If it exists, it is clicked to redirect to the latest changes of this PR.

Relates to the following suggestion: https://github.com/refined-github/refined-github/issues/4648#issuecomment-921957276

## Test URLs
URL for which a redirect should happen: https://github.com/refined-github/refined-github/pull/6646/files/abc..def
"Good" URLs which should not redirect:
- https://github.com/refined-github/refined-github/pull/6646/files
- https://github.com/refined-github/refined-github/pull/6488/files/274865d4a0ecea7039a57383337b0e9a3bc72bca..5be67c6d9d698f59c79d513ed0e1acfdae0459be

## Screenshot
![pr-files-commit-range-not-found](https://github.com/refined-github/refined-github/assets/8899636/2fec2f38-7311-4e7d-9050-9449f75a5317)
