### PR TITLE
Prevent `easy-toggle-commit-messages` when selecting text

### DIFF
--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -39,3 +39,18 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/sandbox/tree/254a81ef488dcb3866cf8a4cacde501d9faaa588
+
+How to test:
+
+1. Ensure that clicking the ellipsis can still expand/elide the commit message correctly.
+2. Ensure that clicking next to the ellipsis can also expand/elide the commit message.
+3. Ensure that clicking on the expanded commit message can elide it.
+4. Ensure that selecting texts in the expanded commit message would not elide it.
+
+*/

--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -5,13 +5,20 @@ import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../feature-manager.js';
 
 function toggleCommitMessage(event: DelegateEvent<MouseEvent>): void {
+	// The clicked element is a button, a link or a popup ("Verified" badge, CI details, etc.)
 	const elementClicked = event.target as HTMLElement;
-	// The clicked element is not a button, a link or a popup ("Verified" badge, CI details, etc.)
-	if (!elementClicked.closest('a, button, clipboard-copy, details')) {
-		select('.ellipsis-expander', event.delegateTarget)?.dispatchEvent(
-			new MouseEvent('click', {bubbles: true, altKey: event.altKey}),
-		);
+	if (elementClicked.closest('a, button, clipboard-copy, details')) {
+		return;
 	}
+
+	// There is text selection
+	if (window.getSelection()?.toString().length !== 0) {
+		return;
+	}
+
+	select('.ellipsis-expander', event.delegateTarget)?.dispatchEvent(
+		new MouseEvent('click', {bubbles: true, altKey: event.altKey}),
+	);
 }
 
 const commitMessagesSelector = [


### PR DESCRIPTION
Currently, `easy-toggle-commit-messages` feature will toggle the commit message when a click event triggers, which is not helpful if you want to select (and copy) something from the commit message.

This PR suppresses the toggle when text is selected.

## Test Procedure

Go to https://github.com/rust-lang/rust, expand the commit message, and select some text in expanded commit message.

Current: The commit message is elided (toggled)
After this PR: Text is selected
