### PR TITLE
Discard truncated linkified URLs

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -63,5 +63,6 @@ void features.add(import.meta.url, {
 ## Test URLs
 
 - Discussions: https://github.com/File-New-Project/EarTrumpet/discussions/877
+- Code Search: https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code
 
 */

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -80,6 +80,10 @@ export function linkifyURLs(element: Element): Element[] | void {
 		},
 	});
 
+	if(linkified.lastChild && linkified.lastChild.textContent === '…') { // Link is followed by …
+		return;
+	}
+
 	if (linkified.children.length === 0) { // Children are <a>
 		return;
 	}

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -80,7 +80,7 @@ export function linkifyURLs(element: Element): Element[] | void {
 		},
 	});
 
-	if(linkified.lastChild && linkified.lastChild.textContent === '…') { // Link is followed by …
+	if (linkified.lastChild && linkified.lastChild.textContent === '…') { // Link is followed by …
 		return;
 	}
 

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -80,7 +80,7 @@ export function linkifyURLs(element: Element): Element[] | void {
 		},
 	});
 
-	if (linkified.lastChild && linkified.lastChild.textContent === '…') { // Link is followed by …
+	if (linkified.lastChild?.textContent === '…') { // Link is followed by …
 		return;
 	}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

* Closes #6841
 
Simply checks if the linkified URL is followed by `…`

`linkified.lastChild.textContent === '…'`

## Test URLs

* https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code

## Screenshot

#### Before

![image](https://github.com/refined-github/refined-github/assets/58778985/7ab8629c-1175-4644-85b1-b225f0fde5b7)

#### After

![image](https://github.com/refined-github/refined-github/assets/58778985/65ec6fda-d290-41ae-bbcb-e7348e31e86e)
