### PR TITLE
`use-first-commit-message-for-new-prs` - Do not replace title on page reload

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -37,6 +37,14 @@ function getFirstCommit(): {title: string; body: string | undefined} {
 }
 
 async function init(): Promise<void | false> {
+	if (window.performance.navigation?.type === 1 ||
+		window.performance.getEntriesByType('navigation').some(
+			(nav) => (nav as PerformanceNavigationTiming).type === 'reload')
+		) {
+		// if the page is reloaded, let github restore the previous title
+		return false;
+	}
+
 	const requestedContent = new URL(location.href).searchParams;
 	const commitCountIcon = await elementReady('div.Box.mb-3 .octicon-git-commit');
 	const commitCount = commitCountIcon?.nextElementSibling;

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -37,11 +37,12 @@ function getFirstCommit(): {title: string; body: string | undefined} {
 }
 
 async function init(): Promise<void | false> {
-	if (window.performance.navigation?.type === 1 ||
-		window.performance.getEntriesByType('navigation').some(
-			(nav) => (nav as PerformanceNavigationTiming).type === 'reload')
-		) {
-		// if the page is reloaded, let github restore the previous title
+	if (window.performance.navigation?.type === 1
+		|| window.performance.getEntriesByType('navigation').some(
+			nav => (nav as PerformanceNavigationTiming).type === 'reload',
+		)
+	) {
+		// If the page is reloaded, let github restore the previous title
 		return false;
 	}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes https://github.com/refined-github/refined-github/issues/7191.

Do not set the title to the first commit message on page reload.
It avoids overwriting user input.

The feature still works on page `load`, but not on `reload`, github just restores whatever input was before, whether the first commit title or user input.

## Test URLs
https://github.com/pgimalac/refined-github/compare/main...pgimalac:refined-github:pgimalac/fit-rendered-markdown?expand=1

## Screenshot

https://github.com/refined-github/refined-github/assets/23154723/8d70e4e2-560c-4363-bc19-d5bd8d0ca1d3
