### PR TITLE
`tags-on-commits-list` - Support new commit list style

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -296,7 +296,7 @@ Thanks for contributing! 🦋🙌
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif)
 - [](# "hide-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
 - [](# "suggest-commit-title-limit") [Suggests limiting commit titles to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
-- [](# "tags-on-commits-list") [Displays the corresponding tags next to commits.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261457544-eb22c570-b295-4e02-a41a-969a11763873.png)
+- [](# "tags-on-commits-list") [Displays the corresponding tags next to commits.](https://user-images.githubusercontent.com/1402241/285106537-3c882cb2-6847-4098-9e51-cf2951dee818.png)
 - [](# "mark-merge-commits-in-list") [Marks merge commits in commit lists.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261457100-07ed6fd2-1d47-453a-aced-9578179f53d6.png)
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png)
 - [](# "new-or-deleted-file") [Indicates with an icon whether files in commits and pull requests are being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -37,7 +37,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 export function getCommitHash(commit: HTMLElement): string {
 	return $([
 		'a.markdown-title',
-		'.markdown-title a'
+		'.markdown-title a',
 	], commit)!.pathname.split('/').pop()!;
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -35,11 +35,10 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 };
 
 export function getCommitHash(commit: HTMLElement): string {
-	return $('a.markdown-title', commit)!.pathname.split('/').pop()!;
-}
-
-export function getFeatureCommitHash(commit: HTMLElement): string {
-	return $('.markdown-title a', commit)!.pathname.split('/').pop()!;
+	return $([
+		'a.markdown-title',
+		'.markdown-title a'
+	], commit)!.pathname.split('/').pop()!;
 }
 
 async function init(): Promise<void> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -34,11 +34,15 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	return mergeCommits;
 };
 
-export function getCommitHash(commit: HTMLElement): string {
+function getCommitLink(commit: HTMLElement): HTMLAnchorElement | undefined {
 	return $([
-		'a.markdown-title',
+		'a.markdown-title', // Old view style (before November 2023)
 		'.markdown-title a',
-	], commit)!.pathname.split('/').pop()!;
+	], commit);
+}
+
+export function getCommitHash(commit: HTMLElement): string {
+	return getCommitLink(commit)!.pathname.split('/').pop()!;
 }
 
 async function init(): Promise<void> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -38,6 +38,10 @@ export function getCommitHash(commit: HTMLElement): string {
 	return $('a.markdown-title', commit)!.pathname.split('/').pop()!;
 }
 
+export function getFeatureCommitHash(commit: HTMLElement): string {
+	return $('.markdown-title a', commit)!.pathname.split('/').pop()!;
+}
+
 async function init(): Promise<void> {
 	const pageCommits = $$([
 		'.js-commits-list-item', // `isCommitList`

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -88,6 +88,7 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 async function init(): Promise<void | false> {
 	const cacheKey = `tags:${getRepo()!.nameWithOwner}`;
 
+	// TODO: Drop in June 2024
 	let isLegacy = false;
 	let commitsOnPage = $$('.listviewitem');
 

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {getCommitHash, getFeatureCommitHash} from './mark-merge-commits-in-list.js';
+import {getCommitHash} from './mark-merge-commits-in-list.js';
 import {buildRepoURL, getRepo} from '../github-helpers/index.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
 
@@ -97,11 +97,11 @@ async function init(): Promise<void | false> {
 		commitsOnPage = $$('.js-commits-list-item');
 	}
 
-	const lastCommitOnPage = isLegacy ? getCommitHash(commitsOnPage.at(-1)!) : getFeatureCommitHash(commitsOnPage.at(-1)!);
+	const lastCommitOnPage = getCommitHash(commitsOnPage.at(-1)!);
 	let cached = await cache.get<Record<string, string[]>>(cacheKey) ?? {};
 	const commitsWithNoTags = [];
 	for (const commit of commitsOnPage) {
-		const targetCommit = isLegacy ? getCommitHash(commit) : getFeatureCommitHash(commit);
+		const targetCommit = getCommitHash(commit);
 		let targetTags = cached[targetCommit];
 
 		if (!targetTags) {

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -128,8 +128,9 @@ async function init(): Promise<void | false> {
 					{...targetTags.map(tag => (
 						<>
 							{' '}
+							{/* .markdown-title enables the background color */}
 							<a
-								className="Link--muted"
+								className="Link--muted markdown-title"
 								href={buildRepoURL('releases/tag', tag)}
 							>
 								<code>{tag}</code>

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {getCommitHash} from './mark-merge-commits-in-list.js';
+import {getCommitHash, getFeatureCommitHash} from './mark-merge-commits-in-list.js';
 import {buildRepoURL, getRepo} from '../github-helpers/index.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
 
@@ -88,13 +88,21 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 async function init(): Promise<void | false> {
 	const cacheKey = `tags:${getRepo()!.nameWithOwner}`;
 
-	const commitsOnPage = $$('.js-commits-list-item');
-	const lastCommitOnPage = getCommitHash(commitsOnPage.at(-1)!);
+	let isLegacy = false;
+	let commitsOnPage = $$('.listviewitem');
+
+	if (commitsOnPage.length === 0) {
+		isLegacy = true;
+		commitsOnPage = $$('.js-commits-list-item');
+	}
+
+	const lastCommitOnPage = isLegacy ? getCommitHash(commitsOnPage.at(-1)!) : getFeatureCommitHash(commitsOnPage.at(-1)!);
 	let cached = await cache.get<Record<string, string[]>>(cacheKey) ?? {};
 	const commitsWithNoTags = [];
 	for (const commit of commitsOnPage) {
-		const targetCommit = getCommitHash(commit);
+		const targetCommit = isLegacy ? getCommitHash(commit) : getFeatureCommitHash(commit);
 		let targetTags = cached[targetCommit];
+
 		if (!targetTags) {
 			// No tags for this commit found in the cache, check in github
 			cached = mergeTags(cached, await getTags(lastCommitOnPage)); // eslint-disable-line no-await-in-loop
@@ -105,10 +113,16 @@ async function init(): Promise<void | false> {
 			// There was no tags for this commit, save that info to the cache
 			commitsWithNoTags.push(targetCommit);
 		} else if (targetTags.length > 0) {
-			const commitMeta = $('.flex-auto .d-flex.mt-1', commit)!;
-			commitMeta.classList.add('flex-wrap');
+			let commitMeta;
+			if (isLegacy) {
+				commitMeta = $('.flex-auto .d-flex.mt-1', commit)!;
+				commitMeta.classList.add('flex-wrap');
+			} else {
+				commitMeta = $('div[data-testid="listview-item-description"]', commit)!;
+			}
+
 			commitMeta.append(
-				<span>
+				<span className={isLegacy ? '' : 'd-flex flex-items-center gap-1'}>
 					<TagIcon className="ml-1"/>
 					{...targetTags.map(tag => (
 						<>


### PR DESCRIPTION
close: #7045 

## Test URLs

https://github.com/refined-github/refined-github/commits/19.5.21.1921

## Screenshot

before:

![image](https://github.com/refined-github/refined-github/assets/82451257/63abb645-1ccd-47a4-82ba-29067fdf10f3)

after:

![image](https://github.com/refined-github/refined-github/assets/82451257/99290a85-ed42-4076-a8f8-97cb814d7a34)
