### PR TITLE
`small-user-avatars` - Don't mistakenly add to commit authors

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -45,9 +45,7 @@ function init(): void {
 		'.js-issue-row [data-hovercard-type="user"]',
 		'.notification-thread-subscription [data-hovercard-type="user"]',
 	], addAvatar);
-	observe([
-		'.user-mention:not(.commit-author)[data-hovercard-type="user"]',
-	], addMentionAvatar);
+	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }
 
 void features.add(import.meta.url, {

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -3,6 +3,7 @@ import React from 'dom-chef';
 import onetime from 'onetime';
 
 import features from '../feature-manager.js';
+import {assertNodeContent} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
 
@@ -22,6 +23,7 @@ function addAvatar(link: HTMLElement): void {
 }
 
 function addMentionAvatar(link: HTMLElement): void {
+	assertNodeContent(link, '/^@/');
 	const username = link.textContent.slice(1);
 	const size = 16;
 
@@ -43,7 +45,9 @@ function init(): void {
 		'.js-issue-row [data-hovercard-type="user"]',
 		'.notification-thread-subscription [data-hovercard-type="user"]',
 	], addAvatar);
-	observe('.user-mention[data-hovercard-type="user"]', addMentionAvatar);
+	observe([
+		'.user-mention:not(.commit-author)[data-hovercard-type="user"]',
+	], addMentionAvatar);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fix #7137 based on https://github.com/refined-github/refined-github/issues/7137#issuecomment-1839574252

## Test URLs
https://github.com/sopel-irc/sopel/commit/120477fe28f470f9308163203c43688ff9121e12

## Screenshot
Before:
![image](https://github.com/refined-github/refined-github/assets/164140/a692dfc7-a8ee-4143-8b45-56d4e8ba7662)

After:
![image](https://github.com/refined-github/refined-github/assets/164140/21a57de4-96a5-4f95-a919-19b01c576b64)

----

Verified that small-user-avatars are still added on regular mentions in comments, e.g. https://github.com/sopel-irc/sopel/pull/2533#issuecomment-1784202911