### PR TITLE
Fix notifications action bar overflow

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -28,6 +28,8 @@ https://github.com/notifications?query=reason%3Acomment (which is an unsaved fil
 */
 .js-check-all-container .js-bulk-action-toasts ~ div .Box-header {
 	flex-wrap: wrap;
+	height: auto !important; /* Unset the default height to allow wrapping*/
+	min-height: 52px; /* Re-set the default height as a minimum height */
 }
 
 :is(.js-notifications-mark-selected-actions, .js-notifications-mark-all-actions):not([hidden]) {

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -28,7 +28,7 @@ https://github.com/notifications?query=reason%3Acomment (which is an unsaved fil
 */
 .js-check-all-container .js-bulk-action-toasts ~ div .Box-header {
 	flex-wrap: wrap;
-	height: auto !important; /* Unset the default height to allow wrapping*/
+	height: auto !important; /* Unset the default height to allow wrapping */
 	min-height: 52px; /* Re-set the default height as a minimum height */
 }
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6749
- Caused by https://github.com/refined-github/refined-github/pull/6655

## Test URLs

https://github.com/notifications

## Screenshot mobile


<img src="https://github.com/refined-github/refined-github/assets/1402241/7079aac2-5092-48a4-93a3-3db6c8c46dfa" height=100>

## Screenshot desktop


<img src="https://github.com/refined-github/refined-github/assets/1402241/1c4d0088-d11c-46f4-976b-773096acac9e" height=100>

## Future

- [ ]  https://github.com/refined-github/refined-github/issues/5704
- [ ]  Turn wrap into horizontal overflow (can't be done now due to the dropdown)

