### PR TITLE
`show-names` - Exclude invalid elements on new dashboard

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -16,7 +16,8 @@ const batchUpdateLinks = batchedFunction(async (batchedUsernameElements: HTMLAnc
 	const myUsername = getUsername();
 	for (const element of new Set(batchedUsernameElements)) {
 		const username = element.textContent;
-		if (username && username !== myUsername && username !== 'ghost') {
+
+		if (username && username !== myUsername && username !== 'ghost' && element.href.endsWith(`/${username}`)) {
 			usernames.add(element.textContent!);
 		}
 
@@ -82,7 +83,7 @@ const usernameLinksSelector = [
 	// On dashboard
 	// `.Link--primary` excludes avatars
 	// `.color-shadow-medium` excludes links in cards #6530
-	'#dashboard article header a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
+	'#dashboard a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
 ] as const;
 
 function init(signal: AbortSignal): void {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -82,7 +82,7 @@ const usernameLinksSelector = [
 	// On dashboard
 	// `.Link--primary` excludes avatars
 	// `.color-shadow-medium` excludes links in cards #6530
-	'#dashboard a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
+	'#dashboard article header a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
 ] as const;
 
 function init(signal: AbortSignal): void {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -17,7 +17,7 @@ const batchUpdateLinks = batchedFunction(async (batchedUsernameElements: HTMLAnc
 	for (const element of new Set(batchedUsernameElements)) {
 		const username = element.textContent;
 
-		if (username && username !== myUsername && username !== 'ghost' && element.href.endsWith(`/${username}`)) {
+		if (username && username !== myUsername && username !== 'ghost') {
 			usernames.add(element.textContent!);
 		}
 

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -82,8 +82,8 @@ const usernameLinksSelector = [
 
 	// On dashboard
 	// `.Link--primary` excludes avatars
-	// `.color-shadow-medium` excludes links in cards #6530
-	'#dashboard a.Link--primary[data-hovercard-type="user"]:not(.color-shadow-medium a)',
+	// [aria-label="card content"] excludes links in cards #6530 #6915
+	'#dashboard a.Link--primary[data-hovercard-type="user"]:not([aria-label="card content"] *)',
 ] as const;
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
## Description
- Closes #6915 
- Fix `show-names` fetches redundant username on `followed article` in `GitHub newsfeed`

## Test URLs
- https://github.com/ (some followed article)

## Screenshot
![image](https://github.com/refined-github/refined-github/assets/50487467/3e75d696-6600-4248-83cf-6096042c2162)
<img width="600" src="https://github.com/refined-github/refined-github/assets/50487467/5c45d654-44c5-4464-87fd-c87301b8f3a7"/>

