### PR TITLE
Enable `parse-backticks` on search and subscription pages

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -41,5 +41,7 @@ Test URLs:
 
 Commits: https://github.com/refined-github/refined-github/commits/main
 isRepoSearch: https://github.com/search?q=repo%3Arefined-github%2Frefined-github+latest+reliable+button+is%3Aissue&type=Issues
+isGlobalSearchResults: https://github.com/search?q=repo%3Arefined-github%2Frefined-github+is%3Aissue&type=issues
+Subscriptions: https://github.com/notifications/subscriptions
 
 */

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -23,7 +23,7 @@ const selectors = [
 	'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 	'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`
 	'a[data-hovercard-type="discussion"]', // `isDiscussionList`
-	'.search-title', // `isGlobalSearchResults` search titles
+	'.search-title a', // `isGlobalSearchResults` search titles
 	'.notification-thread-subscription [id^="subscription_link_"]', // Subscription titles
 ] as const;
 

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -23,6 +23,8 @@ const selectors = [
 	'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 	'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`
 	'a[data-hovercard-type="discussion"]', // `isDiscussionList`
+	'.search-title .search-match', // `isGlobalSearchResults` search titles
+	'.notification-thread-subscription [id^="subscription_link_"]', // subscription titles
 ] as const;
 
 // No `include`, no `signal` necessary

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -24,7 +24,7 @@ const selectors = [
 	'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`
 	'a[data-hovercard-type="discussion"]', // `isDiscussionList`
 	'.search-title .search-match', // `isGlobalSearchResults` search titles
-	'.notification-thread-subscription [id^="subscription_link_"]', // subscription titles
+	'.notification-thread-subscription [id^="subscription_link_"]', // Subscription titles
 ] as const;
 
 // No `include`, no `signal` necessary

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -23,7 +23,7 @@ const selectors = [
 	'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 	'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`
 	'a[data-hovercard-type="discussion"]', // `isDiscussionList`
-	'.search-title .search-match', // `isGlobalSearchResults` search titles
+	'.search-title', // `isGlobalSearchResults` search titles
 	'.notification-thread-subscription [id^="subscription_link_"]', // Subscription titles
 ] as const;
 
@@ -42,6 +42,7 @@ Test URLs:
 Commits: https://github.com/refined-github/refined-github/commits/main
 isRepoSearch: https://github.com/search?q=repo%3Arefined-github%2Frefined-github+latest+reliable+button+is%3Aissue&type=Issues
 isGlobalSearchResults: https://github.com/search?q=repo%3Arefined-github%2Frefined-github+is%3Aissue&type=issues
+isGlobalSearchResults: https://github.com/search?q=repo%3Acommunity%2Fcommunity+backticks+in+titles&type=discussions
 Subscriptions: https://github.com/notifications/subscriptions
 
 */


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

* Closes #6806 
* Also enables backticks on subscription pages

## Test URLs

* https://github.com/search?q=repo%3Arefined-github%2Frefined-github+is%3Aissue&type=issues
* https://github.com/search?q=repo%3Arefined-github%2Frefined-github+is%3Apr&type=pullrequests
* https://github.com/search?q=repo%3Acommunity%2Fcommunity+backticks+in+titles&type=discussions
* https://github.com/notifications/subscriptions

## Screenshot

<details>
<summary>Search - Issue</summary>

#### Before (Search - Issue)

![image](https://github.com/refined-github/refined-github/assets/58778985/159be887-a728-4e12-8309-fe2c9dc657b8)

#### After (Search - Issue)

![image](https://github.com/refined-github/refined-github/assets/58778985/d17e6639-e49d-4388-8ebe-e333e0f70ca5)

</details>

<details>
<summary>Search - PR</summary>

#### Before (Search - PR)

![image](https://github.com/refined-github/refined-github/assets/58778985/08b77d10-f2b4-404a-8664-996396765b09)

#### After (Search - PR)

![image](https://github.com/refined-github/refined-github/assets/58778985/675d7487-5abe-4cb5-83e7-a86a990107c3)

</details>

<details>
<summary>Search - Discussions</summary>

#### Before (Search - Discussions)

![image](https://github.com/refined-github/refined-github/assets/58778985/0b267d68-1d05-46b5-83a1-c17b94b2ae61)

#### After (Search - Discussions)

![image](https://github.com/refined-github/refined-github/assets/58778985/31ea7363-76f0-4f11-881f-e564896e12fc)

</details>

<details>
<summary>Subscriptions</summary>

#### Before (Subscriptions)

![image](https://github.com/refined-github/refined-github/assets/58778985/25bac485-6f6f-44c7-9dbe-a0e766690b71)

#### After (Subscriptions)

![image](https://github.com/refined-github/refined-github/assets/58778985/94ff658b-261d-41b7-948a-ab5d9dd8d98e)

</details>