### PR TITLE
New feature to create a copy of an issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,8 @@ Thanks for contributing! 🦋🙌
 - [](# "jump-to-conversation-close-event") [Adds a link to jump to the latest close event of a conversation.](https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif)
 - [](# "close-as-unplanned") [Lets you "close issue as unplanned" in one click instead of three.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png)
 - [](# "locked-issue") [Show a label on locked issues and PRs.](https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png)
+- [](# "copy-issue") Adds option to make a copy of an issue.
+
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/copy-issue.tsx
+++ b/source/features/copy-issue.tsx
@@ -1,0 +1,75 @@
+import React from 'dom-chef';
+import {$} from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import observe from '../helpers/selector-observer.js';
+
+function getPathDetails(pathname = location.pathname): {ownerName: string; repoName: string; issueNumber: string} {
+	const [, ownerName, repoName, , issueNumber] = pathname.split('/');
+	return {ownerName, repoName, issueNumber};
+}
+
+type GitHubIssue = {
+	title: string;
+	body: string;
+	labels: Array<{name: string}>;
+	assignees: Array<{login: string}>;
+	milestone: {number: number} | undefined;
+};
+
+function addDropdownLink(menu: HTMLElement): void {
+	$('.show-more-popover', menu.parentElement!)!.append(
+		<div className="dropdown-divider"/>,
+		<a
+			href="#"
+			className="dropdown-item btn-link rgh-copy-issue"
+			role="menuitem"
+			title="Create a new issue from this one"
+			target="_blank"
+			rel="noreferrer" onClick={async event => {
+				event.preventDefault();
+				const {ownerName, repoName, issueNumber} = getPathDetails();
+				const issue = await api.v3(`issues/${issueNumber}`) as unknown as GitHubIssue;
+
+				// Set the href to the creation url of the current issue
+				// See: https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query
+				const parameters = new URLSearchParams({
+					title: `Copy of: ${issue.title}`,
+					body: issue.body,
+					labels: issue.labels.map(label => label.name).join(','),
+					assignees: issue.assignees.map(assignee => assignee.login).join(','),
+					milestone: issue.milestone?.number.toString() ?? '',
+				});
+				const creationUrl = new URL(`https://${location.hostname}/${ownerName}/${repoName}/issues/new?${parameters.toString()}`);
+
+				window.open(creationUrl, '_blank');
+			}}
+		>
+			Copy this issue
+		</a>,
+	);
+}
+
+function init(signal: AbortSignal): void {
+	observe('.timeline-comment-actions > details:last-child', menu => {
+		addDropdownLink(menu);
+	}, {signal});
+}
+
+void features.add(import.meta.url, {
+	asLongAs: [
+		pageDetect.isIssue,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/internetarchive/openlibrary/issues/8544
+https://github.com/metabase/metabase/issues/35858
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -216,3 +216,4 @@ import './features/repo-header-info.js';
 import './features/rgh-pr-template.js';
 import './features/close-as-unplanned.js';
 import './features/locked-issue.js';
+import './features/copy-issue.js';


### PR DESCRIPTION
Closes #7080 . Adds a new feature to create a copy of an existing issue.

## Test URLs

https://github.com/internetarchive/openlibrary/issues/8544

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/6251786/6add2c86-8769-4ba6-85fe-6dad69599253)
Which then copies over the title, body, labels, assignees, milestones, and sends you to here:
![image](https://github.com/refined-github/refined-github/assets/6251786/b9171288-6322-4b4c-8e54-82bf46fc82eb)
to save your new issue.