### PR TITLE
Fix forks dropdown bug caused by `sticky-sidebar`

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -1,5 +1,7 @@
-.rgh-sticky-sidebar-enabled #js-repo-pjax-container .pagehead ul.pagehead-actions {
-	z-index: initial; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
+.rgh-sticky-sidebar-enabled #js-repo-pjax-container ul.pagehead-actions,
+/* https://github.com/refined-github/refined-github/issues/6761 */
+.rgh-sticky-sidebar-enabled [id^="my-forks-menu"] {
+	z-index: initial !important; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
 }
 
 /*

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -1,6 +1,6 @@
 .rgh-sticky-sidebar-enabled #js-repo-pjax-container ul.pagehead-actions,
 /* https://github.com/refined-github/refined-github/issues/6761 */
-.rgh-sticky-sidebar-enabled [id^="my-forks-menu"] {
+.rgh-sticky-sidebar-enabled [id^='my-forks-menu'] {
 	z-index: initial !important; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
 }
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6761

## Test URLs

Any page

## Screenshot

Strangely only the forks dropdown was broken. Now it works. We had the same issue before with the whole action bar

https://github.com/refined-github/refined-github/assets/1402241/318b81d1-0cba-4acb-a61c-95bdb3822e84

