### PR TITLE
Add `mention-avatars` feature

### DIFF
--- a/source/features/mention-avatars.css
+++ b/source/features/mention-avatars.css
@@ -1,0 +1,4 @@
+.rgh-mention-avatars {
+	margin-left: -3px;
+	margin-right: 2px !important;
+}

--- a/source/features/mention-avatars.css
+++ b/source/features/mention-avatars.css
@@ -1,4 +1,3 @@
 .rgh-mention-avatars {
-	margin-left: -3px;
-	margin-right: 2px !important;
+	margin-bottom: 2px;
 }

--- a/source/features/mention-avatars.tsx
+++ b/source/features/mention-avatars.tsx
@@ -11,7 +11,7 @@ function addAvatar(link: HTMLElement): void {
 
 	link.prepend(
 		<img
-			className="avatar avatar-user mb-1 mr-1 rgh-mention-avatars"
+			className="avatar avatar-user mr-1 rgh-mention-avatars"
 			src={getUserAvatarURL(username, size)!}
 			width={size}
 			height={size}

--- a/source/features/mention-avatars.tsx
+++ b/source/features/mention-avatars.tsx
@@ -1,0 +1,40 @@
+import './mention-avatars.css';
+import React from 'dom-chef';
+
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
+
+function addAvatar(link: HTMLElement): void {
+	const username = link.textContent!.slice(1);
+	const size = 16;
+
+	link.prepend(
+		<img
+			className="avatar avatar-user mb-1 mr-1 rgh-mention-avatars"
+			src={getUserAvatarURL(username, size)!}
+			width={size}
+			height={size}
+			loading="lazy"
+		/>,
+	);
+}
+
+function init(signal: AbortSignal): void {
+	// Excludes bots
+	observe('.user-mention[data-hovercard-type="user"]', addAvatar, {signal});
+}
+
+void features.add(import.meta.url, {
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/issues/6919
+https://github.com/refined-github/refined-github/releases
+https://github.com/refined-github/refined-github/releases/tag/23.9.21
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -216,3 +216,4 @@ import './features/rgh-dim-commits.js';
 import './features/mobile-tabs.js';
 import './features/repo-header-info.js';
 import './features/rgh-pr-template.js';
+import './features/mention-avatars.js';


### PR DESCRIPTION
Closes #6919 

Adds user avatars before any user mention

## Test URLs

* https://github.com/refined-github/refined-github/issues/6919
* https://github.com/refined-github/refined-github/releases
* https://github.com/refined-github/refined-github/releases/tag/23.9.21

## Screenshot

<details>
<summary>Issue</summary>

![image](https://github.com/refined-github/refined-github/assets/58778985/078416f7-26a7-4cbb-b79a-c7a2bdce0f3f)

</details>

<details>
<summary>Release</summary>

![image](https://github.com/refined-github/refined-github/assets/58778985/a2418ccb-2427-4c2c-a137-acc77f0a6221)

</details>

<details>
<summary>Hovercard</summary>

![image](https://github.com/refined-github/refined-github/assets/58778985/0786b645-b748-4653-b25b-eedb73c6bf35)

</details>
