### PR TITLE
Meta: Rename `GitHubURL` to `GitHubFileURL`

### DIFF
--- a/source/features/actionable-pr-view-file.tsx
+++ b/source/features/actionable-pr-view-file.tsx
@@ -10,7 +10,7 @@ function alter(viewFileLink: HTMLAnchorElement): void {
 	const {nameWithOwner, branch} = getBranches().head;
 	const filePath = viewFileLink.closest('[data-path]')!.getAttribute('data-path')!;
 
-	// Do not replace with `GitHubURL` #3152 #3111 #2595
+	// Do not replace with `GitHubFileURL` #3152 #3111 #2595
 	viewFileLink.pathname = [nameWithOwner, 'blob', branch, filePath].join('/');
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import addNotice from '../github-widgets/notice-bar.js';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters.js';
 import {buildRepoURL, isPermalink} from '../github-helpers/index.js';
@@ -13,7 +13,7 @@ import {saveOriginalHref} from './sort-conversations-by-update-time.js';
 import observe from '../helpers/selector-observer.js';
 import GetCommitAtDate from './comments-time-machine-links.gql';
 
-async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> {
+async function updateURLtoDatedSha(url: GitHubFileURL, date: string): Promise<void> {
 	const {repository} = await api.v4(GetCommitAtDate, {variables: {date, branch: url.branch}});
 
 	const [{oid}] = repository.ref.target.history.nodes;
@@ -21,7 +21,7 @@ async function updateURLtoDatedSha(url: GitHubURL, date: string): Promise<void> 
 }
 
 async function showTimeMachineBar(): Promise<void | false> {
-	const url = new URL(location.href); // This can't be replaced with `GitHubURL` because `getCurrentGitRef` throws on 404s
+	const url = new URL(location.href); // This can't be replaced with `GitHubFileURL` because `getCurrentGitRef` throws on 404s
 	const date = url.searchParams.get('rgh-link-date')!;
 
 	// Drop parameter from current page after using it
@@ -44,7 +44,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		const parsedUrl = new GitHubURL(location.href);
+		const parsedUrl = new GitHubFileURL(location.href);
 		// Due to GitHub’s bug of supporting branches with slashes: #2901
 		void updateURLtoDatedSha(parsedUrl, date); // Don't await it, since the link will usually work without the update
 

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -7,6 +7,7 @@ import batchedFunction from 'batched-function';
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import observe from '../helpers/selector-observer.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 async function addIcon(links: HTMLAnchorElement[]): Promise<void> {
 	const prConfigs = links.map(link => {
@@ -48,6 +49,9 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isIssueOrPRList,
 	],

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -8,7 +8,7 @@ import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import showToast from '../github-helpers/toast.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import observe from '../helpers/selector-observer.js';
@@ -47,7 +47,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 	const blameHunk = blameElement.closest('.blame-hunk')!;
 	const prNumbers = select.all('.issue-link', blameHunk).map(pr => looseParseInt(pr));
 	const prCommit = select('a.message', blameHunk)!.pathname.split('/').pop()!;
-	const blameUrl = new GitHubURL(location.href);
+	const blameUrl = new GitHubFileURL(location.href);
 
 	await showToast(async () => {
 		blameUrl.branch = await getPullRequestBlameCommit(prCommit, prNumbers, blameUrl.filePath);

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import {ChevronLeftIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import {groupButtons} from '../github-helpers/group-buttons.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import observe from '../helpers/selector-observer.js';
@@ -19,7 +19,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 		return;
 	}
 
-	const url = new GitHubURL(location.href);
+	const url = new GitHubFileURL(location.href);
 	if (pageDetect.isRepoRoot()) {
 		// The default branch of the root directory is just /user/repo/
 		url.route = '';

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 
@@ -21,7 +21,7 @@ function linkifyHovercard(hovercard: HTMLElement): void {
 	const {href} = hovercard.querySelector('a.Link--primary')!;
 
 	for (const reference of hovercard.querySelectorAll('.commit-ref')) {
-		const url = new GitHubURL(href).assign({
+		const url = new GitHubFileURL(href).assign({
 			route: 'tree',
 			branch: reference.title,
 		});

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -8,13 +8,13 @@ import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {buildRepoURL, cacheByRepo} from '../github-helpers/index.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import observe from '../helpers/selector-observer.js';
 import listPrsForFileQuery from './list-prs-for-file.gql';
 
 function getPRUrl(prNumber: number): string {
 	// https://caniuse.com/url-scroll-to-text-fragment
-	const hash = isFirefox() ? '' : `#:~:text=${new GitHubURL(location.href).filePath}`;
+	const hash = isFirefox() ? '' : `#:~:text=${new GitHubFileURL(location.href).filePath}`;
 	return buildRepoURL('pull', prNumber, 'files') + hash;
 }
 
@@ -84,7 +84,7 @@ const getPrsByFile = new CachedFunction('files-with-prs', {
 });
 
 async function addToSingleFile(moreFileActionsDropdown: HTMLElement): Promise<void> {
-	const path = new GitHubURL(location.href).filePath;
+	const path = new GitHubFileURL(location.href).filePath;
 	const prsByFile = await getPrsByFile.get();
 	const prs = prsByFile[path];
 
@@ -99,7 +99,7 @@ async function addToSingleFile(moreFileActionsDropdown: HTMLElement): Promise<vo
 }
 
 async function addToEditingFile(saveButton: HTMLElement): Promise<false | void> {
-	const path = new GitHubURL(location.href).filePath;
+	const path = new GitHubFileURL(location.href).filePath;
 	const prsByFile = await getPrsByFile.get();
 	let prs = prsByFile[path];
 

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -4,14 +4,14 @@ import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
 
 import features from '../feature-manager.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 
 function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	dropdown.classList.add('rgh-more-file-links'); // Mark this as processed
 
 	const viewFile = select('a[data-ga-click^="View file"]', dropdown)!;
 	const getDropdownLink = (name: string, route: string): JSX.Element => {
-		const {href} = new GitHubURL(viewFile.href).assign({route});
+		const {href} = new GitHubFileURL(viewFile.href).assign({route});
 		return (
 			<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 dropdown-item btn-link" role="menuitem">
 				View {name}

--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -38,3 +38,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+https://github.com/refined-github/sandbox/pull/55/files
+https://github.com/refined-github/sandbox/compare/41c25160f0f574b302d72652ac83f4b2dab47e19...770d2ad5f086371da8a5f078f4267e6847e649f5
+https://github.com/refined-github/sandbox/commit/0504e7dccb40374c24c1217f37d3579993d6071e
+
+*/

--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -5,11 +5,11 @@ import {VersionsIcon} from '@primer/octicons-react';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import api from '../github-helpers/api.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import previousVersionQuery from './previous-version.gql';
 
 async function getPreviousCommitForFile(pathname: string): Promise<string | undefined> {
-	const {user, repository, branch, filePath} = new GitHubURL(pathname);
+	const {user, repository, branch, filePath} = new GitHubFileURL(pathname);
 	const {resource} = await api.v4(previousVersionQuery, {
 		variables: {
 			filePath,
@@ -27,7 +27,7 @@ async function add(historyButton: HTMLElement): Promise<void> {
 		return;
 	}
 
-	const url = new GitHubURL(location.href)
+	const url = new GitHubFileURL(location.href)
 		.assign({branch: previousCommit});
 
 	historyButton.before(

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils.js';
 import features from '../feature-manager.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import {isArchivedRepoAsync, isPermalink} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {directoryListingFileIcon} from '../github-helpers/selectors.js';
@@ -17,7 +17,7 @@ async function linkifyIcon(fileIcon: Element): Promise<void> {
 		.closest('.js-navigation-item, .react-directory-filename-column')!
 		.querySelector('a.js-navigation-open, a.Link--primary')!;
 
-	const url = new GitHubURL(fileLink.href).assign({
+	const url = new GitHubFileURL(fileLink.href).assign({
 		route: 'edit',
 	});
 

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -3,6 +3,7 @@ import * as pageDetect from 'github-url-detection';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 // Source: https://github.com/fregante/release-with-changelog/blob/779fd5e658f82e5b11b1c0a352a6838d3bd8f67f/generate-release-notes.js#L6
 const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
@@ -20,6 +21,7 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	asLongAs: [
 		isRefinedGitHubRepo,
+		isHasSelectorSupported,
 	],
 	include: [
 		pageDetect.isCommitList,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import GitHubURL from '../github-helpers/github-url.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {getCleanPathname, isUrlReachable} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
@@ -80,7 +80,7 @@ async function getChangesToFileInCommit(sha: string, filePath: string): Promise<
 }
 
 async function getUrlToFileOnDefaultBranch(): Promise<string | void> {
-	const parsedUrl = new GitHubURL(location.href);
+	const parsedUrl = new GitHubFileURL(location.href);
 	if (!parsedUrl.branch) {
 		return;
 	}
@@ -133,7 +133,7 @@ async function showDefaultBranchLink(): Promise<void> {
 }
 
 async function getGitObjectHistoryLink(): Promise<HTMLElement | undefined> {
-	const url = new GitHubURL(location.href);
+	const url = new GitHubFileURL(location.href);
 	if (!url.branch || !url.filePath) {
 		return;
 	}

--- a/source/github-helpers/does-file-exist.tsx
+++ b/source/github-helpers/does-file-exist.tsx
@@ -1,8 +1,8 @@
 import api from './api.js';
-import GitHubURL from './github-url.js';
+import GitHubFileURL from './github-file-url.js';
 import DoesFileExist from './does-file-exist.gql';
 
-export default async function doesFileExist(url: GitHubURL): Promise<boolean> {
+export default async function doesFileExist(url: GitHubFileURL): Promise<boolean> {
 	const {repository} = await api.v4(DoesFileExist, {
 		variables: {
 			owner: url.user,

--- a/source/github-helpers/get-current-git-ref.ts
+++ b/source/github-helpers/get-current-git-ref.ts
@@ -7,7 +7,7 @@ import {branchSelector} from './selectors.js';
 const typesWithGitRef = new Set(['tree', 'blob', 'blame', 'edit', 'commit', 'commits', 'compare']);
 const titleWithGitRef = / at (?<branch>[.\w-/]+)( · [\w-]+\/[\w-]+)?$/i;
 
-/** Must not be async because it's used by GitHubURL. May return different results depending on whether it's called before or after DOM ready */
+/** Must not be async because it's used by GitHubFileURL. May return different results depending on whether it's called before or after DOM ready */
 export default function getCurrentGitRef(): string | undefined {
 	// Note: This is not in the <head> so it's only available on AJAXed loads.
 	// It appears on every Code page except `commits` on folders/files

--- a/source/github-helpers/github-file-url.test.ts
+++ b/source/github-helpers/github-file-url.test.ts
@@ -1,9 +1,9 @@
 import {test, assert} from 'vitest';
 
-import GitHubURL from './github-url.js';
+import GitHubFileURL from './github-file-url.js';
 
 test('branch', () => {
-	const url = new GitHubURL('https://github.com/microsoft/TypeScript/tree/master');
+	const url = new GitHubFileURL('https://github.com/microsoft/TypeScript/tree/master');
 	assert.equal(url.user, 'microsoft');
 	assert.equal(url.repository, 'TypeScript');
 	assert.equal(url.route, 'tree');
@@ -15,7 +15,7 @@ test('branch', () => {
 });
 
 test('branch with multiple slashes', () => {
-	const url = new GitHubURL('https://github.com/yakov116/TestR/tree/this/branch%2Fhas%2Fmany%2Fslashes');
+	const url = new GitHubFileURL('https://github.com/yakov116/TestR/tree/this/branch%2Fhas%2Fmany%2Fslashes');
 	assert.equal(url.user, 'yakov116');
 	assert.equal(url.repository, 'TestR');
 	assert.equal(url.route, 'tree');
@@ -27,7 +27,7 @@ test('branch with multiple slashes', () => {
 });
 
 test('object', () => {
-	const url = new GitHubURL('https://github.com/microsoft/TypeScript/tree/master/src');
+	const url = new GitHubFileURL('https://github.com/microsoft/TypeScript/tree/master/src');
 	assert.equal(url.user, 'microsoft');
 	assert.equal(url.repository, 'TypeScript');
 	assert.equal(url.route, 'tree');
@@ -39,7 +39,7 @@ test('object', () => {
 });
 
 test('nested object', () => {
-	const url = new GitHubURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js');
+	const url = new GitHubFileURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js');
 	assert.equal(url.user, 'microsoft');
 	assert.equal(url.repository, 'TypeScript');
 	assert.equal(url.route, 'tree');
@@ -51,7 +51,7 @@ test('nested object', () => {
 });
 
 test('change branch', () => {
-	const url = new GitHubURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js').assign({
+	const url = new GitHubFileURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js').assign({
 		branch: 'dev',
 	});
 	assert.equal(url.user, 'microsoft');
@@ -65,7 +65,7 @@ test('change branch', () => {
 });
 
 test('change filePath', () => {
-	const url = new GitHubURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js').assign({
+	const url = new GitHubFileURL('https://github.com/microsoft/TypeScript/tree/master/src/index.js').assign({
 		filePath: 'package.json',
 	});
 	assert.equal(url.user, 'microsoft');
@@ -79,7 +79,7 @@ test('change filePath', () => {
 });
 
 test('get filePath from search', () => {
-	const url = new GitHubURL('https://github.com/yakov116/refined-github/commits/f23b687b3b89aa95a76193722cdfeff740646670?after=f23b687b3b89aa95a76193722cdfeff740646670+34&path%5B%5D=source&path%5B%5D=features&path%5B%5D=release-download-count.tsx');
+	const url = new GitHubFileURL('https://github.com/yakov116/refined-github/commits/f23b687b3b89aa95a76193722cdfeff740646670?after=f23b687b3b89aa95a76193722cdfeff740646670+34&path%5B%5D=source&path%5B%5D=features&path%5B%5D=release-download-count.tsx');
 	assert.equal(url.user, 'yakov116');
 	assert.equal(url.repository, 'refined-github');
 	assert.equal(url.route, 'commits');

--- a/source/github-helpers/github-file-url.ts
+++ b/source/github-helpers/github-file-url.ts
@@ -2,7 +2,7 @@ import {isRepoRoot} from 'github-url-detection';
 
 import getCurrentGitRef from './get-current-git-ref.js';
 
-export default class GitHubURL {
+export default class GitHubFileURL {
 	user = '';
 	repository = '';
 	route = '';
@@ -21,7 +21,7 @@ export default class GitHubURL {
 		return this.href;
 	}
 
-	assign(...replacements: Array<Partial<GitHubURL>>): this {
+	assign(...replacements: Array<Partial<GitHubFileURL>>): this {
 		Object.assign(this, ...replacements);
 		return this;
 	}


### PR DESCRIPTION
Since Firefox still fails, we can only rename the class.

- Replaces https://github.com/refined-github/refined-github/pull/6870