### PR TITLE
Restore `linkify-user-location` in hover cards

### DIFF
--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -44,4 +44,3 @@ https://github.com/docubot
 https://github.com/
 
 */
-

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -28,7 +28,7 @@ function addLocation({nextElementSibling, nextSibling}: SVGElement): Element {
 function init(): void {
 	observe([
 		'[itemprop="homeLocation"] svg.octicon-location', // `isUserProfile`
-		'[aria-label="user location"] svg.octicon-location', // Hover cards
+		'[aria-label="User location"] svg.octicon-location', // Hover cards
 	], addLocation);
 }
 

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -35,3 +35,12 @@ function init(): void {
 void features.add(import.meta.url, {
 	init,
 });
+
+/*
+
+Test URLs
+
+https://github.com/refined-github/refined-github/issues
+
+*/
+

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -40,7 +40,8 @@ void features.add(import.meta.url, {
 
 Test URLs
 
-https://github.com/refined-github/refined-github/issues
+https://github.com/docubot
+https://github.com/
 
 */
 


### PR DESCRIPTION
Due to a recent change in title-casing of the `aria-label` attribute of user location anchors in the GitHub UI, the selector used on [line 31 of `linkify-user-location.tsx`](https://github.com/refined-github/refined-github/blob/05099f2d2e0ba38d18b2145333e70eca86a68e2a/source/features/linkify-user-location.tsx#L31) is now invalid.

## Test URLs
* [here](https://github.com/refined-github/refined-github/pull/6847)
* https://github.com/refined-github/refined-github/issues
* https://github.com/refined-github/refined-github/pulls

## Before

![Screenshot 2023-08-22 at 9 17 14 PM](https://github.com/refined-github/refined-github/assets/83146190/2615cdda-6f50-41f3-b75c-1b3d1a729e58)

## After 

![Screenshot 2023-08-22 at 9 18 16 PM](https://github.com/refined-github/refined-github/assets/83146190/2c33513f-ccb7-47fd-aa6b-3d69e40dc3a7)


