### PR TITLE
`releases-tab`: Hide dropdown item when there are no releases

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -3,6 +3,7 @@ import {CachedFunction} from 'webext-storage-cache';
 import {TagIcon} from '@primer/octicons-react';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
+import {$} from 'select-dom';
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
@@ -69,7 +70,15 @@ async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | v
 	triggerRepoNavOverflow();
 }
 
-function addReleasesDropdownItem(dropdownMenu: HTMLElement): void {
+async function addReleasesDropdownItem(dropdownMenu: HTMLElement): Promise<false | void> {
+	const repo = getRepo()!.nameWithOwner;
+	const count = await releasesCount.get(repo);
+
+	if (count === 0) {
+		$('.dropdown-divider', dropdownMenu)?.remove();
+		return false;
+	}
+
 	appendBefore(
 		dropdownMenu,
 		'.dropdown-divider', // Won't exist if `more-dropdown` is disabled


### PR DESCRIPTION
## Test URLs

close: #7001 

## Screenshot

after:
![image](https://github.com/refined-github/refined-github/assets/82451257/4b147db1-48ab-4e7a-b0ad-30cc9a3eadc2)
