### PR TITLE
Add `mark-private-repos` feature

### DIFF
--- a/source/features/mark-private-repos.css
+++ b/source/features/mark-private-repos.css
@@ -1,0 +1,4 @@
+li.private .Label--secondary {
+	border-color: var(--color-attention-muted);
+	color: var(--color-attention-emphasis);
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -20,6 +20,7 @@ import './features/sticky-file-header.css';
 import './features/readable-title-change-events.css';
 import './features/clean-checks-list.css';
 import './features/sticky-csv-header.css';
+import './features/mark-private-repos.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
The official styling in each user's list of personal repositories makes it difficult to distinguish public from private repos at a glance.

This commit colors the "Private" label with GitHub's "attention" color so that it stands out more prominently.

closes #6656

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs
`https://github.com/YOUR_USERNAME?tab=repositories`

## Screenshot

![](https://user-images.githubusercontent.com/47901316/252435148-9260abd3-54e7-427b-9dcf-70a0187fb217.png)
