### PR TITLE
Fix notification action bar style

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -128,3 +128,13 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+	
+https://github.com/notifications (Grouped by date)
+https://github.com/notifications (Grouped by repo)
+https://github.com/notifications?query=reason%3Acomment (which is an unsaved filter)
+
+*/

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -70,7 +70,7 @@ function removeOpenUnreadButtons(container: ParentNode = document): void {
 
 function addSelectedButton(selectedActionsGroup: HTMLElement): void {
 	const button = (
-		<button className={'btn btn-sm ' + openSelected.class} type="button">
+		<button className={'btn btn-sm mr-2 ' + openSelected.class} type="button">
 			<LinkExternalIcon className="mr-1"/>Open
 		</button>
 	);

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -132,7 +132,7 @@ void features.add(import.meta.url, {
 /*
 
 Test URLs:
-	
+
 https://github.com/notifications (Grouped by date)
 https://github.com/notifications (Grouped by repo)
 https://github.com/notifications?query=reason%3Acomment (which is an unsaved filter)

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -27,9 +27,7 @@ https://github.com/notifications (Grouped by repo)
 https://github.com/notifications?query=reason%3Acomment (which is an unsaved filter)
 */
 .js-check-all-container .js-bulk-action-toasts ~ div .Box-header {
-	height: auto !important;
 	flex-wrap: wrap;
-	gap: 4px 8px;
 }
 
 .js-check-all-container .js-bulk-action-toasts ~ div .Box-header .mr-2 {

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -30,10 +30,6 @@ https://github.com/notifications?query=reason%3Acomment (which is an unsaved fil
 	flex-wrap: wrap;
 }
 
-.js-check-all-container .js-bulk-action-toasts ~ div .Box-header .mr-2 {
-	margin-right: 0 !important; /* Spacing via `gap` instead */
-}
-
 :is(.js-notifications-mark-selected-actions, .js-notifications-mark-all-actions):not([hidden]) {
 	display: contents !important;
 }


### PR DESCRIPTION
- Partially reverts https://github.com/refined-github/refined-github/pull/5707

## Test URL

- https://github.com/notifications (sort by date OR repo)

## Native

![before](https://github.com/refined-github/refined-github/assets/1402241/238ac323-b03a-41ac-9e1a-111fc6f0fe86)

## Refined GitHub  (causes jump)

![after](https://github.com/refined-github/refined-github/assets/1402241/af296dc9-c6bb-4893-a64a-21b3b8967a7e)

## This PR

![afterr](https://github.com/refined-github/refined-github/assets/1402241/824d69e1-62c7-4c1f-8ca6-bd3a3202d22b)
