### PR TITLE
`link-to-changelog-file` - Drop extraneous character in tooltip

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -57,7 +57,7 @@ async function init(): Promise<void | false> {
 	const changelogButton = (
 		<a
 			className={'tooltipped tooltipped-n btn ml-3' + (pageDetect.isEnterprise() ? '' : ' flex-self-start')}
-			aria-label={`View the ${changelog} file}`}
+			aria-label={`View the ${changelog} file`}
 			href={buildRepoURL('blob', 'HEAD', changelog)}
 			style={pageDetect.isEnterprise() ? {padding: '6px 16px'} : {}}
 			role="button"


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Hello 👋 
This PR remove the additional `}` on the tooltip label of the link to the changelog file.

Have a great day ☀️ !

## Test URLs
https://github.com/aws/aws-sdk-php/tags

## Screenshot

<img width="540" alt="image" src="https://github.com/refined-github/refined-github/assets/86676740/d0ad5c45-151e-4a4c-b7f6-b911046d4252">
