### PR TITLE
Reverse `open-all-notifications` tab open order (#6755)

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -25,8 +25,10 @@ function getUnreadNotifications(container: ParentNode = document): HTMLElement[]
 
 async function openNotifications(notifications: Element[], markAsDone = false): Promise<void> {
 	const urls: string[] = [];
-	for (const notification of notifications) {
-		urls.push(notification.querySelector('a')!.href);
+
+	// iterate in reverse to open notification tabs in chronological order
+	for (let i = notifications.length - 1; i >= 0; --i) {
+		urls.push(notifications[i]!.querySelector('a')!.href);
 	}
 
 	const openingTabs = openTabs(urls);


### PR DESCRIPTION
As proposed in #6755, this PR reverses the order in which new tabs are opened when using the `open-all-notifications` feature to have them opened in chronological order (especially useful when following only releases of a repository). Implemented using a classic for-loop counting from the last index downward instead of the suggested `Array.prototype.reverse()` usage to save an array copy.

Closes #6755

## Test URLs

https://github.com/notifications
