### PR TITLE
Faster `releases-tab` on repo home

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {cacheByRepo} from '../github-helpers/index.js';
+import {cacheByRepo, triggerRepoNavOverflow} from '../github-helpers/index.js';
 import SearchQuery from '../github-helpers/search-query.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils.js';
@@ -107,8 +107,7 @@ async function addBugsTab(): Promise<void | false> {
 		issuesTab.after(bugsTab);
 	}
 
-	// Trigger a reflow to push the right-most tab into the overflow dropdown
-	window.dispatchEvent(new Event('resize'));
+	triggerRepoNavOverflow();
 
 	// Update bugs count
 	try {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -120,6 +120,7 @@ async function addBugsTab(): Promise<void | false> {
 	}
 }
 
+// TODO: Use native highlighting https://github.com/refined-github/refined-github/pull/6909#discussion_r1322607091
 function highlightBugsTab(): void {
 	// Remove highlighting from "Issues" tab
 	unhighlightTab(select('.UnderlineNav-item[data-hotkey="g i"]')!);

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -6,7 +6,8 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 // The h2 is to avoid hiding website links that include '/releases' #4424
-export const releasesSidebarSelector = '.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]';
+// TODO: It's broken
+const releasesSidebarSelector = '.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]';
 async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady(releasesSidebarSelector, {waitForChildren: false});
 	if (!sidebarReleases) {

--- a/source/features/more-dropdown-links.css
+++ b/source/features/more-dropdown-links.css
@@ -2,8 +2,3 @@
 .rgh-has-more-dropdown .UnderlineNav-actions {
 	visibility: visible !important;
 }
-
-/* Only show the divider if there are other items above it */
-.UnderlineNav-actions [hidden] + .dropdown-divider {
-	display: none;
-}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -1,6 +1,5 @@
 import React from 'dom-chef';
 import {CachedFunction} from 'webext-storage-cache';
-import select from 'select-dom';
 import {TagIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
@@ -8,22 +7,15 @@ import * as pageDetect from 'github-url-detection';
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';
-import {buildRepoURL, cacheByRepo, getRepo} from '../github-helpers/index.js';
-import {releasesSidebarSelector} from './clean-repo-sidebar.js';
-import {appendBefore, highlightTab, unhighlightTab} from '../helpers/dom-utils.js';
-import {repoUnderlineNavUrl, repoUnderlineNavDropdownUl} from '../github-helpers/selectors.js';
+import {buildRepoURL, cacheByRepo, getRepo, triggerRepoNavOverflow} from '../github-helpers/index.js';
+import {appendBefore} from '../helpers/dom-utils.js';
+import {repoUnderlineNavUl, repoUnderlineNavDropdownUl} from '../github-helpers/selectors.js';
 import GetReleasesCount from './releases-tab.gql';
 
-async function parseCountFromDom(): Promise<number> {
-	const moreReleasesCountElement = await elementReady(releasesSidebarSelector + ' .Counter');
-	if (moreReleasesCountElement) {
-		return looseParseInt(moreReleasesCountElement);
-	}
-
-	return 0;
+function detachHighlightFromCodeTab(codeTab: HTMLAnchorElement): void {
+	codeTab.dataset.selectedLinks = codeTab.dataset.selectedLinks!.replace('repo_releases ', '');
 }
 
 async function fetchFromApi(nameWithOwner: string): Promise<number> {
@@ -40,26 +32,24 @@ async function fetchFromApi(nameWithOwner: string): Promise<number> {
 // - It only contains pre-releases (count badge won't be shown)
 // For this reason, if we can't find a count from the DOM, we ask the API instead (see #6298)
 export const releasesCount = new CachedFunction('releases-count', {
-	updater: async (nameWithOwner: string) => await parseCountFromDom() || fetchFromApi(nameWithOwner),
+	updater: fetchFromApi,
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 3},
 	cacheKey: cacheByRepo,
 });
 
-async function addReleasesTab(): Promise<false | void> {
+async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | void> {
 	const repo = getRepo()!.nameWithOwner;
-	const count = pageDetect.isRepoRoot()
-		// Always prefer the information in the DOM
-		? await releasesCount.getFresh(repo)
-		: await releasesCount.get(repo);
+	const count = await releasesCount.get(repo);
 
 	if (count === 0) {
 		return false;
 	}
 
-	// Wait for the tab bar to be loaded
-	const repoNavigationBar = (await elementReady(repoUnderlineNavUrl))!;
-	const releasesTab = (
+	// Wait for the dropdown because `observe` fires as soon as it encounter the container. `releases-tab` must be appended.
+	await elementReady(repoUnderlineNavUl);
+
+	repoNavigationBar.append(
 		<li className="d-flex">
 			<a
 				href={buildRepoURL('releases')}
@@ -67,25 +57,21 @@ async function addReleasesTab(): Promise<false | void> {
 				data-hotkey="g r"
 				data-selected-links="repo_releases"
 				data-tab-item="rgh-releases-item"
+				data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
 			>
 				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline"/>
 				<span data-content="Releases">Releases</span>
 				{count && <span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>}
 			</a>
-		</li>
+		</li>,
 	);
-	repoNavigationBar.append(releasesTab);
 
-	// This re-triggers the overflow listener forcing it to also hide this tab if necessary #3347
-	repoNavigationBar.replaceWith(repoNavigationBar);
+	triggerRepoNavOverflow();
+}
 
-	// Trigger a reflow to push the right-most tab into the overflow dropdown (second attempt #4254)
-	window.dispatchEvent(new Event('resize'));
-
-	const dropdownMenu = await elementReady(repoUnderlineNavDropdownUl);
-
+function addReleasesDropdownItem(dropdownMenu: HTMLElement): void {
 	appendBefore(
-		dropdownMenu!,
+		dropdownMenu,
 		'.dropdown-divider', // Won't exist if `more-dropdown` is disabled
 		createDropdownItem('Releases', buildRepoURL('releases'), {
 			'data-menu-item': 'rgh-releases-item',
@@ -93,19 +79,10 @@ async function addReleasesTab(): Promise<false | void> {
 	);
 }
 
-function highlightReleasesTab(signal: AbortSignal): void {
-	observe('.UnderlineNav-item.selected:not(.rgh-releases-tab)', unhighlightTab, {signal});
-	highlightTab(select('.rgh-releases-tab')!);
-}
-
 async function init(signal: AbortSignal): Promise<void> {
-	if (!select.exists('.rgh-releases-tab')) {
-		await addReleasesTab();
-	}
-
-	if (pageDetect.isReleasesOrTags()) {
-		highlightReleasesTab(signal);
-	}
+	observe(repoUnderlineNavUl, addReleasesTab, {signal});
+	observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
+	observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -77,6 +77,8 @@ function addReleasesDropdownItem(dropdownMenu: HTMLElement): void {
 			'data-menu-item': 'rgh-releases-item',
 		}),
 	);
+
+	triggerRepoNavOverflow();
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -6,7 +6,7 @@ import {RequireAtLeastOne} from 'type-fest';
 import * as pageDetect from 'github-url-detection';
 import mem from 'mem';
 
-import {branchSelector, repoUnderlineNavUl} from './selectors.js';
+import {branchSelector} from './selectors.js';
 
 // This never changes, so it can be cached here
 export const getUsername = onetime(pageDetect.utils.getUsername);

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -6,7 +6,7 @@ import {RequireAtLeastOne} from 'type-fest';
 import * as pageDetect from 'github-url-detection';
 import mem from 'mem';
 
-import {branchSelector} from './selectors.js';
+import {branchSelector, repoUnderlineNavUl} from './selectors.js';
 
 // This never changes, so it can be cached here
 export const getUsername = onetime(pageDetect.utils.getUsername);
@@ -154,4 +154,9 @@ export function addAfterBranchSelector(branchSelectorParent: HTMLDetailsElement,
 	const row = branchSelectorParent.closest('.position-relative')!;
 	row.classList.add('d-flex', 'flex-shrink-0', 'gap-2');
 	row.append(sibling);
+}
+
+/** Trigger a reflow to push the right-most tab into the overflow dropdown */
+export function triggerRepoNavOverflow(): void {
+	window.dispatchEvent(new Event('resize'));
 }

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -1,13 +1,13 @@
 /** The repo navigation bar */
-export const repoUnderlineNavUrl = '.js-responsive-underlinenav ul.UnderlineNav-body';
-export const repoUnderlineNavUrl_ = [
+export const repoUnderlineNavUl = '.js-responsive-underlinenav ul.UnderlineNav-body';
+export const repoUnderlineNavUl_ = [
 	'https://github.com/refined-github/refined-github',
 	'https://github.com/refined-github/refined-github/releases',
 ];
 
 /** The repo navigation bar’s overflow menu */
 export const repoUnderlineNavDropdownUl = '.js-responsive-underlinenav .dropdown-menu ul';
-export const repoUnderlineNavDropdownUl_ = repoUnderlineNavUrl_;
+export const repoUnderlineNavDropdownUl_ = repoUnderlineNavUl_;
 
 export const branchSelector = '[data-hotkey="w"]';
 export const branchSelector_ = [


### PR DESCRIPTION
Following https://github.com/refined-github/refined-github/pull/6901 I took a further look at the feature and made some changes. See self-review

It might fix https://github.com/refined-github/refined-github/issues/6293, so I'll close it until I see that bug again.