### PR TITLE
Fix `textContent` types

### DIFF
--- a/source/features/action-pr-link.tsx
+++ b/source/features/action-pr-link.tsx
@@ -11,7 +11,7 @@ function setSearchParameter(anchorElement: HTMLAnchorElement, name: string, valu
 }
 
 async function addForRepositoryActions(prLink: HTMLAnchorElement): Promise<void> {
-	const prNumber = prLink.textContent!.slice(1);
+	const prNumber = prLink.textContent.slice(1);
 
 	const runLink = prLink.closest('.Box-row')!.querySelector('a.Link--primary')!;
 	setSearchParameter(runLink, 'pr', prNumber);

--- a/source/features/archive-forks-link.tsx
+++ b/source/features/archive-forks-link.tsx
@@ -6,7 +6,7 @@ import observe from '../helpers/selector-observer.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 
 function addLinkToBanner(banner: HTMLElement): void {
-	if (banner.lastChild!.textContent!.includes('repository has been archived')) {
+	if (banner.lastChild!.textContent.includes('repository has been archived')) {
 		banner.lastChild!.after(
 			' You can check out ',
 			<a href={buildRepoURL('forks')}>its forks</a>,

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -38,7 +38,7 @@ const hasAnyProjects = new CachedFunction('has-projects', {
 });
 
 function getCount(element: HTMLElement): number {
-	return Number(element.textContent!.trim());
+	return Number(element.textContent.trim());
 }
 
 async function hideMilestones(): Promise<void> {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -15,7 +15,7 @@ async function cleanIssueHeader(byline: HTMLElement): Promise<void> {
 	// Shows on issues: octocat opened this issue on 1 Jan · [1 comments]
 	// Removes on issues: octocat opened this issue on 1 Jan [·] 1 comments
 	const commentCount = select('relative-time', byline)!.nextSibling!;
-	commentCount.replaceWith(<span>{commentCount.textContent!.replace('·', '')}</span>);
+	commentCount.replaceWith(<span>{commentCount.textContent.replace('·', '')}</span>);
 }
 
 async function cleanPrHeader(byline: HTMLElement): Promise<void> {

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -43,7 +43,7 @@ function createReleaseUrl(): string | undefined {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`)!.textContent!;
+	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`)!.textContent;
 	const tagName = await firstTag.get(mergeCommit);
 
 	if (tagName) {

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -4,8 +4,8 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
 function addIndicator(button: HTMLElement): void {
-	const preposition = button.textContent!.includes('Add') ? ' to ' : ' on ';
-	button.textContent! += preposition + 'draft PR';
+	const preposition = button.textContent.includes('Add') ? ' to ' : ' on ';
+	button.textContent += preposition + 'draft PR';
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -14,14 +14,14 @@ function init(): void | false {
 		return; // Don't return false, This feature’s CSS already takes care of this
 	}
 
-	if (!lastBranchAction?.closest('.TimelineItem-body')!.textContent!.includes(' deleted ')) {
+	if (!lastBranchAction?.closest('.TimelineItem-body')!.textContent.includes(' deleted ')) {
 		return false;
 	}
 
-	const deletedBranchName = lastBranchAction.textContent!.trim();
+	const deletedBranchName = lastBranchAction.textContent.trim();
 	const repoRootUrl = headReferenceLink?.href.split('/', 5).join('/');
 	for (const element of select.all('.commit-ref')) {
-		const branchName = element.textContent!.trim();
+		const branchName = element.textContent.trim();
 		if (branchName === deletedBranchName) {
 			element.title = 'This branch has been deleted';
 

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -51,7 +51,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 
 	await showToast(async () => {
 		blameUrl.branch = await getPullRequestBlameCommit(prCommit, prNumbers, blameUrl.filePath);
-		blameUrl.hash = 'L' + select('.js-line-number', blameHunk)!.textContent!;
+		blameUrl.hash = 'L' + select('.js-line-number', blameHunk)!.textContent;
 		location.href = blameUrl.href;
 	}, {
 		message: 'Fetching pull request',

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -36,7 +36,7 @@ function isGist(link: HTMLAnchorElement): boolean {
 	return parseGistLink(link)?.replace(/[^/]/g, '').length === 1; // Exclude user links and file links
 }
 
-const isOnlyChild = (link: HTMLAnchorElement): boolean => link.textContent!.trim() === link.parentNode!.textContent!.trim();
+const isOnlyChild = (link: HTMLAnchorElement): boolean => link.textContent.trim() === link.parentElement!.textContent.trim();
 
 async function embedGist(link: HTMLAnchorElement): Promise<void> {
 	const info = <em> (loading)</em>;

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -20,13 +20,13 @@ function addMergeLink(): void {
 
 		if (lastLinkQuery.includes('is:merged')) {
 			// It's a "Total" link for "is:merged"
-			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent!.replace('Total', 'Merged');
+			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent.replace('Total', 'Merged');
 			continue;
 		}
 
 		if (lastLinkQuery.includes('is:unmerged')) {
 			// It's a "Total" link for "is:unmerged"
-			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent!.replace('Total', 'Unmerged');
+			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent.replace('Total', 'Unmerged');
 			continue;
 		}
 

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -133,7 +133,7 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 
 	setTimeout(() => {
 		// The content of `relative-time` might is not immediately available
-		addTooltip(workflowListItem, `Next run: ${relativeTime.shadowRoot!.textContent!}`);
+		addTooltip(workflowListItem, `Next run: ${relativeTime.shadowRoot!.textContent}`);
 	}, 500);
 }
 

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -44,7 +44,7 @@ function init(): void {
 			continue;
 		}
 
-		if (!isLowQualityComment(commentText.textContent!)) {
+		if (!isLowQualityComment(commentText.textContent)) {
 			continue;
 		}
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -70,7 +70,7 @@ function linkBestComment(bestComment: HTMLElement): void {
 		return;
 	}
 
-	const text = select('.comment-body', bestComment)!.textContent!.slice(0, 100);
+	const text = select('.comment-body', bestComment)!.textContent.slice(0, 100);
 	const {hash} = select('a.js-timestamp', bestComment)!;
 	const avatar = select('img.avatar', bestComment)!.cloneNode();
 

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -24,7 +24,7 @@ async function highlightCollaborators(): Promise<void> {
 	const list = await collaborators.get();
 	await domLoaded;
 	for (const author of select.all('.js-issue-row [data-hovercard-type="user"]')) {
-		if (list.includes(author.textContent!.trim())) {
+		if (list.includes(author.textContent.trim())) {
 			author.classList.add('rgh-collaborator');
 		}
 	}

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -9,7 +9,7 @@ import observe from '../helpers/selector-observer.js';
 function getLinkToGitHubIo(repoTitle: HTMLElement, className?: string): JSX.Element {
 	return (
 		<a
-			href={`https://${repoTitle.textContent!.trim().replace(/com$/, 'io')}`}
+			href={`https://${repoTitle.textContent.trim().replace(/com$/, 'io')}`}
 			className={className}
 		>
 			<LinkIcon className="v-align-middle"/>

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -7,7 +7,7 @@ import {buildRepoURL} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 
 function linkifyQuickPR(element: HTMLElement): void {
-	const branchUrl = buildRepoURL('tree', element.textContent!);
+	const branchUrl = buildRepoURL('tree', element.textContent);
 	element.replaceWith(
 		<span className="commit-ref">
 			<a className="no-underline" href={branchUrl} data-turbo-frame="repo-content-turbo-frame">
@@ -28,7 +28,7 @@ function linkifyHovercard(hovercard: HTMLElement): void {
 
 		const user = reference.querySelector('.user');
 		if (user) {
-			url.user = user.textContent!;
+			url.user = user.textContent;
 		}
 
 		reference.replaceChildren(

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -11,7 +11,7 @@ function linkifyLabel(label: Element): void {
 	const isPR = select.exists('.octicon-git-pull-request', activity);
 	const repository = select('a[data-hovercard-type="repository"]', activity)!;
 	const url = new URL(`${repository.href}/${isPR ? 'pulls' : 'issues'}`);
-	const labelName = label.textContent!.trim();
+	const labelName = label.textContent.trim();
 
 	url.searchParams.set('q', `is:${isPR ? 'pr' : 'issue'} is:open sort:updated-desc label:"${labelName}"`);
 	wrap(label, <a href={url.href}/>);

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -6,7 +6,7 @@ import observe from '../helpers/selector-observer.js';
 
 function linkify(header: HTMLElement): void {
 	header.append(
-		<a className="color-fg-inherit" href={'/' + header.textContent!.trim()}>
+		<a className="color-fg-inherit" href={'/' + header.textContent.trim()}>
 			{header.firstChild}
 		</a>,
 	);

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager.js';
 function init(): void {
 	if (select('.file-mode')?.textContent === 'symbolic link') {
 		const line = select('.js-file-line')!;
-		wrap(line.firstChild!, <a href={line.textContent!} data-turbo-frame="repo-content-turbo-frame"/>);
+		wrap(line.firstChild!, <a href={line.textContent} data-turbo-frame="repo-content-turbo-frame"/>);
 	}
 }
 

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -8,7 +8,7 @@ function addLocation({nextElementSibling, nextSibling}: SVGElement): Element {
 	// `nextSibling` alone might point to an empty TextNode before an element, if there’s an element
 	const userLocation = nextElementSibling ?? nextSibling as Element;
 
-	const locationName = userLocation.textContent!.trim();
+	const locationName = userLocation.textContent.trim();
 	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 
 	userLocation.before(' '); // Keeps the link’s underline from extending out to the icon

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -80,7 +80,7 @@ function attachPRButtons(dropdownIcon: SVGElement): void {
 	const prTitle = select('.pr-toolbar .js-issue-title');
 	if (prTitle && select.exists('.pr-toolbar progress-bar')) { // Only review view has progress-bar
 		prTitle.style.maxWidth = '24em';
-		prTitle.title = prTitle.textContent!;
+		prTitle.title = prTitle.textContent;
 	}
 
 	// Make space for the new button #655

--- a/source/features/one-click-pr-or-gist.tsx
+++ b/source/features/one-click-pr-or-gist.tsx
@@ -15,8 +15,8 @@ function init(): void | false {
 	}
 
 	for (const dropdownItem of select.all('.select-menu-item', initialGroupedButtons)) {
-		let title = select('.select-menu-item-heading', dropdownItem)!.textContent!.trim();
-		const description = select('.description', dropdownItem)!.textContent!.trim();
+		let title = select('.select-menu-item-heading', dropdownItem)!.textContent.trim();
+		const description = select('.description', dropdownItem)!.textContent.trim();
 		const radioButton = select('input[type=radio]', dropdownItem)!;
 		const classList = ['btn', 'ml-2', 'tooltipped', 'tooltipped-s'];
 

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -41,7 +41,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 		const tooltip = parent.querySelector([
 			'p', // TODO: Remove after April 2024
 			'.FormControl-caption',
-		])!.textContent!.trim().replace(/.$/, '');
+		])!.textContent.trim().replace(/.$/, '');
 		assertNodeContent(labelElement, /^(Approve|Request changes|Comment)$/);
 
 		const classes = ['btn btn-sm'];

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -12,12 +12,12 @@ function preview(hiddenCommentHeader: HTMLElement): void {
 	details.classList.add('rgh-preview-hidden-comments'); // Used in CSS
 
 	const comment = select('.comment-body', details)!;
-	const commentText = comment.textContent!.trim();
+	const commentText = comment.textContent.trim();
 	if (commentText.length === 0) {
 		return;
 	}
 
-	const commentHeader = hiddenCommentHeader.textContent!;
+	const commentHeader = hiddenCommentHeader.textContent;
 	if (/disruptive|spam/.test(commentHeader)) {
 		return;
 	}

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -23,7 +23,7 @@ type Participant = {
 function getParticipants(button: HTMLButtonElement): Participant[] {
 	// The list of people who commented is in an adjacent `<tool-tip>` element #5698
 	const users = button.nextElementSibling!
-		.textContent!
+		.textContent
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -34,7 +34,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 
 	const releaseName = container
 		.querySelector('.octicon-tag ~ span')!
-		.textContent!
+		.textContent
 		.trim();
 
 	const assets = await getAssetsForTag(releaseName);

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -89,7 +89,7 @@ async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>):
 		const [originalFileName, newFileName = originalFileName] = menuItem
 			.closest('[data-path]')!
 			.querySelector('.Link--primary')!
-			.textContent!
+			.textContent
 			.split(' → ');
 		await showToast(async progress => discardChanges(progress!, originalFileName, newFileName), {
 			message: 'Loading info…',

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -9,7 +9,7 @@ import {isHasSelectorSupported} from '../helpers/select-has.js';
 const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
 
 function dim(commitTitle: HTMLElement): void {
-	if (excludePreset.test(commitTitle.textContent!.trim())) {
+	if (excludePreset.test(commitTitle.textContent.trim())) {
 		commitTitle.closest('.js-commits-list-item')!.style.opacity = '50%';
 	}
 }

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -9,7 +9,7 @@ import {isAnyRefinedGitHubRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 
 function linkifyFeature(possibleFeature: HTMLElement): void {
-	const id = getNewFeatureName(possibleFeature.textContent!);
+	const id = getNewFeatureName(possibleFeature.textContent);
 	if (!id) {
 		return;
 	}

--- a/source/features/rgh-linkify-yolo-issues.tsx
+++ b/source/features/rgh-linkify-yolo-issues.tsx
@@ -7,7 +7,7 @@ import {createRghIssueLink} from '../helpers/rgh-issue-link.js';
 
 // Linkify with hovercards
 function linkify(issueCell: HTMLElement): void {
-	issueCell.replaceChildren(createRghIssueLink(issueCell.textContent!));
+	issueCell.replaceChildren(createRghIssueLink(issueCell.textContent));
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -18,7 +18,7 @@ async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise
 		const username = element.textContent;
 
 		if (username && username !== myUsername && username !== 'ghost') {
-			usernames.add(element.textContent!);
+			usernames.add(element.textContent);
 		}
 
 		// Drop 'commented' label to shorten the copy
@@ -40,7 +40,7 @@ async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise
 	);
 
 	for (const usernameElement of batchedUsernameElements) {
-		const username = usernameElement.textContent!;
+		const username = usernameElement.textContent;
 		const userKey = api.escapeKey(username);
 
 		// For the currently logged in user, `names[userKey]` would not be present

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer.js';
 import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
 
 function addAvatar(link: HTMLElement): void {
-	const username = link.textContent!;
+	const username = link.textContent;
 	const size = 14;
 
 	link.prepend(
@@ -23,7 +23,7 @@ function addAvatar(link: HTMLElement): void {
 }
 
 function addMentionAvatar(link: HTMLElement): void {
-	const username = link.textContent!.slice(1);
+	const username = link.textContent.slice(1);
 	const size = 16;
 
 	link.prepend(

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -31,7 +31,7 @@ function getReasonElement(subscriptionButton: HTMLButtonElement): HTMLParagraphE
 }
 
 function getCurrentStatus(subscriptionButton: HTMLButtonElement): 'none' | 'all' | 'status' {
-	const reason = getReasonElement(subscriptionButton).textContent!;
+	const reason = getReasonElement(subscriptionButton).textContent;
 
 	// You’re receiving notifications because you chose custom settings for this thread.
 	if (reason.includes('custom settings')) {

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -16,7 +16,7 @@ function init(): void {
 
 	// Compares against the "base" branch if the URL only has one reference
 	if (references.length === 1) {
-		references.unshift(select('.branch span')!.textContent!);
+		references.unshift(select('.branch span')!.textContent);
 	}
 
 	const referencePicker = select('.range-editor .d-inline-block + .range-cross-repo-pair')!;

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -40,7 +40,7 @@ function parseTags(element: HTMLElement): TagDetails {
 	return {
 		element,
 		tag,
-		commit: select('[href*="/commit/"]', element)!.textContent!.trim(),
+		commit: select('[href*="/commit/"]', element)!.textContent.trim(),
 		...parseTag(decodeURIComponent(tag)), // `version`, `namespace`
 	};
 }

--- a/source/features/unwrap-unnecessary-dropdowns.tsx
+++ b/source/features/unwrap-unnecessary-dropdowns.tsx
@@ -23,7 +23,7 @@ async function unwrapNotifications(): Promise<void | false> {
 	}
 
 	const dropdown = forms[0].closest('details')!;
-	const currentView = select('summary i', dropdown)!.nextSibling!.textContent!.trim();
+	const currentView = select('summary i', dropdown)!.nextSibling!.textContent.trim();
 	const desiredForm = currentView === 'Date' ? forms[0] : forms[1];
 
 	// Replace dropdown
@@ -32,7 +32,7 @@ async function unwrapNotifications(): Promise<void | false> {
 	// Fix button’s style
 	const button = select('[type="submit"]', desiredForm)!;
 	button.className = 'btn';
-	button.textContent = `Group by ${button.textContent!.toLowerCase()}`;
+	button.textContent = `Group by ${button.textContent.toLowerCase()}`;
 }
 
 void features.add(import.meta.url, {

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -10,12 +10,12 @@ function interpretNode(node: ChildNode): string | void {
 	switch (node instanceof Element && node.tagName) {
 		case false:
 		case 'A': {
-			return node.textContent!;
+			return node.textContent;
 		}
 
 		case 'CODE': {
 			// Restore backticks that GitHub loses when rendering them
-			return '`' + node.textContent! + '`';
+			return '`' + node.textContent + '`';
 		}
 
 		default:
@@ -26,7 +26,7 @@ function interpretNode(node: ChildNode): string | void {
 function getFirstCommit(): {title: string; body: string | undefined} {
 	const titleParts = select('.js-commits-list-item:first-child p')!.childNodes;
 	const body = select('.js-commits-list-item:first-child .Details-content--hidden pre')
-		?.textContent!.trim() ?? undefined;
+		?.textContent.trim() ?? undefined;
 
 	const title = [...titleParts]
 		.map(node => interpretNode(node))

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -38,7 +38,7 @@ function getStrikeThrough(text: string): HTMLElement {
 
 async function crossIfNonExistent(anchor: HTMLElement): Promise<void> {
 	if (anchor instanceof HTMLAnchorElement && !await isUrlReachable(anchor.href)) {
-		anchor.replaceWith(getStrikeThrough(anchor.textContent!));
+		anchor.replaceWith(getStrikeThrough(anchor.textContent));
 	}
 }
 

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -9,7 +9,7 @@ import {getRepo} from '../github-helpers/index.js';
 async function init(): Promise<false | void> {
 	let defaultBranch;
 	if (select.exists('.is-cross-repo')) {
-		const forkedRepository = getRepo(select('[title^="head: "]')!.textContent!)!;
+		const forkedRepository = getRepo(select('[title^="head: "]')!.textContent)!;
 		defaultBranch = await defaultBranchOfRepo.get(forkedRepository);
 	} else {
 		defaultBranch = await getDefaultBranch();

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -33,7 +33,7 @@ export function linkifyIssues(
 	element: Element,
 	options: Partial<TypeDomOptions> = {},
 ): void {
-	const linkified = linkifyIssuesCore(element.textContent!, {
+	const linkified = linkifyIssuesCore(element.textContent, {
 		user: currentRepo.owner ?? '/',
 		repository: currentRepo.name ?? '/',
 		type: 'dom',
@@ -64,7 +64,7 @@ export function linkifyIssues(
 }
 
 export function linkifyURLs(element: Element): Element[] | void {
-	if (element.textContent!.length < 15) { // Must be long enough for a URL
+	if (element.textContent.length < 15) { // Must be long enough for a URL
 		return;
 	}
 
@@ -72,7 +72,7 @@ export function linkifyURLs(element: Element): Element[] | void {
 		return select.all(linkifiedURLSelector, element);
 	}
 
-	const linkified = linkifyURLsCore(element.textContent!, {
+	const linkified = linkifyURLsCore(element.textContent, {
 		type: 'dom' as const,
 		attributes: {
 			rel: 'noreferrer noopener',
@@ -89,7 +89,7 @@ export function linkifyURLs(element: Element): Element[] | void {
 
 export function parseBackticks(element: Element): void {
 	for (const node of getTextNodes(element)) {
-		const fragment = parseBackticksCore(node.textContent!);
+		const fragment = parseBackticksCore(node.textContent);
 
 		if (fragment.children.length > 0) {
 			node.replaceWith(fragment);

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -133,7 +133,7 @@ export const isUrlReachable = mem(async (url: string): Promise<boolean> => {
 // Don't make the argument optional, sometimes we really expect it to exist and want to throw an error
 export function extractCurrentBranchFromBranchPicker(branchPicker: HTMLElement): string {
 	return branchPicker.title === 'Switch branches or tags'
-		? branchPicker.textContent!.trim() // Branch name is shown in full
+		? branchPicker.textContent.trim() // Branch name is shown in full
 		: branchPicker.title; // Branch name was clipped, so they placed it in the title attribute
 }
 

--- a/source/github-helpers/pr-branches.ts
+++ b/source/github-helpers/pr-branches.ts
@@ -53,7 +53,7 @@ export function parseReferenceRaw(absolute: string, relative: string): PrReferen
 
 function parseReference(referenceElement: HTMLElement): PrReference {
 	const {title, textContent} = referenceElement;
-	return parseReferenceRaw(title, textContent!.trim());
+	return parseReferenceRaw(title, textContent.trim());
 }
 
 export function getBranches(): {base: PrReference; head: PrReference} {

--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -8,8 +8,8 @@ export const FAILURE = Symbol('Failure');
 export const PENDING = Symbol('Pending');
 export type CommitStatus = false | typeof SUCCESS | typeof FAILURE | typeof PENDING;
 
-export function getLastCommitReference(): string | undefined {
-	return select.last(`${prCommit} code`)!.textContent ?? undefined;
+export function getLastCommitReference(): string {
+	return select.last(`${prCommit} code`)!.textContent;
 }
 
 export function getLastCommitStatus(): CommitStatus {

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -13,6 +13,18 @@ interface FeatureMeta {
 	screenshot?: string;
 }
 
+// These types are unnecessarily loose
+// https://dom.spec.whatwg.org/#dom-node-textcontent
+interface ChildNode {
+	textContent: string;
+}
+interface Text {
+	textContent: string;
+}
+interface Element {
+	textContent: string;
+}
+
 interface Window {
 	content: GlobalFetch;
 }

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -93,7 +93,7 @@ export const isTextNodeContaining = (node: Nullable<Text | ChildNode>, expectati
 		throw new TypeError(`Expected Text node, received ${String(node?.nodeName)}`);
 	}
 
-	const content = node.textContent!.trim();
+	const content = node.textContent.trim();
 	return matchString(expectation, content);
 };
 
@@ -103,7 +103,7 @@ export const assertNodeContent = <N extends Text | ChildNode>(node: Nullable<N>,
 	}
 
 	console.warn('Error', node!.parentElement);
-	const content = node!.textContent!.trim();
+	const content = node!.textContent.trim();
 	throw new Error(`Expected node matching ${escapeMatcher(expectation)}, found ${escapeMatcher(content)}`);
 };
 

--- a/source/helpers/loose-parse-int.ts
+++ b/source/helpers/loose-parse-int.ts
@@ -1,10 +1,10 @@
-export default function looseParseInt(text: Node | string | undefined): number {
+export default function looseParseInt(text: ChildNode | string | undefined): number {
 	if (!text) {
 		return 0;
 	}
 
 	if (typeof text !== 'string') {
-		text = text.textContent!;
+		text = text.textContent;
 	}
 
 	return Number(text.replaceAll(/\D+/g, ''));

--- a/source/helpers/show-whitespace-on-line.tsx
+++ b/source/helpers/show-whitespace-on-line.tsx
@@ -7,7 +7,7 @@ export default function showWhiteSpacesOnLine(line: Element, shouldAvoidSurround
 	const textNodesOnThisLine = getTextNodes(line);
 	for (const [nodeIndex, textNode] of textNodesOnThisLine.entries()) {
 		// `textContent` reads must be cached #2737
-		let text = textNode.textContent!;
+		let text = textNode.textContent;
 		if (text.length > 1000) { // #5092
 			continue;
 		}
@@ -47,7 +47,7 @@ export default function showWhiteSpacesOnLine(line: Element, shouldAvoidSurround
 			textNode.splitText(i);
 
 			// Update cached variable here because it just changed
-			text = textNode.textContent!;
+			text = textNode.textContent;
 
 			textNode.after(
 				<span data-rgh-whitespace={thisCharacter === '\t' ? 'tab' : 'space'}>


### PR DESCRIPTION
We've been unnecessarily fighting this type for years. It turns out, every element has `textContent`, even `img`, `meta`, `br`, `input`, etc even comment nodes have it. The only common Node that doesn't is `document`. 