### PR TITLE
`hide-yarn-berry-cache` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -310,6 +310,11 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263195425-85cf0951-c6ed-45fe-8cfc-e447e3ed2a25.png"
 	},
 	{
+		"id": "hide-yarn-berry-cache",
+		"description": "Always collapse a lot of <code>.yarn/cache</code> diff in PRs.",
+		"screenshot": "https://github.com/refined-github/refined-github/assets/29156835/9432f9b8-1406-434a-8752-4779ceac8884"
+	},
+	{
 		"id": "highest-rated-comment",
 		"description": "Highlights the most useful comment in conversations.",
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png"

--- a/build/__snapshots__/imported-features.txt
+++ b/build/__snapshots__/imported-features.txt
@@ -60,6 +60,7 @@ hide-low-quality-comments
 hide-navigation-hover-highlight
 hide-newsfeed-noise
 hide-user-forks
+hide-yarn-berry-cache
 highest-rated-comment
 highlight-collaborators-and-own-conversations
 highlight-non-default-base-branch

--- a/readme.md
+++ b/readme.md
@@ -274,6 +274,7 @@ Thanks for contributing! 🦋🙌
 - [](# "view-last-pr-deployment") [Adds a link to open the latest deployment from the header of a PR.](https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png)
 - [](# "no-unnecessary-split-diff-view") [Always uses unified diffs on files where split diffs aren’t useful.](https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png)
 - [](# "emphasize-draft-pr-label") [Makes it easier to distinguish draft PR in lists.](https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png)
+- [](# "hide-yarn-berry-cache") [Always collapse a lot of `.yarn/cache` diff in PRs.](https://github.com/refined-github/refined-github/assets/29156835/9432f9b8-1406-434a-8752-4779ceac8884)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/hide-yarn-berry-cache.css
+++ b/source/features/hide-yarn-berry-cache.css
@@ -1,0 +1,26 @@
+/*
+ * Reduce margin between yarn berry diff blocks
+ */
+div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) {
+	margin-top: 8px !important;
+	margin-bottom: 8px !important;
+}
+
+/*
+ * Reduce padding yarn berry diff blocks
+ * and make them semi-transparent
+ */
+div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) > div:first-child {
+	padding-top: 2px;
+	padding-bottom: 2px;
+
+	background: var(--color-scale-gray-9) !important;
+	opacity: 0.75;
+}
+
+/*
+ * Make yarn berry diff block to be one line
+ */
+div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) > div:first-child > div:first-child {
+	display: flex !important;
+}

--- a/source/features/hide-yarn-berry-cache.css
+++ b/source/features/hide-yarn-berry-cache.css
@@ -1,7 +1,7 @@
 /*
  * Reduce margin between yarn berry diff blocks
  */
-div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) {
+div[id^='diff-']:is([data-tagsearch-path*='.yarn/cache']) {
 	margin-top: 8px !important;
 	margin-bottom: 8px !important;
 }
@@ -10,17 +10,18 @@ div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) {
  * Reduce padding yarn berry diff blocks
  * and make them semi-transparent
  */
-div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) > div:first-child {
+div[id^='diff-']:is([data-tagsearch-path*='.yarn/cache']) > div:first-child {
 	padding-top: 2px;
 	padding-bottom: 2px;
-
 	background: var(--color-scale-gray-9) !important;
-	opacity: 0.75;
+	opacity: 75%;
 }
 
 /*
  * Make yarn berry diff block to be one line
  */
-div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"]) > div:first-child > div:first-child {
+div[id^='diff-']:is([data-tagsearch-path*='.yarn/cache'])
+	> div:first-child
+	> div:first-child {
 	display: flex !important;
 }

--- a/source/features/hide-yarn-berry-cache.tsx
+++ b/source/features/hide-yarn-berry-cache.tsx
@@ -15,16 +15,16 @@ function collapseYarnCacheDiff(divElement: HTMLDivElement): void {
  * Collapse the yarn berry cache directory in the file tree list on PR files page
  */
 function collapseYarnCacheDirectory(buttonElement: HTMLButtonElement): void {
-	if (buttonElement.innerText  === '.yarn' || buttonElement.innerText === '.yarn/cache') {
+	if (buttonElement.textContent === '.yarn' || buttonElement.textContent === '.yarn/cache') {
 		buttonElement.ariaExpanded = 'false';
 	}
 }
 
 // Select diff elements which is yarn berry cache
-const yarnBinaryDiffSelector = `div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"])`;
+const yarnBinaryDiffSelector = 'div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"])';
 
 // Select directory elements from the file tree list on left side
-const yarnBinaryDirectorySelector = `button[aria-expanded="true"].ActionList-content`;
+const yarnBinaryDirectorySelector = 'button[aria-expanded="true"].ActionList-content';
 
 function init(): void {
 	observe(yarnBinaryDiffSelector, collapseYarnCacheDiff);
@@ -34,9 +34,9 @@ function init(): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRFiles,
-		pageDetect.isCompare
+		pageDetect.isCompare,
 	],
-	init
+	init,
 });
 
 /*

--- a/source/features/hide-yarn-berry-cache.tsx
+++ b/source/features/hide-yarn-berry-cache.tsx
@@ -1,0 +1,50 @@
+import './hide-yarn-berry-cache.css';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+
+/**
+ * Collapse the yarn berry cache diff blocks on PR files or compare page
+ */
+function collapseYarnCacheDiff(divElement: HTMLDivElement): void {
+	divElement.classList.remove('open', 'Details--on');
+}
+
+/**
+ * Collapse the yarn berry cache directory in the file tree list on PR files page
+ */
+function collapseYarnCacheDirectory(buttonElement: HTMLButtonElement): void {
+	if (buttonElement.innerText  === '.yarn' || buttonElement.innerText === '.yarn/cache') {
+		buttonElement.ariaExpanded = 'false';
+	}
+}
+
+// Select diff elements which is yarn berry cache
+const yarnBinaryDiffSelector = `div[id^="diff-"]:is([data-tagsearch-path*=".yarn/cache"])`;
+
+// Select directory elements from the file tree list on left side
+const yarnBinaryDirectorySelector = `button[aria-expanded="true"].ActionList-content`;
+
+function init(): void {
+	observe(yarnBinaryDiffSelector, collapseYarnCacheDiff);
+	observe(yarnBinaryDirectorySelector, collapseYarnCacheDirectory);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRFiles,
+		pageDetect.isCompare
+	],
+	init
+});
+
+/*
+Test URLs
+
+on PR:
+- https://github.com/refined-github/sandbox/pull/78/files
+
+on compare:
+- https://github.com/refined-github/sandbox/compare/default-a...effx13:sandbox:test-yarn-berry
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -221,3 +221,4 @@ import './features/visit-tag.js';
 import './features/prevent-comment-loss.js';
 import './features/fix-no-pr-search.js';
 import './features/clean-readme-url.js';
+import './features/hide-yarn-berry-cache.js';


### PR DESCRIPTION
While using a [Yarn berry Zero-installs](https://yarnpkg.com/features/caching#zero-installs) feature, yarn berry creates a huge load of binary zip files.
This feature is very useful for developers, but yarn berry makes it difficult to see and makes me angry when I see PRs.
For instance, if I accidentally delete node_modules and attempts to reinstall, I would have to review hundreds of files again.

Therefore, I created a feature to collapse the `.yarn/cache` folder by default and reduce its size. 

## Test URLs

on PR:
- https://github.com/refined-github/sandbox/pull/78/files

on Compare:
- https://github.com/refined-github/sandbox/compare/default-a...effx13:sandbox:test-yarn-berry

## Screenshot

<img src="https://github.com/refined-github/refined-github/assets/29156835/9432f9b8-1406-434a-8752-4779ceac8884">