### PR TITLE
Meta: Use variables in GraphQL

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -13,6 +13,7 @@
 		],
 		"no-alert": "off",
 		"no-warning-comments": "off",
+		"unicorn/no-nested-ternary": "off",
 		"unicorn/prefer-top-level-await": "off",
 		"unicorn/prefer-dom-node-dataset": "off",
 		"unicorn/expiring-todo-comments": ["warn", {

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -31,7 +31,7 @@ function findCssFileError(filename: string): string | void {
 
 function findError(filename: string): string | void {
 	// TODO: Replace second condition with "is gitignored"
-	if (filename === 'index.tsx' || filename === '.DS_Store') {
+	if (filename === 'index.tsx' || filename === '.DS_Store' || filename.endsWith('.gql')) {
 		return;
 	}
 

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -43,14 +43,16 @@ async function countBugsWithUnknownLabel(): Promise<number> {
 
 async function countIssuesWithLabel(label: string): Promise<number> {
 	const {repository} = await api.v4(`
-		repository() {
-			label(name: "${label}") {
-				issues(states: OPEN) {
-					totalCount
+		query bugIssueCount($owner: String!, $name: String!, $label: String!) {
+			repository() {
+				label(name: $label) {
+					issues(states: OPEN) {
+						totalCount
+					}
 				}
 			}
 		}
-	`);
+	`, {variables: {label}});
 
 	return repository.label?.issues.totalCount ?? 0;
 }

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -44,7 +44,7 @@ async function countBugsWithUnknownLabel(): Promise<number> {
 async function countIssuesWithLabel(label: string): Promise<number> {
 	const {repository} = await api.v4(`
 		query bugIssueCount($owner: String!, $name: String!, $label: String!) {
-			repository() {
+			repository(owner: $owner, name: $name) {
 				label(name: $label) {
 					issues(states: OPEN) {
 						totalCount
@@ -188,3 +188,13 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+"bug" label: https://github.com/refined-github/refined-github/issues
+"bug-fix" label: https://github.com/axios/axios/issues
+Issues disabled: https://github.com/refined-github/yolo
+
+*/

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -5,14 +5,14 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {cacheByRepo, getRepo} from '../github-helpers/index.js';
+import {cacheByRepo} from '../github-helpers/index.js';
 
 const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean> => {
 	const {repository, organization} = await api.v4(`
 		repository() {
 			projects { totalCount }
 		}
-		organization(login: "${getRepo()!.owner}") {
+		organization(login: $owner) {
 			projects { totalCount }
 		}
 	`, {

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -4,22 +4,30 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import api from '../github-helpers/api.js';
+import api, {expectTokenScope} from '../github-helpers/api.js';
 import {cacheByRepo} from '../github-helpers/index.js';
 
 const hasAnyProjects = cache.function('has-projects', async (): Promise<boolean> => {
+	await expectTokenScope('read:project');
 	const {repository, organization} = await api.v4(`
-		repository() {
-			projects { totalCount }
-		}
-		organization(login: $owner) {
-			projects { totalCount }
+		query hasAnyProjects($owner: String!, $name: String!) {
+			repository(owner: $owner, name: $name) {
+				projects { totalCount }
+				projectsV2 { totalCount }
+			}
+			organization(login: $owner) {
+				projects { totalCount }
+				projectsV2 { totalCount }
+			}
 		}
 	`, {
 		allowErrors: true,
 	});
 
-	return Boolean(repository.projects.totalCount) && Boolean(organization?.projects?.totalCount);
+	return Boolean(repository.projects.totalCount)
+	|| Boolean(repository.projectsV2.totalCount)
+	|| Boolean(organization?.projects?.totalCount)
+	|| Boolean(organization?.projectsV2?.totalCount);
 }, {
 	maxAge: {days: 1},
 	staleWhileRevalidate: {days: 20},
@@ -80,3 +88,11 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/facebook/react/pulls
+
+*/

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -14,20 +14,22 @@ import observe from '../helpers/selector-observer.js';
 
 async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> {
 	const {repository} = await api.v4(`
-		repository() {
-			ref(qualifiedName: "${url.branch}") {
-				target {
-					... on Commit {
-						history(first: 1, until: "${date}") {
-							nodes {
-								oid
+		query GetCommitAtDate($owner: String!, $name: String!, $branch: String!, $date: GitTimestamp!) {
+			repository(owner: $owner, name: $name) {
+				ref(qualifiedName: $branch) {
+					target {
+						... on Commit {
+							history(first: 1, until: $date) {
+								nodes {
+									oid
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-	`);
+	`, {variables: {date, branch: url.branch}});
 
 	const [{oid}] = repository.ref.target.history.nodes;
 	select('a.rgh-link-date')!.pathname = url.assign({branch: oid}).pathname;

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -155,4 +155,8 @@ void features.add(import.meta.url, {
 Test URLs
 
 Find them in https://github.com/refined-github/refined-github/pull/1863
+
+See the bar on:
+
+- https://github.com/sindresorhus/refined-github/blob/main/source/features/mark-merge-commits-in-list.tsx?rgh-link-date=2019-03-04T13%3A04%3A18Z
 */

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -250,3 +250,12 @@ void features.add(import.meta.url, {
 	},
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/pull/4030
+https://github.com/refined-github/refined-github/issues/4008
+
+*/

--- a/source/features/deep-reblame.css
+++ b/source/features/deep-reblame.css
@@ -7,3 +7,11 @@ button.rgh-deep-reblame .octicon-versions {
 	color: var(--color-scale-pink-7, #800080);
 	opacity: 70%;
 }
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/blame/main/source/refined-github.ts
+
+*/

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -116,3 +116,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/blame/main/source/refined-github.ts
+
+*/

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -15,22 +15,24 @@ import observe from '../helpers/selector-observer.js';
 
 const getPullRequestBlameCommit = mem(async (commit: string, prNumbers: number[], currentFilename: string): Promise<string> => {
 	const {repository} = await api.v4(`
-		repository() {
-			file: object(expression: "${commit}:${currentFilename}") {
-				id
-			}
-			object(expression: "${commit}") {
-				... on Commit {
-					associatedPullRequests(last: 1) {
-						nodes {
-							number
-							mergeCommit {
-								oid
-							}
-							commits(last: 1) {
-								nodes {
-									commit {
-										oid
+		query getPullRequestBlameCommit($owner: String!, $name: String!, $file: String!, $commit: String!) {
+			repository(owner: $owner, name: $name) {
+				file: object(expression: $file) {
+					id
+				}
+				object(expression: $commit) {
+					... on Commit {
+						associatedPullRequests(last: 1) {
+							nodes {
+								number
+								mergeCommit {
+									oid
+								}
+								commits(last: 1) {
+									nodes {
+										commit {
+											oid
+										}
 									}
 								}
 							}
@@ -39,7 +41,12 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumbers: number[]
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			commit,
+			file: commit + ':' + currentFilename,
+		},
+	});
 
 	const associatedPR = repository.object.associatedPullRequests.nodes[0];
 

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -65,5 +65,6 @@ Test URLs
 - Folder: https://github.com/fregante/refined-github/tree/main/.github
 - PR list: https://github.com/fregante/refined-github/pulls
 - Tags list: https://github.com/fregante/refined-github/tags
+- Non-existent file: https://github.com/fregante/refined-github/blob/main/IT'S%20A%20NEW%20WORLD
 
 */

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -65,6 +65,5 @@ Test URLs
 - Folder: https://github.com/fregante/refined-github/tree/main/.github
 - PR list: https://github.com/fregante/refined-github/pulls
 - Tags list: https://github.com/fregante/refined-github/tags
-- Non-existent file: https://github.com/fregante/refined-github/blob/main/IT'S%20A%20NEW%20WORLD
 
 */

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -73,5 +73,6 @@ void features.add(import.meta.url, {
 
 PR: https://github.com/refined-github/refined-github/pull/5631/files
 PR with CODEOWNERS: https://github.com/dotnet/winforms/pull/6028/files
+Commit: https://github.com/refined-github/sandbox/commit/1ed862e3abd13004009927b26355a51a109d6855
 
 */

--- a/source/features/list-prs-for-file.gql
+++ b/source/features/list-prs-for-file.gql
@@ -1,0 +1,22 @@
+query getPrsByFile($owner: String!, $name: String!, $defaultBranch: String!) {
+	repository(owner: $owner, name: $name) {
+		pullRequests(
+			first: 25,
+			states: OPEN,
+			baseRefName: $defaultBranch,
+			orderBy: {
+				field: UPDATED_AT,
+				direction: DESC
+			}
+		) {
+			nodes {
+				number
+				files(first: 100) {
+					nodes {
+						path
+					}
+				}
+			}
+		}
+	}
+}

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -10,6 +10,7 @@ import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {buildRepoURL, cacheByRepo} from '../github-helpers/index.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import observe from '../helpers/selector-observer.js';
+import listPrsForFileQuery from './list-prs-for-file.gql';
 
 function getPRUrl(prNumber: number): string {
 	// https://caniuse.com/url-scroll-to-text-fragment
@@ -57,30 +58,8 @@ function getDropdown(prs: number[]): HTMLElement {
 @returns prsByFile {"filename1": [10, 3], "filename2": [2]}
 */
 const getPrsByFile = cache.function('files-with-prs', async (): Promise<Record<string, number[]>> => {
-	const {repository} = await api.v4(`
-		query getPrsByFile($owner: String!, $name: String!, $defaultBranch: String!) {
-			repository(owner: $owner, name: $name) {
-				pullRequests(
-					first: 25,
-					states: OPEN,
-					baseRefName: $defaultBranch,
-					orderBy: {
-						field: UPDATED_AT,
-						direction: DESC
-					}
-				) {
-					nodes {
-						number
-						files(first: 100) {
-							nodes {
-								path
-							}
-						}
-					}
-				}
-			}
-		}
-	`, {
+	debugger;
+	const {repository} = await api.v4(listPrsForFileQuery, {
 		variables: {
 			defaultBranch: await getDefaultBranch(),
 		},

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -58,7 +58,6 @@ function getDropdown(prs: number[]): HTMLElement {
 @returns prsByFile {"filename1": [10, 3], "filename2": [2]}
 */
 const getPrsByFile = cache.function('files-with-prs', async (): Promise<Record<string, number[]>> => {
-	debugger;
 	const {repository} = await api.v4(listPrsForFileQuery, {
 		variables: {
 			defaultBranch: await getDefaultBranch(),

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -169,9 +169,9 @@ void features.add(import.meta.url, {
 
 ## Test URLs
 
-- isSingleFile: One PR https://github.com/refined-github/sandbox/blob/default-a/4679
+- isSingleFile: One PR https://github.com/refined-github/sandbox/blob/6619/6619
 - isSingleFile: Multiple PRs https://github.com/refined-github/sandbox/blob/default-a/README.md
-- isEditingFile: One PR https://github.com/refined-github/sandbox/edit/default-a/4679
+- isEditingFile: One PR https://github.com/refined-github/sandbox/edit/6619/6619
 - isEditingFile: Multiple PRs https://github.com/refined-github/sandbox/edit/default-a/README.md
 
 */

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -58,27 +58,33 @@ function getDropdown(prs: number[]): HTMLElement {
 */
 const getPrsByFile = cache.function('files-with-prs', async (): Promise<Record<string, number[]>> => {
 	const {repository} = await api.v4(`
-		repository() {
-			pullRequests(
-				first: 25,
-				states: OPEN,
-				baseRefName: "${await getDefaultBranch()}",
-				orderBy: {
-					field: UPDATED_AT,
-					direction: DESC
-				}
-			) {
-				nodes {
-					number
-					files(first: 100) {
-						nodes {
-							path
+		query getPrsByFile($owner: String!, $name: String!, $defaultBranch: String!) {
+			repository(owner: $owner, name: $name) {
+				pullRequests(
+					first: 25,
+					states: OPEN,
+					baseRefName: $defaultBranch,
+					orderBy: {
+						field: UPDATED_AT,
+						direction: DESC
+					}
+				) {
+					nodes {
+						number
+						files(first: 100) {
+							nodes {
+								path
+							}
 						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			defaultBranch: await getDefaultBranch(),
+		},
+	});
 
 	const files: Record<string, number[]> = {};
 

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -9,15 +9,21 @@ import pluralize from '../helpers/pluralize.js';
 
 const getCommitChanges = cache.function('commit-changes', async (commit: string): Promise<[additions: number, deletions: number]> => {
 	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "${commit}") {
-				... on Commit {
-					additions
-					deletions
+		query getCommitChanges($commit: String!) {
+			repository(owner: $owner, name: $name) {
+				object(expression: $commit) {
+					... on Commit {
+						additions
+						deletions
+					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			commit,
+		},
+	});
 
 	return [repository.object.additions, repository.object.deletions];
 });

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -53,3 +53,11 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/pull/6674/commits/3d93b7823e3c31d3bd1900ab1ec98f5ce41203bf
+
+*/

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -9,8 +9,8 @@ import pluralize from '../helpers/pluralize.js';
 
 const getCommitChanges = cache.function('commit-changes', async (commit: string): Promise<[additions: number, deletions: number]> => {
 	const {repository} = await api.v4(`
-		query getCommitChanges($commit: String!) {
-			repository(owner: $owner, name: $name) {
+	query getCommitChanges($owner: String!, $name: String!, $commit: String!) {
+		repository(owner: $owner, name: $name) {
 				object(expression: $commit) {
 					... on Commit {
 						additions

--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -11,16 +11,23 @@ import GitHubURL from '../github-helpers/github-url.js';
 async function getPreviousCommitForFile(pathname: string): Promise<string> {
 	const {user, repository, branch, filePath} = new GitHubURL(pathname);
 	const {resource} = await api.v4(`
-		resource(url: "/${user}/${repository}/commit/${branch}") {
-			... on Commit {
-				history(path: "${filePath}", first: 2) {
-					nodes {
-						oid
+		query getPreviousCommitForFile($resource: URI!, $filePath: String!) {
+			resource(url: $resource) {
+				... on Commit {
+					history(path: $filePath, first: 2) {
+						nodes {
+							oid
+						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			filePath,
+			resource: `/${user}/${repository}/commit/${branch}`,
+		},
+	});
 
 	// The first commit refers to the current one, so we skip it
 	return resource.history.nodes[1].oid;

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -12,12 +12,16 @@ import observe from '../helpers/selector-observer.js';
 
 const getGistCount = cache.function('gist-count', async (username: string): Promise<number> => {
 	const {user} = await api.v4(`
-		user(login: "${username}") {
-			gists(first: 0) {
-				totalCount
+		query getGistCount($username: String!) {
+			user(login: $username) {
+				gists(first: 0) {
+					totalCount
+				}
 			}
 		}
-	`);
+	`, {
+		variables: {username},
+	});
 	return user.gists.totalCount;
 }, {
 	maxAge: {days: 1},

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -69,7 +69,7 @@ async function appendTab(navigationBar: Element): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe('nav[aria-label="User profile"]', appendTab, {signal});
+	observe('nav[aria-label="User"] > ul', appendTab, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -78,3 +78,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URL:
+
+Has gists: https://github.com/fregante
+No gists: https://github.com/someone
+
+*/

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -42,21 +42,27 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 
 async function getRepoAge(commitSha: string, commitsCount: number): Promise<[committedDate: string, resourcePath: string]> {
 	const {repository} = await api.v4(`
-		repository() {
-			defaultBranchRef {
-				target {
-					... on Commit {
-						history(first: 5, after: "${commitSha} ${commitsCount - Math.min(6, commitsCount)}") {
-							nodes {
-								committedDate
-								resourcePath
+		query getRepoAge($owner: String!, $name: String!, $cursor: String!) {
+			repository(owner: $owner, name: $name) {
+				defaultBranchRef {
+					target {
+						... on Commit {
+							history(first: 5, after: $cursor) {
+								nodes {
+									committedDate
+									resourcePath
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			cursor: `${commitSha} ${commitsCount - Math.min(6, commitsCount)}`,
+		},
+	});
 
 	const {committedDate, resourcePath} = repository.defaultBranchRef.target.history.nodes
 		.reverse()

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -137,3 +137,12 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/sandbox
+https://github.com/refined-github/sandbox/tree/6619
+
+*/

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -15,21 +15,27 @@ function getLinkCopy(count: number): string {
 
 const countPRs = cache.function('prs-on-forked-repo', async (forkedRepo: string): Promise<[prCount: number, singlePrNumber?: number]> => {
 	const {search} = await api.v4(`
-		search(
-			first: 100,
-			type: ISSUE,
-			query: "is:pr is:open archived:false repo:${forkedRepo} author:${getUsername()!}"
-		) {
-			nodes {
-				... on PullRequest {
-					number
-					headRepository {
-						nameWithOwner
+		query getPRs($query: String!) {
+			search(
+				first: 100,
+				type: ISSUE,
+				query: $query
+			) {
+				nodes {
+					... on PullRequest {
+						number
+						headRepository {
+							nameWithOwner
+						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			query: `is:pr is:open archived:false repo:${forkedRepo} author:${getUsername()!}`,
+		},
+	});
 
 	// Only show PRs originated from the current repo
 	const prs = search.nodes.filter((pr: AnyObject) => pr.headRepository.nameWithOwner === getRepo()!.nameWithOwner);

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -112,3 +112,13 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh',
 	init: initDeleteHint,
 });
+
+/*
+
+Test URLs:
+
+1. Visit https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3A%40me+archived%3Afalse+-user%3A%40me
+2. Find a PR made from a fork
+3. In it, open your own fork
+
+*/

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -224,3 +224,12 @@ void features.add(import.meta.url, 	{
 	],
 	init: onetime(initPRCommit),
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/issues/888888
+https://github.com/refined-github/refined-github/blob/main/source/features/a-horse-with-no-name.tsx
+
+*/

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -56,18 +56,25 @@ function parseCurrentURL(): string[] {
 
 async function getLatestCommitToFile(branch: string, filePath: string): Promise<string | void> {
 	const {repository} = await api.v4(`
-		repository() {
-			object(expression: "${branch}") {
-				... on Commit {
-					history(first: 1, path: "${filePath}") {
-						nodes {
-							oid
+		query getLatestCommitToFile($owner: String!, $name: String!, $branch: String!, $filePath: String!) {
+			repository(owner: $owner, name: $name) {
+				object(expression: $branch) {
+					... on Commit {
+						history(first: 1, path: $filePath) {
+							nodes {
+								oid
+							}
 						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			branch,
+			filePath,
+		},
+	});
 	const commit = repository.object?.history.nodes[0];
 	return commit?.oid;
 }

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -179,19 +179,24 @@ export const v4uncached = async (
 	// Automatically provide variables common variables only when used.
 	// GraphQL doesn't like unused variables.
 	const variables: JsonObject = {};
+	const parameters: string[] = [];
 	if (query.includes('$owner')) {
 		variables.owner = owner;
+		parameters.push('$owner: String!');
 	}
 
 	if (query.includes('$name')) {
 		variables.name = name;
+		parameters.push('$name: String!');
 	}
 
 	Object.assign(variables, options.variables);
 
 	const fullQuery = /^\s+(query|mutation)/.test(query)
 		? query
-		: `query ($owner: String!, $name: String!) {${query}}`;
+		: parameters.length === 0
+			? `query {${query}}`
+			: `query (${parameters.join(',')}) {${query}}`;
 
 	features.log.http(fullQuery);
 

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -192,7 +192,7 @@ export const v4uncached = async (
 
 	Object.assign(variables, options.variables);
 
-	const fullQuery = /^\s+(query|mutation)/.test(query)
+	const fullQuery = /^\s*(query|mutation)/.test(query)
 		? query
 		: parameters.length === 0
 			? `query {${query}}`

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -72,7 +72,7 @@ export async function expectTokenScope(scope: string): Promise<void> {
 	const {headers} = await v3('/');
 	const tokenScopes = headers.get('X-OAuth-Scopes')!;
 	if (!tokenScopes.split(', ').includes(scope)) {
-		throw new Error('The token you provided does not have ' + (tokenScopes ? `the \`${scope}\` scope. It only includes \`${tokenScopes}\`.` : 'any scope.'));
+		throw new Error('The token you provided does not have ' + (tokenScopes ? `the \`${scope}\` scope. It only includes \`${tokenScopes}\`.` : 'any scope. You can change the scope of your token at https://github.com/settings/tokens'));
 	}
 }
 

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -173,7 +173,7 @@ export const v4uncached = async (
 
 	// TODO: Remove automatic usage of globals via `getRepo()`
 	// https://github.com/refined-github/refined-github/issues/5821
-	const {owner, name} = getRepo()!;
+	const currentRepoIfAny = getRepo(); // Don't destructure, it's `undefined` outside repos
 	query = query.replace('repository() {', () => 'repository(owner: $owner, name: $name) {');
 
 	// Automatically provide variables common variables only when used.
@@ -181,12 +181,12 @@ export const v4uncached = async (
 	const variables: JsonObject = {};
 	const parameters: string[] = [];
 	if (query.includes('$owner')) {
-		variables.owner = owner;
+		variables.owner = currentRepoIfAny!.owner;
 		parameters.push('$owner: String!');
 	}
 
 	if (query.includes('$name')) {
-		variables.name = name;
+		variables.name = currentRepoIfAny!.name;
 		parameters.push('$name: String!');
 	}
 

--- a/source/github-helpers/does-file-exist.tsx
+++ b/source/github-helpers/does-file-exist.tsx
@@ -3,12 +3,20 @@ import GitHubURL from './github-url.js';
 
 export default async function doesFileExist(url: GitHubURL): Promise<boolean> {
 	const {repository} = await api.v4(`
-		repository(owner: "${url.user}", name: "${url.repository}") {
-			file: object(expression: "${url.branch}:${url.filePath}") {
-				id
+		query doesFileExist($owner: String!, $name: String!, $file: String!) {
+			repository(owner: $owner, name: $name) {
+				file: object(expression: $file) {
+					id
+				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			owner: url.user,
+			name: url.repository,
+			file: `${url.branch}:${url.filePath}`,
+		},
+	});
 
 	return Boolean(repository.file);
 }

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -22,12 +22,19 @@ async function fromDOM(): Promise<string | undefined> {
 
 async function fromAPI(repository: RepositoryInfo): Promise<string> {
 	const response = await api.v4(`
-		repository(owner: "${repository.owner}", name: "${repository.name}") {
-			defaultBranchRef {
-				name
+		query getDefaultBranch($owner: String!, $name: String!) {
+			repository(owner: $owner, name: $name) {
+				defaultBranchRef {
+					name
+				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			owner: repository.owner,
+			name: repository.name,
+		},
+	});
 
 	return response.repository.defaultBranchRef.name;
 }

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -1,8 +1,9 @@
-import * as api from './api.js';
+import api from './api.js';
 import {getConversationNumber} from './index.js';
 
 export type PullRequestInfo = {
 	baseRefOid: string;
+	headRefOid: string;
 	// https://docs.github.com/en/graphql/reference/enums#mergeablestate
 	mergeable: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN';
 	viewerCanEditFiles: boolean;
@@ -10,38 +11,34 @@ export type PullRequestInfo = {
 	behindBy: number;
 };
 
-export default async function getPrInfo(base: string, conversationNumber = getConversationNumber()!): Promise<PullRequestInfo> {
-	const {repository} = await api.v4(`
-		query getPrInfo($owner: String!, $name: String!, $conversationNumber: Int!, $base: String!) {
-			repository(owner: $owner, name: $name) {
-				pullRequest(number: $conversationNumber) {
-					baseRefOid
-					mergeable
-					viewerCanEditFiles
-					headRef {
-						compare(headRef: $base) {
-							status
-							aheadBy
-						}
+export default async function getPrInfo(base: string, number = getConversationNumber()!): Promise<PullRequestInfo> {
+	const {repository} = await api.v4uncached(`
+		repository() {
+			pullRequest(number: ${number}) {
+				baseRefOid
+				headRefOid
+				mergeable
+				viewerCanEditFiles
+				headRef {
+					compare(headRef: "${base}") {
+						status
+						aheadBy
 					}
 				}
 			}
 		}
-	`, {
-		variables: {
-			conversationNumber,
-			base,
-		},
-	});
+	`);
 
 	const {
 		baseRefOid,
+		headRefOid,
 		mergeable,
 		viewerCanEditFiles,
 		headRef,
 	} = repository.pullRequest;
 	return {
 		baseRefOid,
+		headRefOid,
 		mergeable,
 		viewerCanEditFiles,
 		// The comparison in the API is base -> head, so it must be flipped

--- a/source/github-helpers/get-pr-info.ts
+++ b/source/github-helpers/get-pr-info.ts
@@ -1,9 +1,8 @@
-import api from './api.js';
+import * as api from './api.js';
 import {getConversationNumber} from './index.js';
 
 export type PullRequestInfo = {
 	baseRefOid: string;
-	headRefOid: string;
 	// https://docs.github.com/en/graphql/reference/enums#mergeablestate
 	mergeable: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN';
 	viewerCanEditFiles: boolean;
@@ -11,34 +10,38 @@ export type PullRequestInfo = {
 	behindBy: number;
 };
 
-export default async function getPrInfo(base: string, number = getConversationNumber()!): Promise<PullRequestInfo> {
-	const {repository} = await api.v4uncached(`
-		repository() {
-			pullRequest(number: ${number}) {
-				baseRefOid
-				headRefOid
-				mergeable
-				viewerCanEditFiles
-				headRef {
-					compare(headRef: "${base}") {
-						status
-						aheadBy
+export default async function getPrInfo(base: string, conversationNumber = getConversationNumber()!): Promise<PullRequestInfo> {
+	const {repository} = await api.v4(`
+		query getPrInfo($owner: String!, $name: String!, $conversationNumber: Int!, $base: String!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $conversationNumber) {
+					baseRefOid
+					mergeable
+					viewerCanEditFiles
+					headRef {
+						compare(headRef: $base) {
+							status
+							aheadBy
+						}
 					}
 				}
 			}
 		}
-	`);
+	`, {
+		variables: {
+			conversationNumber,
+			base,
+		},
+	});
 
 	const {
 		baseRefOid,
-		headRefOid,
 		mergeable,
 		viewerCanEditFiles,
 		headRef,
 	} = repository.pullRequest;
 	return {
 		baseRefOid,
-		headRefOid,
 		mergeable,
 		viewerCanEditFiles,
 		// The comparison in the API is base -> head, so it must be flipped

--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -40,20 +40,22 @@ export function getLastCommitStatus(): CommitStatus {
 
 export async function getCommitStatus(commitSha: string): Promise<CommitStatus> {
 	const {repository} = await api.v4uncached(`
-		repository() {
-			object(expression: "${commitSha}") {
-				... on Commit {
-					checkSuites(first: 100) {
-						nodes {
-							checkRuns { totalCount }
-							status
-							conclusion
+		query getCommitStatus($owner: String!, $name: String!, $commitSha: GitObjectID!) {
+			repository(owner: $owner, name: $name) {
+				object(expression: $commitSha) {
+					... on Commit {
+						checkSuites(first: 100) {
+							nodes {
+								checkRuns { totalCount }
+								status
+								conclusion
+							}
 						}
 					}
 				}
 			}
 		}
-	`);
+	`, {variables: {commitSha}});
 
 	if (repository.object.checkSuites.nodes === 0) {
 		return false; // The commit doesn't have any CI checks associated to it

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -23,6 +23,10 @@ declare module '*.md' { // It should be just for readme.md, but 🤷‍♂️
 	export const featuresMeta: FeatureMeta[];
 }
 
+declare module '*.gql' {
+	export = string;
+}
+
 // Custom UI events specific to RGH
 interface GlobalEventHandlersEventMap {
 	'details:toggled': CustomEvent;

--- a/source/options.html
+++ b/source/options.html
@@ -28,6 +28,7 @@
 			<li data-validation data-scope="public_repo">The <code>public_repo</code> scope lets them <strong>edit</strong> your public repositories
 			<li data-validation data-scope="repo">The <code>repo</code> scope lets them <strong>edit private</strong> repositories as well
 			<li data-validation data-scope="delete_repo">The <code>delete_repo</code> scope is only used by the <code>quick-repo-deletion</code> feature
+			<li data-validation data-scope="read:projects">The <code>read:projects</code> scope lets them determine if a repository or organization uses projects
 		</ul>
 	</details>
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/no-nested-ternary */
 import 'webext-base-css/webext-base.css';
 import './options.css';
 import React from 'dom-chef';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -26,6 +26,10 @@ const config: Configuration = {
 	module: {
 		rules: [
 			{
+				test: /\.gql/,
+				type: 'asset/source',
+			},
+			{
 				test: /[/\\]readme\.md$/,
 				loader: '../build/readme.loader.ts',
 			},


### PR DESCRIPTION
- Extracted from https://github.com/refined-github/refined-github/pull/6671
- Closes https://github.com/refined-github/refined-github/issues/5848

This PR

-  ✅  Adds support for variables
- ❌  Extracts GraphQL expressions into their own .gql files (https://www.apollographql.com/docs/react/integrations/webpack/)

This is harder than anticipated: 

- you can't include variable data in the JSON and not use them (i.e. no default user/repo)
- you can't just _use_ variables; each query must ALSO declare them…

```diff
- query {
+ query ($owner: String!, $name: String!) {
    repository(owner: $owner, name: $name) {
```

## Test

Extensions suggested: 
- https://chrome.google.com/webstore/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln
- https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax