### PR TITLE
Fix `ci-link` duplicates on mobile

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -44,8 +44,8 @@ async function init(signal: AbortSignal): Promise<void> {
 		// Desktop
 		'.AppHeader-context-item:not([data-hovercard-type])',
 
-		// Mobile. `:first-child` avoids finding our own element
-		'.AppHeader-context-compact-mainItem span:first-child',
+		// Mobile. `> *:first-child` avoids finding our own element
+		'.AppHeader-context-compact-mainItem > span:first-child',
 
 		// Old selector: `.avatar` excludes "Global navigation update"
 		// Repo title (aware of forks and private repos)


### PR DESCRIPTION
Somehow this only happens in Chrome’s responsive view

## Before


https://github.com/refined-github/refined-github/assets/1402241/087b9ce2-7db0-45b6-a16c-0126b20a6301



## After


https://github.com/refined-github/refined-github/assets/1402241/e5ed3992-41e8-4fe4-bd5c-c6e002a57ec8

