### PR TITLE
`default-branch-button` - Fix mistaken display on commits list

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -71,6 +71,7 @@ Test URLs:
 - isRepoTree https://github.com/refined-github/refined-github/tree/07ecc75
 - isSingleFile, 410 Gone from default branch https://github.com/refined-github/refined-github/blob/07ecc75/extension/content.js
 - isRepoCommitList: https://github.com/refined-github/refined-github/commits/07ecc75/
+- isRepoCommitList (already on default branch): https://github.com/typed-ember/ember-cli-typescript/commits/master
 - isRepoCommitListRoot (no branchs selector): https://github.com/refined-github/refined-github/commits/07ecc75/extension
 
 */

--- a/source/github-helpers/is-default-branch.ts
+++ b/source/github-helpers/is-default-branch.ts
@@ -15,7 +15,7 @@ export default async function isDefaultBranch(): Promise<boolean> {
 		return true;
 	}
 
-	if (type !== 'tree' && type !== 'blob') {
+	if (!['tree', 'blob', 'commits'].includes(type)) {
 		// Like /user/repo/pulls
 		return false;
 	}


### PR DESCRIPTION



## Test URLs

https://github.com/typed-ember/ember-cli-typescript/commits/master

## Before

<img width="273" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/ed553648-6e57-49f1-aea8-8e7bcfada342">

## After

<img width="273" alt="Screenshot 4" src="https://github.com/refined-github/refined-github/assets/1402241/c8c60e79-7c9e-4c41-83d4-8dfb9dcb3e7c">



