### PR TITLE
Bold current pull request tab

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -54,3 +54,8 @@
 	pointer-events: none;
 	filter: grayscale(0.5);
 }
+
+/* Bold current pull request tab */
+.tabnav-tab.selected {
+	font-weight: var(--base-text-weight-semibold, 600);
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -56,6 +56,7 @@
 }
 
 /* Bold current pull request tab */
+/* Test: https://github.com/refined-github/refined-github/pull/7128 */
 .tabnav-tab.selected {
 	font-weight: var(--base-text-weight-semibold, 600);
 }


### PR DESCRIPTION
The current repository tab is made bold, so should the current pull request tab.

![image](https://github.com/refined-github/refined-github/assets/44045911/1e2f75f8-b1dd-4eb5-adb3-39b7a890e90d)

Based on [my dogfooding](https://github.com/kidonng/cherry/commit/0517b4317825c407962c7c6eadb8bd05f032776b) this has remain unchanged for > 1.5 years :shrug: 

## Test URLs

Here

## Screenshot

<table>
<tr>
 <td>Before
 <td>

![image](https://github.com/refined-github/refined-github/assets/44045911/99724634-188a-4c0a-affc-013f282683fd)

<tr>
 <td>After
 <td>

![image](https://github.com/refined-github/refined-github/assets/44045911/3e4b05f6-81c0-49e9-911e-a2541b2db201)

</table>