### PR TITLE
Fix VIP label check for low quality comments

### DIFF
--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -62,9 +62,7 @@ function init(): void | false {
 		// Ensure that they're not by VIPs (owner, collaborators, etc)
 		// TODO: use :has()
 		const comment = commentText.closest('.js-timeline-item')!;
-		const vips = ['Owner', 'Author', 'Maintainer', 'Member', 'Contributor'];
-		const label = select('.Label', comment);
-		if (label && vips.includes(label.innerHTML)) {
+		if (select.exists('.Label', comment)) {
 			continue;
 		}
 

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -62,8 +62,8 @@ function init(): void | false {
 		// Ensure that they're not by VIPs (owner, collaborators, etc)
 		// TODO: use :has()
 		const comment = commentText.closest('.js-timeline-item')!;
-		const vips = ["Owner", "Author", "Maintainer", "Member", "Contributor"];
-		const label = select(".Label", comment);
+		const vips = ['Owner', 'Author', 'Maintainer', 'Member', 'Contributor'];
+		const label = select('.Label', comment);
 		if (label && vips.includes(label.innerHTML)) {
 			continue;
 		}

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -62,7 +62,9 @@ function init(): void | false {
 		// Ensure that they're not by VIPs (owner, collaborators, etc)
 		// TODO: use :has()
 		const comment = commentText.closest('.js-timeline-item')!;
-		if (select.exists('.timeline-comment-label', comment)) {
+		const vips = ["Owner", "Author", "Maintainer", "Member", "Contributor"];
+		const label = select(".Label", comment);
+		if (label && vips.includes(label.innerHTML)) {
 			continue;
 		}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
Hi everyone, thanks for the great extension!

## Description

This PR will fix the "VIP label" check to still show "low quality" comments if it was posted by a VIP like owner, maintainer, author etc. 
closes #6799 

## How
The previous check is not working since the `.timeline-comment-label` has been removed at some point. The code now checks for the `.Label` class that is given to labels and then tests the innerHTML to be one of the VIPs defined in an array above.


## Test URLs
https://github.com/sindresorhus/type-fest/issues/621 -> comment by repo owner is now shown
https://github.com/oslabs-beta/ReacTree/issues/35 -> if low quality comment was posted by non-VIP, comment is hidden

## Screenshot

current behavior
<img width="932" alt="image" src="https://github.com/refined-github/refined-github/assets/103483059/c9b98e97-3628-48f9-82aa-f5f3a69dbe02">


behavior with PR
<img width="842" alt="image" src="https://github.com/refined-github/refined-github/assets/103483059/d8707a7c-761e-442a-bd38-a4a28bdf0245">

