### PR TITLE
Ask for review in the Safari extension app

### DIFF
--- a/safari/Refined GitHub/MainScreen.swift
+++ b/safari/Refined GitHub/MainScreen.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 import SafariServices
+import StoreKit
 
 struct MainScreen: View {
+	@Environment(\.requestReview) private var requestReview
+	@AppStorage("hasRequestedReview") private var hasRequestedReview = false
 	@State private var isEnabled = false
 
 	var body: some View {
@@ -41,6 +44,9 @@ struct MainScreen: View {
 		}
 			.padding()
 			.offset(y: -12) // Looks better than fully center.
+			.task {
+				requestReviewIfNeeded()
+			}
 			#if os(macOS)
 			.padding()
 			.padding()
@@ -94,6 +100,19 @@ struct MainScreen: View {
 		}
 	}
 	#endif
+
+	@MainActor
+	private func requestReviewIfNeeded() {
+		guard
+			!SSApp.isFirstLaunch,
+			!hasRequestedReview
+		else {
+			return
+		}
+
+		requestReview()
+		hasRequestedReview = true
+	}
 }
 
 struct MainScreen_Previews: PreviewProvider {

--- a/safari/Refined GitHub/Utilities.swift
+++ b/safari/Refined GitHub/Utilities.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 
 
+enum SSApp {
+	static let isFirstLaunch: Bool = {
+		let key = "SS_hasLaunched"
+
+		if UserDefaults.standard.bool(forKey: key) {
+			return false
+		}
+
+		UserDefaults.standard.set(true, forKey: key)
+		return true
+	}()
+}
+
+
 struct ShareAppLink: View {
 	let appStoreIdentifier: String
 


### PR DESCRIPTION
The review is requested on the second launch, and to not be annoying, it's only requested once ever. We kinda have to do it on the second launch as most don't even launch it a second time, even less a third time.