### PR TITLE
Fix page number calculation in `last-notification-page-button`

### DIFF
--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -12,7 +12,7 @@ const itemsPerNotificationsPage = 25;
 function linkify(nextButton: HTMLAnchorElement): void {
 	const totalNotificationsNode = select('.js-notifications-list-paginator-counts')!.lastChild!;
 	assertNodeContent(totalNotificationsNode, /^of \d+$/);
-	const totalNotificationsNumber = looseParseInt(totalNotificationsNode); // 225
+	const totalNotificationsNumber = looseParseInt(totalNotificationsNode);
 	const lastCursor = Math.floor((totalNotificationsNumber-1) / itemsPerNotificationsPage) * itemsPerNotificationsPage;
 	const nextButtonSearch = new URLSearchParams(nextButton.search);
 	nextButtonSearch.set('after', btoa(`cursor:${lastCursor}`));

--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -13,7 +13,7 @@ function linkify(nextButton: HTMLAnchorElement): void {
 	const totalNotificationsNode = select('.js-notifications-list-paginator-counts')!.lastChild!;
 	assertNodeContent(totalNotificationsNode, /^of \d+$/);
 	const totalNotificationsNumber = looseParseInt(totalNotificationsNode);
-	const lastCursor = Math.floor((totalNotificationsNumber-1) / itemsPerNotificationsPage) * itemsPerNotificationsPage;
+	const lastCursor = Math.floor((totalNotificationsNumber - 1) / itemsPerNotificationsPage) * itemsPerNotificationsPage;
 	const nextButtonSearch = new URLSearchParams(nextButton.search);
 	nextButtonSearch.set('after', btoa(`cursor:${lastCursor}`));
 	totalNotificationsNode.replaceWith(
@@ -35,3 +35,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/notifications
+
+*/

--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -10,16 +10,16 @@ import observe from '../helpers/selector-observer.js';
 const itemsPerNotificationsPage = 25;
 
 function linkify(nextButton: HTMLAnchorElement): void {
-	const lastNotificationPageNode = select('.js-notifications-list-paginator-counts')!.lastChild!;
-	assertNodeContent(lastNotificationPageNode, /^of \d+$/);
-	const lastNotificationPageNumber = looseParseInt(lastNotificationPageNode);
-	const lastCursor = Math.floor(lastNotificationPageNumber / itemsPerNotificationsPage) * itemsPerNotificationsPage;
+	const totalNotificationsNode = select('.js-notifications-list-paginator-counts')!.lastChild!;
+	assertNodeContent(totalNotificationsNode, /^of \d+$/);
+	const totalNotificationsNumber = looseParseInt(totalNotificationsNode); // 225
+	const lastCursor = Math.floor((totalNotificationsNumber-1) / itemsPerNotificationsPage) * itemsPerNotificationsPage;
 	const nextButtonSearch = new URLSearchParams(nextButton.search);
 	nextButtonSearch.set('after', btoa(`cursor:${lastCursor}`));
-	lastNotificationPageNode.replaceWith(
+	totalNotificationsNode.replaceWith(
 		' of ',
 		<a href={'?' + String(nextButtonSearch)}>
-			{lastNotificationPageNumber}
+			{totalNotifications}
 		</a>,
 	);
 }

--- a/source/features/last-notification-page-button.tsx
+++ b/source/features/last-notification-page-button.tsx
@@ -19,7 +19,7 @@ function linkify(nextButton: HTMLAnchorElement): void {
 	totalNotificationsNode.replaceWith(
 		' of ',
 		<a href={'?' + String(nextButtonSearch)}>
-			{totalNotifications}
+			{totalNotificationsNumber}
 		</a>,
 	);
 }


### PR DESCRIPTION
Main change here is the `-1` that is subtracted from the number of total notifications to make the calculation return the correct value for the cursor.

<img width="335" alt="image" src="https://github.com/refined-github/refined-github/assets/183673/60920d43-2390-4747-a061-3541b4685976">

Other changes are renaming variables to make them more descriptive waht they contain.

Closes https://github.com/refined-github/refined-github/issues/6691