### PR TITLE
`conversation-links-on-repo-lists` - Restore on global search

### DIFF
--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -40,7 +40,12 @@ function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
 		.closest('[data-testid="results-list"] > div')!
 		.querySelector('ul > span:last-of-type')!
 		.before(
-			<li className="d-flex text-small ml-2">
+			<span
+				aria-hidden="true"
+				className="color-fg-muted mx-2"
+			>·
+			</span>,
+			<li className="d-flex text-small">
 				<a
 					className="Link--muted"
 					href={repositoryLink.href + '/issues'}

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -43,7 +43,9 @@ function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
 			<span
 				aria-hidden="true"
 				className="color-fg-muted mx-2"
-			>·</span>,
+			>
+				·
+			</span>,
 			<li className="d-flex text-small">
 				<a
 					className="Link--muted"

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -19,18 +19,20 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 		$('relative-time', repository)!.previousSibling,
 		'Updated',
 	).before(
-		<a
-			className="Link--muted mr-3"
-			href={repositoryLink.href + '/issues'}
-		>
-			<IssueOpenedIcon/>
-		</a>,
-		<a
-			className="Link--muted mr-3"
-			href={repositoryLink.href + '/pulls'}
-		>
-			<GitPullRequestIcon/>
-		</a>,
+		<>
+			<a
+				className="Link--muted mr-3"
+				href={repositoryLink.href + '/issues'}
+			>
+				<IssueOpenedIcon/>
+			</a>
+			<a
+				className="Link--muted mr-3"
+				href={repositoryLink.href + '/pulls'}
+			>
+				<GitPullRequestIcon/>
+			</a>
+		</>,
 	);
 }
 
@@ -40,28 +42,30 @@ function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
 		.closest('[data-testid="results-list"] > div')!
 		.querySelector('ul > span:last-of-type')!
 		.before(
-			<span
-				aria-hidden="true"
-				className="color-fg-muted mx-2"
-			>
-				·
-			</span>,
-			<li className="d-flex text-small">
-				<a
-					className="Link--muted"
-					href={repositoryLink.href + '/issues'}
+			<>
+				<span
+					aria-hidden="true"
+					className="color-fg-muted mx-2"
 				>
-					<IssueOpenedIcon/>
-				</a>
-			</li>,
-			<li className="d-flex text-small ml-2">
-				<a
-					className="Link--muted"
-					href={repositoryLink.href + '/pulls'}
-				>
-					<GitPullRequestIcon/>
-				</a>
-			</li>,
+					·
+				</span>
+				<li className="d-flex text-small">
+					<a
+						className="Link--muted"
+						href={repositoryLink.href + '/issues'}
+					>
+						<IssueOpenedIcon/>
+					</a>
+				</li>
+				<li className="d-flex text-small ml-2">
+					<a
+						className="Link--muted"
+						href={repositoryLink.href + '/pulls'}
+					>
+						<GitPullRequestIcon/>
+					</a>
+				</li>
+			</>,
 		);
 }
 

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -35,27 +35,28 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
-	const repository = repositoryLink.closest('[data-testid="results-list"] > div')!;
-
 	// Place before the update date ·
-	$('ul > span:last-of-type', repository)!.before(
-		<li className="d-flex text-small ml-2">
-			<a
-				className="Link--muted"
-				href={repositoryLink.href + '/issues'}
-			>
-				<IssueOpenedIcon/>
-			</a>
-		</li>,
-		<li className="d-flex text-small ml-2">
-			<a
-				className="Link--muted"
-				href={repositoryLink.href + '/pulls'}
-			>
-				<GitPullRequestIcon/>
-			</a>
-		</li>,
-	);
+	repositoryLink
+		.closest('[data-testid="results-list"] > div')!
+		.querySelector('ul > span:last-of-type')!
+		.before(
+			<li className="d-flex text-small ml-2">
+				<a
+					className="Link--muted"
+					href={repositoryLink.href + '/issues'}
+				>
+					<IssueOpenedIcon/>
+				</a>
+			</li>,
+			<li className="d-flex text-small ml-2">
+				<a
+					className="Link--muted"
+					href={repositoryLink.href + '/pulls'}
+				>
+					<GitPullRequestIcon/>
+				</a>
+			</li>,
+		);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -34,20 +34,48 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 	);
 }
 
-const selectors = [
-	'a[itemprop="name codeRepository"]', // `isProfileRepoList`
-	'.repo-list-item .f4 a', // `isGlobalSearchResults`
-] as const;
+function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
+	const repository = repositoryLink.closest('[data-testid="results-list"] > div')!;
+
+	// Place before the update date ·
+	$('ul > span:last-of-type', repository)!.before(
+		<li className="d-flex text-small ml-2">
+			<a
+				className="Link--muted"
+				href={repositoryLink.href + '/issues'}
+			>
+				<IssueOpenedIcon/>
+			</a>
+		</li>,
+		<li className="d-flex text-small ml-2">
+			<a
+				className="Link--muted"
+				href={repositoryLink.href + '/pulls'}
+			>
+				<GitPullRequestIcon/>
+			</a>
+		</li>,
+	);
+}
+
 function init(signal: AbortSignal): void {
-	observe(selectors, addConversationLinks, {signal});
+	observe('a[itemprop="name codeRepository"]', addConversationLinks, {signal});
+}
+
+function initSearch(signal: AbortSignal): void {
+	observe('.search-title a', addSearchConversationLinks, {signal});
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isUserProfileRepoTab, // Organizations already have these links
-		() => pageDetect.isGlobalSearchResults() && new URLSearchParams(location.search).get('type') === 'repositories',
 	],
 	init,
+}, {
+	include: [
+		() => pageDetect.isGlobalSearchResults() && new URLSearchParams(location.search).get('type') === 'repositories',
+	],
+	init: initSearch,
 });
 
 /*

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -43,8 +43,7 @@ function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
 			<span
 				aria-hidden="true"
 				className="color-fg-muted mx-2"
-			>·
-			</span>,
+			>·</span>,
 			<li className="d-flex text-small">
 				<a
 					className="Link--muted"


### PR DESCRIPTION
Fixes #7174

## Test URLs

https://github.com/search?q=user%3Afregante&type=repositories

## Screenshot

![image](https://github.com/refined-github/refined-github/assets/58778985/61b880a3-3f99-4157-a91a-6f3eb8c55cf3)
