### PR TITLE
`clean-rich-text-editor` - Restore feature

### DIFF
--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -1,8 +1,20 @@
 /* Hide unnecessary comment toolbar items, but only on desktop #5743 */
 /* Kinda excludes "soft keyboards" devices https://github.com/w3c/csswg-drafts/issues/3871 */
+/* TODO: Drop selectors other than [data-md-button] in June 2024 */
 @media (hover: hover) and (pointer: fine) {
 	[rgh-clean-rich-text-editor]
-		:is(md-mention, md-ref, md-header, md-bold, md-italic):not(:focus) {
+		:is(
+			[data-md-button='mention'],
+			md-mention,
+			[data-md-button='ref'],
+			md-ref,
+			[data-md-button='header-3'],
+			md-header,
+			[data-md-button='bold'],
+			md-bold,
+			[data-md-button='italic'],
+			md-italic
+		):not(:focus) {
 		/* Like GitHub’s `show-on-focus` class. Needed because we target `md-ref` with the observer in `table-input` and `collapsible-content-button` */
 		position: absolute;
 		width: 1px;


### PR DESCRIPTION
- Fixes #7013 


## Test URLs

Here

## Before

<img width="693" alt="Screenshot 11" src="https://github.com/refined-github/refined-github/assets/1402241/f8ffb5d5-1013-44ac-bd79-6e360b0b4332">

## After

<img width="693" alt="Screenshot 12" src="https://github.com/refined-github/refined-github/assets/1402241/dd2949ad-70bb-4074-abed-56f28fe48423">

