### PR TITLE
Restore `ci-link` on repos that have generated commits

### DIFF
--- a/source/features/ci-link.gql
+++ b/source/features/ci-link.gql
@@ -1,0 +1,18 @@
+query GetChecks($owner: String!, $name: String!) {
+	repository(owner: $owner, name: $name) {
+		defaultBranchRef {
+			target {
+				... on Commit {
+					history(first: 3) {
+						nodes {
+							oid
+							statusCheckRollup {
+								state
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/5863


## Test URLs

- https://github.com/refined-github/github-url-detection

## Screenshot

<img width="343" alt="Screenshot 2" src="https://github.com/refined-github/refined-github/assets/1402241/a32c4c25-7301-4b79-abf8-1d30903554be">

