### PR TITLE
Improve support of New Repository Overview

### DIFF
--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -11,7 +11,7 @@ const isCurrentRepo = ({nameWithOwner}: RepositoryInfo): boolean => Boolean(getR
 // Do not make this function complicated. We're only optimizing for the repo root.
 async function fromDOM(): Promise<string | undefined> {
 	if (!['', 'commits'].includes(getRepo()!.path)) {
-		return undefined;
+		return;
 	}
 
 	// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
@@ -20,7 +20,7 @@ async function fromDOM(): Promise<string | undefined> {
 	const element = await elementReady(branchSelector);
 
 	if (!element) {
-		return undefined;
+		return;
 	}
 
 	return extractCurrentBranchFromBranchPicker(element);

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -1,9 +1,7 @@
 import {CachedFunction} from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import {type RepositoryInfo} from 'github-url-detection';
-
 import domLoaded from 'dom-loaded';
-
 import delay from 'delay';
 
 import api from './api.js';

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -2,6 +2,10 @@ import {CachedFunction} from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import {type RepositoryInfo} from 'github-url-detection';
 
+import domLoaded from 'dom-loaded';
+
+import delay from 'delay';
+
 import api from './api.js';
 import {extractCurrentBranchFromBranchPicker, getRepo} from './index.js';
 import {branchSelector} from './selectors.js';
@@ -13,6 +17,9 @@ async function fromDOM(): Promise<string | undefined> {
 	if (!['', 'commits'].includes(getRepo()!.path)) {
 		return undefined;
 	}
+
+	await domLoaded; // DOM-based filter
+	await delay(100);
 
 	// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
 	// /user/repo

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -1,8 +1,6 @@
 import {CachedFunction} from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import {type RepositoryInfo} from 'github-url-detection';
-import domLoaded from 'dom-loaded';
-import delay from 'delay';
 
 import api from './api.js';
 import {extractCurrentBranchFromBranchPicker, getRepo} from './index.js';
@@ -16,13 +14,16 @@ async function fromDOM(): Promise<string | undefined> {
 		return undefined;
 	}
 
-	await domLoaded; // DOM-based filter
-	await delay(100);
-
 	// We're on the default branch, so we can extract it from the current page. This exclusively happens on the exact pages:
 	// /user/repo
 	// /user/repo/commits (without further path)
-	return extractCurrentBranchFromBranchPicker((await elementReady(branchSelector))!);
+	const element = await elementReady(branchSelector);
+
+	if (!element) {
+		return undefined;
+	}
+
+	return extractCurrentBranchFromBranchPicker(element);
 }
 
 async function fromAPI(repository: RepositoryInfo): Promise<string> {


### PR DESCRIPTION
## Describe
- Closes #6818

When visiting some pages which using `getDefaultBranch()` API, like repository's main page with enabling GitHub feature preview: `New Repository Overview`, The below error is occuring.
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'title')
    at extractCurrentBranchFromBranchPicker (refined-github.js:3455:57)
    at refined-github.js:4646:81
    at async CachedFunction.updater (refined-github.js:4645:121)
    at async getSet (refined-github.js:2344:30)
```

- The reason is `getDefaultBranch()` uses DOM-Selector
  - `getDefaultBranch()` -> `fromDOM()` uses `export const branchSelector = '[data-hotkey="w"]';`
  - We can fix the #6818 with adding option `awaitDomReady: true` to `repo-wide-file-finder`
  - However, the other rgh-features which using `getDefaultBranch()` and doesn't added `awaitDomReady: true` will occur same issue
  - This error is not occurred frequently since `getDefaultBranch()` uses caching.
  - Add awaiting-DOM to `fromDOM()` function to make function it works self

## Test URLs

- Enable GitHub feature preview: `New Repository Overview`
  - Visit some new repositories where you are as owner

## Screenshot
- no screenshot
