### PR TITLE
Fix: `show-whitespace` and `linkify-code` disappears after load

### DIFF
--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -14,7 +14,8 @@ export const linkifiedURLClass = 'rgh-linkified-code';
 export const linkifiedURLSelector = '.rgh-linkified-code';
 
 export const codeElementsSelector = [
-	'.blob-code-inner', // Code lines
+	// Sometimes formatted diffs are loaded later and discard our formatting #5870
+	'.blob-code-inner:not(deferred-diff-lines.awaiting-highlight *)', // Code lines
 	':not(.notranslate) > .notranslate', // Code blocks in comments. May be wrapped twice
 ];
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/5870

Super easy, barely an inconvenience.

In short:

1. GitHub sometimes defers the syntax highlighting and sends unformatted code
2. This code is wrapped in a `deferred-diff-lines` element with `awaiting-highlight` class
3. The new code is loaded via ajax and `awaiting-highlight` is removed
4. NOW we can run `show-whitespace` 

## Test URLs

1. Open a fresh PR to find one that probably isn't cached by GitHub yet
2. Go to the Files tab
3. You can try again by picking a different commit in the PR commit dropdown

## Screenshot

Notice how, for an instant, the code loaded after the commit selection is not syntax-highlighted. After the highlighting comes in, `show-whitespace` is also applied.

Before this PR, our whitespace would be applied before the highlighting.



![afterr](https://github.com/refined-github/refined-github/assets/1402241/f9eacdf4-ef30-4954-bac1-4cc881b67a7e)


