### PR TITLE
Enable rgh-pr-template for all repos

### DIFF
--- a/source/features/pr-template.tsx
+++ b/source/features/pr-template.tsx
@@ -24,7 +24,6 @@ function init(signal: AbortSignal): void {
 
 void features.add(import.meta.url, {
 	asLongAs: [
-		isRefinedGitHubRepo,
 		pageDetect.isCompare,
 	],
 	init,

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -214,7 +214,7 @@ import './features/action-pr-link.js';
 import './features/rgh-dim-commits.js';
 import './features/mobile-tabs.js';
 import './features/repo-header-info.js';
-import './features/rgh-pr-template.js';
+import './features/pr-template.js';
 import './features/close-as-unplanned.js';
 import './features/locked-issue.js';
 import './features/visit-tag.js';


### PR DESCRIPTION
Enable `rgh-pr-template` for all repos and rename to `pr-template`. 

Is there a reason why this feature was locked to refined-github only? It would be very nice if we could get this as a part of rgh on all repos :)

## Test URLs

https://github.com/refined-github/refined-github/compare/main...sandbox/keep-branch?quick_pull=1

## Screenshot

See #6947
