### PR TITLE
Restore `clean-conversation-sidebar`

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -94,7 +94,7 @@ async function cleanSidebar(): Promise<void> {
 
 		const content = select('[aria-label="Select reviewers"] > .css-truncate')!;
 		if (!content.firstElementChild) {
-			content.remove(); // Drop "No reviews"
+			removeTextNodeContaining(content, 'No reviews');
 		}
 	}
 
@@ -106,7 +106,11 @@ async function cleanSidebar(): Promise<void> {
 	}
 
 	// Development (linked issues/PRs)
-	select('[aria-label="Link issues"] p')?.remove(); // "Successfully merging a pull request may close this issue." This may not exist if issues are disabled
+	const developmentHint = select('[aria-label="Link issues"] p');
+	if (developmentHint) { // This may not exist if issues are disabled
+		removeTextNodeContaining(developmentHint, /^(No branches or pull requests|Successfully merging (a|this) pull request may close (this issue|these issues).)$/);
+	}
+
 	const createBranchLink = select('button[data-action="click:create-issue-branch#openDialog"]');
 	if (createBranchLink) {
 		createBranchLink.classList.add('Link--muted');
@@ -138,3 +142,19 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // The sidebar is at the end of the page + it needs to be fully loaded
 	init,
 });
+
+/*
+
+Test URLs:
+
+* open issue: https://github.com/refined-github/sandbox/issues/15
+* open issue with linked PR: https://github.com/refined-github/sandbox/issues/3
+* closed issue: https://github.com/refined-github/sandbox/issues/56
+* draft PR: https://github.com/refined-github/sandbox/pull/7
+* merged PR: https://github.com/refined-github/sandbox/pull/58
+* open issue with a milestone and assignee: https://github.com/microsoft/TypeScript/issues/18836
+* User has triage access
+  * issue: https://github.com/download-directory/download-directory.github.io/issues/39
+  * PR: https://github.com/download-directory/download-directory.github.io/pull/37
+
+*/

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -81,9 +81,12 @@ const matchString = (matcher: RegExp | string, string: string): boolean =>
 const escapeMatcher = (matcher: RegExp | string): string =>
 	typeof matcher === 'string' ? `"${matcher}"` : String(matcher);
 
+const isTextNode = (node: Text | ChildNode) =>
+	node instanceof Text || ([...node.childNodes].every(childNode => childNode instanceof Text))
+
 // eslint-disable-next-line @typescript-eslint/ban-types -- Nodes may be exactly `null`
 export const assertNodeContent = <N extends Text | ChildNode>(node: N | null, expectation: RegExp | string): N => {
-	if (!node || !(node instanceof Text)) {
+	if (!node || !isTextNode(node)) {
 		console.warn('TypeError', node);
 		throw new TypeError(`Expected Text node, received ${String(node?.nodeName)}`);
 	}


### PR DESCRIPTION
Closes #6116.

## Test URLs

* open issue: https://github.com/refined-github/sandbox/issues/15
* open issue with linked PR: https://github.com/refined-github/sandbox/issues/3
* closed issue: https://github.com/refined-github/sandbox/issues/56
* draft PR: https://github.com/refined-github/sandbox/pull/7
* merged PR: https://github.com/refined-github/sandbox/pull/58
* open issue with a milestone and assignee: https://github.com/microsoft/TypeScript/issues/18836
* User has triage access
  * issue: https://github.com/download-directory/download-directory.github.io/issues/39
  * PR: https://github.com/download-directory/download-directory.github.io/pull/37

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/202916/6cf48dac-2810-47db-a273-fc3cb125d187)
