### PR TITLE
`quick-review` - Restore automatic review box opening

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -84,6 +84,16 @@ async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> 
 	}
 }
 
+async function openReviewPopup(button: HTMLButtonElement): Promise<void> {
+	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
+	(button.popoverTargetElement as HTMLElement).showPopover();
+}
+
+function initNativeDeepLinking(signal: AbortSignal): void {
+	// Cannot target the [popover] itself because observe() can't see hidden elements
+	observe('[popovertarget="review-changes-modal"]', openReviewPopup, {signal});
+}
+
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
@@ -97,6 +107,12 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 	],
 	init: initReviewButtonEnhancements,
+}, {
+	asLongAs: [
+		() => location.hash === '#review-changes-modal',
+		pageDetect.isPRFiles,
+	],
+	init: initNativeDeepLinking,
 });
 
 /*


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7077


## Test URLs

https://github.com/refined-github/sandbox/pull/4/files#review-changes-modal

## Screenshot

It works whether you click "Review now" or if you visit that page via direct hash


https://github.com/refined-github/refined-github/assets/1402241/35a24145-536f-416d-a49c-be8166d39e78

