### PR TITLE
Dim unclickable reaction buttons

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -98,6 +98,7 @@
 }
 
 /* Disable hover state on unclickable reaction buttons */
+/* Test: https://github.com/refined-github/sandbox/pull/48 */
 .social-reaction-summary-item[disabled]:hover {
 	background-color: transparent;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -97,12 +97,9 @@
 	margin-right: 4px;
 }
 
-/* Disable hover state on unclickable reaction buttons */
+/* Mute unclickable reaction buttons, disable hover */
 /* Test: https://github.com/refined-github/sandbox/pull/48 */
-.social-reaction-summary-item[disabled]:hover {
-	background-color: transparent;
-}
-
-.social-reaction-summary-item.user-has-reacted[disabled]:hover  {
-	background-color: var(--color-accent-subtle) !important;
+.social-reaction-summary-item[disabled] {
+	pointer-events: none;
+	filter: grayscale(0.5);
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -96,3 +96,8 @@
 .Box-row :is(.octicon-package, .octicon-file-zip):has(+ a[rel='nofollow']) {
 	margin-right: 4px;
 }
+
+/* Disable hover state on unclickable reaction buttons */
+.social-reaction-summary-item[disabled]:hover {
+	background: none;
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -99,5 +99,9 @@
 
 /* Disable hover state on unclickable reaction buttons */
 .social-reaction-summary-item[disabled]:hover {
-	background: none;
+	background-color: transparent;
+}
+
+.social-reaction-summary-item.user-has-reacted[disabled]:hover  {
+	background-color: var(--color-accent-subtle) !important;
 }


### PR DESCRIPTION
This has annoyed me for quite a while: locked issues still have hoverable buttons. Notice how the button does not turn into a hand, but the background changes:

![before](https://github.com/refined-github/refined-github/assets/1402241/f84e6ea4-469f-4a14-8062-27aee72d418e)


After:

![a](https://github.com/refined-github/refined-github/assets/1402241/e36fc0e0-e4f0-4ac4-a7eb-9f2d68cab2c0)

Also tested on own reactions:

![after](https://github.com/refined-github/refined-github/assets/1402241/1256240f-f9e5-4886-9e63-c7cc33978885)



Test URL:

- https://github.com/refined-github/sandbox/pull/48
- https://togithub.com/RupertBenWiser/Web-Environment-Integrity/issues/28