### PR TITLE
Restore `one-click-review-submission` feature

### DIFF
--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -9,7 +9,6 @@ import observe from '../helpers/selector-observer.js';
 function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	const form = originalSubmitButton.form!;
 	const actionsRow = originalSubmitButton.closest('.form-actions')!;
-	const formAttribute = originalSubmitButton.getAttribute('form')!;
 
 	// Do not use `select.all` because elements can be outside `form`
 	// `RadioNodeList` is dynamic, so we need to make a copy
@@ -43,18 +42,19 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			classes.push('tooltipped tooltipped-nw tooltipped-no-delay');
 		}
 
+		const label = document.querySelector(`label[for="${radio.id}"]`)?.textContent;
+
 		const button = (
 			<button
 				type="submit"
 				name="pull_request_review[event]"
 				// The buttons are no longer inside the form itself; this links the form
-				form={formAttribute}
 				value={radio.value}
 				className={classes.join(' ')}
 				aria-label={tooltip!}
 				disabled={radio.disabled}
 			>
-				{radio.nextSibling}
+				{label}
 			</button>
 		);
 
@@ -68,9 +68,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	}
 
 	// Remove original fields at last to avoid leaving a broken form
-	for (const radio of radios) {
-		radio.closest('.form-checkbox')!.remove();
-	}
+	radios[0].closest('fieldset')!.remove();
 
 	originalSubmitButton.remove();
 }

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -35,7 +35,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	for (const radio of radios) {
 		const labelNode = radio.labels?.[0];
 
-		// new ?? old. Backwards-compat tooltip content queries. Issue #6963
+		// New ?? old. Backwards-compat tooltip content queries. Issue #6963
 		const tooltip = labelNode?.nextElementSibling?.textContent ?? radio.parentElement!.getAttribute('aria-label');
 
 		const classes = ['btn btn-sm'];
@@ -58,7 +58,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 				aria-label={tooltip!}
 				disabled={radio.disabled}
 			>
-				{/* new ?? old. Backwards-compat label content queries. Issue #6963. */}
+				{/* New ?? old. Backwards-compat label content queries. Issue #6963. */}
 				{labelNode?.textContent ?? radio.nextSibling}
 			</button>
 		);

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -35,8 +35,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	for (const radio of radios) {
 		const labelNode = radio.labels?.[0];
 
-		// New ?? old. Backwards-compat tooltip content queries. Issue #6963
-		const tooltip = labelNode?.nextElementSibling?.textContent ?? radio.parentElement!.getAttribute('aria-label');
+		const tooltip = labelNode?.nextElementSibling?.textContent;
 
 		const classes = ['btn btn-sm'];
 		if (radio.value === 'comment') {
@@ -58,8 +57,8 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 				aria-label={tooltip!}
 				disabled={radio.disabled}
 			>
-				{/* New ?? old. Backwards-compat label content queries. Issue #6963. */}
-				{labelNode?.textContent ?? radio.nextSibling}
+				{/* Old || new. Backwards-compat label content queries. Issue #6963. */}
+				{radio.nextSibling?.textContent?.trim() || labelNode?.textContent}
 			</button>
 		);
 

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -46,6 +46,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			classes.push('tooltipped tooltipped-nw tooltipped-no-delay');
 		}
 
+		const oldLabel = radio.nextSibling?.textContent?.trim();
 		const button = (
 			<button
 				type="submit"
@@ -57,8 +58,8 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 				aria-label={tooltip!}
 				disabled={radio.disabled}
 			>
-				{/* Old || new. Backwards-compat label content queries. Issue #6963. */}
-				{radio.nextSibling?.textContent?.trim() || labelNode?.textContent}
+				{/* Backwards-compat label content queries. Issue #6963. */}
+				{oldLabel ? oldLabel : labelNode?.textContent}
 			</button>
 		);
 

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -31,7 +31,9 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 
 	// Generate the new buttons
 	for (const radio of radios) {
-		const tooltip = radio.parentElement!.getAttribute('aria-label');
+		const labelNode = radio.labels?.[0];
+
+		const tooltip = labelNode?.nextElementSibling?.textContent;
 
 		const classes = ['btn btn-sm'];
 		if (radio.value === 'comment') {
@@ -42,8 +44,6 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			classes.push('tooltipped tooltipped-nw tooltipped-no-delay');
 		}
 
-		const label = document.querySelector(`label[for="${radio.id}"]`)?.textContent;
-
 		const button = (
 			<button
 				type="submit"
@@ -53,7 +53,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 				aria-label={tooltip!}
 				disabled={radio.disabled}
 			>
-				{label}
+				{labelNode?.textContent}
 			</button>
 		);
 

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -48,7 +48,6 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			<button
 				type="submit"
 				name="pull_request_review[event]"
-				// The buttons are no longer inside the form itself; this links the form
 				value={radio.value}
 				className={classes.join(' ')}
 				aria-label={tooltip!}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



Fixes #6963.

GitHub have changed their review submission modal so that it:
- now has the radio buttons properly nested in a form
- the radios' labels are not adjacent siblings anymore

## Test URLs

[This PR??](https://github.com/refined-github/refined-github/pull/6964)

## Screenshot

<img width="706" alt="Capture d’écran 2023-09-27 à 10 21 11 PM" src="https://github.com/refined-github/refined-github/assets/609062/253961a8-3991-41fb-a7b0-05f0fbcb4f04">


https://github.com/refined-github/refined-github/assets/609062/be30dd75-a894-49e4-8023-9d7994165440


### Description tooltips

![image](https://github.com/refined-github/refined-github/assets/609062/f08aecce-fb29-4ae9-a661-37a91e58472b)
![image](https://github.com/refined-github/refined-github/assets/609062/5413beee-e258-4a0a-b7ec-7242643699a3)
![image](https://github.com/refined-github/refined-github/assets/609062/ed3b33bc-c8c8-4291-abed-6e3bcb337b7d)

