### PR TITLE
`quick-comment-hiding` - Use AJAX again

### DIFF
--- a/source/features/quick-comment-hiding.tsx
+++ b/source/features/quick-comment-hiding.tsx
@@ -29,7 +29,7 @@ function generateSubmenu(hideButton: Element): void {
 	newForm.setAttribute('novalidate', 'true');	// Ignore the form's required attributes
 
 	// Imitate existing menu, reset classes
-	newForm.className = ['dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in'].join(' ');
+	newForm.className = ['js-comment-minimize', 'dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in'].join(' ');
 
 	for (const reason of $$('option:not([value=""])', hideCommentForm.elements.classifier)) {
 		newForm.append(


### PR DESCRIPTION
Fixes #7171.

## Description

The assignment of `newForm.className` removes the existing class `.js-comment-minimize`. I haven't scrutinized the implementation code, but this solution seems to work:

```diff
-	newForm.className = ['dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in'].join(' ');
+	newForm.className = ['js-comment-minimize', 'dropdown-menu', 'dropdown-menu-sw', 'color-fg-default', 'show-more-popover', 'anim-scale-in'].join(' ');
```

## Test URLs

https://github.com/refined-github/refined-github/issues/7171#issuecomment-1893057145 or any comment you can hide it.

## Screenshot

https://github.com/refined-github/refined-github/assets/18693190/e51f2a67-84e6-42c7-8f5a-27048f3f8696