### PR TITLE
Fix `quick-review` position due to race condition

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -55,3 +55,11 @@ void features.add(import.meta.url, {
 	],
 	init: initReviewButtonEnhancements,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/sandbox/pull/10
+
+*/

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,4 +1,5 @@
 import React from 'dom-chef';
+import delay from 'delay';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
@@ -7,11 +8,13 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
-function addSidebarReviewButton(reviewersSection: Element): void {
+async function addSidebarReviewButton(reviewersSection: Element): Promise<void> {
 	const reviewFormUrl = new URL(location.href);
 	reviewFormUrl.pathname += '/files';
 	reviewFormUrl.hash = 'review-changes-modal';
 
+	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
+	await delay(300);
 	reviewersSection.append(
 		<span className="text-normal">
 			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v" data-turbo-frame="repo-content-turbo-frame">review now</a>


### PR DESCRIPTION
Old bug. I was sure it was reported before but… nope.

I don't see any other "reasonable" positions so I'll just add a delay


## Test URLs

Any PR

## Issue

<img width="322" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/8e512f28-4dfc-4158-acbe-716e16a8ac86">

