### PR TITLE
`mark-merge-commits-in-list` - Use selector-observer

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -47,9 +47,8 @@ export function getCommitHash(commit: HTMLElement): string {
 	return getCommitLink(commit)!.pathname.split('/').pop()!;
 }
 
-
 function updateCommitIcon(commit: HTMLElement): void {
- 	const isPRConversation = pageDetect.isPRConversation();
+	const isPRConversation = pageDetect.isPRConversation();
 	if (isPRConversation) {
 		// Align icon to the line; rem used to match the native units
 		$('.octicon-git-commit', commit)!.replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -47,9 +47,8 @@ export function getCommitHash(commit: HTMLElement): string {
 	return getCommitLink(commit)!.pathname.split('/').pop()!;
 }
 
-function updateCommitIcon(commit: HTMLElement): void {
-	const isPRConversation = pageDetect.isPRConversation();
-	if (isPRConversation) {
+function updateCommitIcon(commit: HTMLElement, replace: boolean): void {
+	if (replace) {
 		// Align icon to the line; rem used to match the native units
 		$('.octicon-git-commit', commit)!.replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);
 	} else {
@@ -58,21 +57,23 @@ function updateCommitIcon(commit: HTMLElement): void {
 }
 
 async function markCommits(commits: HTMLElement[]): Promise<void> {
+	const isPRConversation = pageDetect.isPRConversation();
 	const mergeCommits = await filterMergeCommits(commits.map(commit => getCommitHash(commit)));
 	for (const commit of commits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');
-			updateCommitIcon(commit);
+			updateCommitIcon(commit, isPRConversation);
 		}
 	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.listviewitem',
+		'.listviewitem',// `isCommitList`
+
 		// Old view style (before November 2023)
 		'.js-commits-list-item', // `isCommitList`
-		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`, "js-timeline-item" to exclude "isCommitList"
+		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`; "js-timeline-item" excludes "isCommitList"
 	], batchedFunction(markCommits, {delay: 100}), {signal});
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -86,7 +86,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 		pageDetect.isCompare,
 	],
-	deduplicate: 'has-rgh-inner',
 	init,
 });
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -47,9 +47,9 @@ export function getCommitHash(commit: HTMLElement): string {
 	return getCommitLink(commit)!.pathname.split('/').pop()!;
 }
 
-const isPRConversation = pageDetect.isPRConversation();
 
 function updateCommitIcon(commit: HTMLElement): void {
+ 	const isPRConversation = pageDetect.isPRConversation();
 	if (isPRConversation) {
 		// Align icon to the line; rem used to match the native units
 		$('.octicon-git-commit', commit)!.replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -69,7 +69,7 @@ async function markCommits(commits: HTMLElement[]): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.listviewitem',// `isCommitList`
+		'.listviewitem', // `isCommitList`
 
 		// Old view style (before November 2023)
 		'.js-commits-list-item', // `isCommitList`


### PR DESCRIPTION
Use `observe` and `batchedFunction`

## Test URLs

- isCommitList: [typed-ember/ember-cli-typescript@master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174 (commits)](https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174)

## Screenshot
new view:
![image](https://github.com/refined-github/refined-github/assets/82451257/95931f94-e3ba-4b8b-a33a-5f19d883626f)

old view:
![image](https://github.com/refined-github/refined-github/assets/82451257/6c834749-9e2c-46dc-9440-d29b2a2364d6)