### PR TITLE
`locked-issue` - Disable on logged out users due to false positives

### DIFF
--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -30,8 +30,9 @@ function addStickyLock(element: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	// If reactions-menu exists, then .js-pick-reaction is the second child
-	observe(':has(.js-pick-reaction:first-child) .gh-header-meta > :first-child', addLock, {signal});
-	observe(':has(.js-pick-reaction:first-child) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
+	// Logged out users never have the menu, so they should be excluded
+	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-meta > :first-child', addLock, {signal});
+	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -42,6 +43,7 @@ void features.add(import.meta.url, {
 		pageDetect.isConversation,
 	],
 	exclude: [
+		// TODO: Find alternative detection that works even for GHE that don't have reactions enabled
 		// https://github.com/refined-github/refined-github/issues/7063
 		pageDetect.isEnterprise,
 	],


### PR DESCRIPTION
Every issue is marked as locked when logged out because logged out users cannot react.

cc @Katsute we might need an improved logic in the future, also considering:

- #7063 


## Test URLs

1. Log out
2. Visit any conversation, like https://github.com/refined-github/refined-github/pull/7051


## Before

<img width="366" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/5d301273-42b0-413c-bc09-7cc3e1422f96">


## After

<img width="366" alt="Screenshot 4" src="https://github.com/refined-github/refined-github/assets/1402241/5fe8a184-21d9-455f-b2aa-6b21523aa74b">

