### PR TITLE
Restore `quick-comment-hiding`

### DIFF
--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -26,6 +26,7 @@ function generateSubmenu(hideButton: Element): void {
 	const newForm = hideCommentForm.cloneNode();
 	const fields = [...hideCommentForm.elements].map(field => field.cloneNode());
 	newForm.append(<i hidden>{fields}</i>); // Add existing fields (comment ID, token)
+	newForm.setAttribute('novalidate', 'true');	// Ignore the form's required attributes
 
 	// Imitate existing menu, reset classes
 	newForm.className = ['dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in'].join(' ');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
## Description
- Closes #6350 
- The `select` element has `required` attribute
  - Chrome tried to focus `select` element for notify some alert like "empty value"
  - But failed since `select` element is invisible.

```html
<select name="classifier" class="form-select mr-2" aria-label="Reason" required></select>
```

## Test URLs
- https://github.com/refined-github/refined-github/issues/6350#issuecomment-1434102807

## Screenshot
- **Before** (Error on dev-console)
  - <img width="500px" src="https://github.com/refined-github/refined-github/assets/50487467/6db4840f-21bc-4dcb-abbb-bf3fadc6d07d">

- **After**
  - <img width="500px" src="https://github.com/refined-github/refined-github/assets/50487467/3a204fc4-d1d1-415c-b664-97467f7c1baa">


