### PR TITLE
`small-user-avatars` - Restore feature

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -23,7 +23,7 @@ function addAvatar(link: HTMLElement): void {
 }
 
 function addMentionAvatar(link: HTMLElement): void {
-	assertNodeContent(link, '/^@/');
+	assertNodeContent(link.firstChild, /^@/);
 	const username = link.textContent.slice(1);
 	const size = 16;
 


### PR DESCRIPTION
Fixes an error in the implementation of #7139 as shown [here](https://github.com/refined-github/refined-github/pull/7139#issuecomment-1858889250). (As I [said](https://github.com/refined-github/refined-github/pull/7139#issuecomment-1839706110), I'm clearly not a JS dev!)

## Test URLs
Commit header (don't add): https://github.com/sopel-irc/sopel/commit/120477fe28f470f9308163203c43688ff9121e12

Release notes (add): https://github.com/refined-github/refined-github/releases/tag/23.12.1

Comment mention (add): https://github.com/sopel-irc/sopel/pull/2533#issuecomment-1784202911

## Screenshot
Still not adding extra avatars to commit header:

<img width="168" alt="image" src="https://github.com/refined-github/refined-github/assets/164140/31c78493-b679-4051-9191-038b365eb96b">

Plus additional verification that the feature is working as expected in expected places, in release notes:

<img width="341" alt="image" src="https://github.com/refined-github/refined-github/assets/164140/58250eca-7a8f-4746-9b0b-6c1de2d71224">

In a comment:

<img width="334" alt="image" src="https://github.com/refined-github/refined-github/assets/164140/af6c2120-a420-42f8-9ab9-1532bbf71ac6">

## Further thoughts
If always using `link.firstChild` proves to be more fragile than expected, I'd say to use `link.textContent.trim()` and the text-matching helper directly:

https://github.com/refined-github/refined-github/blob/9cdd6a88bda657f57720ab6dc8f368004c91153f/source/helpers/dom-utils.ts#L80-L81

Alternatively, I suppose that `assertNodeContent` could be extended to take a `Text` node _or_ a string, or an `assertTextContent` sibling method could be created.