### PR TITLE
Add missing `isSingleReleaseOrTag` when `isReleasesOrTags` usage

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -88,6 +88,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 		pageDetect.isReleasesOrTags,
+		pageDetect.isSingleReleaseOrTag,
 		pageDetect.isDiscussion,
 	],
 	init,

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -79,6 +79,7 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isReleasesOrTags,
+		pageDetect.isSingleReleaseOrTag,
 	],
 	init,
 });

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -63,3 +63,14 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs
+
+- isReleasesOrTags: https://github.com/refined-github/refined-github/releases
+- isSingleCommit: https://github.com/refined-github/refined-github/releases/tag/23.7.25
+- isIssue: https://github.com/refined-github/refined-github/issues
+- isPR: https://github.com/refined-github/refined-github/pull
+
+*/

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -54,6 +54,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasComments,
 		pageDetect.isReleasesOrTags,
+		pageDetect.isSingleReleaseOrTag,
 		pageDetect.isCommitList,
 		pageDetect.isSingleCommit,
 		pageDetect.isRepoWiki,

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -141,6 +141,7 @@ async function init(): Promise<void> {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isReleasesOrTags,
+		pageDetect.isSingleReleaseOrTag,
 	],
 	exclude: [
 		pageDetect.isEmptyRepoRoot,


### PR DESCRIPTION
Closes #6831

Hope I haven't missed every `isReleasesOrTags` usage



## Test URLs

- https://github.com/refined-github/refined-github/releases/tag/23.7.25


## Screenshot

* Before
<img width="1142" alt="image" src="https://github.com/refined-github/refined-github/assets/36906329/fa1c11d1-2f72-46a8-b117-290e8c953d62">

* After

![image](https://github.com/refined-github/refined-github/assets/36906329/31e4d238-e7ce-42b0-a7f9-f4e38c5c724f)


