### PR TITLE
Restore `download-folder-button` on new file list UI

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -36,7 +36,7 @@ function add({parentElement: deleteDirectoryItem}: HTMLAnchorElement): void {
 function init(signal: AbortSignal): void {
 	observe('a[aria-keyshortcuts="d"]', add, {signal});
 
-	// TODO: Drop in mid 2023. Old file view #6154
+	// TODO: Drop in late 2023. Old file view #6154
 	observe('[aria-label="Add file"] + details', addLegacy, {signal});
 }
 

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -28,7 +28,7 @@ function add({parentElement: deleteDirectoryItem}: HTMLAnchorElement): void {
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 	link.href = downloadUrl.href;
-	link.textContent = 'Download folder';
+	link.textContent = 'Download directory';
 
 	deleteDirectoryItem!.before(item);
 }

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
-function add(folderDropdown: HTMLElement): void {
+function addLegacy(folderDropdown: HTMLElement): void {
 	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 
@@ -22,11 +22,22 @@ function add(folderDropdown: HTMLElement): void {
 	);
 }
 
+function add({parentElement: deleteDirectoryItem}: HTMLAnchorElement): void {
+	const item = deleteDirectoryItem!.cloneNode(true);
+	const link = item.firstElementChild as HTMLAnchorElement;
+	const downloadUrl = new URL('https://download-directory.github.io/');
+	downloadUrl.searchParams.set('url', location.href);
+	link.href = downloadUrl.href;
+	link.textContent = 'Download folder';
+
+	deleteDirectoryItem!.before(item);
+}
+
 function init(signal: AbortSignal): void {
-	observe([
-		'[title="More options"]',
-		'[aria-label="Add file"] + details', // TODO: Drop in mid 2023. Old file view #6154
-	], add, {signal});
+	observe('a[aria-keyshortcuts="d"]', add, {signal});
+
+	// TODO: Drop in mid 2023. Old file view #6154
+	observe('[aria-label="Add file"] + details', addLegacy, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- Closes #6414 
- Related to https://github.com/refined-github/refined-github/issues/6554

## Pros

- This also points the link to the correct folder, before it would get stuck
- This moves the link back into the dropdown, as the [feature screenshot](https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png) showed

## Cons

- I'm pretty sure that archived repos don't have a "Delete directory" link so it's now broken there

## Test URLs

https://github.com/refined-github/refined-github/tree/main/source

## Screenshot

<img width="402" alt="Screenshot 10" src="https://github.com/refined-github/refined-github/assets/1402241/c952a3b1-c7ba-4225-b0db-d1a20fc27242">
