### PR TITLE
`unreleased-commits` - Restore support for old repository overview

### DIFF
--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -121,7 +121,7 @@ async function init(signal: AbortSignal): Promise<false | void> {
 
 	await api.expectToken();
 
-	observe(branchSelector, add, {signal});
+	observe(`table[aria-labelledby="folders-and-files"] ${branchSelector}`, add, {signal});
 
 	// TODO: Drop after Repository overview update
 	observe(branchSelectorParent, addLegacy, {signal});

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -91,27 +91,22 @@ async function add(branchSelector: HTMLButtonElement): Promise<void> {
 		return;
 	}
 
-	wrapAll(
-		[
-			branchSelector,
+	const parent = branchSelector.closest(branchSelectorParent);
+	if (parent) {
+		// TODO: For legacy; Drop after Repository overview update
+		addAfterBranchSelector(
+			parent,
 			await createLink(latestTag, aheadBy),
-		],
-		<div className="d-flex gap-2"/>,
-	);
-}
-
-async function addLegacy(branchSelectorParent: HTMLDetailsElement): Promise<void> {
-	const {latestTag, aheadBy} = await repoPublishState.get();
-	const isAhead = aheadBy > 0;
-
-	if (!latestTag || !isAhead) {
-		return;
+		);
+	} else {
+		wrapAll(
+			[
+				branchSelector,
+				await createLink(latestTag, aheadBy),
+			],
+			<div className="d-flex gap-2"/>,
+		);
 	}
-
-	addAfterBranchSelector(
-		branchSelectorParent,
-		await createLink(latestTag, aheadBy),
-	);
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
@@ -121,10 +116,7 @@ async function init(signal: AbortSignal): Promise<false | void> {
 
 	await api.expectToken();
 
-	observe(`table[aria-labelledby="folders-and-files"] ${branchSelector}`, add, {signal});
-
-	// TODO: Drop after Repository overview update
-	observe(branchSelectorParent, addLegacy, {signal});
+	observe(branchSelector, add, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
## Description
- Closes #6922 
- Disabled via hotfix: https://github.com/refined-github/yolo/commit/4581c8158898b8a8e2e7abe0039aa33200b475ac
- Reason is described here: https://github.com/refined-github/refined-github/issues/6922#issuecomment-1723228576

## Test URLs
- https://github.com/refined-github/refined-github

## Screenshot
- `New repository overview` disabled
  <img width="199" alt="image" src="https://github.com/refined-github/refined-github/assets/50487467/9d1efc08-77f9-4898-ba20-fa521c6c9520">


- `New repository overview` enabled
  <img width="223" alt="image" src="https://github.com/refined-github/refined-github/assets/50487467/57db469c-c6ec-45b6-9c3d-7ee449c42d64">


