### PR TITLE
`rgh-dim-commits` - Add support for new commit view

### DIFF
--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -3,9 +3,17 @@ import * as pageDetect from 'github-url-detection';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
+import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 // Source: https://github.com/fregante/release-with-changelog/blob/779fd5e658f82e5b11b1c0a352a6838d3bd8f67f/generate-release-notes.js#L6
 const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
+
+// TODO: Remove in June 2024
+function dimOld(commitTitle: HTMLElement): void {
+	if (excludePreset.test(commitTitle.textContent.trim())) {
+		commitTitle.closest('.js-commits-list-item')!.style.opacity = '50%';
+	}
+}
 
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
@@ -14,12 +22,14 @@ function dim(commitTitle: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('[data-testid="commit-row-item"] [data-testid="listview-item-title-container"] span', dim, {signal});
+	observe('.js-commits-list-item p:has(> .js-navigation-open)', dimOld, {signal}); // TODO: Remove in June 2024
+	observe('[data-testid="listview-item-title-container"] .markdown-title span', dim, {signal});
 }
 
 void features.add(import.meta.url, {
 	asLongAs: [
 		isRefinedGitHubRepo,
+		isHasSelectorSupported,
 	],
 	include: [
 		pageDetect.isCommitList,

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -9,7 +9,7 @@ const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencie
 
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
-		commitTitle.closest('[data-testid="commit-row-item"] ')!.style.opacity = '50%';
+		commitTitle.closest('[data-testid="commit-row-item"]')!.style.opacity = '50%';
 	}
 }
 

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -10,7 +10,10 @@ const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencie
 
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
-		commitTitle.closest(['.js-commits-list-item', '[data-testid="commit-row-item"]'])!.style.opacity = '50%';
+		commitTitle.closest([
+			'.js-commits-list-item', // TODO: Remove in June 2024
+			'[data-testid="commit-row-item"]',
+		])!.style.opacity = '50%';
 	}
 }
 

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -3,25 +3,23 @@ import * as pageDetect from 'github-url-detection';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import {isHasSelectorSupported} from '../helpers/select-has.js';
 
 // Source: https://github.com/fregante/release-with-changelog/blob/779fd5e658f82e5b11b1c0a352a6838d3bd8f67f/generate-release-notes.js#L6
 const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
 
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
-		commitTitle.closest('.js-commits-list-item')!.style.opacity = '50%';
+		commitTitle.closest('[data-testid="commit-row-item"] ')!.style.opacity = '50%';
 	}
 }
 
 function init(signal: AbortSignal): void {
-	observe('.js-commits-list-item p:has(> .js-navigation-open)', dim, {signal});
+	observe('[data-testid="commit-row-item"] [data-testid="listview-item-title-container"] span', dim, {signal});
 }
 
 void features.add(import.meta.url, {
 	asLongAs: [
 		isRefinedGitHubRepo,
-		isHasSelectorSupported,
 	],
 	include: [
 		pageDetect.isCommitList,

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -8,22 +8,17 @@ import {isHasSelectorSupported} from '../helpers/select-has.js';
 // Source: https://github.com/fregante/release-with-changelog/blob/779fd5e658f82e5b11b1c0a352a6838d3bd8f67f/generate-release-notes.js#L6
 const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
 
-// TODO: Remove in June 2024
-function dimOld(commitTitle: HTMLElement): void {
-	if (excludePreset.test(commitTitle.textContent.trim())) {
-		commitTitle.closest('.js-commits-list-item')!.style.opacity = '50%';
-	}
-}
-
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
-		commitTitle.closest('[data-testid="commit-row-item"]')!.style.opacity = '50%';
+		commitTitle.closest(['.js-commits-list-item', '[data-testid="commit-row-item"]'])!.style.opacity = '50%';
 	}
 }
 
 function init(signal: AbortSignal): void {
-	observe('.js-commits-list-item p:has(> .js-navigation-open)', dimOld, {signal}); // TODO: Remove in June 2024
-	observe('[data-testid="listview-item-title-container"] .markdown-title span', dim, {signal});
+	observe([
+		'.js-commits-list-item p:has(> .js-navigation-open)', // TODO: Remove in June 2024
+		'[data-testid="listview-item-title-container"] .markdown-title span',
+	], dim, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Fix #7179

## Test URLs

https://github.com/refined-github/refined-github/commits/98fb24e53704b436d68f254429885fb7bef09541/source/features/bypass-checks.tsx

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/bf1b72ec-f289-4ed3-9515-45c742740b35)
