### PR TITLE
`mark-merge-commits-in-list` - Avoid duplicating icon

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -3,11 +3,11 @@ import React from 'dom-chef';
 import {$, $$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
+import {FeedMergedIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import {isHasSelectorSupported} from '../helpers/select-has.js';
-import {FeedMergedIcon} from '@primer/octicons-react';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -3,7 +3,7 @@ import React from 'dom-chef';
 import {$, $$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
-import {FeedMergedIcon} from '@primer/octicons-react';
+import {GitMergeIcon} from '@primer/octicons-react';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -46,6 +46,7 @@ export function getCommitHash(commit: HTMLElement): string {
 }
 
 async function init(): Promise<void> {
+	const isPRConversation = pageDetect.isPRConversation();
 	const pageCommits = $$([
 		'.listviewitem',
 
@@ -62,7 +63,12 @@ async function init(): Promise<void> {
 	for (const commit of pageCommits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');
-			getCommitLink(commit)!.before(<FeedMergedIcon/>);
+			if (isPRConversation) {
+				// Align icon to the line; rem used to match the native units
+				$('.octicon-git-commit', commit)!.replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);
+			} else {
+				getCommitLink(commit)!.before(<GitMergeIcon className="mr-1"/>);
+			}
 		}
 	}
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,13 +1,13 @@
 import './mark-merge-commits-in-list.css';
 import React from 'dom-chef';
 import {$, $$} from 'select-dom';
-import {GitMergeIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import {isHasSelectorSupported} from '../helpers/select-has.js';
+import {FeedMergedIcon} from '@primer/octicons-react';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`
@@ -52,7 +52,7 @@ async function init(): Promise<void> {
 	for (const commit of pageCommits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');
-			$('a.markdown-title', commit)!.before(<GitMergeIcon className="mr-1"/>);
+			$('.octicon-git-commit', commit)!.replaceWith(<FeedMergedIcon/>);
 		}
 	}
 }


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/6852


## Test URLs



- isPRConversation: https://github.com/refined-github/refined-github/pull/6194
- isCommitList (untouched): https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174


## Native

<img width="448" alt="Screenshot 10" src="https://github.com/refined-github/refined-github/assets/1402241/70683307-0689-4546-8d28-bf04b198415f">


## Before

<img width="448" alt="Screenshot 9" src="https://github.com/refined-github/refined-github/assets/1402241/85f32ddd-9810-4f6a-8f9d-d93636b9099a">

## `feed-merged`

I think it gives it too much weigh


<img width="448" alt="Screenshot 6" src="https://github.com/refined-github/refined-github/assets/1402241/eb37cf2f-3ea7-497f-a353-a4b01aa1d55d">

## No icon

Can't do it because GitHub does that when the commit is just a reference from elsewhere.  See https://github.com/refined-github/refined-github/pull/3015

## Replaced icon

<img width="448" alt="Screenshot 7" src="https://github.com/refined-github/refined-github/assets/1402241/1b351076-20cd-4715-ac89-526f75a04586">


## Aligned icon (final)

<img width="448" alt="Screenshot 8" src="https://github.com/refined-github/refined-github/assets/1402241/87cfcb86-faeb-4b45-8642-6061ec36fb9e">

