### PR TITLE
Ignore `clean-repo-sidebar` report link error

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -56,8 +56,11 @@ async function hideEmptyMeta(): Promise<void> {
 async function moveReportLink(): Promise<void> {
 	await domLoaded;
 
-	const reportLink = select('.Layout-sidebar a[href^="/contact/report-content"]')!.parentElement!;
-	select('.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell')!.append(reportLink);
+	const reportLink = select('.Layout-sidebar a[href^="/contact/report-content"]')?.parentElement;
+	if (reportLink) {
+		// Your own repos don't include this link
+		select('.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell')!.append(reportLink);
+	}
 }
 
 async function init(): Promise<void> {


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6648

## Test URLs

The homepage of one of your own repos, like

https://github.com/fregante/doma


## Before

<img width="897" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/18983729-f735-4f5f-99bb-a444b0dafc95">

