### PR TITLE
Add support for New Repository Overview in `unreleased-commits`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ Thanks for contributing! 🦋🙌
 - [](# "repo-avatars") [Adds the profile picture to the header of public repositories.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/255323568-aee4d90e-844e-41e8-880a-ce466826516c.png)
 - [](# "quick-new-issue") [Adds a link to create issues from anywhere in a repository.](https://user-images.githubusercontent.com/1402241/218251057-b94b62dd-a944-4763-b78a-fc233f7c9fd3.png)
 - [](# "small-user-avatars") [Shows a small avatar next to the username in conversation lists.](https://user-images.githubusercontent.com/44045911/230960291-721f42cc-e1ac-4fdc-83ea-2430b062f9ce.png)
-- [](# "unreleased-commits") 🔥 [Tells you whether you're looking at the latest version of a repository, or if there are any unreleased commits.](https://user-images.githubusercontent.com/1402241/234576563-1a0ca255-4c0d-45ae-883d-2b1aa2d7f4c1.png)
+- [](# "unreleased-commits") 🔥 [Tells you whether you're looking at the latest version of a repository, or if there are any unreleased commits.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267236196-8564c193-a3c7-4248-9735-54749c1990c7.png)
 - [](# "action-pr-link") 🔥 [Adds a link back to the PR that ran the workflow.](https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png)
 - [](# "mobile-tabs") [Makes the tabs more compact on mobile so more of them can be seen.](https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png)
 

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -12,6 +12,7 @@ import pluralize from '../helpers/pluralize.js';
 import {branchSelector} from '../github-helpers/selectors.js';
 import getPublishRepoState from './unreleased-commits.gql';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
+import {wrapAll} from '../helpers/dom-utils.js';
 import abbreviateString from '../helpers/abbreviate-string.js';
 
 type RepoPublishState = {
@@ -77,19 +78,19 @@ async function add(branchSelector: HTMLButtonElement): Promise<void> {
 			: pluralize(aheadBy, '$$ unreleased commit');
 	const label = `There are ${commitCount} since ${abbreviateString(latestTag, 30)}`;
 
-	const container = <div className="d-flex gap-2"/>;
-	branchSelector.before(container);
-
-	container.append(
-		branchSelector,
-		<a
-			className="btn px-2 tooltipped tooltipped-se"
-			href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
-			aria-label={label}
-		>
-			<TagIcon className="v-align-middle"/>
-			{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
-		</a>,
+	wrapAll(
+		[
+			branchSelector,
+			<a
+				className="btn px-2 tooltipped tooltipped-se"
+				href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
+				aria-label={label}
+			>
+				<TagIcon className="v-align-middle"/>
+				{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
+			</a>,
+		],
+		<div className="d-flex gap-2"/>,
 	);
 }
 

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -1,18 +1,18 @@
 import React from 'dom-chef';
-import { CachedFunction } from 'webext-storage-cache';
+import {CachedFunction} from 'webext-storage-cache';
 import * as pageDetect from 'github-url-detection';
-import { TagIcon } from '@primer/octicons-react';
+import {TagIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import api from '../github-helpers/api.js';
-import { addAfterBranchSelector, buildRepoURL, cacheByRepo, getLatestVersionTag } from '../github-helpers/index.js';
+import {addAfterBranchSelector, buildRepoURL, cacheByRepo, getLatestVersionTag} from '../github-helpers/index.js';
 import isDefaultBranch from '../github-helpers/is-default-branch.js';
 import pluralize from '../helpers/pluralize.js';
-import { branchSelector, branchSelectorParent } from '../github-helpers/selectors.js';
+import {branchSelector, branchSelectorParent} from '../github-helpers/selectors.js';
 import getPublishRepoState from './unreleased-commits.gql';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
-import { wrapAll } from '../helpers/dom-utils.js';
+import {wrapAll} from '../helpers/dom-utils.js';
 import abbreviateString from '../helpers/abbreviate-string.js';
 
 type RepoPublishState = {
@@ -64,6 +64,25 @@ export const repoPublishState = new CachedFunction('tag-ahead-by', {
 	cacheKey: cacheByRepo,
 });
 
+async function createUnreleasedCommitsTag(latestTag: string, aheadBy: number): Promise<HTMLElement> {
+	const commitCount
+		= aheadBy === undeterminableAheadBy
+			? 'more than 20 unreleased commits'
+			: pluralize(aheadBy, '$$ unreleased commit');
+	const label = `There are ${commitCount} since ${abbreviateString(latestTag, 30)}`;
+
+	return (
+		<a
+			className="btn px-2 tooltipped tooltipped-se"
+			href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
+			aria-label={label}
+		>
+			<TagIcon className="v-align-middle"/>
+			{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
+		</a>
+	);
+}
+
 async function add(branchSelectorParent: HTMLDetailsElement): Promise<void> {
 	const {latestTag, aheadBy} = await repoPublishState.get();
 	const isAhead = aheadBy > 0;
@@ -72,23 +91,10 @@ async function add(branchSelectorParent: HTMLDetailsElement): Promise<void> {
 		return;
 	}
 
-	const commitCount
-		= aheadBy === undeterminableAheadBy
-		? 'more than 20 unreleased commits'
-		: pluralize(aheadBy, '$$ unreleased commit');
-	const label = `There are ${commitCount} since ${latestTag}`;
-
 	addAfterBranchSelector(
 		branchSelectorParent,
-		<a
-			className="btn px-2 tooltipped tooltipped-se"
-			href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
-			aria-label={label}
-		>
-			<TagIcon className="v-align-middle"/>
-			{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
-		</a>,
-	)
+		await createUnreleasedCommitsTag(latestTag, aheadBy),
+	);
 }
 
 async function addForNewRepositoryOverview(branchSelector: HTMLButtonElement): Promise<void> {
@@ -99,23 +105,10 @@ async function addForNewRepositoryOverview(branchSelector: HTMLButtonElement): P
 		return;
 	}
 
-	const commitCount
-		= aheadBy === undeterminableAheadBy
-			? 'more than 20 unreleased commits'
-			: pluralize(aheadBy, '$$ unreleased commit');
-	const label = `There are ${commitCount} since ${abbreviateString(latestTag, 30)}`;
-
 	wrapAll(
 		[
 			branchSelector,
-			<a
-				className="btn px-2 tooltipped tooltipped-se"
-				href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
-				aria-label={label}
-			>
-				<TagIcon className="v-align-middle"/>
-				{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
-			</a>,
+			await createUnreleasedCommitsTag(latestTag, aheadBy),
 		],
 		<div className="d-flex gap-2"/>,
 	);

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -6,12 +6,13 @@ import {TagIcon} from '@primer/octicons-react';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import api from '../github-helpers/api.js';
-import {addAfterBranchSelector, buildRepoURL, cacheByRepo, getLatestVersionTag} from '../github-helpers/index.js';
+import {buildRepoURL, cacheByRepo, getLatestVersionTag} from '../github-helpers/index.js';
 import isDefaultBranch from '../github-helpers/is-default-branch.js';
-import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import pluralize from '../helpers/pluralize.js';
-import {branchSelectorParent} from '../github-helpers/selectors.js';
+import {branchSelector} from '../github-helpers/selectors.js';
 import getPublishRepoState from './unreleased-commits.gql';
+import getDefaultBranch from '../github-helpers/get-default-branch.js';
+import abbreviateString from '../helpers/abbreviate-string.js';
 
 type RepoPublishState = {
 	latestTag: string | false;
@@ -62,7 +63,7 @@ export const repoPublishState = new CachedFunction('tag-ahead-by', {
 	cacheKey: cacheByRepo,
 });
 
-async function add(branchSelectorParent: HTMLDetailsElement): Promise<void> {
+async function add(branchSelector: HTMLButtonElement): Promise<void> {
 	const {latestTag, aheadBy} = await repoPublishState.get();
 	const isAhead = aheadBy > 0;
 
@@ -74,12 +75,15 @@ async function add(branchSelectorParent: HTMLDetailsElement): Promise<void> {
 		= aheadBy === undeterminableAheadBy
 			? 'more than 20 unreleased commits'
 			: pluralize(aheadBy, '$$ unreleased commit');
-	const label = `There are ${commitCount} since ${latestTag}`;
+	const label = `There are ${commitCount} since ${abbreviateString(latestTag, 30)}`;
 
-	addAfterBranchSelector(
-		branchSelectorParent,
+	const container = <div className="d-flex gap-2"/>;
+	branchSelector.before(container);
+
+	container.append(
+		branchSelector,
 		<a
-			className="btn px-2 tooltipped tooltipped-ne"
+			className="btn px-2 tooltipped tooltipped-se"
 			href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
 			aria-label={label}
 		>
@@ -96,7 +100,7 @@ async function init(signal: AbortSignal): Promise<false | void> {
 
 	await api.expectToken();
 
-	observe(branchSelectorParent, add, {signal});
+	observe(branchSelector, add, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/helpers/abbreviate-string.ts
+++ b/source/helpers/abbreviate-string.ts
@@ -1,3 +1,3 @@
 export default function abbreviateString(string_: string, length: number, abbrevMarker = '…'): string {
-	return string_.slice(0, length) + abbrevMarker;
+	return string_.length < length ? string : string_.slice(0, length) + '…';
 }

--- a/source/helpers/abbreviate-string.ts
+++ b/source/helpers/abbreviate-string.ts
@@ -1,3 +1,5 @@
-export default function abbreviateString(string_: string, length: number, abbrevMarker = '…'): string {
-	return string_.length < length ? string : string_.slice(0, length) + '…';
+export default function abbreviateString(string: string, length: number): string {
+	return string.length < length
+		? string
+		: string.slice(0, length) + '…';
 }

--- a/source/helpers/abbreviate-string.ts
+++ b/source/helpers/abbreviate-string.ts
@@ -1,0 +1,3 @@
+export default function abbreviateString(string_: string, length: number): string {
+	return string_.slice(0, length) + '…';
+}

--- a/source/helpers/abbreviate-string.ts
+++ b/source/helpers/abbreviate-string.ts
@@ -1,3 +1,3 @@
-export default function abbreviateString(string_: string, length: number, abbrevMarker: string = '…'): string {
+export default function abbreviateString(string_: string, length: number, abbrevMarker = '…'): string {
 	return string_.slice(0, length) + abbrevMarker;
 }

--- a/source/helpers/abbreviate-string.ts
+++ b/source/helpers/abbreviate-string.ts
@@ -1,3 +1,3 @@
-export default function abbreviateString(string_: string, length: number): string {
-	return string_.slice(0, length) + '…';
+export default function abbreviateString(string_: string, length: number, abbrevMarker: string = '…'): string {
+	return string_.slice(0, length) + abbrevMarker;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Describe
- Closes #6851 

## Test URLs
- Repo with no tags (no button)
https://github.com/refined-github/yolo

- Repo with too many unreleased commits
https://github.com/refined-github/sandbox

- Repo with some unreleased commits (If no button, check if is latest tag)
https://github.com/refined-github/refined-github

## Screenshot
<img width="522" alt="image" src="https://github.com/refined-github/refined-github/assets/50487467/d569e368-4e67-4c46-ac1f-9df46370ae42">
