### PR TITLE
Hide reason text in `status-subscription`

### DIFF
--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -92,6 +92,7 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 	originalId.remove();
 	subscriptionButton.hidden = true;
 
+	// 'all' can have many reasons, but the other two don't add further information #6684
 	if (status !== 'all') {
 		getReasonElement(subscriptionButton).hidden = true;
 	}

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -24,11 +24,14 @@ function SubButton(): JSX.Element {
 	);
 }
 
-function getCurrentStatus(subscriptionButton: HTMLButtonElement): 'none' | 'all' | 'status' {
-	const reason = subscriptionButton
+function getReasonElement(subscriptionButton: HTMLButtonElement): HTMLParagraphElement {
+	return subscriptionButton
 		.closest('.thread-subscription-status')!
-		.querySelector('.reason')!
-		.textContent!;
+		.querySelector('p.reason')!;
+}
+
+function getCurrentStatus(subscriptionButton: HTMLButtonElement): 'none' | 'all' | 'status' {
+	const reason = getReasonElement(subscriptionButton).textContent!;
 
 	// You’re receiving notifications because you chose custom settings for this thread.
 	if (reason.includes('custom settings')) {
@@ -88,6 +91,10 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 	// Remove it only if the form was successfully added
 	originalId.remove();
 	subscriptionButton.hidden = true;
+
+	if (status !== 'all') {
+		getReasonElement(subscriptionButton).hidden = true;
+	}
 }
 
 function init(signal: AbortSignal): void | false {

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -97,7 +97,8 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 	}
 }
 
-function init(signal: AbortSignal): void | false {
+function init(signal: AbortSignal): void {
+	// Repos you're ignoring can't be subscribed to, so the button is disabled
 	observe('button[data-thread-subscribe-button]:not([disabled])', addButton, {signal});
 }
 
@@ -115,5 +116,6 @@ Test URLs
 
 - Issue: https://github.com/refined-github/sandbox/issues/3
 - PR: https://github.com/refined-github/sandbox/pull/4
+- Also test a repo you're completely ignoring
 
 */

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -98,7 +98,7 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 }
 
 function init(signal: AbortSignal): void | false {
-	observe('button[data-thread-subscribe-button]', addButton, {signal});
+	observe('button[data-thread-subscribe-button]:not([disabled])', addButton, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Extracted from a discussion in https://github.com/refined-github/refined-github/pull/6667 cc @FloEdelmann 

This text doesn't add anything more to the state shown by the feature, except when "all" is selected, because it can be one of:

- You’re receiving notifications because you’re watching this repository.
- You’re receiving notifications because you authored the thread.
- You’re receiving notifications because you commented.
- You’re receiving notifications because you were mentioned.
- _who knows what else_




## Demo

![](https://github.com/refined-github/refined-github/assets/1402241/021ef26f-376e-4f31-95f1-a171bc8cce0c)

## URL

Here