### PR TITLE
Meta: Automatically clear cache on reload while developing

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -93,4 +93,8 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 	// Hope that the feature was fixed in this version
 	await cache.delete('hotfixes:');
 	await cache.delete('style-hotfixes:');
+
+	if (isDevelopmentVersion()) {
+		await cache.clear();
+	}
 });


### PR DESCRIPTION
## Context

- https://github.com/fregante/webext-storage-cache/issues/3

## Solution

Clear cache on reload.

## Context

While working a cached part of the extension, you expect a fresh version to appear every time you change the code. This setup also preserves the natural cache behavior without adding custom logic anywhere to shorten it.

## Drawbacks

Can't test `isExpired` (which we haven't been using) https://github.com/fregante/webext-storage-cache/issues/11#issuecomment-572206603


