### PR TITLE
`fit-textareas` - Fit on focus

### DIFF
--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -18,6 +18,7 @@ function inputListener({target}: Event): void {
 
 function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
 	textarea.addEventListener('input', inputListener, {signal}); // The user triggers `input` event
+	textarea.addEventListener('focus', inputListener, {signal}); // The user triggers `focus` event
 	textarea.addEventListener('change', inputListener, {signal}); // File uploads trigger `change` events
 	textarea.form?.addEventListener('reset', resetListener, {signal});
 	fitTextarea(textarea);


### PR DESCRIPTION
Closes https://github.com/refined-github/refined-github/issues/7196.

Make `fit-textareas` listen to focus events to resize.

## Test URLs
https://github.com/refined-github/refined-github/issues/new?assignees=&labels=bug&projects=&template=1_bug_report.yml

## Screenshot

<table>
<tr>
 <td> Previously
 <td> With fix
<tr>
 <td> <video src="https://github.com/refined-github/refined-github/assets/23154723/3ea3dca7-a2ac-4954-8b14-cd4ba649cc9a">
 <td> <video src="https://github.com/refined-github/refined-github/assets/23154723/0622f800-703a-4142-8892-191b555d884d">
</table>
