### PR TITLE
`clean-repo-sidebar` - Hide empty deployments

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -36,6 +36,15 @@ async function hideEmptyPackages(): Promise<void> {
 	}
 }
 
+async function hideEmptyDeployments(): Promise<void> {
+	await domLoaded;
+
+	const deployments = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/deployments"]', {waitForChildren: false})!;
+	if (deployments?.parentElement.parentElement.querySelector('ul').children.length === 0) {
+		deployments.closest('.BorderGrid-row')!.hidden = true;
+	}
+}
+
 async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
@@ -77,6 +86,7 @@ void features.add(import.meta.url, {
 		init,
 		cleanReleases,
 		hideEmptyPackages,
+		hideEmptyDeployments,
 		hideLanguageHeader,
 		hideEmptyMeta,
 		moveReportLink,
@@ -88,5 +98,6 @@ void features.add(import.meta.url, {
 Test URLs:
 
 https://github.com/refined-github/refined-github
+https://github.com/kidonng/sushi
 
 */

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -40,7 +40,7 @@ async function hideEmptyDeployments(): Promise<void> {
 	await domLoaded;
 
 	const deployments = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/deployments"]', {waitForChildren: false})!;
-	if (deployments?.parentElement.parentElement.querySelector('ul').children.length === 0) {
+	if (deployments && deployments.parentElement!.parentElement!.querySelector('ul')!.children.length === 0) {
 		deployments.closest('.BorderGrid-row')!.hidden = true;
 	}
 }
@@ -68,8 +68,10 @@ async function moveReportLink(): Promise<void> {
 
 	const reportLink = $('.Layout-sidebar a[href^="/contact/report-content"]')?.parentElement;
 	if (reportLink) {
-		// Your own repos don't include this link
-		$('.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell')!.append(reportLink);
+		setTimeout(() => { // Wait for other hide init methods to run first before checking which is not hidden
+			// Your own repos don't include this link
+			$('.Layout-sidebar .BorderGrid-row:nth-last-child(1 of :not([hidden])) .BorderGrid-cell')!.append(reportLink);
+		}, 100);
 	}
 }
 


### PR DESCRIPTION
* Closes #6359 
* Also: fixes reports link attaching themselves to sidebar elements that were hidden

## Test URLs

https://github.com/kidonng/sushi

## Screenshot

|before|after|
|---|---|
|![image](https://github.com/refined-github/refined-github/assets/58778985/1108bce0-5cad-4d1f-bebd-d7a770431a24)|![image](https://github.com/refined-github/refined-github/assets/58778985/465e41ff-339b-4712-9d98-fa491fdac10e)|