### PR TITLE
Drop ability to `quick-file-edit` on permalinks

### DIFF
--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -9,7 +9,6 @@ import {wrap} from '../helpers/dom-utils.js';
 import features from '../feature-manager.js';
 import GitHubURL from '../github-helpers/github-url.js';
 import {isArchivedRepoAsync, isPermalink} from '../github-helpers/index.js';
-import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import observe from '../helpers/selector-observer.js';
 import {directoryListingFileIcon} from '../github-helpers/selectors.js';
 
@@ -22,17 +21,13 @@ async function linkifyIcon(fileIcon: Element): Promise<void> {
 		route: 'edit',
 	});
 
-	if (await isPermalink()) {
-		// Permalinks can't be edited
-		url.branch = await getDefaultBranch();
-	}
-
 	wrap(fileIcon, <a href={url.href} className="rgh-quick-file-edit"/>);
 	fileIcon.after(<PencilIcon/>);
 }
 
 async function init(signal: AbortSignal): Promise<void | false> {
-	if (await isArchivedRepoAsync()) {
+	const [archive, permalink] = await Promise.all([isArchivedRepoAsync(), isPermalink()]);
+	if (archive || permalink) {
 		return false;
 	}
 


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/6875