### PR TITLE
Fix conflict with native mobile toggle in `toggle-files-button`

### DIFF
--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -3,20 +3,17 @@
 	margin-right: -10px;
 	padding: 10px 13px;
 }
-
-body:not(.rgh-files-hidden) .rgh-toggle-files .octicon-unfold,
-body.rgh-files-hidden .rgh-toggle-files .octicon-fold {
-	display: none !important;
-}
-
-.rgh-files-hidden #files ~ :is(
-.Details, /* Loaded */
-include-fragment[src*='/file-list/'] /* Loading skeleton */
-) {
-	display: none;
-}
-
 .rgh-files-hidden .Box-header {
 	border-radius: 6px;
 	border-bottom: none;
+}
+
+.Box:has(
+	/* Native status */
+	#files ~ .Details:not(.open)
+):has(
+	/* After the first click */
+	[aria-labelledby="files"]:not(.d-md-block)
+) .rgh-toggle-files {
+	display: none;
 }

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -17,3 +17,13 @@
 ) .rgh-toggle-files {
 	display: none;
 }
+
+/* "md" media query */
+@media screen and not (min-width: 768px) {
+	.Box:has(
+		/* Native status */
+		#files ~ .Details:not(.open)
+	) .rgh-toggle-files {
+		display: none;
+	}
+}

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -3,17 +3,18 @@
 	margin-right: -10px;
 	padding: 10px 13px;
 }
+
 .rgh-files-hidden .Box-header {
 	border-radius: 6px;
 	border-bottom: none;
 }
 
 .Box:has(
-	/* Native status */
-	#files ~ .Details:not(.open)
+/* Native status */
+#files ~ .Details:not(.open)
 ):has(
-	/* After the first click */
-	[aria-labelledby="files"]:not(.d-md-block)
+/* After the first click */
+[aria-labelledby='files']:not(.d-md-block)
 ) .rgh-toggle-files {
 	display: none;
 }
@@ -21,9 +22,9 @@
 /* "md" media query */
 @media screen and not (min-width: 768px) {
 	.Box:has(
-		/* Native status */
-		#files ~ .Details:not(.open)
-	) .rgh-toggle-files {
+	/* Native status */
+	#files ~ .Details:not(.open)
+) .rgh-toggle-files {
 		display: none;
 	}
 }

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -1,81 +1,64 @@
 import './toggle-files-button.css';
+import select from 'select-dom';
 import cache from 'webext-storage-cache';
 import React from 'dom-chef';
-import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
-import {FoldIcon, UnfoldIcon, ArrowUpIcon} from '@primer/octicons-react';
+import {ChevronDownIcon, FoldIcon, UnfoldIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import selectHas from '../helpers/select-has.js';
-import attachElement from '../helpers/attach-element.js';
 import observe from '../helpers/selector-observer.js';
 
 const cacheKey = 'files-hidden';
-const hiddenFilesClass = 'rgh-files-hidden';
 const toggleButtonClass = 'rgh-toggle-files';
-const noticeClass = 'rgh-files-hidden-notice';
-
-// 19px align this icon with the <UnfoldIcon/> above it
-const noticeStyle = {paddingRight: '19px'};
 
 function addButton(filesBox: HTMLElement): void {
-	attachElement(selectHas('ul:has(.octicon-history)', filesBox)!, {
-		allowMissingAnchor: true,
-		className: toggleButtonClass,
-		append: () => (
-			<button
-				type="button"
-				className="btn-octicon"
-				aria-label="Toggle files section"
-			>
-				<FoldIcon/>
-				<UnfoldIcon/>
-			</button>
-		),
-	});
-}
-
-function addFilesHiddenNotice(fileBox: Element): void {
-	// Add notice so the user knows that the list was collapsed #5524
-	attachElement(fileBox, {
-		className: noticeClass,
-		after: () => (
-			<div
-				className="mb-3 mt-n3 py-1 text-right text-small color-fg-subtle"
-				style={noticeStyle}
-			>
-				The file list was collapsed via Refined GitHub <ArrowUpIcon className="v-align-middle"/>
-			</div>
-		),
-	});
+	selectHas('ul:has(.octicon-history)', filesBox)?.append(
+		<button
+			type="button"
+			className={`btn-octicon ${toggleButtonClass}`}
+			aria-label="Hide files"
+		>
+			<ChevronDownIcon/>
+		</button>,
+	);
 }
 
 function toggle(toggle?: boolean): boolean {
-	return document.body.classList.toggle(hiddenFilesClass, toggle);
+	const fileList = select('[aria-labelledby="files"]')!;
+	const button = fileList.nextElementSibling!;
+	const isHidden = fileList.classList.toggle('d-md-block', toggle);
+	button.classList.toggle('d-md-none', isHidden);
+	return isHidden;
 }
 
-async function toggleHandler(): Promise<void> {
-	// Remove notice after the first click
-	select(`.${noticeClass}`)?.remove();
+async function toggleList(): Promise<void> {
+	const fileList = select('[aria-labelledby="files"]')!;
+	const button = fileList.nextElementSibling!;
 
-	const isHidden = toggle();
-	await cache.set(cacheKey, isHidden);
+	if (fileList.classList.contains('d-md-block')) {
+		// Desktop, collapse list and enable native toggling
+		fileList.classList.remove('d-md-block');
+		button.classList.remove('d-md-none');
+	} else {
+		// Toggle file list via native button
+		(button.firstElementChild as HTMLButtonElement).click()
+	}
 }
 
 async function updateView(anchor: HTMLHeadingElement): Promise<void> {
 	const filesBox = anchor.parentElement!;
 	addButton(filesBox);
 	if (await cache.get<boolean>(cacheKey)) {
-		toggle(true);
-		addFilesHiddenNotice(filesBox);
+		// toggle(true);
 	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	// TODO: Use `.Box:has(> #files)` instead
 	observe('.Box h2#files', updateView, {signal});
-	delegate(`.${toggleButtonClass}, .${noticeClass}`, 'click', toggleHandler, {signal});
+	delegate(`.${toggleButtonClass}`, 'click', toggleList, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -89,3 +89,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs
+
+https://github.com/refined-github/refined-github
+https://github.com/refined-github/sandbox/tree/other-branch
+
+*/


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6284

## Test URLs

https://github.com/refined-github/refined-github

## Desktop demo

- new chevron icon 🆕
- clicking it shows the native toggle 🆕
- reloading the page while collapsed preserves the states
- reloading the page after expanding it restores the state

https://github.com/refined-github/refined-github/assets/1402241/62ff90a9-f5d4-43f0-aee4-8da260bb3f1e


## Mobile demo

- starts collapsed as usual
- after uncollapsing, the collapse button appears 🆕
- reloading the page after expanding does not preserve the state 🆕 bug fix

https://github.com/refined-github/refined-github/assets/1402241/e0dd3d15-bff3-4710-9006-8f3b24f6c7fe


