### PR TITLE
`bugs-tab` - Support the labels `triage:bug` and `triage/bug`

### DIFF
--- a/source/github-helpers/bugs-label.test.ts
+++ b/source/github-helpers/bugs-label.test.ts
@@ -11,6 +11,8 @@ type/bug
 type:bug
 kind/bug
 kind:bug
+triage/bug
+triage:bug
 :bug:bug
 :bug: bug
 🐛bug

--- a/source/github-helpers/bugs-label.ts
+++ b/source/github-helpers/bugs-label.ts
@@ -1,4 +1,4 @@
-const supportedLabels = /^(bug|bug-?fix|confirmed-bug|type[:/]bug|kind[:/]bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(bug|bug-?fix|confirmed-bug|(type|kind|triage)[:/]bug|(:[\w-]+:|\p{Emoji})bug)$/iu;
 export default function isBugLabel(label: string): boolean {
 	return supportedLabels.test(label.replaceAll(/\s/g, ''));
 }


### PR DESCRIPTION
Fixes #6882.


## Test URLs

https://github.com/crim-ca/weaver