### PR TITLE
`locked-issue` - Restore on GitHub Enterprise

### DIFF
--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,3 +1,9 @@
-:has(.js-pick-reaction:not(:first-child)) .rgh-locked-issue {
+:is(
+		:has(.js-lock-issue [action$='/lock']),
+		body:not(:has(.js-lock-issue)):has(
+				#new_comment_form .js-previewable-comment-form
+			)
+	)
+	.rgh-locked-issue {
 	display: none !important;
 }

--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,9 +1,0 @@
-:is(
-		:has(.js-lock-issue [action$='/lock']),
-		body:not(:has(.js-lock-issue)):has(
-				#new_comment_form .js-previewable-comment-form
-			)
-	)
-	.rgh-locked-issue {
-	display: none !important;
-}

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -29,10 +29,10 @@ function addStickyLock(element: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	// If reactions-menu exists, then .js-pick-reaction is the second child
+	// Locked when unlock option is available for collaborators or comment form is locked
 	// Logged out users never have the menu, so they should be excluded
-	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-meta > :first-child', addLock, {signal});
-	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
+	observe('.logged-in:has(.js-lock-issue [action$="/unlock"], #new_comment_form .blankslate) .gh-header-meta > :first-child', addLock, {signal});
+	observe('.logged-in:has(.js-lock-issue [action$="/unlock"], #new_comment_form .blankslate) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -41,11 +41,6 @@ void features.add(import.meta.url, {
 	],
 	include: [
 		pageDetect.isConversation,
-	],
-	exclude: [
-		// TODO: Find alternative detection that works even for GHE that don't have reactions enabled
-		// https://github.com/refined-github/refined-github/issues/7063
-		pageDetect.isEnterprise,
 	],
 	init,
 });

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -18,7 +18,7 @@ function LockedIndicator(): JSX.Element {
 
 function processTimeline(): void {
 	// Gather lock related events and sort by event ID
-	const events: HTMLElement[] = $$('.js-discussion .TimelineItem:has(.octicon-key, .octicon-lock)').sort((a, b) => a.id.localeCompare(b.id));
+	const events: HTMLElement[] = $$('.js-discussion .TimelineItem:has(.octicon-key, .octicon-lock)').sort((a, b) => b.id.localeCompare(a.id));
 	// If most recent lock change event is locked
 	if (elementExists('.octicon-lock', events[0])) {
 		$('.gh-header-meta:not(:has(.rgh-locked-issue)) > :first-child')?.after(

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -1,5 +1,5 @@
-import './locked-issue.css';
 import React from 'react';
+import {$, $$} from 'select-dom';
 import {LockIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
@@ -16,23 +16,25 @@ function LockedIndicator(): JSX.Element {
 	);
 }
 
-function addLock(element: HTMLElement): void {
-	element.after(
-		<LockedIndicator className="mb-2 rgh-locked-issue"/>,
-	);
-}
-
-function addStickyLock(element: HTMLElement): void {
-	element.after(
-		<LockedIndicator className="mr-2 mb-2 rgh-locked-issue"/>,
-	);
+function processTimeline(element: HTMLElement): void {
+	const events: HTMLElement[] = $$(`.octicon-key, .octicon-lock`, element.parentElement!);
+	// If final lock change event is locked
+	if (events.length > 0 && events.reverse()[0].classList.contains('octicon-lock')) {
+		$('.gh-header-meta:not(:has(.rgh-locked-issue)) > :first-child')?.after(
+			<LockedIndicator className="mb-2 rgh-locked-issue"/>,
+		);
+		$('.gh-header-sticky:not(:has(.rgh-locked-issue)) .flex-row > :first-child')?.after(
+			<LockedIndicator className="mr-2 mb-2 rgh-locked-issue"/>,
+		);
+	} else { // Remove existing badge otherwise
+		$('.gh-header-meta > .rgh-locked-issue')?.remove();
+		$('.gh-header-sticky .flex-row > .rgh-locked-issue')?.remove();
+	}
 }
 
 function init(signal: AbortSignal): void {
-	// Locked when unlock option is available for collaborators or comment form is locked
-	// Logged out users never have the menu, so they should be excluded
-	observe('.logged-in:has(.js-lock-issue [action$="/unlock"], #new_comment_form .blankslate) .gh-header-meta > :first-child', addLock, {signal});
-	observe('.logged-in:has(.js-lock-issue [action$="/unlock"], #new_comment_form .blankslate) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
+    // Observe only non-hidden timeline events
+	observe('.js-discussion > div > .js-timeline-item', processTimeline, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -18,7 +18,7 @@ function LockedIndicator(): JSX.Element {
 
 function processTimeline(element: HTMLElement): void {
 	const events: HTMLElement[] = $$(`.octicon-key, .octicon-lock`, element.parentElement!);
-	// If final lock change event is locked
+	// If most recent lock change event is locked
 	if (events.length > 0 && events.reverse()[0].classList.contains('octicon-lock')) {
 		$('.gh-header-meta:not(:has(.rgh-locked-issue)) > :first-child')?.after(
 			<LockedIndicator className="mb-2 rgh-locked-issue"/>,
@@ -34,7 +34,7 @@ function processTimeline(element: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
     // Observe only non-hidden timeline events
-	observe('.js-discussion > div > .js-timeline-item', processTimeline, {signal});
+	observe(':not(#js-progressive-timeline-item-container) > .js-timeline-item', processTimeline, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -19,7 +19,7 @@ function LockedIndicator(): JSX.Element {
 function processTimeline(): void {
 	// Gather lock related events and sort by event ID
 	const events: HTMLElement[] = $$('.js-discussion .TimelineItem:has(.octicon-key, .octicon-lock)').sort((a, b) => b.id.localeCompare(a.id));
-	// If most recent lock change event is locked
+	// If the most recent lock change event is locked
 	if (elementExists('.octicon-lock', events[0])) {
 		$('.gh-header-meta:not(:has(.rgh-locked-issue)) > :first-child')?.after(
 			<LockedIndicator className="mb-2 rgh-locked-issue"/>,
@@ -34,7 +34,6 @@ function processTimeline(): void {
 }
 
 function init(signal: AbortSignal): void {
-	// Observe only non-hidden timeline events
 	observe('.js-discussion .js-timeline-item', processTimeline, {signal});
 }
 

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {$, $$} from 'select-dom';
+import {$, $$, elementExists} from 'select-dom';
 import {LockIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
@@ -16,10 +16,11 @@ function LockedIndicator(): JSX.Element {
 	);
 }
 
-function processTimeline(element: HTMLElement): void {
-	const events: HTMLElement[] = $$(`.octicon-key, .octicon-lock`, element.parentElement!);
+function processTimeline(): void {
+	// Gather lock related events and sort by event ID
+	const events: HTMLElement[] = $$('.js-discussion .TimelineItem:has(.octicon-key, .octicon-lock)').sort((a, b) => a.id.localeCompare(b.id));
 	// If most recent lock change event is locked
-	if (events.length > 0 && events.reverse()[0].classList.contains('octicon-lock')) {
+	if (elementExists('.octicon-lock', events[0])) {
 		$('.gh-header-meta:not(:has(.rgh-locked-issue)) > :first-child')?.after(
 			<LockedIndicator className="mb-2 rgh-locked-issue"/>,
 		);
@@ -33,8 +34,8 @@ function processTimeline(element: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-    // Observe only non-hidden timeline events
-	observe(':not(#js-progressive-timeline-item-container) > .js-timeline-item', processTimeline, {signal});
+	// Observe only non-hidden timeline events
+	observe('.js-discussion .js-timeline-item', processTimeline, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
This PR basically rewrites all the logic for this feature so it's also compatible with:

* Enterprise (needs testing, but should work as long as a timeline exists)
* Archived repos
* Logged out users

Determines the lock status based on the latest lock change event in the timeline. Works with truncated timelines (ex: https://togithub.com/microsoft/vscode/issues/224) and live updates (see screenshots).

## Test URLs

issue: https://github.com/refined-github/sandbox/issues/74
PR: https://github.com/refined-github/sandbox/pull/48
long issue: https://togithub.com/microsoft/vscode/issues/224

## Screenshot

**Collaborators:**

https://github.com/refined-github/refined-github/assets/58778985/e3d634fc-92fa-4ea5-80bd-bb95f22c554d

**Non-collaborators:**

https://github.com/refined-github/refined-github/assets/58778985/39bd0c05-bd3c-4d19-a68c-139516b1a656

