### PR TITLE
`one-click-review-submission` - Fix "Abandon review" position

### DIFF
--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -9,10 +9,9 @@ import {assertNodeContent} from '../helpers/dom-utils.js';
 
 function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 	const form = originalSubmitButton.form!;
-	const actionsRow = originalSubmitButton.closest([
-		'.form-actions', // TODO: For GHE. Remove after June 2024
-		'.Overlay-footer',
-	])!;
+	const actionsRow = originalSubmitButton.closest('.Overlay-footer');
+	// TODO: For GHE. Remove after June 2024
+	const legacyActionsRow = originalSubmitButton.closest('.form-actions')!;
 	const formAttribute = originalSubmitButton.getAttribute('form')!;
 
 	// Do not use `$$` because elements can be outside `form`
@@ -32,6 +31,11 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 				value="comment"
 			/>,
 		);
+	}
+
+	if (actionsRow) {
+		actionsRow.prepend(<span className="spacer.gif ml-auto"/>);
+		radios.reverse();
 	}
 
 	// Generate the new buttons
@@ -74,7 +78,11 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			button.prepend(<FileDiffIcon className="color-fg-danger"/>);
 		}
 
-		actionsRow.append(button);
+		if (actionsRow) {
+			actionsRow.prepend(button);
+		} else {
+			legacyActionsRow.append(button);
+		}
 	}
 
 	// Remove original fields at last to avoid leaving a broken form


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7043


## Test URLs

https://github.com/refined-github/refined-github/pull/7056/files

## Base (unaffected)

<img width="500" alt="Screenshot 1" src="https://github.com/refined-github/refined-github/assets/1402241/c0edabce-a39d-412a-8b0f-da4adb63c34a">

##  Pending comment

<img width="500" alt="Screenshot 2" src="https://github.com/refined-github/refined-github/assets/1402241/6897add4-e784-488f-8387-a05d88a098d9">

## Pending comment + abandon

<img width="500" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/604dfafa-9b62-457e-891a-48d772e17cfb">

## Pending comment + abandon + all buttons enabled 

<img width="500" alt="Screenshot 3" src="https://github.com/refined-github/refined-github/assets/1402241/fa5e049d-c521-4826-b7db-289d3e492aab">
