### PR TITLE
Fix `previous-version` throws error on brand-new files

### DIFF
--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer.js';
 import api from '../github-helpers/api.js';
 import GitHubURL from '../github-helpers/github-url.js';
 
-async function getPreviousCommitForFile(pathname: string): Promise<string> {
+async function getPreviousCommitForFile(pathname: string): Promise<string | false> {
 	const {user, repository, branch, filePath} = new GitHubURL(pathname);
 	const {resource} = await api.v4(`
 		query getPreviousCommitForFile($resource: URI!, $filePath: String!) {
@@ -28,6 +28,10 @@ async function getPreviousCommitForFile(pathname: string): Promise<string> {
 			resource: `/${user}/${repository}/commit/${branch}`,
 		},
 	});
+
+	if (resource.history.nodes.length < 2) {
+		return false;
+	}
 
 	// The first commit refers to the current one, so we skip it
 	return resource.history.nodes[1].oid;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Description
- Closes #6681
- > New files don't have a previous version, the API returns one commit instead of 2.
Quick solution: if there's only one "node" in the response, return false



## Test URLs
1. [refined-github/sandbox@6619/6619](https://github.com/refined-github/sandbox/blob/6619/6619?rgh-link-date=2023-05-21T13%3A33%3A12Z)

## Screenshot
Before
- <img width="400" alt="image" src="https://github.com/refined-github/refined-github/assets/50487467/a73927cf-b898-4f78-a0d7-c1f23b406a0a">
After
- No Error

