### PR TITLE
`vertical-front-matter` - Fix flickering/loss of the feature on content rehydration

### DIFF
--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -2,27 +2,18 @@ import './vertical-front-matter.css';
 import React from 'dom-chef';
 import {$$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import elementReady from 'element-ready';
 
 import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
 
 // https://github.com/github/markup/blob/cd01f9ec87c86ce5a7c70188a74ef40fc4669c5b/lib/github/markup/markdown.rb#L34
 const hasFrontMatter = (): boolean => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee)$/.test(location.pathname);
 
-async function init(): Promise<false | void> {
-	const table = await elementReady('.markdown-body > table:first-child');
-	if (!table) {
-		return false;
-	}
-
-	const headers = $$(':scope > thead th', table);
-	if (headers.length <= 4) {
-		return false;
-	}
-
+function transpose(table: HTMLElement): void {
 	const rows = $$(':scope > tbody > tr', table);
-	if (rows.length !== 1 || headers.length !== rows[0].childElementCount) {
-		return false;
+	const headers = $$(':scope > thead th', table);
+	if (headers.length <= 4 || rows.length !== 1 || headers.length !== rows[0].childElementCount) {
+		return;
 	}
 
 	const values = [...rows[0].children];
@@ -40,10 +31,13 @@ async function init(): Promise<false | void> {
 	);
 }
 
+function init(signal: AbortSignal): void {
+	observe('.markdown-body > table:first-child', transpose, {signal});
+}
+
 void features.add(import.meta.url, {
 	include: [
 		hasFrontMatter,
 	],
-	deduplicate: '.rgh-vertical-front-matter-table',
 	init,
 });

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -41,3 +41,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/github/docs/blob/114de99a/content/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github.md
+
+*/


### PR DESCRIPTION
- Close https://github.com/refined-github/refined-github/issues/6865

It seems that the issue was caused by GitHub reloading/rehydrating the content.

Using the new observer also somewhat improves the feature, however this is still an issue:


- https://github.com/refined-github/refined-github/issues/6554


## Test URLs

https://github.com/github/docs/blob/main/content/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github.md?rgh-link-date=2023-09-01T21%3A37%3A35Z


## Screenshot

<img width="1051" alt="Screenshot 4" src="https://github.com/refined-github/refined-github/assets/1402241/4eaf808b-e3b1-4bbb-9e97-7074e189ce01">


