### PR TITLE
`unreleased-commits` - Show on Releases page

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -46,7 +46,7 @@ async function init(): Promise<void | false> {
 
 	const changelogButton = (
 		<a
-			className={'tooltipped tooltipped-n btn ml-3' + (pageDetect.isEnterprise() ? '' : ' flex-self-start')}
+			className={'tooltipped tooltipped-n btn mx-3' + (pageDetect.isEnterprise() ? '' : ' flex-self-start')}
 			aria-label={`View the ${changelog} file`}
 			href={buildRepoURL('blob', 'HEAD', changelog)}
 			style={pageDetect.isEnterprise() ? {padding: '6px 16px'} : {}}
@@ -63,7 +63,8 @@ async function init(): Promise<void | false> {
 	].join(',');
 
 	const navbar = (await elementReady(releasesOrTagsNavbarSelector, {waitForChildren: false}))!;
-	navbar.classList.remove('flex-1');
+	navbar.classList.remove('flex-1'); // Remove margin-right
+	navbar.classList.add('d-flex'); // Avoid wrapping
 	wrapAll(<div className="d-flex flex-justify-start flex-1"/>, navbar, changelogButton);
 }
 

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -205,4 +205,13 @@ https://github.com/refined-github/sandbox
 Repo with some unreleased commits
 https://github.com/refined-github/refined-github
 
+Releases page with unreleased commits
+https://github.com/facebook/react/releases
+
+Releases page with unreleased commits (user can release)
+https://github.com/refined-github/refined-github/releases
+
+Releases page with changelog file
+https://github.com/fczbkk/css-selector-generator/releases
+
 */

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -78,9 +78,9 @@ async function createLink(
 ): Promise<HTMLElement> {
 	const commitCount
 		= aheadBy === undeterminableAheadBy
-			? 'more than 20 unreleased commits'
+			? 'More than 20 unreleased commits'
 			: pluralize(aheadBy, '$$ unreleased commit');
-	const label = `There are ${commitCount} since ${abbreviateString(latestTag, 30)}`;
+	const label = `${commitCount}\nsince ${abbreviateString(latestTag, 30)}`;
 
 	return (
 		<a


### PR DESCRIPTION
- Extracted from https://github.com/refined-github/refined-github/pull/7121
- #6977 


## Test URLs

- Can release: https://github.com/refined-github/sandbox/releases
- Cannot release: https://github.com/facebook/react/releases
- Cannot release, has changelog file https://github.com/fczbkk/css-selector-generator/releases
- It's missing from the tag page for now

## Mobile

<img width="592" alt="Screenshot 6" src="https://github.com/refined-github/refined-github/assets/1402241/96019d19-a666-41b9-a9c7-e5d59e4f1fe1">

<img width="592" alt="Screenshot 7" src="https://github.com/refined-github/refined-github/assets/1402241/fe1fda2d-d8b7-46a2-8cbd-ad1fa132ee54">

<img width="592" alt="Screenshot 5" src="https://github.com/refined-github/refined-github/assets/1402241/6bc554e7-52f9-4c60-a911-6ffc670f5a2e">

## Desktop

<img width="881" alt="Screenshot 9" src="https://github.com/refined-github/refined-github/assets/1402241/aa02b8d2-fad8-4d3f-9cf1-64237f9369f4">

<img width="881" alt="Screenshot 8" src="https://github.com/refined-github/refined-github/assets/1402241/77d19a4c-aab0-4de9-9b80-54c075460ad9">

<img width="881" alt="Screenshot 10" src="https://github.com/refined-github/refined-github/assets/1402241/e31fe140-07e1-482d-8427-492111c9ac09">

