### PR TITLE
Fix: “Clear filters” doesn’t work due to `hide-user-forks`

### DIFF
--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -7,7 +7,7 @@ function addSourceTypeToLink(link: HTMLAnchorElement): void {
 	link.search = String(search);
 }
 
-const skipUrlsWithType = ':not([href*="&type="])';
+const skipUrlsWithType = ':not([href*="&type="], .issues-reset-query)';
 
 const selectors = [
 	// User repos

--- a/source/features/hide-user-forks.tsx
+++ b/source/features/hide-user-forks.tsx
@@ -28,7 +28,7 @@ void features.add(import.meta.url, {
 
 /*
 
-## Test
+## Test URLs
 
 - https://github.com/fregante?tab=repositories
 - https://github.com/orgs/refined-github/repositories


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6687



## Test URLs

https://github.com/wakamex?tab=repositories&type=source

## Screenshot

![afterr](https://github.com/refined-github/refined-github/assets/1402241/f6886f44-cb43-4809-86f2-207c17bcd451)

