### PR TITLE
Move "Toggle all features" into the "Identify feature" section

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -55,6 +55,18 @@
 		<p>
 			<button id="find-feature">Start process to identify feature…</button>
 		</p>
+
+		<p>Related debugging tools:</p>
+		<p>
+			<button id="toggle-all-features">Toggle all features…</button>
+		</p>
+		<p class="toggle-all-features" hidden>
+			If you're trying to identify a feature, please use "Identify feature" instead. Refined GitHub only implements lightweight features that are helpful to most people, even if they're tiny improvements. They're meant to "blend in" and fill in the gaps of GitHub's interface. If you want to go through and only select a few improvements, you'll miss out on the best parts of Refined GitHub. Also note that new features will still be enabled by default and that some CSS-only refinements cannot be disabled.
+		</p>
+		<p class="toggle-all-features" hidden>
+			<button id="disable-all-features">Disable all features</button>
+			<button id="enable-all-features">Enable all features</button>
+		</p>
 	</details>
 
 	<details id="css">
@@ -92,17 +104,6 @@
 		<p>
 			<button id="clear-cache">Clear cache</button>
 		</p>
-		<p>
-			<button id="toggle-all-features">Toggle all features?</button>
-		</p>
-		<p class="toggle-all-features" hidden>
-			If you're trying to identify a feature, please use the "Identify feature" section instead. Refined GitHub only implements lightweight features that are helpful to most people, even if they're tiny improvements. They're meant to "blend in" and fill in the gaps of GitHub's interface. If you want to go through and only select a few improvements, you'll miss out on the best parts of Refined GitHub. Also note that new features will still be enabled by default and that some CSS-only refinements cannot be disabled.
-		</p>
-		<p class="toggle-all-features" hidden>
-			<button id="disable-all-features">Disable all features</button>
-			<button id="enable-all-features">Enable all features</button>
-		</p>
-
 	</details>
 
 	<details id="hotfixes">


### PR DESCRIPTION
I wasn't a fan of how the button invited every debugger to toggle all features

<img width="546" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/6b5c8def-8512-40e5-b45a-4318ef8313f6">

So I moved it into the section that the follow-up paragraph invites the user to use:

<img width="546" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/68b50d83-dfd4-4e7e-95ba-8247fbce425b">
