### PR TITLE
`linkify-code` - Fix issue links on global search pages

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -29,7 +29,18 @@ function linkifyContent(wrapper: Element): void {
 	// Linkify issue refs in comments, exclude gists:
 	// https://github.com/refined-github/refined-github/pull/3844#issuecomment-751427568
 	if (!pageDetect.isGist()) {
-		const currentRepo = getRepo() ?? {};
+		let currentRepo: {owner?: string; name?: string} | undefined = getRepo();
+
+		if (!currentRepo) { // Code search
+			// Grab repo from line url
+			const lineUrl = wrapper.parentElement!.querySelector('.blob-num a')!.getAttribute('href')!.split('/');
+
+			currentRepo = {
+				owner: lineUrl[1],
+				name: lineUrl[2],
+			};
+		}
+
 		for (const element of select.all('.pl-c', wrapper)) {
 			linkifyIssues(currentRepo, element);
 		}
@@ -63,6 +74,7 @@ void features.add(import.meta.url, {
 
 - Discussions: https://github.com/File-New-Project/EarTrumpet/discussions/877
 - Code Search: https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code
+- Code Search: https://github.com/search?q=org%3Arefined-github+%2F%23%5Cd%2B%2F&type=code
 - Comment: https://github.com/sindresorhus/linkify-urls/pull/40#pullrequestreview-1593302757
 
 */

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -31,10 +31,9 @@ function linkifyContent(wrapper: Element): void {
 	if (!pageDetect.isGist()) {
 		let currentRepo: {owner?: string; name?: string} | undefined = getRepo();
 
-		if (!currentRepo) { // Code search
-			// Grab repo from line url
+		// If unable to get repo from page detect, get repo using line url
+		if (!currentRepo) {
 			const lineUrl = wrapper.parentElement!.querySelector('.blob-num a')!.getAttribute('href')!.split('/');
-
 			currentRepo = {
 				owner: lineUrl[1],
 				name: lineUrl[2],

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -67,7 +67,7 @@ void features.add(import.meta.url, {
 
 - Discussions: https://github.com/File-New-Project/EarTrumpet/discussions/877
 - Code Search: https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code
-- Code Search: https://github.com/search?q=org%3Arefined-github+%2F%23%5Cd%2B%2F&type=code
+- Code Search: https://github.com/search?q=%2F%23%5Cd%7B4%2C%7D%2F+language%3Atypescript&type=code
 - Comment: https://github.com/sindresorhus/linkify-urls/pull/40#pullrequestreview-1593302757
 
 */

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -29,15 +29,16 @@ function linkifyContent(wrapper: Element): void {
 	// Linkify issue refs in comments, exclude gists:
 	// https://github.com/refined-github/refined-github/pull/3844#issuecomment-751427568
 	if (!pageDetect.isGist()) {
-		let currentRepo: {owner?: string; name?: string} | undefined = getRepo();
+		let currentRepo;
 
-		// If unable to get repo from page detect, get repo using line url
-		if (!currentRepo) {
+		if (pageDetect.isGlobalSearchResults()) {
 			const lineUrl = wrapper.parentElement!.querySelector('.blob-num a')!.getAttribute('href')!.split('/');
 			currentRepo = {
 				owner: lineUrl[1],
 				name: lineUrl[2],
 			};
+		} else {
+			currentRepo = getRepo() || {};
 		}
 
 		for (const element of select.all('.pl-c', wrapper)) {

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -38,7 +38,7 @@ function linkifyContent(wrapper: Element): void {
 				name: lineUrl[2],
 			};
 		} else {
-			currentRepo = getRepo() || {};
+			currentRepo = getRepo() ?? {};
 		}
 
 		for (const element of select.all('.pl-c', wrapper)) {

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -30,6 +30,7 @@ function linkifyContent(wrapper: Element): void {
 	}
 
 	const currentRepo = pageDetect.isGlobalSearchResults()
+		// Look for the link on the line number
 		? getRepo(wrapper.parentElement!.querySelector('.blob-num a')!.href)
 		: getRepo();
 	// Some non-repo pages like gists have issue references #3844


### PR DESCRIPTION
Fixes #6996

Retrieves the repository using the line url when getRepo doesn't work

![image](https://github.com/refined-github/refined-github/assets/58778985/10ae1c00-bcf0-4327-b57f-6992c25c2cfa)

`/notion-enhancer/notion-repackaged/blob/4eefa99dc1bcde18268d70bb2b7f050786229feb/scripts/extract-src.sh#L50`

↑ pull repo from this

## Test URLs

https://github.com/search?q=repo%3Anotion-enhancer%2Fnotion-repackaged%20sqlite&type=code

https://github.com/search?q=org%3Arefined-github+%2F%23%5Cd%2B%2F&type=code

https://github.com/search?q=%2F%23%5Cd%7B4%2C%7D%2F+language%3Atypescript&type=code

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/ad334034-00fb-46b5-936a-e147fd9598bb)

---

![image](https://github.com/refined-github/refined-github/assets/58778985/2aeea320-9a77-4ec3-bb32-b7ff92daabd5)

