### PR TITLE
Meta: Drop `mini-css-extract-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
 				"eslint-plugin-react-hooks": "^4.6.0",
 				"highlight.js": "^11.8.0",
 				"jsdom": "^22.1.0",
-				"mini-css-extract-plugin": "^2.7.6",
 				"npm-run-all": "^4.1.5",
 				"snarkdown": "^2.0.0",
 				"stylelint": "^15.10.3",
@@ -6900,25 +6899,6 @@
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/mini-css-extract-plugin": {
-			"version": "2.7.6",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
-			"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
-			"dev": true,
-			"dependencies": {
-				"schema-utils": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/minimatch": {
@@ -16195,15 +16175,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-		},
-		"mini-css-extract-plugin": {
-			"version": "2.7.6",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
-			"integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
-			"dev": true,
-			"requires": {
-				"schema-utils": "^4.0.0"
-			}
 		},
 		"minimatch": {
 			"version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"highlight.js": "^11.8.0",
 		"jsdom": "^22.1.0",
-		"mini-css-extract-plugin": "^2.7.6",
 		"npm-run-all": "^4.1.5",
 		"snarkdown": "^2.0.0",
 		"stylelint": "^15.10.3",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import TerserPlugin from 'terser-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import webpack, {Configuration} from 'webpack';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 const config: Configuration = {
 	devtool: false, // Only inline source maps work in extensions, but they would slow down the extension for everyone
@@ -12,6 +11,9 @@ const config: Configuration = {
 		preset: 'errors-warnings',
 		entrypoints: true,
 		timings: true,
+	},
+	experiments: {
+		css: true,
 	},
 	performance: {
 		hints: false,
@@ -24,6 +26,7 @@ const config: Configuration = {
 	].map(name => [name, `./${name}.js`])),
 	context: path.resolve('source'),
 	output: {
+		publicPath: '',
 		path: path.resolve('distribution/assets'),
 	},
 	module: {
@@ -44,17 +47,11 @@ const config: Configuration = {
 					target: 'es2022',
 				},
 			},
-			{
-				test: /\.css$/,
-				use: [
-					MiniCssExtractPlugin.loader,
-					'css-loader',
-				],
-			},
 		],
 	},
 	plugins: [
-		new MiniCssExtractPlugin(),
+		// TODO: Drop once `webpackIgnore` is supported https://github.com/webpack/webpack/issues/14893
+		new webpack.IgnorePlugin({resourceRegExp: /^chrome:/}),
 		new webpack.ProvidePlugin({
 			browser: 'webextension-polyfill',
 		}),


### PR DESCRIPTION
For https://github.com/refined-github/refined-github/issues/6000#issuecomment-1627449860

Blocked by https://github.com/webpack/webpack/issues/14893#issuecomment-1704046657

```
Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
    at loadCssChunkData (refined-github.js:28644:21)
```