### PR TITLE
`small-user-avatars` - Adjust spacing

### DIFF
--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -3,9 +3,9 @@
 	border-radius: 2em;
 	padding: 2px 5px;
 
-    .rgh-small-user-avatars {
-        margin-left: -3px;
-        margin-right: 2px !important;
-    }
+	.rgh-small-user-avatars {
+		margin-left: -3px;
+		margin-right: 2px !important;
+	}
 
 }

--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -7,5 +7,4 @@
 		margin-left: -3px;
 		margin-right: 2px !important;
 	}
-
 }

--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -2,4 +2,10 @@
 	border: 1px solid var(--color-border-default);
 	border-radius: 2em;
 	padding: 2px 5px;
+
+    .rgh-small-user-avatars {
+        margin-left: -3px;
+        margin-right: 2px !important;
+    }
+
 }

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -5,5 +5,5 @@
 }
 
 .user-mention .rgh-small-user-avatars {
-	margin-left: 2px;
+	margin-left: 1px;
 }

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -3,3 +3,7 @@
 	margin-left: -3px;
 	margin-right: 2px !important;
 }
+
+.user-mention .rgh-small-user-avatars {
+	margin-left: 2px;
+}

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -1,9 +1,0 @@
-/* Adjust `highlight-collaborators-and-own-conversations` styles */
-.rgh-collaborator .rgh-small-user-avatars {
-	margin-left: -3px;
-	margin-right: 2px !important;
-}
-
-.user-mention .rgh-small-user-avatars {
-	margin-left: 1px;
-}

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -1,4 +1,3 @@
-import './small-user-avatars.css';
 import React from 'dom-chef';
 
 import onetime from 'onetime';
@@ -29,6 +28,7 @@ function addMentionAvatar(link: HTMLElement): void {
 	link.prepend(
 		<img
 			className="avatar avatar-user mb-1 mr-1 rgh-small-user-avatars"
+			style={{marginLeft: 1}}
 			src={getUserAvatarURL(username, size)!}
 			width={size}
 			height={size}

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -28,7 +28,7 @@ function addMentionAvatar(link: HTMLElement): void {
 
 	link.prepend(
 		<img
-			className="avatar avatar-user mb-1 mr-1 rgh-small-user-avatars"
+			className="avatar avatar-user ml-1 mb-1 mr-1 rgh-small-user-avatars"
 			src={getUserAvatarURL(username, size)!}
 			width={size}
 			height={size}

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -56,7 +56,7 @@ Test URLs:
 
 https://github.com/notifications/subscriptions
 https://github.com/refined-github/refined-github/issues
-https://github.com/refined-github/refined-github/issues/6919
+https://github.com/refined-github/refined-github/pull/7004
 https://github.com/refined-github/refined-github/releases
 https://github.com/refined-github/refined-github/releases/tag/23.9.21
 https://github.com/orgs/community/discussions/5841#discussioncomment-1450320

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -28,7 +28,7 @@ function addMentionAvatar(link: HTMLElement): void {
 
 	link.prepend(
 		<img
-			className="avatar avatar-user ml-1 mb-1 mr-1 rgh-small-user-avatars"
+			className="avatar avatar-user mb-1 mr-1 rgh-small-user-avatars"
 			src={getUserAvatarURL(username, size)!}
 			width={size}
 			height={size}


### PR DESCRIPTION
Fixes #7002 

Adds left margin to user avatars to better match word spacing

## Test URLs

<table><td>
Hello world. @Katsute
<br>
Hello world. Omniscience 
</td></table>

<table><td>
@Katsute
<br>
Ordinary
</td></table>

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/9db81a16-a26a-4df3-85f5-641e78442d0c)
↓
![image](https://github.com/refined-github/refined-github/assets/58778985/19500162-8a56-442b-b23b-742da795cbf3)