### PR TITLE
Fix `conversation-activity-filter` overlap with "Tracked in"

### DIFF
--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -37,3 +37,9 @@
 #rgh-conversation-activity-filter-select-menu:not(.js-issues-results details) {
 	display: none !important;
 }
+
+/* Our `position:relative` overlaps this element https://github.com/refined-github/refined-github/issues/6663 */
+.gh-header-meta .tracked-in-parent-pill {
+	z-index: 1;
+	background-color: red;
+}

--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -41,5 +41,4 @@
 /* Our `position:relative` overlaps this element https://github.com/refined-github/refined-github/issues/6663 */
 .gh-header-meta .tracked-in-parent-pill {
 	z-index: 1;
-	background-color: red;
 }


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6663

## Test URLs

https://github.com/electron/electron/issues/21457

## Screenshot


![afterr](https://github.com/refined-github/refined-github/assets/1402241/647945c2-e75d-4e56-8d7d-5049bf5b7787)

