### PR TITLE
Restore `wait-for-checks` (no more Firefox support)

### DIFF
--- a/build/verify-test-urls.sh
+++ b/build/verify-test-urls.sh
@@ -17,6 +17,8 @@ https://github.com/a/REAL/url/here
 https://github.com/another/REAL/url/here
 
 */
+
+You can find or create a test URL on our sandbox repo: https://github.com/refined-github/sandbox
 "
 
 # Replace line breaks with "%0A"

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -14,6 +14,8 @@ import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open.js';
 import {onPrMergePanelLoad} from '../github-events/on-fragment-load.js';
 import onAbort from '../helpers/abort-controller.js';
 import {userCanLikelyMergePR} from '../github-helpers/index.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
+import {actionsTab, prCommitStatusIcon} from '../github-helpers/selectors.js';
 
 // Reuse the same checkbox to preserve its status
 const generateCheckbox = onetime(() => (
@@ -43,7 +45,7 @@ function showCheckboxIfNecessary(): void {
 
 	const isNecessary = lastCommitStatus === prCiStatus.PENDING
 		// If the latest commit is missing an icon, add the checkbox as long as there's at least one CI icon on the page (including `ci-link`)
-		|| (lastCommitStatus === false && select.exists(prCiStatus.commitStatusIconSelector));
+		|| (lastCommitStatus === false && select.exists(prCommitStatusIcon));
 
 	if (!checkbox && isNecessary) {
 		select('.js-merge-form .select-menu')?.append(generateCheckbox());
@@ -181,10 +183,11 @@ function init(signal: AbortSignal): void {
 
 void features.add(import.meta.url, {
 	asLongAs: [
+		isHasSelectorSupported,
 		userCanLikelyMergePR,
 		pageDetect.isOpenPR,
 		// The repo has enabled Actions
-		() => select.exists('#actions-tab'),
+		() => select.exists(actionsTab),
 	],
 	include: [
 		pageDetect.isPRConversation,

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -203,6 +203,7 @@ void features.add(import.meta.url, {
 
 Test URLs
 
-https://github.com/refined-github/sandbox/pull/12
+Checks: https://github.com/refined-github/sandbox/pull/12
+No Checks: https://github.com/refined-github/sandbox/pull/10
 
 */

--- a/source/features/wait-for-checks.tsx
+++ b/source/features/wait-for-checks.tsx
@@ -198,3 +198,11 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // DOM-based inclusions
 	init,
 });
+
+/*
+
+Test URLs
+
+https://github.com/refined-github/sandbox/pull/12
+
+*/

--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -1,24 +1,21 @@
 import select from 'select-dom';
 
-import * as api from './api.js';
+import api from './api.js';
+import {prCommit, prCommitStatusIcon} from './selectors.js';
 
 export const SUCCESS = Symbol('Success');
 export const FAILURE = Symbol('Failure');
 export const PENDING = Symbol('Pending');
 export type CommitStatus = false | typeof SUCCESS | typeof FAILURE | typeof PENDING;
 
-export const commitSelector = '[data-test-selector="pr-timeline-commits-list"] .TimelineItem';
-
-// `summary` is needed because the details dropdown contains the list of check runs, each with its status icon
-export const commitStatusIconSelector = 'details.commit-build-statuses summary .octicon';
-
 export function getLastCommitReference(): string | undefined {
-	return select.last(`${commitSelector} code`)!.textContent ?? undefined;
+	return select.last(`${prCommit} code`)!.textContent ?? undefined;
 }
 
 export function getLastCommitStatus(): CommitStatus {
-	const lastCommit = select.last(commitSelector)!;
-	const lastCommitStatusIcon = lastCommit.querySelector(commitStatusIconSelector);
+	// Select the last commit first, THEN pick the icon, otherwise it might pick non-last commit while the CI is starting up
+	const lastCommit = select.last(prCommit)!;
+	const lastCommitStatusIcon = select(prCommitStatusIcon, lastCommit);
 
 	// Some commits don't have a CI status icon at all
 	if (lastCommitStatusIcon) {

--- a/source/github-helpers/selectors.test.ts
+++ b/source/github-helpers/selectors.test.ts
@@ -22,8 +22,9 @@ describe.concurrent('selectors', () => {
 		assert.isArray(urls, `No URLs defined for "${name}"`);
 		await Promise.all(urls.map(async url => {
 			const {window} = await fetchDocument(url);
-			// TODO: Drop replacements after https://github.com/jsdom/jsdom/issues/3506
-			assert.isDefined(window.document.querySelector(selector.replaceAll(':has', ':matches')));
+			// TODO: Drop replacement after https://github.com/jsdom/jsdom/issues/3506
+			// It's not equivalent at the moment, but at least the tests don't fail. Let's see how it goes
+			assert.isDefined(window.document.querySelector(selector.replaceAll(':has', ':is')));
 		}));
 	}, {timeout: 9999});
 });

--- a/source/github-helpers/selectors.test.ts
+++ b/source/github-helpers/selectors.test.ts
@@ -22,7 +22,8 @@ describe.concurrent('selectors', () => {
 		assert.isArray(urls, `No URLs defined for "${name}"`);
 		await Promise.all(urls.map(async url => {
 			const {window} = await fetchDocument(url);
-			assert.isDefined(window.document.querySelector(selector));
+			// TODO: Drop replacements after https://github.com/jsdom/jsdom/issues/3506
+			assert.isDefined(window.document.querySelector(selector.replaceAll(':has', ':matches')));
 		}));
 	}, {timeout: 9999});
 });

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -27,3 +27,19 @@ export const directoryListingFileIcon_ = [
 	'https://github.com/refined-github/refined-github',
 	'https://github.com/refined-github/refined-github/tree/main/.github',
 ];
+
+export const prCommit = '.TimelineItem--condensed:has(.octicon-git-commit)';
+export const prCommit_ = [
+	'https://github.com/refined-github/sandbox/pull/10',
+];
+
+// `summary` is needed because the details dropdown contains the list of check runs, each with its status icon
+export const prCommitStatusIcon = `:is(${prCommit}) details.commit-build-statuses summary .octicon`;
+export const prCommitStatusIcon_ = [
+	'https://github.com/refined-github/sandbox/pull/10',
+];
+
+export const actionsTab = '#actions-tab';
+export const actionsTab_ = [
+	'https://github.com/refined-github/sandbox',
+];


### PR DESCRIPTION
- Fixes #6321


Test URLs:

- https://github.com/refined-github/sandbox/pull/10


No Firefox support due to:

- #5797 