### PR TITLE
`release-download-count` - Restore feature

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -33,7 +33,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		?? assetsList.closest('.Box:not(.Box--condensed)')!; // Releases list, excludes the assets list’s own .Box
 
 	const releaseName = container
-		.querySelector('.octicon-tag ~ span')!
+		.querySelector('.Link[href*="/tree/"]')!
 		.textContent
 		.trim();
 


### PR DESCRIPTION
Fix #7125

## Test URLs

https://github.com/refined-github/refined-github/releases

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/44045911/0708ce4b-636d-4bb4-a525-e15d929f7604)
