### PR TITLE
Disable broken `sticky-sidebar` in Firefox

### DIFF
--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -6,6 +6,7 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import onAbort from '../helpers/abort-controller.js';
 import calculateCssCalcString from '../helpers/calculate-css-calc-string.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 const minimumViewportWidthForSidebar = 768; // Less than this, the layout is single-column
 
@@ -64,6 +65,9 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isRepoRoot,
 		pageDetect.isConversation,


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6834
- Fixes https://github.com/refined-github/refined-github/issues/6408

Due to lack of `has` selector support