### PR TITLE
Allow certain bots for issues

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -57,9 +57,10 @@ function init(signal: AbortSignal): void {
 	}
 
 	for (const bot of select.all(prSelectors)) {
-		if (allowedBotNames.includes(bot.textContent)) {
+		if (allowedBotNames.includes(bot.textContent!)) {
 			return;
 		}
+
 		bot.closest('.commit, .Box-row')!.classList.add(dimBots.class);
 	}
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -20,7 +20,7 @@ const botNames = [
 ] as const;
 
 const allowedBotNames = [
-	'issue-up'
+	'issue-up',
 ] as const;
 
 const commitSelectors = [
@@ -57,7 +57,9 @@ function init(signal: AbortSignal): void {
 	}
 
 	for (const bot of select.all(prSelectors)) {
-		if (allowedBotNames.includes(bot.innerText)) return;
+		if (allowedBotNames.includes(bot.textContent)) {
+			return;
+		}
 		bot.closest('.commit, .Box-row')!.classList.add(dimBots.class);
 	}
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -19,6 +19,10 @@ const botNames = [
 	'weblate',
 ] as const;
 
+const allowedBotNames = [
+	'issue-up'
+] as const;
+
 const commitSelectors = [
 	...botNames.map(bot => `.commit-author[href$="?author=${bot}"]`),
 	'.commit-author[href$="%5Bbot%5D"]', // Generic `[bot]` label in author name
@@ -53,6 +57,7 @@ function init(signal: AbortSignal): void {
 	}
 
 	for (const bot of select.all(prSelectors)) {
+		if (allowedBotNames.includes(bot.innerText)) return;
 		bot.closest('.commit, .Box-row')!.classList.add(dimBots.class);
 	}
 


### PR DESCRIPTION
Right now, issues by the "issue-up" are hidden. This bot is used for forwarding bug reports between projects and its issues should not be hidden.

Example usage of the bot: https://github.com/nuxt/nuxt/issues/22133 -> https://github.com/unjs/nitro/issues/1432
