### PR TITLE
CI: Leave reminder to update `broken-features`

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,9 +2,6 @@
 name: actionlint
 
 on:
-  push:
-    paths:
-      - .github/workflows/*.yml
   pull_request:
     paths:
       - .github/workflows/*.yml

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            This issue has been fixed and will appear in the next version. Ensure that the hotfix is disabled there. Add `${{env.WAS_HOTFIXED}}` to https://github.com/refined-github/yolo/edit/main/broken-features.csv
+            To maintainers: Disable the hotfix by adding `${{env.WAS_HOTFIXED}}` to https://github.com/refined-github/yolo/edit/main/broken-features.csv

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Was it hotfixed?
         run: |
           if grep -q ",${{ github.event.issue.number }}," broken-features.csv; then
-            TODAY=$(npx utc-version --short)
+            TODAY="$(npx utc-version --short)"
             echo "WAS_HOTFIXED=$TODAY" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           if grep -q ",${{ github.event.issue.number }}," broken-features.csv; then
             TODAY="$(npx utc-version --short)"
-            echo "WAS_HOTFIXED=$TODAY" >> $GITHUB_ENV
+            echo "WAS_HOTFIXED=$TODAY" >> "$GITHUB_ENV"
           fi
 
       - name: Leave comment

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -1,0 +1,32 @@
+name: Hotfix
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  reminder:
+    name: Reminder
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch CSV file
+        run: |
+          curl -o broken-features.csv https://raw.githubusercontent.com/refined-github/yolo/main/broken-features.csv
+          cat broken-features.csv
+
+      - name: Was it hotfixed?
+        run: |
+          if grep -q ",${{ github.event.issue.number }}," broken-features.csv; then
+            TODAY=$(npx utc-version --short)
+            echo "WAS_HOTFIXED=$TODAY" >> $GITHUB_ENV
+          fi
+
+      - name: Leave comment
+        if: env.WAS_HOTFIXED
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            This issue has been fixed and will appear in the next version. Ensure that the hotfix is disabled there. Add `${{env.WAS_HOTFIXED}}` to https://github.com/refined-github/yolo/edit/main/broken-features.csv


### PR DESCRIPTION
Closes https://github.com/refined-github/refined-github/issues/6259

Tested in https://github.com/refined-github/sandbox/issues/3#issuecomment-1572361491 via https://github.com/refined-github/sandbox/actions/runs/5146817251

Example _(the message has since been changed)_

<img width="645" alt="Screenshot 12" src="https://github.com/refined-github/refined-github/assets/1402241/b4c0377e-9e6a-487c-948d-58a8f3dd3750">
