### PR TITLE
Meta: Add graphql schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
 		"node": ">= 16",
 		"npm": ">= 7"
 	},
+	"graphql": {
+		"schema": "https://docs.github.com/public/schema.docs.graphql"
+	},
 	"webExt": {
 		"sourceDir": "distribution",
 		"run": {


### PR DESCRIPTION
- For https://github.com/refined-github/refined-github/issues/6686

This PR only adds autocomplete support in your IDE, via https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql


<img width="1074" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/ea6d0931-c6a6-497b-bc19-aeb752403189">



I thought getting the types out of the graphql files just required a TS plugin, but apparently you must _also_ run an additional generator. Plus all the documentation expects you to use an existing client like Apollo instead of a plain `fetch` like we do.

GitHub’s own API client does not support this out of the box either, you're supposed to write your own types: https://github.com/octokit/graphql.js/pull/99

I found https://github.com/Quramy/ts-graphql-plugin but there are a couple of issues I'm stuck on: https://github.com/Quramy/ts-graphql-plugin/issues?q=is%3Aissue+author%3Afregante