### PR TITLE
`one-click-review-submission` - Fix selector

### DIFF
--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -9,7 +9,7 @@ import {assertNodeContent} from '../helpers/dom-utils.js';
 
 function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	const form = originalSubmitButton.form!;
-	const actionsRow = originalSubmitButton.closest('.form-actions')!;
+	const actionsRow = originalSubmitButton.parentElement!;
 	const formAttribute = originalSubmitButton.getAttribute('form')!;
 
 	// Do not use `$$` because elements can be outside `form`


### PR DESCRIPTION
Fixes #7010 

- changed the selector to use `.parentElement` instead of `.closest('.form-actions')` since it looks like there's no `.form-actions` anymore


## Test URLs

Any open PR URLs where you have access to review the changes

e.g. https://github.com/refined-github/refined-github/pull/7005

## Screenshot

<img width="664" alt="image" src="https://github.com/refined-github/refined-github/assets/8295888/7a9aa50f-93f8-4247-a6a8-c0bf9eb6794e">

with tooltip
<img width="666" alt="image" src="https://github.com/refined-github/refined-github/assets/8295888/0bfc0251-df48-44c4-a721-22d69c14671b">
