### PR TITLE
Fix: Some features show information from the wrong/previous repository visited

### DIFF
--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -237,7 +237,7 @@ export const v4 = mem(v4uncached, {
 		// https://github.com/refined-github/refined-github/issues/5821
 		// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1864
 		const key = [query, options];
-		if (query.includes('repository() {')) {
+		if (query.includes('repository() {') || query.includes('owner: $owner, name: $name')) {
 			key.push(getRepo()?.nameWithOwner);
 		}
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/6988


## Testing

Look for `repo-header-info`

1. Clear cache
2. Open this in a new tab https://github.com/sindresorhus/p-retry/releases/tag/v6.1.0
3. Click "separate package"


## Demo


https://github.com/refined-github/refined-github/assets/1402241/e31d9b26-a514-4a80-81a6-f4e4857bbd8f

