### PR TITLE
`close-as-planned` - Fix "close with comment" bug

### DIFF
--- a/source/features/close-as-unplanned.tsx
+++ b/source/features/close-as-unplanned.tsx
@@ -27,6 +27,8 @@ function update(dropdown: HTMLElement): void {
 	unplannedButton.append(icon);
 	unplannedButton.id = id;
 	unplannedButton.classList.add('btn', 'tooltipped', 'tooltipped-nw', 'mr-0');
+	// Prevent content from being changed #7024
+	unplannedButton.classList.remove('js-comment-and-button');
 	unplannedButton.setAttribute('aria-label', 'Close as not planned.\nWon’t fix, can’t repro, duplicate, stale');
 
 	dropdown.replaceWith(unplannedButton);


### PR DESCRIPTION
Fix #7024

The `.js-comment-and-button` class is only for changing the text (see https://github.githubassets.com/assets/app/assets/modules/github/behaviors/commenting/close.ts), so our button doesn't need it.

## Test URLs

#7024

## Screenshot

[Kooha-2023-11-02-03-09-33.webm](https://github.com/refined-github/refined-github/assets/44045911/588cc07b-29e5-4f6f-bc26-1d98026a02ee)
