### PR TITLE
Meta: Fix `selector` tests

### DIFF
--- a/source/github-helpers/selectors.test.ts
+++ b/source/github-helpers/selectors.test.ts
@@ -5,7 +5,11 @@ import {parseHTML} from 'linkedom';
 import * as exports from './selectors.js';
 
 const fetchDocument = mem(async (url: string): Promise<Window> => {
-	const request = await fetch(url);
+	const request = await fetch(url, {
+		headers: {
+			Accept: 'text/html',
+		},
+	});
 	const contents = await request.text();
 	return parseHTML(contents);
 });
@@ -27,7 +31,7 @@ describe.concurrent('selectors', () => {
 		await Promise.all(urls.map(async url => {
 			const {window} = await fetchDocument(url);
 			// It's not equivalent at the moment, but at least the tests don't fail. Let's see how it goes
-			assert.isDefined(window.document.querySelector(selector));
+			assert(window.document.querySelector(selector), `Selector "${selector}" not found in "${url}"`);
 		}));
 	}, {timeout: 9999});
 });


### PR DESCRIPTION
While working on https://github.com/refined-github/refined-github/pull/7165 I realized that `selector.test.ts` would _always_ pass. Great.

Now the issue is that these selectors don't actually exist on logged-out pages. _What do?_