### PR TITLE
`one-click-diff-options` - Disable on single commits

### DIFF
--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -139,7 +139,7 @@ void features.add(import.meta.url, {
 }, {
 	shortcuts,
 	include: [
-		pageDetect.isCompare
+		pageDetect.isCompare,
 	],
 	init,
 });

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -139,8 +139,7 @@ void features.add(import.meta.url, {
 }, {
 	shortcuts,
 	include: [
-		pageDetect.isSingleCommit,
-		pageDetect.isCompare,
+		() => pageDetect.isCompare() && !elementExists('[href="#files_bucket"]'),
 	],
 	init,
 });

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -139,7 +139,7 @@ void features.add(import.meta.url, {
 }, {
 	shortcuts,
 	include: [
-		() => pageDetect.isCompare() && !elementExists('[href="#files_bucket"]'),
+		pageDetect.isCompare
 	],
 	init,
 });


### PR DESCRIPTION
Fixes #7184 

## Test URLs

https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e
https://github.com/refined-github/sandbox/commit/96451b68751d9807d5da0964868f418c5eeee148

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/6685e213-1d06-48f1-98d9-deb200b952ad)
