### PR TITLE
Hide `conversation-activity-filter` on PR Files tab

### DIFF
--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -32,3 +32,8 @@
 .gh-header-meta .rgh-conversation-activity-filter-wrapper {
 	margin-bottom: 8px; /* Preserve centered vertical alignment with status badge */
 }
+
+/* Temporary (?) AJAX issue https://github.com/refined-github/refined-github/issues/6437#issuecomment-1540526012 */
+#rgh-conversation-activity-filter-select-menu:not(.js-issues-results details) {
+	display: none !important;
+}


### PR DESCRIPTION
Issue described in  https://github.com/refined-github/refined-github/issues/6437#issuecomment-1540526012

Already hotfixed on 23.5.10 and 23.5.20, but I don't want to see it anymore so I'll push this to main.

The issue is that the header is not regenerated between page loads and the lack of `.js-issues-results` element on the Files page leaves both icons visible.

The issue and final solution will be similar to what's required for:

- https://github.com/refined-github/refined-github/issues/6554


Which probably is: have features revalidate themselves and hide/remove themselves when the page changes.