### PR TITLE
`select-notifications` - Add filter for "Anything other than issues and PRs"

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -13,22 +13,26 @@ import {
 	GitPullRequestDraftIcon,
 	GitPullRequestIcon,
 	IssueOpenedIcon,
+	SquirrelIcon,
 	XCircleIcon,
 } from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
+const prIcons = ':is(.octicon-git-pull-request, .octicon-git-pull-request-closed, .octicon-git-pull-request-draft, .octicon-git-merge)';
+const issueIcons = ':is(.octicon-issue-opened, .octicon-issue-closed)';
 const filters = {
-	'Pull requests': ':is(.octicon-git-pull-request, .octicon-git-pull-request-closed, .octicon-git-pull-request-draft, .octicon-git-merge)',
-	Issues: ':is(.octicon-issue-opened, .octicon-issue-closed)',
+	'Pull requests': prIcons,
+	Issues: issueIcons,
+	Others: `.octicon:not(${prIcons}, ${issueIcons})`,
 	Open: ':is(.octicon-issue-opened, .octicon-git-pull-request)',
 	Closed: ':is(.octicon-issue-closed, .octicon-git-pull-request-closed, .octicon-skip)',
 	Draft: '.octicon-git-pull-request-draft',
 	Merged: '.octicon-git-merge',
 	Read: '.notification-read',
 	Unread: '.notification-unread',
-};
+} as const;
 
 type Filter = keyof typeof filters;
 type Category = 'Type' | 'Status' | 'Read';
@@ -85,6 +89,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 		'Pull requests': <GitPullRequestIcon className="color-fg-muted"/>,
 		Issues: <IssueOpenedIcon className="color-fg-muted"/>,
 		Open: <CheckCircleIcon className="color-fg-success"/>,
+		Others: <SquirrelIcon className="color-fg-muted"/>,
 		Closed: <XCircleIcon className="color-fg-danger"/>,
 		Draft: <GitPullRequestDraftIcon className="color-fg-subtle"/>,
 		Merged: <GitMergeIcon className="color-fg-done"/>,
@@ -142,7 +147,7 @@ const createDropdown = onetime(() => (
 		>
 			<div className="SelectMenu-modal">
 				<form id="rgh-select-notifications-form">
-					{createDropdownList('Type', ['Pull requests', 'Issues'])}
+					{createDropdownList('Type', ['Pull requests', 'Issues', 'Others'])}
 					{createDropdownList('Status', ['Open', 'Closed', 'Merged', 'Draft'])}
 					{createDropdownList('Read', ['Read', 'Unread'])}
 				</form>

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -21,11 +21,12 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
 const prIcons = ':is(.octicon-git-pull-request, .octicon-git-pull-request-closed, .octicon-git-pull-request-draft, .octicon-git-merge)';
-const issueIcons = ':is(.octicon-issue-opened, .octicon-issue-closed)';
+const issueIcons = ':is(.octicon-issue-opened, .octicon-issue-closed, .octicon-skip)';
 const filters = {
 	'Pull requests': prIcons,
 	Issues: issueIcons,
-	Others: `.octicon:not(${prIcons}, ${issueIcons})`,
+	// This selector is a bit too loose, so it needs to be be scoped to the smallest possible element and exclude the bookmark icon
+	Others: `.notification-list-item-link .octicon:not(${prIcons}, ${issueIcons}, .octicon-bookmark)`,
 	Open: ':is(.octicon-issue-opened, .octicon-git-pull-request)',
 	Closed: ':is(.octicon-issue-closed, .octicon-git-pull-request-closed, .octicon-skip)',
 	Draft: '.octicon-git-pull-request-draft',

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -183,3 +183,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/notifications
+
+*/


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6980

I think "others" includes

- new tags
- comments on commits
- discussions
- deployments
- cancelled actions, if notifications are active
- dependabot alerts?


## Test URLs

https://github.com/notifications

## Screenshot

![gif2](https://github.com/refined-github/refined-github/assets/1402241/10d4dc6c-3f13-4309-acd5-f6685e1e3789)

