### PR TITLE
Automatically fit comment preview height

### DIFF
--- a/build/verify-test-urls.sh
+++ b/build/verify-test-urls.sh
@@ -36,7 +36,7 @@ echo
 
 for FILE in "$@"; do
 	# skip github-bugs.css
-	if [ "$FILE" = "source/github-bugs.css" ]; then
+	if [ "$FILE" = "source/features/github-bugs.css" ]; then
 		continue
 	fi
 

--- a/build/verify-test-urls.sh
+++ b/build/verify-test-urls.sh
@@ -35,13 +35,20 @@ echo WILL VERIFY:
 echo
 
 for FILE in "$@"; do
-	LAST_LINE=$(wc -l < "$FILE")
+	# skip github-bugs.css
+	if [ "$FILE" = "source/github-bugs.css" ]; then
+		continue
+	fi
+
 	IS_FILE_CSS=$(echo "$FILE" | grep -q "\.css$" && echo 1 || echo 0)
 	SIBLING_TSX_FILE=$(echo "$FILE" | sed 's/\.css$/.tsx/')
 	DOES_SIBLING_EXIST=$(test -f "$SIBLING_TSX_FILE" && echo 1 || echo 0)
-	IS_FILE_CSS_AND_SIBLING_EXISTS=$(test "$IS_FILE_CSS" -eq 1 && test "$DOES_SIBLING_EXIST" -eq 1 && echo 1 || echo 0)
+	if test "$IS_FILE_CSS" -eq 1 && test "$DOES_SIBLING_EXIST" -eq 1; then
+		continue
+	fi
 
-	if grep -q "test url" -i "$FILE" || test "$IS_FILE_CSS_AND_SIBLING_EXISTS" -eq 1; then
+	LAST_LINE=$(wc -l < "$FILE")
+	if grep -q "test url" -i "$FILE"; then
 		echo ✅ "$FILE"
 		echo "::notice file=$FILE,line=$LAST_LINE::✅" >> "$ANNOTATIONS"
 	else

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -63,5 +63,5 @@
 
 /* Fit rendered markdown div to its content #7187 */
 div.markdown-body {
-	min-height: 0 !important;
+	min-height: 2em !important;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -60,3 +60,8 @@
 .comment-form-head.tabnav:has(~ div .octicon-lock) {
 	display: none;
 }
+
+/* Fit rendered markdown div to its content #7187 */
+div.markdown-body {
+	min-height: 0 !important;
+}


### PR DESCRIPTION
Fix https://github.com/refined-github/refined-github/issues/7187.

Rendered markdown div automatically fit their content, but for some reason Github explicitly sets the `min-height` style property to the height of the input textarea.
Simply overriding the `min-height` to `0` fixes this bug.

Affects any div that renders markdown.

## Screenshot

| Input | Original | Fixed |
|--------|--------|--------|
| <img width="846" alt="image" src="https://github.com/refined-github/refined-github/assets/23154723/684c367a-924d-4fd6-b5bc-7b956e633aee"> | <img width="847" alt="image" src="https://github.com/refined-github/refined-github/assets/23154723/9f5e12bc-e41b-4e7e-b12b-c9c41ee6d56c"> | <img width="846" alt="image" src="https://github.com/refined-github/refined-github/assets/23154723/ea44d760-bd5a-4025-8c6d-de9ff8b962e9"> | 

