### PR TITLE
Disable `dim-bots` only when clicking on empty areas

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -1,7 +1,7 @@
 import './dim-bots.css';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import delegate from 'delegate-it';
+import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
 import preserveScroll from '../helpers/preserve-scroll.js';
@@ -35,7 +35,12 @@ const prSelectors = [
 
 const dimBots = features.getIdentifiers(import.meta.url);
 
-function undimBots(event: Event): void {
+function undimBots(event: Event | DelegateEvent): void {
+	// Only undim when clicking on empty areas
+	if ('delegateTarget' in event && event.target !== event.delegateTarget) {
+		return;
+	}
+
 	const resetScroll = preserveScroll(event.target as HTMLElement);
 	for (const bot of select.all(dimBots.selector)) {
 		bot.classList.add('rgh-interacted');

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -36,12 +36,13 @@ const prSelectors = [
 const dimBots = features.getIdentifiers(import.meta.url);
 
 function undimBots(event: DelegateEvent): void {
+	const target = event.target as HTMLElement;
 	// Only undim when clicking on empty areas
-	if (event.target.closest('a, button, input, [tabindex]')) {
+	if (target.closest('a, button, input, [tabindex]')) {
 		return;
 	}
 
-	const resetScroll = preserveScroll(event.target as HTMLElement);
+	const resetScroll = preserveScroll(target);
 	for (const bot of select.all(dimBots.selector)) {
 		bot.classList.add('rgh-interacted');
 	}

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -35,9 +35,9 @@ const prSelectors = [
 
 const dimBots = features.getIdentifiers(import.meta.url);
 
-function undimBots(event: Event | DelegateEvent): void {
+function undimBots(event: DelegateEvent): void {
 	// Only undim when clicking on empty areas
-	if ('delegateTarget' in event && event.target !== event.delegateTarget) {
+	if (event.target.closest('a, button, input, [tabindex]')) {
 		return;
 	}
 
@@ -63,9 +63,6 @@ function init(signal: AbortSignal): void {
 
 	// Undim on mouse focus
 	delegate(dimBots.selector, 'click', undimBots, {signal});
-
-	// Undim on keyboard focus
-	document.documentElement.addEventListener('navigation:keydown', undimBots, {once: true, signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -7,7 +7,7 @@ const html = document.documentElement;
 
 function init(): void {
 	html.setAttribute(attribute, '');
-	html.addEventListener('navigation:focus', () => {
+	html.addEventListener('navigation:keydown', () => {
 		html.removeAttribute(attribute);
 	}, {once: true});
 }


### PR DESCRIPTION
This was annoying to do until now: ctrl-click multiple PRs.

This PR makes 2 changes:

- the bots won't undim when clicking on active elements 
- the bots won't undim when pressing _any_ keys

https://github.com/refined-github/refined-github/assets/1402241/5841672a-767f-4226-895a-095456313d81



## Test URL

https://github.com/mozilla/web-ext/pulls