### PR TITLE
Only show the options if JS has loaded correctly

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -1,3 +1,7 @@
+#js-failed + form {
+	display: none;
+}
+
 @media not screen and (width: 400px) {
 	/* Excludes Edge */
 	:root {

--- a/source/options.html
+++ b/source/options.html
@@ -4,6 +4,7 @@
 <base target="_blank">
 <title>Refined GitHub options</title>
 <link rel="stylesheet" href="options.css">
+<div id="js-failed">JavaScript failed to load. Your development build failed or your browser has some issue.</div>
 <form id="options-form" class="detail-view-container">
 	<details id="info" open>
 		<summary><strong>👋 Information</strong></summary>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -271,6 +271,9 @@ async function generateDom(): Promise<void> {
 	// Update list from saved options
 	await perDomainOptions.syncForm('form');
 
+	// Only now the form is ready, we can show it
+	select('#js-failed')!.remove();
+
 	// Decorate list
 	moveDisabledFeaturesToTop();
 


### PR DESCRIPTION
Occasionally javascript fails to run correctly in the browser, often in unsupported browsers, but this isn't not immediately clear because we currently show a partially-empty page.

## Before

<img width="400" alt="Screenshot 9" src="https://github.com/refined-github/refined-github/assets/1402241/0e2f830e-0cf7-400e-8b19-9cec95e5a521">

## After

<img width="400" alt="Screenshot 8" src="https://github.com/refined-github/refined-github/assets/1402241/6a71f1e0-5b62-4ea5-abd9-1cf270482c0d">

