### PR TITLE
`visit-tag` - New feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ Thanks for contributing! 🦋🙌
 - [](# "action-pr-link") 🔥 [Adds a link back to the PR that ran the workflow.](https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png)
 - [](# "mobile-tabs") [Makes the tabs more compact on mobile so more of them can be seen.](https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png)
 - [](# "repo-header-info") [Shows whether a repo is a fork and adds the number of stars to its header.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png)
+- [](# "visit-tag") [When navigating a repo's file on a specific tag, it adds a link to see the release/tag itself.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ArrowUpRightIcon} from '@primer/octicons-react';
+import {ArrowUpRightIcon, CodeIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import {branchSelector} from '../github-helpers/selectors.js';
@@ -30,6 +30,15 @@ async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
 	);
 }
 
+function replaceIcon(tagIcon: SVGElement): void {
+	// https://github.com/refined-github/refined-github/issues/6499#issuecomment-1505256426
+	tagIcon.replaceWith(<CodeIcon/>);
+}
+
+function clarifyIcon(signal: AbortSignal): void {
+	observe('.Link[href*="/tree/"] svg.octicon-tag', replaceIcon, {signal});
+}
+
 function init(signal: AbortSignal): void {
 	observe(branchSelector, addLink, {signal});
 }
@@ -40,6 +49,11 @@ void features.add(import.meta.url, {
 		pageDetect.isSingleFile,
 	],
 	init,
+}, {
+	include: [
+		pageDetect.isReleasesOrTags,
+	],
+	init: clarifyIcon,
 });
 
 /*
@@ -47,5 +61,11 @@ void features.add(import.meta.url, {
 Test URLs:
 
 - https://github.com/refined-github/refined-github/tree/23.11.15
+- https://github.com/refined-github/refined-github/blob/23.4.10/.editorconfig
+
+Second part:
+
+- https://github.com/refined-github/refined-github/releases
+- https://github.com/refined-github/refined-github/releases/tag/23.11.15
 
 */

--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -7,9 +7,10 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {wrapAll} from '../helpers/dom-utils.js';
 import {buildRepoURL} from '../github-helpers/index.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
-	const tag = branchSelector.getAttribute('aria-label');
+	const tag = branchSelector.getAttribute('aria-label')?.replace(/ tag$/, '');
 	if (!tag) {
 		features.log.error(import.meta.url, 'Tag not found in DOM. The feature needs to be updated');
 		return;
@@ -20,7 +21,7 @@ async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
 			branchSelector,
 			<a
 				className="btn px-2 tooltipped tooltipped-se"
-				href={buildRepoURL('releases/tag/', tag)}
+				href={buildRepoURL('releases/tag', tag)}
 				aria-label="Visit tag"
 			>
 				<ArrowUpRightIcon className="v-align-middle"/>
@@ -40,10 +41,13 @@ function clarifyIcon(signal: AbortSignal): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe(branchSelector, addLink, {signal});
+	observe(`:is(${branchSelector}):has(.octicon-tag)`, addLink, {signal});
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isHasSelectorSupported,
+	],
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile,

--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {ArrowUpRightIcon} from '@primer/octicons-react';
+import * as pageDetect from 'github-url-detection';
+
+import {branchSelector} from '../github-helpers/selectors.js';
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+import {wrapAll} from '../helpers/dom-utils.js';
+import {buildRepoURL} from '../github-helpers/index.js';
+
+async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
+	const tag = branchSelector.getAttribute('aria-label');
+	if (!tag) {
+		features.log.error(import.meta.url, 'Tag not found in DOM. The feature needs to be updated');
+		return;
+	}
+
+	wrapAll(
+		[
+			branchSelector,
+			<a
+				className="btn px-2 tooltipped tooltipped-se"
+				href={buildRepoURL('releases/tag/', tag)}
+				aria-label="Visit tag"
+			>
+				<ArrowUpRightIcon className="v-align-middle"/>
+			</a>,
+		],
+		<div className="d-flex gap-2"/>,
+	);
+}
+
+function init(signal: AbortSignal): void {
+	observe(branchSelector, addLink, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepoTree,
+		pageDetect.isSingleFile,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+- https://github.com/refined-github/refined-github/tree/23.11.15
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -216,3 +216,4 @@ import './features/repo-header-info.js';
 import './features/rgh-pr-template.js';
 import './features/close-as-unplanned.js';
 import './features/locked-issue.js';
+import './features/visit-tag.js';


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6499


## Test URLs


### Core feature

- https://github.com/refined-github/refined-github/tree/23.11.15
- https://github.com/refined-github/refined-github/blob/23.4.10/.editorconfig

<img width="278" alt="Screenshot 14" src="https://github.com/refined-github/refined-github/assets/1402241/e5f4fa0a-3f48-49ef-9b87-2fd6f183c923">

### Second part

- https://github.com/refined-github/refined-github/releases
- https://github.com/refined-github/refined-github/releases/tag/23.11.15

<img width="192" alt="Screenshot 16" src="https://github.com/refined-github/refined-github/assets/1402241/22c864bd-8982-4eb5-9ad3-ea690d0609e6">

## Demo

![gif2](https://github.com/refined-github/refined-github/assets/1402241/5df35b6a-385a-48f2-a600-cdbf16f6e2c4)
