### PR TITLE
`default-branch-button` - Don't show on the default branch

### DIFF
--- a/source/github-helpers/is-default-branch.ts
+++ b/source/github-helpers/is-default-branch.ts
@@ -24,5 +24,5 @@ export default async function isDefaultBranch(): Promise<boolean> {
 	// defaultBranch === 'a/b' && currentBranch === 'a'
 	const path = parts.join('/');
 	const defaultBranch = await getDefaultBranch();
-	return path === defaultBranch || defaultBranch.startsWith(`${path}/`);
+	return path === defaultBranch || path.startsWith(`${defaultBranch}/`);
 }


### PR DESCRIPTION
I noticed this while debugging https://github.com/refined-github/refined-github/issues/6988#issuecomment-1801165960

This affects 3 features but they're not as visible as `default-branch-button`


## Test URLs

https://github.com/sindresorhus/is-network-error/tree/main/.github/workflows


## Before

<img width="440" alt="Screenshot 8" src="https://github.com/refined-github/refined-github/assets/1402241/44973491-1cbb-4c8f-82e4-71be0b281298">

## After

<img width="440" alt="Screenshot 7" src="https://github.com/refined-github/refined-github/assets/1402241/d441479b-6bdc-4711-837a-5a5ec27acdbd">

