### PR TITLE
Restore `show-names`

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -73,7 +73,6 @@ const usernameLinksSelector = [
 		.js-discussion,
 		.inline-comments
 	) a.author:not(
-		[show_full_name="false"],
 		[href="#"],
 		[href*="/apps/"],
 		[href*="/marketplace/"],

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -68,7 +68,7 @@ const batchUpdateLinks = batchedFunction(async (batchedUsernameElements: HTMLAnc
 
 const usernameLinksSelector = [
 	// `a` selector needed to skip commits by non-GitHub users
-	// # and `show_full_name` target mannequins #6504
+	// # targets mannequins #6504
 	`:is(
 		.js-discussion,
 		.inline-comments
@@ -97,3 +97,14 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+- issue: https://github.com/isaacs/github/issues/297
+- pr with reviews: https://github.com/rust-lang/rfcs/pull/2544
+- mannequins: https://togithub.com/python/cpython/issues/67591
+- newsfeed: https://github.com
+
+*/


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6793

This selector was introduced by:

- https://github.com/refined-github/refined-github/pull/6505


## Test URLs

https://togithub.com/streetcomplete/StreetComplete/issues/5164


## Screenshot

<img width="303" alt="Screenshot 1" src="https://github.com/refined-github/refined-github/assets/1402241/776b1a30-06c6-4181-88bf-181122ebb06f">

