### PR TITLE
`pr-jump-to-first-non-viewed-file` - Restore feature in all PRs

### DIFF
--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -6,8 +6,8 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 
 function jumpToFirstNonViewed(): void {
-	const firstNonViewedFile = $('.file:not([data-file-user-viewed])')!;
-	if (firstNonViewedFile) {
+	const firstNonViewedFile = $('.file[data-details-container-group="file"]:not([data-file-user-viewed])')!;
+	if (firstNonViewedFile && firstNonViewedFile.id) {
 		// Scroll to file without pushing to history
 		location.replace('#' + firstNonViewedFile.id);
 	} else {

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -6,8 +6,8 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 
 function jumpToFirstNonViewed(): void {
-	const firstNonViewedFile = $('.file[data-details-container-group="file"]:not([data-file-user-viewed])')!;
-	if (firstNonViewedFile?.id) {
+	const firstNonViewedFile = $('[id][data-details-container-group="file"]:not([data-file-user-viewed])')!;
+	if (firstNonViewedFile) {
 		// Scroll to file without pushing to history
 		location.replace('#' + firstNonViewedFile.id);
 	} else {

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -33,7 +33,6 @@ void features.add(import.meta.url, {
 	init,
 });
 
-
 /*
 
 Test URLs:

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -7,7 +7,7 @@ import features from '../feature-manager.js';
 
 function jumpToFirstNonViewed(): void {
 	const firstNonViewedFile = $('.file[data-details-container-group="file"]:not([data-file-user-viewed])')!;
-	if (firstNonViewedFile && firstNonViewedFile.id) {
+	if (firstNonViewedFile?.id) {
 		// Scroll to file without pushing to history
 		location.replace('#' + firstNonViewedFile.id);
 	} else {

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -32,3 +32,13 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+
+/*
+
+Test URLs:
+
+PR: https://github.com/refined-github/sandbox/pull/55/files
+Large PR https://github.com/pixiebrix/pixiebrix-extension/pull/6808/files
+
+*/


### PR DESCRIPTION
## Description
This PR fixes the issue with the `pr-jump-to-first-non-viewed-file` feature by adapting the selector and tighten the check a bit by not only checking against the `firstNonViewedFile` value but also its `id`.
Fixes #7030


## Test URLs
https://github.com/pixiebrix/pixiebrix-extension/pull/6808/files

