### PR TITLE
Fix occasional `table-input` misalignment

### DIFF
--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -37,11 +37,15 @@
 }
 
 .rgh-tic:hover div,
-.rgh-tic:is(:nth-child(5n+1)):has(~ :hover:nth-child(5n+1)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2)):has(~ :hover:nth-child(5n+2)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3)):has(~ :hover:nth-child(5n+3)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4)):has(~ :hover:nth-child(5n+4)) div,
-.rgh-tic:is(:nth-child(5n+1), :nth-child(5n+2), :nth-child(5n+3), :nth-child(5n+4), :nth-child(5n+5)):has(~ :hover:nth-child(5n+5)) div {
+.rgh-tic:is(:nth-of-type(5n+1)):has(~ :hover:nth-of-type(5n+1)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2)):has(~ :hover:nth-of-type(5n+2)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3)):has(~ :hover:nth-of-type(5n+3)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4)):has(~ :hover:nth-of-type(5n+4)) div,
+.rgh-tic:is(:nth-of-type(5n+1), :nth-of-type(5n+2), :nth-of-type(5n+3), :nth-of-type(5n+4), :nth-of-type(5n+5)):has(~ :hover:nth-of-type(5n+5)) div {
 	border-color: #79b8ff;
 	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
+}
+
+.rgh-table-input .sentinel { /* https://github.com/refined-github/refined-github/issues/6515 */
+	display: none;
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6515


## Repro
 
> 1. Open [link](https://github.com/refined-github/refined-github/issues/6515) on new tab
> 2. Click `Code` tab on the repository indicator which is top of the page
> 3. Go to previous page
> 4. Check your [`table-input`](https://github.com/refined-github/refined-github/blob/main/source/features/table-input.tsx) extension
> 
> <img alt="image" width="125" src="https://user-images.githubusercontent.com/50487467/235415050-9cd9fc53-aeaf-478e-abf5-dcd904d33643.png">
> 
> > On normal issue, the pad appears one.
> > On bug issue, the pad appears two since the page is redirecting from issue to bug ([`bugs-tab`](https://github.com/refined-github/refined-github/blob/main/source/features/bugs-tab.tsx))




## Screenshot

_Not yet tested_