### PR TITLE
`quick-mention` - Fix "locked issue" detection

### DIFF
--- a/source/features/quick-mention.css
+++ b/source/features/quick-mention.css
@@ -18,6 +18,7 @@ button.rgh-quick-mention:not(:hover, :focus) {
 }
 
 /* Conversation is locked. Hide the elements here because the feature runs before DOM ready. */
-body:has(.js-pick-reaction:first-child) .rgh-quick-mention {
+/* Locked conversations still have a comment field open to collaborators */
+body:not(:has(.js-comment-field)) .rgh-quick-mention {
 	display: none;
 }

--- a/source/features/quick-mention.css
+++ b/source/features/quick-mention.css
@@ -1,9 +1,9 @@
 /* Show button when the avatar or the button itself are hovered/focused */
-:not(:hover, :focus) + button.rgh-quick-mention:not(:hover, :focus) {
+:not(:hover, :focus) + .rgh-quick-mention:not(:hover, :focus) {
 	opacity: 10%;
 }
 
-button.rgh-quick-mention {
+.rgh-quick-mention {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -13,7 +13,7 @@ button.rgh-quick-mention {
 }
 
 /* Show icon in black if it's not hovered/focused, instead of the blue color caused by .btn-link */
-button.rgh-quick-mention:not(:hover, :focus) {
+.rgh-quick-mention:not(:hover, :focus) {
 	color: inherit;
 }
 

--- a/source/features/quick-mention.css
+++ b/source/features/quick-mention.css
@@ -16,9 +16,3 @@
 .rgh-quick-mention:not(:hover, :focus) {
 	color: inherit;
 }
-
-/* Conversation is locked. Hide the elements here because the feature runs before DOM ready. */
-/* Locked conversations still have a comment field open to collaborators */
-body:not(:has(.js-comment-field)) .rgh-quick-mention {
-	display: none;
-}

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -11,6 +11,8 @@ import features from '../feature-manager.js';
 import {getUsername, isArchivedRepoAsync} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 
+const fieldSelector = 'textarea#new_comment_field';
+
 function prefixUserMention(userMention: string): string {
 	// The alt may or may not have it #4859
 	return '@' + userMention.replace('@', '').replace(/\[bot]$/, '');
@@ -18,7 +20,7 @@ function prefixUserMention(userMention: string): string {
 
 function mentionUser({delegateTarget: button}: DelegateEvent): void {
 	const userMention = button.parentElement!.querySelector('img')!.alt;
-	const newComment = $('textarea#new_comment_field')!;
+	const newComment = $(fieldSelector)!;
 	newComment.focus();
 
 	// If the new comment field has selected text, don’t replace it
@@ -90,7 +92,9 @@ async function init(signal: AbortSignal): Promise<void> {
 	// `:first-child` avoids app badges #2630
 	// The hovercard attribute avoids `highest-rated-comment`
 	// Avatars next to review events aren't wrapped in a <div> #4844
+	// :has(fieldSelector) enables the feature only when/after the "mention" button can actually work
 	observe(`
+		body:has(${fieldSelector})
 		:is(
 			div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child,
 			a.TimelineItem-avatar

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -10,6 +10,7 @@ import {wrap} from '../helpers/dom-utils.js';
 import features from '../feature-manager.js';
 import {getUsername, isArchivedRepoAsync} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 const fieldSelector = 'textarea#new_comment_field';
 
@@ -94,7 +95,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	// Avatars next to review events aren't wrapped in a <div> #4844
 	// :has(fieldSelector) enables the feature only when/after the "mention" button can actually work
 	observe(`
-		body:has(${fieldSelector})
+		${isHasSelectorSupported() ? `body:has(${fieldSelector})` : ''}
 		:is(
 			div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child,
 			a.TimelineItem-avatar

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -69,7 +69,6 @@ function add(avatar: HTMLElement): void {
 	}
 
 	const userMention = $('img', avatar)!.alt;
-	avatar.classList.add('rgh-quick-mention');
 	avatar.after(
 		<button
 			type="button"


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/7070
- Bug exacerbated by #7054 


## Test URLs

### Locked issue, I can comment

https://github.com/refined-github/refined-github/issues/1469

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img width="430" alt="Screenshot 1" src="https://github.com/refined-github/refined-github/assets/1402241/d609a893-10dd-431b-a539-587255db9a48">
 <td><img width="430" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/941484c3-915f-4511-92a7-927cb2f55fbd">
</table>


### Regular PR, logged out

https://github.com/refined-github/refined-github/pull/7069


<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img width="239" alt="Screenshot 2" src="https://github.com/refined-github/refined-github/assets/1402241/a651fe3d-0343-4d37-8888-835b1b16de51">
 <td><img width="239" alt="Screenshot 3" src="https://github.com/refined-github/refined-github/assets/1402241/a6b90fa2-4686-486a-802b-08c44ceca08a">
</table>







