### PR TITLE
Restore full GitHub Enterprise support

### DIFF
--- a/build/prepare-safari-release.sh
+++ b/build/prepare-safari-release.sh
@@ -24,6 +24,9 @@ echo "Will bump the project version" "$PROJECT_VERSION"
 
 trash distribution
 npm run build
+# No GHE support with persistent:false https://github.com/refined-github/refined-github/issues/6025
+# No iOS support with persistent:true :'-(
+npx dot-json distribution/manifest.json background.persistent "false" --json-value
 npx dot-json distribution/manifest.json version "$TAG"
 
 sed -i '' '/MARKETING_VERSION/d' $CONFIG_FILE

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"cross-env": "^7.0.3",
 				"css-loader": "^6.7.3",
 				"daily-version": "^2.0.0",
-				"dot-json": "^1.2.2",
+				"dot-json": "^1.3.0",
 				"esbuild-loader": "^3.0.0",
 				"eslint-config-xo-react": "^0.27.0",
 				"eslint-plugin-react": "^7.32.2",
@@ -2879,9 +2879,9 @@
 			}
 		},
 		"node_modules/dot-json": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.2.2.tgz",
-			"integrity": "sha512-AKL+GsO4wSEU4LU+fAk/PqN4nQ6PB1vT3HpMiZous9xCzK5S0kh4DzfUY0EfU67jsIXLlu0ty71659N9Nmg+Tw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.3.0.tgz",
+			"integrity": "sha512-Pu11Prog/Yjf2lBICow82/DSV46n3a2XT1Rqt/CeuhkO1fuacF7xydYhI0SwQx2Ue0jCyLtQzgKPFEO6ewv+bQ==",
 			"dev": true,
 			"dependencies": {
 				"detect-indent": "~6.0.0",
@@ -13456,9 +13456,9 @@
 			}
 		},
 		"dot-json": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.2.2.tgz",
-			"integrity": "sha512-AKL+GsO4wSEU4LU+fAk/PqN4nQ6PB1vT3HpMiZous9xCzK5S0kh4DzfUY0EfU67jsIXLlu0ty71659N9Nmg+Tw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.3.0.tgz",
+			"integrity": "sha512-Pu11Prog/Yjf2lBICow82/DSV46n3a2XT1Rqt/CeuhkO1fuacF7xydYhI0SwQx2Ue0jCyLtQzgKPFEO6ewv+bQ==",
 			"dev": true,
 			"requires": {
 				"detect-indent": "~6.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"cross-env": "^7.0.3",
 		"css-loader": "^6.7.3",
 		"daily-version": "^2.0.0",
-		"dot-json": "^1.2.2",
+		"dot-json": "^1.3.0",
 		"esbuild-loader": "^3.0.0",
 		"eslint-config-xo-react": "^0.27.0",
 		"eslint-plugin-react": "^7.32.2",

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -33,7 +33,6 @@
 		"page": "assets/options.html"
 	},
 	"background": {
-		"persistent": false,
 		"scripts": [
 			"assets/background.js"
 		]


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6025

Context:

- Dynamic injection isn't fully possible in event pages with the current API: https://github.com/fregante/content-scripts-register-polyfill/commit/eac3418eb435e0e3e220721eee9ff5bee1a1804a
- iOS _only_ supports event pages

Solution:

- Ship regular background pages to desktop browsers
- Ship event pages to Safari/iOS

Future:

- #5531 