### PR TITLE
`locked-issue` - Disable on GitHub Enterprise

### DIFF
--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -41,6 +41,10 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
 	],
+	exclude: [
+		// https://github.com/refined-github/refined-github/issues/7063
+		pageDetect.isEnterprise,
+	],
 	init,
 });
 


### PR DESCRIPTION
- Closes #7063 

