### PR TITLE
Restore `releases-tab` when "Global Navigation Bar" is disabled

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -14,7 +14,7 @@ import createDropdownItem from '../github-helpers/create-dropdown-item.js';
 import {buildRepoURL, cacheByRepo, getRepo} from '../github-helpers/index.js';
 import {releasesSidebarSelector} from './clean-repo-sidebar.js';
 import {appendBefore, highlightTab, unhighlightTab} from '../helpers/dom-utils.js';
-import {underlineNavDropdownUl} from '../github-helpers/selectors.js';
+import {repoUnderlineNavUrl, repoUnderlineNavDropdownUl} from '../github-helpers/selectors.js';
 import GetReleasesCount from './releases-tab.gql';
 
 async function parseCountFromDom(): Promise<number> {
@@ -58,7 +58,7 @@ async function addReleasesTab(): Promise<false | void> {
 	}
 
 	// Wait for the tab bar to be loaded
-	const repoNavigationBar = (await elementReady('ul.UnderlineNav-body'))!;
+	const repoNavigationBar = (await elementReady(repoUnderlineNavUrl))!;
 	const releasesTab = (
 		<li className="d-flex">
 			<a
@@ -82,7 +82,7 @@ async function addReleasesTab(): Promise<false | void> {
 	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
 	window.dispatchEvent(new Event('resize'));
 
-	const dropdownMenu = await elementReady(underlineNavDropdownUl);
+	const dropdownMenu = await elementReady(repoUnderlineNavDropdownUl);
 
 	appendBefore(
 		dropdownMenu!,

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -58,7 +58,7 @@ async function addReleasesTab(): Promise<false | void> {
 	}
 
 	// Wait for the tab bar to be loaded
-	const repoNavigationBar = (await elementReady('.UnderlineNav-body'))!;
+	const repoNavigationBar = (await elementReady('ul.UnderlineNav-body'))!;
 	const releasesTab = (
 		<li className="d-flex">
 			<a

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -1,8 +1,13 @@
-export const underlineNavDropdownUl = '.js-responsive-underlinenav .dropdown-menu ul';
-export const underlineNavDropdownUl_ = [
+/** The repo navigation bar */
+export const repoUnderlineNavUrl = '.js-responsive-underlinenav ul.UnderlineNav-body';
+export const repoUnderlineNavUrl_ = [
 	'https://github.com/refined-github/refined-github',
 	'https://github.com/refined-github/refined-github/releases',
 ];
+
+/** The repo navigation bar’s overflow menu */
+export const repoUnderlineNavDropdownUl = '.js-responsive-underlinenav .dropdown-menu ul';
+export const repoUnderlineNavDropdownUl_ = repoUnderlineNavUrl_;
 
 export const branchSelector = '[data-hotkey="w"]';
 export const branchSelector_ = [


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Description
- Closes #6899
- `releases-tab` is not working when GitHub's Feature preview: `Global Navigation Update` is disabled.
  - Since the `.UnderlineNav-body` count is 3 when disabled. More specifying with `ul.UnderlineNav-body` selector
  - It works both of disabled and enabled

## Test URLs
- https://github.com/refined-github/refined-github

## Screenshot
- Disabled
  ![image](https://github.com/refined-github/refined-github/assets/50487467/537c243f-97be-4676-a272-3883520ad3c5)

- Enabled
  ![image](https://github.com/refined-github/refined-github/assets/50487467/472a9b4f-8409-4985-8280-e882298bf2a7)

