### PR TITLE
Fix `list-prs-for-file` links

### DIFF
--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -14,8 +14,8 @@ import listPrsForFileQuery from './list-prs-for-file.gql';
 
 function getPRUrl(prNumber: number): string {
 	// https://caniuse.com/url-scroll-to-text-fragment
-	const hash = isFirefox() ? '' : `:~:text=${new GitHubURL(location.href).filePath}`;
-	return buildRepoURL('pull', prNumber, 'files', hash);
+	const hash = isFirefox() ? '' : `#:~:text=${new GitHubURL(location.href).filePath}`;
+	return buildRepoURL('pull', prNumber, 'files') + hash;
 }
 
 function getHovercardUrl(prNumber: number): string {


### PR DESCRIPTION
This link is broken:


<img width="288" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/8140e11f-9481-4a7d-9be4-f70cf4ced3cd">

## Test

1. Visit https://github.com/bfred-it-org/github-sandbox/blob/branch/for-pr/README.md
2. Open PRs dropdown
3. Click any PRs