### PR TITLE
Update actions/upload-artifact action to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           webpackStatsFile: ./webpack-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: matrix.os == 'ubuntu-latest'
         with:
           name: refined-github


### PR DESCRIPTION
The v2 version is deprecated.

https://github.com/actions/upload-artifact/releases/tag/v3.0.0