### PR TITLE
Avoid early style removal by GitHub on ajax navigation

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -115,7 +115,7 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 		return;
 	}
 
-	if (select.exists('html.refined-github')) {
+	if (select.exists('[refined-github]')) {
 		console.warn(stripIndent(`
 			Refined GitHub has been loaded twice. This may be because:
 

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -127,7 +127,7 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 		return;
 	}
 
-	document.documentElement.classList.add('refined-github');
+	document.documentElement.setAttribute('refined-github', '');
 
 	void styleHotfixes.get(version).then(applyStyleHotfixes);
 
@@ -278,7 +278,7 @@ async function addCssFeature(url: string, include?: BooleanFunction[]): Promise<
 	void add(id, {
 		include,
 		init() {
-			document.documentElement.classList.add('rgh-' + id);
+			document.documentElement.setAttribute('rgh-' + id, '');
 		},
 	});
 }

--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -1,30 +1,30 @@
 /* Move labels in the Issue/PR list below the title */
-.rgh-align-issue-labels .js-issue-row .min-width-0 {
+[rgh-align-issue-labels] .js-issue-row .min-width-0 {
 	display: flex;
 	flex-wrap: wrap;
 }
 
-.rgh-align-issue-labels .js-issue-row .min-width-0 > .lh-default { /* Labels */
+[rgh-align-issue-labels] .js-issue-row .min-width-0 > .lh-default { /* Labels */
 	order: 1;
 }
 
-.rgh-align-issue-labels .js-issue-row .min-width-0 .text-small {
+[rgh-align-issue-labels] .js-issue-row .min-width-0 .text-small {
 	flex-basis: 100%; /* #4949 */
 }
 
-.rgh-align-issue-labels .js-issue-row .d-inline-block.mr-1 { /* Build status */
+[rgh-align-issue-labels] .js-issue-row .d-inline-block.mr-1 { /* Build status */
 	margin-left: 4px;
 }
 
-.rgh-align-issue-labels .js-issue-row .mt-1.text-small.color-fg-muted { /* Issue details line */
+[rgh-align-issue-labels] .js-issue-row .mt-1.text-small.color-fg-muted { /* Issue details line */
 	flex-basis: 100%;
 }
 
-.rgh-align-issue-labels .js-issue-row .h4 { /* Title */
+[rgh-align-issue-labels] .js-issue-row .h4 { /* Title */
 	max-width: 100%; /* #1518 */
 }
 
-.rgh-align-issue-labels .js-issue-row .IssueLabel {
+[rgh-align-issue-labels] .js-issue-row .IssueLabel {
 	margin-top: 4px;
 	font-size: 11px !important;
 }

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -1,20 +1,20 @@
 /* Changes the layout of pinned issues from side-by-side to a standard list. */
-.rgh-clean-pinned-issues .js-pinned-issues-reorder-container .f4 {
+[rgh-clean-pinned-issues] .js-pinned-issues-reorder-container .f4 {
 	display: none !important; /* Hide title */
 }
 
-.rgh-clean-pinned-issues .js-pinned-issues-reorder-list {
+[rgh-clean-pinned-issues] .js-pinned-issues-reorder-list {
 	gap: 16px;
 }
 
-.rgh-clean-pinned-issues .pinned-issue-item {
+[rgh-clean-pinned-issues] .pinned-issue-item {
 	width: auto !important;
 	flex: 1;
 	margin-inline: 0 !important;
 }
 
 @media (min-width: 700px) {
-	.rgh-clean-pinned-issues .js-pinned-issues-reorder-list {
+	[rgh-clean-pinned-issues] .js-pinned-issues-reorder-list {
 		display: table !important;
 		width: 100%;
 		margin: 0;
@@ -27,12 +27,12 @@
 		border-style: hidden;
 	}
 
-	.rgh-clean-pinned-issues .pinned-issue-item {
+	[rgh-clean-pinned-issues] .pinned-issue-item {
 		display: table-row !important;
 		border-color: var(--rgh-border-color) !important;
 	}
 
-	.rgh-clean-pinned-issues .pinned-issue-item > * {
+	[rgh-clean-pinned-issues] .pinned-issue-item > * {
 		display: table-cell !important;
 		padding: 6px 12px;
 		vertical-align: middle;
@@ -40,17 +40,17 @@
 	}
 
 	/* Move `x` before the title and align both icons */
-	.rgh-clean-pinned-issues .pinned-issue-item > :first-child {
+	[rgh-clean-pinned-issues] .pinned-issue-item > :first-child {
 		display: flex !important;
 		white-space: normal; /* Restore wrapping on title */
 	}
 
-	.rgh-clean-pinned-issues .pinned-issue-handle {
+	[rgh-clean-pinned-issues] .pinned-issue-handle {
 		order: -1;
 		margin-top: -2px;
 	}
 
-	.rgh-clean-pinned-issues .pinned-issue-item form button {
+	[rgh-clean-pinned-issues] .pinned-issue-item form button {
 		float: unset !important;
 		margin-left: -10px;
 		margin-right: 2px !important;

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,26 +1,26 @@
 /* Hide "About" header */
-.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-row:first-child h2 {
+[rgh-clean-repo-sidebar] .Layout-sidebar .BorderGrid-row:first-child h2 {
 	display: none;
 }
 
 /* Align the top of the repo root sidebar with the main page content */
-.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-row:first-child h2 + p.f4 {
+[rgh-clean-repo-sidebar] .Layout-sidebar .BorderGrid-row:first-child h2 + p.f4 {
 	margin-top: 0 !important;
 }
 
 /* Hide "Readme" link made unnecessary by `toggle-files-button` #3580 */
-.rgh-clean-repo-sidebar .Layout-sidebar [href$='#readme'] {
+[rgh-clean-repo-sidebar] .Layout-sidebar [href$='#readme'] {
 	display: none;
 }
 
 @media (min-width: 768px) {
 	/* Hide "Releases" header */
-	.rgh-clean-repo-sidebar .Layout-sidebar h2 [href$='/releases'] {
+	[rgh-clean-repo-sidebar] .Layout-sidebar h2 [href$='/releases'] {
 		display: none;
 	}
 
 	/* Align data section with latest tag/release link #5428 */
-	.rgh-clean-repo-sidebar .Layout-sidebar .Link--muted .octicon {
+	[rgh-clean-repo-sidebar] .Layout-sidebar .Link--muted .octicon {
 		margin-right: 4px !important;
 	}
 }
@@ -30,12 +30,12 @@
  * Hide "Learn more about GitHub Sponsors" link
  * Hide "+ 123 contributors" link
  */
-.rgh-clean-repo-sidebar .Layout-sidebar .BorderGrid-cell > .mt-3 {
+[rgh-clean-repo-sidebar] .Layout-sidebar .BorderGrid-cell > .mt-3 {
 	display: none;
 }
 
 /* Hide Code of conduct links */
-.rgh-clean-repo-sidebar .Layout-sidebar .Link--muted:is(
+[rgh-clean-repo-sidebar] .Layout-sidebar .Link--muted:is(
 [href$='/code-of-conduct.md' i],
 [href$='/code_of_conduct.md' i]
 ) {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -64,7 +64,7 @@ async function moveReportLink(): Promise<void> {
 }
 
 async function init(): Promise<void> {
-	document.documentElement.classList.add('rgh-clean-repo-sidebar');
+	document.documentElement.setAttribute('rgh-clean-repo-sidebar', '');
 
 	await Promise.all([
 		cleanReleases(),

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -82,3 +82,11 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh-inner',
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github
+
+*/

--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -1,7 +1,7 @@
 /* Hide unnecessary comment toolbar items, but only on desktop #5743 */
 /* Kinda excludes "soft keyboards" devices https://github.com/w3c/csswg-drafts/issues/3871 */
 @media (hover: hover) and (pointer: fine) {
-	.rgh-clean-rich-text-editor :is(
+	[rgh-clean-rich-text-editor] :is(
 	md-mention,
 	md-ref,
 	md-header,

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -2,7 +2,7 @@
 
 /* stylelint-disable-next-line media-feature-name-no-vendor-prefix -- It's the only cross-browser media query */
 @media (-webkit-min-device-pixel-ratio: 2) {
-	.rgh-emphasize-draft-pr-label .js-issue-row :is(
+	[rgh-emphasize-draft-pr-label] .js-issue-row :is(
 	/* Repo PR lists */
 	[aria-label='Open draft pull request'],
 	/* Global PR lists */

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -1,6 +1,6 @@
-.rgh-hide-diff-signs .diff-text-cell .diff-text::before, /* Edit page, probably upcoming DOM everywhere */
-.rgh-hide-diff-signs .blob-code-inner::before, /* Inline review blocks in PRs */
-.rgh-hide-diff-signs .blob-code-marker-cell::before { /* Commit page */
+[rgh-hide-diff-signs] .diff-text-cell .diff-text::before, /* Edit page, probably upcoming DOM everywhere */
+[rgh-hide-diff-signs] .blob-code-inner::before, /* Inline review blocks in PRs */
+[rgh-hide-diff-signs] .blob-code-marker-cell::before { /* Commit page */
 	visibility: hidden;
 }
 

--- a/source/features/hide-navigation-hover-highlight.css
+++ b/source/features/hide-navigation-hover-highlight.css
@@ -1,11 +1,11 @@
-.rgh-no-navigation-highlight .Box-row.navigation-focus, /* Issue list */
-.rgh-no-navigation-highlight .react-directory-row:hover, /* React file list */
-.rgh-no-navigation-highlight .navigation-focus td { /* File list */
+[rgh-no-navigation-highlight] .Box-row.navigation-focus, /* Issue list */
+[rgh-no-navigation-highlight] .react-directory-row:hover, /* React file list */
+[rgh-no-navigation-highlight] .navigation-focus td { /* File list */
 	background: none !important;
 }
 
 /* Notifications list */
-.rgh-no-navigation-highlight .notifications-list-item:hover {
+[rgh-no-navigation-highlight] .notifications-list-item:hover {
 	background: none !important;
 	box-shadow: none !important;
 }

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -2,13 +2,13 @@ import './hide-navigation-hover-highlight.css';
 
 import features from '../feature-manager.js';
 
-const className = 'rgh-no-navigation-highlight';
+const attribute = 'rgh-no-navigation-highlight';
 const html = document.documentElement;
 
 function init(): void {
-	html.classList.add(className);
+	html.setAttribute(attribute, '');
 	html.addEventListener('navigation:focus', () => {
-		html.classList.remove(className);
+		html.removeAttribute(attribute);
 	}, {once: true});
 }
 

--- a/source/features/hide-newsfeed-noise.css
+++ b/source/features/hide-newsfeed-noise.css
@@ -10,11 +10,11 @@ edited a gollum (wiki)
 */
 
 /* TODO: Drop old classes, no longer used */
-.rgh-hide-newsfeed-noise .news :is(.push, .fork, .delete, .follow, .release, .gollum) {
+[rgh-hide-newsfeed-noise] .news :is(.push, .fork, .delete, .follow, .release, .gollum) {
 	display: none !important;
 }
 
-.rgh-hide-newsfeed-noise .body:has(
+[rgh-hide-newsfeed-noise] .body:has(
 [data-hydro-click*='"type":"PushEvent"'],
 [data-hydro-click*='"type":"FollowEvent"'],
 [data-hydro-click*='"type":"ReleaseEvent"']

--- a/source/features/minimize-upload-bar.css
+++ b/source/features/minimize-upload-bar.css
@@ -1,17 +1,17 @@
 /* `.js-upload-markdown-image` excludes non-comment attachment drop areas. See #2086 */
 /* `:not(.js-comment-update)` excludes comment edition forms, as they lack the upload image button. See #4542 */
-.rgh-minimize-upload-bar form:not(.js-comment-update) .js-upload-markdown-image.is-default .drag-and-drop {
+[rgh-minimize-upload-bar] form:not(.js-comment-update) .js-upload-markdown-image.is-default .drag-and-drop {
 	display: none !important;
 }
 
-.rgh-minimize-upload-bar form:not(.js-comment-update) .js-upload-markdown-image.is-default textarea {
+[rgh-minimize-upload-bar] form:not(.js-comment-update) .js-upload-markdown-image.is-default textarea {
 	border-bottom-style: solid;
 	border-radius: 6px;
 }
 
 /* Show upload image button in PR minimized upload bar for desktop */
 @media (min-width: 768px) {
-	.rgh-minimize-upload-bar .js-previewable-comment-form label[aria-label^='Attach an image'] {
+	[rgh-minimize-upload-bar] .js-previewable-comment-form label[aria-label^='Attach an image'] {
 		display: block !important;
 		padding: 4px !important;
 	}

--- a/source/features/mobile-tabs.css
+++ b/source/features/mobile-tabs.css
@@ -1,23 +1,23 @@
 @media (max-width: 767px) {
-	:root.rgh-mobile-tabs .AppHeader-localBar {
+	[rgh-mobile-tabs]:root .AppHeader-localBar {
 		padding: 0;
 	}
 
-	.rgh-mobile-tabs .UnderlineNav {
+	[rgh-mobile-tabs] .UnderlineNav {
 		padding-inline: var(--base-size-16, 16px);
 		padding-block: 5px var(--control-medium-gap, 8px);
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-body {
+	[rgh-mobile-tabs] .UnderlineNav-body {
 		align-items: stretch; /* Ensure they have the same height */
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-body > li {
+	[rgh-mobile-tabs] .UnderlineNav-body > li {
 		flex-shrink: 0;
 		flex-basis: 0;
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item {
+	[rgh-mobile-tabs] .UnderlineNav-item {
 		display: flex;
 		justify-content: center;
 		flex-flow: row wrap;
@@ -26,17 +26,17 @@
 		background: var(--color-action-list-item-default-hover-bg);
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item:hover {
+	[rgh-mobile-tabs] .UnderlineNav-item:hover {
 		background: var(--color-action-list-item-default-active-bg); /* From: Counter background color */
 	}
 
 
-	.rgh-mobile-tabs .UnderlineNav-item.selected::after {
+	[rgh-mobile-tabs] .UnderlineNav-item.selected::after {
 		/* Reposition the orange line */
 		bottom: -9px !important;
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item [data-content] {
+	[rgh-mobile-tabs] .UnderlineNav-item [data-content] {
 		order: 2;
 		flex-basis: 100%;
 		line-height: 1;
@@ -51,7 +51,7 @@
 		color: transparent !important;
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item [data-content]::before {
+	[rgh-mobile-tabs] .UnderlineNav-item [data-content]::before {
 		visibility: inherit;
 		height: auto;
 		font-size: 10px;
@@ -59,17 +59,17 @@
 		font-weight: inherit;
 	}
 
-	.rgh-mobile-tabs [data-content='Pull requests']::before {
+	[rgh-mobile-tabs] [data-content='Pull requests']::before {
 		content: 'Pulls' !important;
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item svg {
+	[rgh-mobile-tabs] .UnderlineNav-item svg {
 		margin-right: 0 !important;
 		grid-area: icon;
 		justify-self: center; /* Improve centering if there's no counter */
 	}
 
-	.rgh-mobile-tabs .UnderlineNav-item .Counter {
+	[rgh-mobile-tabs] .UnderlineNav-item .Counter {
 		grid-area: counter;
 		background: none; /* Counters appears as pills */
 		min-width: 0; /* Pills have a min-width we don't need */

--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -1,13 +1,13 @@
 /* The selector looks for diff tables WITHOUT changes on the left XOR on the right */
 /* Instead of duplicating this selector for each rule, we set a variable and pick it up where needed */
-.rgh-no-unnecessary-split-diff-view .js-diff-table:has([data-split-side]):not(
+[rgh-no-unnecessary-split-diff-view] .js-diff-table:has([data-split-side]):not(
 :has([data-split-side='left']:is(.blob-code-addition, .blob-code-deletion))
 ) {
 	--rgh-only-additions: none;
 	table-layout: auto !important;
 }
 
-.rgh-no-unnecessary-split-diff-view .js-diff-table:has([data-split-side]):not(
+[rgh-no-unnecessary-split-diff-view] .js-diff-table:has([data-split-side]):not(
 :has([data-split-side='right']:is(.blob-code-addition, .blob-code-deletion))
 ) {
 	--rgh-only-deletions: none;
@@ -15,16 +15,16 @@
 }
 
 /* Only additions: Hide the left side */
-.rgh-no-unnecessary-split-diff-view :is([data-hunk], .blob-expanded) td:nth-child(2) {
+[rgh-no-unnecessary-split-diff-view] :is([data-hunk], .blob-expanded) td:nth-child(2) {
 	display: var(--rgh-only-additions, table-cell) !important;
 }
 
 /* Only deletions: Hide the right side */
-.rgh-no-unnecessary-split-diff-view :is([data-hunk], .blob-expanded) td:nth-child(4) {
+[rgh-no-unnecessary-split-diff-view] :is([data-hunk], .blob-expanded) td:nth-child(4) {
 	display: var(--rgh-only-deletions, table-cell) !important;
 }
 
 /* Any applicable situation: Re-align annotations */
-.rgh-no-unnecessary-split-diff-view :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
+[rgh-no-unnecessary-split-diff-view] :is(.inline-comments, .js-inline-annotations) .empty-cell:not(.blob-num) {
 	display: var(--rgh-only-additions, var(--rgh-only-deletions, table-cell)) !important;
 }

--- a/source/features/scrollable-areas.css
+++ b/source/features/scrollable-areas.css
@@ -1,14 +1,14 @@
-.rgh-scrollable-areas .comment-body :is(blockquote, pre) {
+[rgh-scrollable-areas] .comment-body :is(blockquote, pre) {
 	position: relative; /* OctoLinker compat: attach the purple balls to the scroll */
 	max-height: 30.5em;
 	overflow-y: auto;
 }
 
 /* A tiny scroll bar appears when the last paragraph contains a `code` or `g-emoji` tag #3012 #4597 */
-.rgh-scrollable-areas .comment-body blockquote {
+[rgh-scrollable-areas] .comment-body blockquote {
 	padding-bottom: 0.2em; /* Do not add to `pre` #5540 */
 }
 
-.rgh-scrollable-areas .comment-body :is(details, blockquote) :is(blockquote, pre) {
+[rgh-scrollable-areas] .comment-body :is(details, blockquote) :is(blockquote, pre) {
 	max-height: none;
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -1,6 +1,6 @@
-.rgh-sticky-sidebar-enabled #js-repo-pjax-container ul.pagehead-actions,
+[rgh-sticky-sidebar-enabled] #js-repo-pjax-container ul.pagehead-actions,
 /* https://github.com/refined-github/refined-github/issues/6761 */
-.rgh-sticky-sidebar-enabled [id^='my-forks-menu'] {
+[rgh-sticky-sidebar-enabled] [id^='my-forks-menu'] {
 	z-index: initial !important; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
 }
 
@@ -37,15 +37,15 @@ Exclusively use simple sums and use `0px` instead of `0`
 }
 
 /* Avoid z-index issue with Stars dropdown in repo header #5214 */
-.rgh-sticky-sidebar-enabled .pagehead-actions .js-user-list-menu {
+[rgh-sticky-sidebar-enabled] .pagehead-actions .js-user-list-menu {
 	z-index: unset;
 }
 
 /* z-index fights 🥲 This is the search dropdown on the repo root #6151 */
-html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .search-with-dialog {
+html[rgh-sticky-sidebar-enabled]:has(.rgh-sticky-sidebar) .search-input.expanded .search-with-dialog {
 	z-index: 95; /* Native: 35 */
 }
 
-html.rgh-sticky-sidebar-enabled:has(.rgh-sticky-sidebar) .search-input.expanded .dark-backdrop {
+html[rgh-sticky-sidebar-enabled]:has(.rgh-sticky-sidebar) .search-input.expanded .dark-backdrop {
 	z-index: 92; /* Native: 32 */
 }

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -73,3 +73,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+Repo: https://github.com/refined-github/refined-github
+Conversation: https://github.com/refined-github/refined-github/issues/6752
+
+*/

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -53,7 +53,7 @@ function updateStickiness(): void {
 }
 
 function init(signal: AbortSignal): void {
-	document.documentElement.classList.add('rgh-sticky-sidebar-enabled');
+	document.documentElement.setAttribute('rgh-sticky-sidebar-enabled', '');
 
 	// The element is recreated when the page is updated
 	// `trackSidebar` also triggers the first update via `sidebarObserver.observe()`


### PR DESCRIPTION
Before Turbo unloads a page, it will reset the HTML and BODY classes, removing our classes too. This often causes FOUC because the page is still visible; `hide-navigation-hover-highlight` on the notifications or `clean-rich-text-editor` are the most visible.

Features that don't use these classes for CSS rules don't have to use attributes (e.g. a feature that adds a class to `body` only for `delegate` or `observe`)

### Before

<img width="586" alt="Screenshot 6" src="https://github.com/refined-github/refined-github/assets/1402241/193041d0-0764-4e0b-ad50-15e6fd00b8e9">

### After

<img width="586" alt="Screenshot 7" src="https://github.com/refined-github/refined-github/assets/1402241/88ee1134-6691-4112-8fd8-c97646f29675">

