### PR TITLE
`conversation-links-on-repo-lists` - Disable on organizations

### DIFF
--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -44,7 +44,7 @@ function init(signal: AbortSignal): void {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isProfileRepoList,
+		pageDetect.isUserProfileRepoTab,
 		() => pageDetect.isGlobalSearchResults() && new URLSearchParams(location.search).get('type') === 'repositories',
 	],
 	init,

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -44,7 +44,7 @@ function init(signal: AbortSignal): void {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isUserProfileRepoTab,
+		pageDetect.isUserProfileRepoTab, // Organizations already have these links
 		() => pageDetect.isGlobalSearchResults() && new URLSearchParams(location.search).get('type') === 'repositories',
 	],
 	init,


### PR DESCRIPTION
Fixes #7173 

## Test URLs

* https://github.com/orgs/refined-github/repositories

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/494ac5b9-8d76-431d-bcb6-a5a43c52a4b6)

