### PR TITLE
`previous-version` - Restore feature

### DIFF
--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -38,7 +38,7 @@ async function add(historyButton: HTMLElement): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe('a[aria-label="History"].react-last-commit-history-group', add, {signal});
+	observe('a.react-last-commit-history-group', add, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
## Description
- Closes #6944
- The reason is css selector of `History` button has changed.
  - `aria-label="History"` -> `aria-label="Commit history"`
![image](https://github.com/refined-github/refined-github/assets/50487467/3112f8b4-e380-4655-84e3-ad59532f506b)


## Test URLs
https://github.com/refined-github/refined-github/blob/main/readme.md

## Screenshot
<img width="861" alt="image" src="https://github.com/refined-github/refined-github/assets/50487467/dcb21b12-c971-4fba-9189-d8f97550f3ca">
