### PR TITLE
Fix `project` scope checker in options for tokens with read- and write-access to projects

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -72,6 +72,10 @@ async function getTokenScopes(personalToken: string): Promise<string[]> {
 		scopes.push('public_repo');
 	}
 
+	if (scopes.includes('project')) {
+		scopes.push('read:project')
+	}
+
 	return scopes;
 }
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

#6726, the previous fix for issue #6724, works for PATs with _only_ the `read:project` scope selected in GitHub's token creation page, but still shows missing permissions for tokens with full (read- and write-) access to projects, as GitHub's API only reports a `project` (instead of `read:project`) scope for those tokens:

## Screenshots

![Scope returned by PATs with full project access](https://github.com/refined-github/refined-github/assets/83146190/d9b80747-3c21-4040-bc18-3defeb5be648)

The project scope selector on GitHub's (classic) token creation page:

![Screenshot 2023-06-02 at 11 46 15 AM](https://github.com/refined-github/refined-github/assets/83146190/edfb78b4-0f51-4bec-b42e-81d78059b7d4)

---

### Before

**The permissions page shown for tokens with full control (which includes read-access) of projects**

_Notice the reported missing permissions for projects_

![Full access to projects permissions](https://github.com/refined-github/refined-github/assets/83146190/d2dd84b6-d7c5-491b-8f66-2e1960c5f997)
&nbsp;

**The permissions page shown for tokens with read-only access to projects**

![Readonly access to projects permissions](https://github.com/refined-github/refined-github/assets/83146190/f1b64598-d0ae-41ec-80ee-8400831f9061)
&nbsp;

**The permissions page shown for tokens with permission to everything**

_Here, the projects scope is reported to be missing, as tokens permission to everything includes write-access to projects, causing the API to return the `project` (instead of `read:project`) scope_

![All permissions](https://github.com/refined-github/refined-github/assets/83146190/e7d1b225-af6d-4c38-9379-a9b5a9acef25)
&nbsp;

### After

**The permissions page shown for tokens with full control of projects**

![Full access to projects permissions](https://github.com/refined-github/refined-github/assets/83146190/3012d161-b97a-43bf-a4ad-8a44bdb76bed)
&nbsp;

**The permissions page shown for tokens with read-only access to projects**

![Readonly access to projects permissions](https://github.com/refined-github/refined-github/assets/83146190/e8257f52-ebff-4ce6-ae3f-78b230a36116)
&nbsp;

**The permissions page shown for tokens with permission to everything**

![All permissions](https://github.com/refined-github/refined-github/assets/83146190/ec572a6f-5264-47c8-b229-ddad74228678)
&nbsp;

## Test locations

Extension options page (varies by browser)
&nbsp;

---
Fully closes #6724

