### PR TITLE
`conflict-marker` - Include all PRs

### DIFF
--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -45,7 +45,7 @@ async function addIcon(links: HTMLAnchorElement[]): Promise<void> {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.js-issue-row:has(.octicon-git-pull-request.color-fg-open) a.js-navigation-open', batchedFunction(addIcon, {delay: 100}), {signal});
+	observe('.js-issue-row a.js-navigation-open[data-hovercard-type="pull_request"]', batchedFunction(addIcon, {delay: 100}), {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
## Description
- Closes #7078 
- Make `conflict-marker` adds icon not only opened PRs but also closed and draft PRs.
- This behavior has been since December 2019 😂 
  - https://github.com/refined-github/refined-github/pull/2587/files#diff-b7f6a4223f761c2163c47dcf6dfec8493df764355a832e8a4910eebdccb250b4R43

## Test URLs
- https://github.com/refined-github/sandbox/issues?q=conflict+sort%3Aupdated-desc

## Screenshot
![image](https://github.com/refined-github/refined-github/assets/50487467/adc3a4c5-3950-4baa-8251-1436e2aac193)
