### PR TITLE
`locked-issue` - Remove after unlocking issue

### DIFF
--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,3 +1,3 @@
 :has(.js-pick-reaction:not(:first-child)) .rgh-locked-issue {
-	display: none;
+	display: none !important;
 }

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -46,6 +46,8 @@ void features.add(import.meta.url, {
 		// TODO: Find alternative detection that works even for GHE that don't have reactions enabled
 		// https://github.com/refined-github/refined-github/issues/7063
 		pageDetect.isEnterprise,
+		// Does not work for archived repos
+		pageDetect.isArchivedRepo,
 	],
 	init,
 });

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -9,7 +9,7 @@ import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 function LockedIndicator(): JSX.Element {
 	return (
-		<span title="Locked" className="State d-flex flex-items-center">
+		<span title="Locked" className="State d-flex flex-items-center flex-shrink-0">
 			<LockIcon className="flex-items-center mr-1"/>
 			Locked
 		</span>
@@ -18,13 +18,13 @@ function LockedIndicator(): JSX.Element {
 
 function addLock(element: HTMLElement): void {
 	element.after(
-		<LockedIndicator className="flex-shrink-0 mb-2 flex-self-start flex-md-self-center rgh-locked-issue"/>,
+		<LockedIndicator className="mb-2 rgh-locked-issue"/>,
 	);
 }
 
 function addStickyLock(element: HTMLElement): void {
 	element.after(
-		<LockedIndicator className="mr-2 mb-2 flex-shrink-0 rgh-locked-issue"/>,
+		<LockedIndicator className="mr-2 mb-2 rgh-locked-issue"/>,
 	);
 }
 

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -46,8 +46,6 @@ void features.add(import.meta.url, {
 		// TODO: Find alternative detection that works even for GHE that don't have reactions enabled
 		// https://github.com/refined-github/refined-github/issues/7063
 		pageDetect.isEnterprise,
-		// Does not work for archived repos
-		pageDetect.isArchivedRepo,
 	],
 	init,
 });


### PR DESCRIPTION
Resolves a bug that was introduced in https://github.com/refined-github/refined-github/pull/7051/commits/ce78ed0e096ec86c321c8a7e5f4e5996551f7f40 ; commit inadvertently put `d-flex` and `rgh-locked-issue` in the same element causing this css issue.

The css used to re-hide the lock state on update was not active because `d-flex` was taking precedence.

![flex](https://github.com/refined-github/refined-github/assets/58778985/29100e97-7d66-4ea4-bd0d-9e9e39efe51f)

## Test URLs

Test requires looking at an issue as it is being unlocked

https://github.com/refined-github/sandbox/issues/74

## Screenshot

`display: none` now takes precedence

![none](https://github.com/refined-github/refined-github/assets/58778985/ea23347d-f29e-4565-9d51-5bde524a2436)
