### PR TITLE
Change the message displayed when bisection fails

### DIFF
--- a/source/helpers/bisect.tsx
+++ b/source/helpers/bisect.tsx
@@ -33,7 +33,7 @@ async function onChoiceButtonClick({currentTarget: button}: React.MouseEvent<HTM
 
 	// Last step, no JS feature was enabled
 	if (answer === 'yes') {
-		createMessageBox('No features were enabled on this page. Try disabling Refined GitHub to see if the change or issue is caused by the extension.');
+		createMessageBox('No public javascript features were enabled on this page. It could be a Refined GitHub feature that cannot be disabled or it could be unrelated to Refined Github. Try disabling Refined GitHub to find out which.');
 	} else {
 		const feature = (
 			<a href={featureLink(bisectedFeatures[0])}>


### PR DESCRIPTION
This changes the text displayed after a failed bisection so that it is less misleading. 

This PR basically implements @cheap-glitch's [suggestion](https://github.com/refined-github/refined-github/issues/5668#issuecomment-1143189820) 
Helps with #5668, but does not close that issue because it would still be nice to start with a step detecting this as suggested [here](https://github.com/refined-github/refined-github/issues/5668#issue-1254939578)
The word "public" and the fact that I say "that cannot be disabled" rather than "CSS feature" are due to #5828