### PR TITLE
`releases-tab`: Add support for tags-only repos

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -91,7 +91,7 @@ function addExistingTagLinkFooter(tagName: string, tagUrl: string): void {
 }
 
 async function addReleaseBanner(text = 'Now you can release this change'): Promise<void> {
-	const [releases] = await getReleases()
+	const [releases] = await getReleases();
 	if (releases === 0) {
 		return;
 	}

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -12,7 +12,7 @@ import TimelineItem from '../github-helpers/timeline-item.js';
 import attachElement from '../helpers/attach-element.js';
 import {canEditEveryComment} from './quick-comment-edit.js';
 import {buildRepoURL, getRepo, isRefinedGitHubRepo} from '../github-helpers/index.js';
-import {releasesCount} from './releases-tab.js';
+import {getReleases} from './releases-tab.js';
 import observe from '../helpers/selector-observer.js';
 
 // TODO: Not an exact match; Moderators can edit comments but not create releases
@@ -91,7 +91,8 @@ function addExistingTagLinkFooter(tagName: string, tagUrl: string): void {
 }
 
 async function addReleaseBanner(text = 'Now you can release this change'): Promise<void> {
-	if (await releasesCount.get(getRepo()!.nameWithOwner) === 0) {
+	const [releases] = await getReleases()
+	if (releases === 0) {
 		return;
 	}
 

--- a/source/features/releases-tab.gql
+++ b/source/features/releases-tab.gql
@@ -3,5 +3,8 @@ query GetReleasesCount($owner: String!, $name: String!) {
 		releases {
 			totalCount
 		}
+		tags: refs(refPrefix: "refs/tags/") {
+			totalCount
+		}
 	}
 }

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -19,7 +19,7 @@ function detachHighlightFromCodeTab(codeTab: HTMLAnchorElement): void {
 	codeTab.dataset.selectedLinks = codeTab.dataset.selectedLinks!.replace('repo_releases ', '');
 }
 
-export async function getReleases(): Promise<[0] | [number, "Tags" | "Releases"]> {
+export async function getReleases(): Promise<[0] | [number, 'Tags' | 'Releases']> {
 	const repo = getRepo()!.nameWithOwner;
 	return releasesCount.get(repo);
 }


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6517


## Test URLs

Releases: https://github.com/refined-github/refined-github
Tags: https://github.com/python/cpython

## Screenshot

<img width="946" alt="Screenshot 5" src="https://github.com/refined-github/refined-github/assets/1402241/ae4fdc54-730a-446f-b20a-6947cdee2348">
