### PR TITLE
Lint API usage

### DIFF
--- a/build/verify-test-urls.sh
+++ b/build/verify-test-urls.sh
@@ -3,7 +3,7 @@
 # Automatically exit on error
 set -e
 
-EXIT_CODE=0
+ERRORS=0
 
 # Keep short because GitHub doesn't wrap it
 ANNOTATION="Test URLs missing.
@@ -30,14 +30,16 @@ for FILE in "$@"; do
 	if grep -q "test url" -i "$FILE"; then
 		echo ✅ "$FILE"
 	else
-		EXIT_CODE=1
+		ERRORS=$((ERRORS+1))
+
 		echo ❌ "$FILE"
 		echo "::error file=$FILE,line=1::$ANNOTATION"
 	fi
 done
 
-if [ $EXIT_CODE -eq 1 ]; then
+# Don't fail PRs that edit a large number of files
+if [ "$ERRORS" -ge 1 ] && [ "$ERRORS" -le 3 ]; then
 	echo
 	echo VERIFICATION FAILED, "Test URLs" MISSING
-	exit $EXIT_CODE
+	exit $ERRORS
 fi

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -6,7 +6,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {cacheByRepo, getRepo} from '../github-helpers/index.js';
 import SearchQuery from '../github-helpers/search-query.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {cacheByRepo, getRepo} from '../github-helpers/index.js';
 
 const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean> => {

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import fetchDom from '../helpers/fetch-dom.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import getTabCount from '../github-helpers/get-tab-count.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import addNotice from '../github-widgets/notice-bar.js';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters.js';

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -6,7 +6,7 @@ import oneMutation from 'one-mutation';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 
 type PRConfig = {
 	number: string;

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate from 'delegate-it';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import showToast from '../github-helpers/toast.js';

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import showToast from '../github-helpers/toast.js';
 import looseParseInt from '../helpers/loose-parse-int.js';

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -6,7 +6,7 @@ import {parseCron} from '@cheap-glitch/mi-cron';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {cacheByRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import {GitPullRequestIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -6,7 +6,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {wrapAll} from '../helpers/dom-utils.js';
 import {buildRepoURL, cacheByRepo} from '../github-helpers/index.js';
 

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import {AlertIcon, GitPullRequestIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {buildRepoURL, cacheByRepo} from '../github-helpers/index.js';
 import GitHubURL from '../github-helpers/github-url.js';

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -6,7 +6,7 @@ import {EyeClosedIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getUsername} from '../github-helpers/index.js';
 
 const getPublicOrganizationsNames = cache.function('public-organizations', async (username: string): Promise<string[]> => {

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -6,7 +6,7 @@ import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import selectHas from '../helpers/select-has.js';
 import attachElement from '../helpers/attach-element.js';
 

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getRepo} from '../github-helpers/index.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 

--- a/source/features/pr-base-commit.tsx
+++ b/source/features/pr-base-commit.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
 import getPrInfo, {PullRequestInfo} from '../github-helpers/get-pr-info.js';
 import pluralize from '../helpers/pluralize.js';

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import pluralize from '../helpers/pluralize.js';
 
 const getCommitChanges = cache.function('commit-changes', async (commit: string): Promise<[additions: number, deletions: number]> => {

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -5,7 +5,7 @@ import {CheckIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import observe from '../helpers/selector-observer.js';
 import {cacheByRepo} from '../github-helpers/index.js';
 

--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -5,7 +5,7 @@ import {VersionsIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import GitHubURL from '../github-helpers/github-url.js';
 
 async function getPreviousCommitForFile(pathname: string): Promise<string> {

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import {CodeSquareIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getCleanPathname} from '../github-helpers/index.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';
 import observe from '../helpers/selector-observer.js';

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import showToast from '../github-helpers/toast.js';
 import {getConversationNumber} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -9,7 +9,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getForkedRepo, getRepo} from '../github-helpers/index.js';
 import pluralize from '../helpers/pluralize.js';
 import addNotice from '../github-widgets/notice-bar.js';

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import {abbreviateNumber} from 'js-abbreviation-number';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import observe from '../helpers/selector-observer.js';
 import {createHeatIndexFunction} from '../helpers/math.js';
 

--- a/source/features/releases-dropdown.tsx
+++ b/source/features/releases-dropdown.tsx
@@ -3,7 +3,7 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 import cache from 'webext-storage-cache';
 
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import features from '../feature-manager.js';
 import {buildRepoURL, cacheByRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -6,7 +6,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {cacheByRepo} from '../github-helpers/index.js';
 
 type CommitTarget = {

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -4,7 +4,7 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import showToast from '../github-helpers/toast.js';
 import {getConversationNumber} from '../github-helpers/index.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
@@ -18,8 +18,8 @@ async function getBaseReference(): Promise<string> {
 
 async function getHeadReference(): Promise<string> {
 	// Get the sha of the latest commit to the PR, required to create a new commit
-	const {repository} = await api.v4(`
-		repository() { # Cache buster ${Math.random()}
+	const {repository} = await api.v4uncached(`
+		repository() {
 			pullRequest(number: ${getConversationNumber()!}) {
 				headRefOid
 			}

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -5,7 +5,7 @@ import {GitMergeIcon, GitPullRequestIcon, GitPullRequestClosedIcon, GitPullReque
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {cacheByRepo, upperCaseFirst} from '../github-helpers/index.js';
 
 type PullRequest = {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import batchedFunction from 'batched-function';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getUsername, compareNames} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {removeTextNodeContaining} from '../helpers/dom-utils.js';

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import pluralize from '../helpers/pluralize.js';
 import {getForkedRepo, getUsername, getRepo} from '../github-helpers/index.js';
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import features from '../feature-manager.js';
 import {getConversationNumber, userCanLikelyMergePR} from '../github-helpers/index.js';
 import onCommitTitleUpdate from '../github-events/on-commit-title-update.js';

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -5,7 +5,7 @@ import {TagIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getCommitHash} from './mark-merge-commits-in-list.js';
 import {buildRepoURL, getRepo} from '../github-helpers/index.js';
 

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -5,7 +5,7 @@ import {TagIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {addAfterBranchSelector, buildRepoURL, cacheByRepo, getLatestVersionTag} from '../github-helpers/index.js';
 import isDefaultBranch from '../github-helpers/is-default-branch.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -8,7 +8,7 @@ import {CheckIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
 import getPrInfo from '../github-helpers/get-pr-info.js';
 import showToast from '../github-helpers/toast.js';

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {getCleanPathname} from '../github-helpers/index.js';

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -9,7 +9,7 @@ import {ClockIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getUsername} from '../github-helpers/index.js';
 
 type Commit = {

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 import {getUsername, getCleanPathname} from '../github-helpers/index.js';
 import attachElement from '../helpers/attach-element.js';
 

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -183,8 +183,8 @@ export const v4uncached = async (
 	const response = await fetch(api4, {
 		headers: {
 			'User-Agent': 'Refined GitHub',
+			'Content-Type': 'application/json',
 			Authorization: `bearer ${personalToken}`,
-			Accept: 'application/vnd.github.merge-info-preview+json',
 		},
 		method: 'POST',
 		body: JSON.stringify({query: query.trimStart().startsWith('mutation') ? query : `{${query}}`}),

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -5,7 +5,7 @@ next to the name of the feature that caused them.
 
 Usage:
 
-import * as api from '../github-helpers/api.js';
+import api from '../github-helpers/api.js';
 const user = await api.v3(`/users/${username}`);
 const repositoryCommits = await api.v3('commits'); // Without a leading `/`, this is equivalent to `/repo/$current-repository/commits`
 const data = await api.v4('{user(login: "user") {name}}');
@@ -164,7 +164,7 @@ export const v3paginated = async function * (
 	}
 };
 
-export const v4 = mem(async (
+export const v4uncached = async (
 	query: string,
 	options: GHGraphQLApiOptions = v4defaults,
 ): Promise<AnyObject> => {
@@ -206,7 +206,9 @@ export const v4 = mem(async (
 	}
 
 	throw await getError(apiResponse as JsonObject);
-}, {
+};
+
+export const v4 = mem(v4uncached, {
 	cacheKey([query, options]) {
 		// `repository()` uses global state and must be handled explicitly
 		// https://github.com/refined-github/refined-github/issues/5821

--- a/source/github-helpers/does-file-exist.tsx
+++ b/source/github-helpers/does-file-exist.tsx
@@ -1,4 +1,4 @@
-import * as api from './api.js';
+import api from './api.js';
 import GitHubURL from './github-url.js';
 
 export default async function doesFileExist(url: GitHubURL): Promise<boolean> {

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -2,7 +2,7 @@ import cache from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import {type RepositoryInfo} from 'github-url-detection';
 
-import * as api from './api.js';
+import api from './api.js';
 import {extractCurrentBranchFromBranchPicker, getRepo} from './index.js';
 import {branchSelector} from './selectors.js';
 

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -1,4 +1,4 @@
-import * as api from './api.js';
+import api from './api.js';
 import {getConversationNumber} from './index.js';
 
 export type PullRequestInfo = {

--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 
-import * as api from './api.js';
+import api from './api.js';
 
 export const SUCCESS = Symbol('Success');
 export const FAILURE = Symbol('Failure');
@@ -39,7 +39,7 @@ export function getLastCommitStatus(): CommitStatus {
 }
 
 export async function getCommitStatus(commitSha: string): Promise<CommitStatus> {
-	const {repository} = await api.v4(`
+	const {repository} = await api.v4uncached(`
 		repository() {
 			object(expression: "${commitSha}") {
 				... on Commit {
@@ -53,7 +53,6 @@ export async function getCommitStatus(commitSha: string): Promise<CommitStatus> 
 				}
 			}
 		}
-		# Cache buster: ${Date.now()}
 	`);
 
 	if (repository.object.checkSuites.nodes === 0) {


### PR DESCRIPTION
This PR

- Simplifies the API import
- Adds an uncached method to avoid the "cache buster"
- Drops an old unused header