### PR TITLE
Restore `clean-repo-header` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -389,7 +389,7 @@ Thanks for contributing! 🦋🙌
 - [](# "prevent-pr-merge-panel-opening") Prevents the merge panel from automatically opening on every page load after it’s been opened once.
 - [](# "command-palette-navigation-shortcuts") Adds keyboard shortcuts to select items in command palette using <kbd>ctrl</kbd> <kbd>n</kbd> and <kbd>ctrl</kbd> <kbd>p</kbd> (macOS only).
 - [](# "submission-via-ctrl-enter-everywhere") Enables submission via <kbd>ctrl</kbd> <kbd>enter</kbd> on every page possible.
-- [](# "clean-repo-header") [Reduces repository name wrapping by hiding the fork and watch count (they're still on the repository’s home page)](https://user-images.githubusercontent.com/1402241/218252904-6a31a933-41a7-452e-b841-9484e67429a8.png)
+- [](# "clean-repo-header") [Avoids content shift and by hiding duplicate information on the repository home.](https://user-images.githubusercontent.com/1402241/218252904-6a31a933-41a7-452e-b841-9484e67429a8.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -389,6 +389,7 @@ Thanks for contributing! 🦋🙌
 - [](# "prevent-pr-merge-panel-opening") Prevents the merge panel from automatically opening on every page load after it’s been opened once.
 - [](# "command-palette-navigation-shortcuts") Adds keyboard shortcuts to select items in command palette using <kbd>ctrl</kbd> <kbd>n</kbd> and <kbd>ctrl</kbd> <kbd>p</kbd> (macOS only).
 - [](# "submission-via-ctrl-enter-everywhere") Enables submission via <kbd>ctrl</kbd> <kbd>enter</kbd> on every page possible.
+- [](# "clean-repo-header") [Reduces repository name wrapping by hiding the fork and watch count (they're still on the repository’s home page)](https://user-images.githubusercontent.com/1402241/218252904-6a31a933-41a7-452e-b841-9484e67429a8.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/clean-repo-header.css
+++ b/source/features/clean-repo-header.css
@@ -1,0 +1,12 @@
+.rgh-clean-repo-header .pagehead-actions :is(#repo-network-counter, #repo-notifications-counter) {
+	display: none;
+}
+
+/* Hide text of "Edit Pins" dropdown button in header of organization repos https://github.com/refined-github/refined-github/pull/5612 */
+.rgh-clean-repo-header .pagehead-actions pin-organization-repo summary {
+	font-size: 0 !important;
+}
+
+.rgh-clean-repo-header .pagehead-actions pin-organization-repo .octicon-pin {
+	vertical-align: middle !important;
+}

--- a/source/features/clean-repo-header.css
+++ b/source/features/clean-repo-header.css
@@ -1,12 +1,16 @@
-.rgh-clean-repo-header .pagehead-actions :is(#repo-network-counter, #repo-notifications-counter) {
+#repo-stars-counter-star,
+#repo-stars-counter-unstar, 
+#repo-network-counter, /* Forks */
+#repo-notifications-counter, /* Watchers */
+.js-codespaces-details-container summary .Button-label /* Green "Code" button label */{
 	display: none;
 }
 
 /* Hide text of "Edit Pins" dropdown button in header of organization repos https://github.com/refined-github/refined-github/pull/5612 */
-.rgh-clean-repo-header .pagehead-actions pin-organization-repo summary {
+.pagehead-actions pin-organization-repo summary {
 	font-size: 0 !important;
 }
 
-.rgh-clean-repo-header .pagehead-actions pin-organization-repo .octicon-pin {
+.pagehead-actions pin-organization-repo .octicon-pin {
 	vertical-align: middle !important;
 }

--- a/source/features/clean-repo-header.css
+++ b/source/features/clean-repo-header.css
@@ -2,7 +2,7 @@
 #repo-stars-counter-unstar, 
 #repo-network-counter, /* Forks */
 #repo-notifications-counter, /* Watchers */
-.js-codespaces-details-container summary .Button-label /* Green "Code" button label */{
+.js-codespaces-details-container summary .Button-label /* Green "Code" button label */ {
 	display: none;
 }
 

--- a/source/features/clean-repo-header.css
+++ b/source/features/clean-repo-header.css
@@ -1,8 +1,11 @@
-#repo-stars-counter-star,
-#repo-stars-counter-unstar, 
-#repo-network-counter, /* Forks */
-#repo-notifications-counter, /* Watchers */
-.js-codespaces-details-container summary .Button-label /* Green "Code" button label */ {
+#repository-container-header:not(:has(.js-repo-nav)) /* Excludes pre-Global Navigation Update header */
+:is(
+	#repo-stars-counter-star,
+	#repo-stars-counter-unstar,
+	#repo-network-counter, /* Forks */
+	#repo-notifications-counter, /* Watchers */
+	.js-codespaces-details-container summary .Button-label /* Green "Code" button label */
+) {
 	display: none;
 }
 

--- a/source/features/clean-repo-header.tsx
+++ b/source/features/clean-repo-header.tsx
@@ -1,0 +1,5 @@
+import './clean-repo-header.css';
+
+import features from '../feature-manager.js';
+
+void features.addCssFeature(import.meta.url);

--- a/source/features/clean-repo-header.tsx
+++ b/source/features/clean-repo-header.tsx
@@ -1,5 +1,0 @@
-import './clean-repo-header.css';
-
-import features from '../feature-manager.js';
-
-void features.addCssFeature(import.meta.url);

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -202,6 +202,7 @@ import './features/last-notification-page-button.js';
 import './features/rgh-linkify-yolo-issues.js';
 import './features/quick-new-issue.js';
 import './features/scrollable-areas.js';
+import './features/clean-repo-header.js';
 import './features/emphasize-draft-pr-label.js';
 import './features/file-age-color.js';
 import './features/netiquette.js';

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -21,6 +21,7 @@ import './features/readable-title-change-events.css';
 import './features/clean-checks-list.css';
 import './features/sticky-csv-header.css';
 import './features/mark-private-repos.css';
+import './features/clean-repo-header.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.
@@ -202,7 +203,6 @@ import './features/last-notification-page-button.js';
 import './features/rgh-linkify-yolo-issues.js';
 import './features/quick-new-issue.js';
 import './features/scrollable-areas.js';
-import './features/clean-repo-header.js';
 import './features/emphasize-draft-pr-label.js';
 import './features/file-age-color.js';
 import './features/netiquette.js';


### PR DESCRIPTION
Reverts refined-github/refined-github#6759

The header is still long, ugly and it still causes a wrap and [Cumulative Layout Shift](https://web.dev/cls/).

We can restore it without making it disableable because _all_ of that information is visible in the sidebar, on the same page, as well as in the upcoming:

- #6900 


<img width="1054" alt="Screenshot 16" src="https://github.com/refined-github/refined-github/assets/1402241/9ee06690-f893-468e-b580-8a84a6f9cdb7">

