### PR TITLE
Adjust wording of `status-subscription`’s tooltip

### DIFF
--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -74,7 +74,7 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 			<SubButton
 				// @ts-expect-error I don't remember how to fix this
 				value="subscribe_to_custom_notifications"
-				aria-label="Subscribe just to status changes (closing, reopening)"
+				aria-label="Subscribe just to status changes&#10;(closing, reopening, merging)"
 				{...(status === 'status' && disableAttrs)}
 			>
 				<IssueReopenedIcon/> Status

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -74,7 +74,7 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 			<SubButton
 				// @ts-expect-error I don't remember how to fix this
 				value="subscribe_to_custom_notifications"
-				aria-label="Subscribe just to the close event"
+				aria-label="Subscribe just to status changes (closing, reopening)"
 				{...(status === 'status' && disableAttrs)}
 			>
 				<IssueReopenedIcon/> Status


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

The button group for but the current label ("Subscribe just to the close event") is a little misleading because that subscription level also includes other status change events (e.g. merging a PR or reopening an issue). I slightly reworded the tooltip to be a bit more accurate.

## Test URLs

This PR, for instance.

## Screenshot

Before:

![Screenshot from 2023-05-27 18-01-51](https://github.com/refined-github/refined-github/assets/478237/08a37df6-9402-49ba-b9dd-e3f1a71b1bf3)

After:

![Screenshot from 2023-05-27 18-04-33](https://github.com/refined-github/refined-github/assets/478237/50038e40-9d88-4f7b-aacd-368442b2f7a1)
