### PR TITLE
Escape `.` in the tooltips of the one-click review radio buttons

### DIFF
--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -41,7 +41,7 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 		const tooltip = parent.querySelector([
 			'p', // TODO: Remove after April 2024
 			'.FormControl-caption',
-		])!.textContent.trim().replace(/.$/, '');
+		])!.textContent.trim().replace(/\.$/, '');
 		assertNodeContent(labelElement, /^(Approve|Request changes|Comment)$/);
 
 		const classes = ['btn btn-sm'];


### PR DESCRIPTION
The regular expression `/.$/` did not escape the `.`. Observe:

<img width="442" alt="image" src="https://github.com/refined-github/refined-github/assets/33201955/ef91b14b-a4a3-4825-9527-47c10714e21e">

Only one of these ends with a `.` What `/.$/` did was transform them all to reduce one character at the end, leading to this:

<img width="348" alt="image" src="https://github.com/refined-github/refined-github/assets/33201955/3654df06-fdd5-4d84-9694-85875fe2ed41">

Whilst this will be right for commenting, it was not right for the rest. Simply escaping the `.` will resolve this issue:

https://github.com/refined-github/refined-github/assets/33201955/81cd80b2-8315-4689-bdc3-e5a8a3ee19ca