### PR TITLE
Restore `hide-navigation-hover-highlight` on files/notifications

### DIFF
--- a/source/features/hide-navigation-hover-highlight.css
+++ b/source/features/hide-navigation-hover-highlight.css
@@ -1,5 +1,6 @@
-.rgh-no-navigation-highlight .list-group-item.navigation-focus, /* Notifications list */
+.rgh-no-navigation-highlight .notifications-list-item:hover, /* Notifications list */
 .rgh-no-navigation-highlight .Box-row.navigation-focus, /* Issue list */
+.rgh-no-navigation-highlight .react-directory-row:hover, /* React file list */
 .rgh-no-navigation-highlight .navigation-focus td { /* File list */
 	background: none !important;
 }

--- a/source/features/hide-navigation-hover-highlight.css
+++ b/source/features/hide-navigation-hover-highlight.css
@@ -1,6 +1,11 @@
-.rgh-no-navigation-highlight .notifications-list-item:hover, /* Notifications list */
 .rgh-no-navigation-highlight .Box-row.navigation-focus, /* Issue list */
 .rgh-no-navigation-highlight .react-directory-row:hover, /* React file list */
 .rgh-no-navigation-highlight .navigation-focus td { /* File list */
 	background: none !important;
+}
+
+/* Notifications list */
+.rgh-no-navigation-highlight .notifications-list-item:hover {
+	background: none !important;
+	box-shadow: none !important;
 }

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -15,3 +15,14 @@ function init(): void {
 void features.add(import.meta.url, {
 	init: onetime(init),
 });
+
+/*
+
+Test URLs
+
+- Notifications list: https://github.com/notifications
+- Issue list: https://github.com/refined-github/refined-github/issues
+- React file list: https://github.com/refined-github/refined-github/tree/main/.github
+- File list: File list
+
+*/

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -4,11 +4,12 @@ import onetime from 'onetime';
 import features from '../feature-manager.js';
 
 const className = 'rgh-no-navigation-highlight';
+const html = document.documentElement;
 
 function init(): void {
-	document.documentElement.classList.add(className);
-	document.documentElement.addEventListener('navigation:keydown', () => {
-		document.documentElement.classList.remove(className);
+	html.classList.add(className);
+	html.addEventListener('navigation:focus', () => {
+		html.classList.remove(className);
 	}, {once: true});
 }
 
@@ -23,6 +24,6 @@ Test URLs
 - Notifications list: https://github.com/notifications
 - Issue list: https://github.com/refined-github/refined-github/issues
 - React file list: https://github.com/refined-github/refined-github/tree/main/.github
-- File list: File list
+- File list: https://github.com/refined-github/refined-github
 
 */

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -1,5 +1,4 @@
 import './hide-navigation-hover-highlight.css';
-import onetime from 'onetime';
 
 import features from '../feature-manager.js';
 
@@ -14,7 +13,7 @@ function init(): void {
 }
 
 void features.add(import.meta.url, {
-	init: onetime(init),
+	init,
 });
 
 /*


### PR DESCRIPTION
## Test URLs


- Notifications list: https://github.com/notifications
- Issue list: https://github.com/refined-github/refined-github/issues
- React file list: https://github.com/refined-github/refined-github/tree/main/.github
- File list: https://github.com/refined-github/refined-github



## Screenshot

![afterr](https://github.com/refined-github/refined-github/assets/1402241/d8f57032-e023-47ba-8187-ec9042ce8466)
