### PR TITLE
`profile-gist-link` - Fix empty dropdown

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -117,6 +117,11 @@ async function updateProjectsTab(): Promise<void | false> {
 }
 
 async function moveRareTabs(): Promise<void | false> {
+	// The user may have disabled `more-dropdown-links` so un-hide it
+	if (!await unhideOverflowDropdown()) {
+		return false;
+	}
+
 	// Wait for the nav dropdown to be loaded #5244
 	await elementReady('.UnderlineNav-actions ul');
 	onlyShowInDropdown('security-tab');
@@ -134,10 +139,6 @@ void features.add(import.meta.url, {
 		updateProjectsTab,
 	],
 }, {
-	asLongAs: [
-		// The user may have disabled `more-dropdown-links` so un-hide it
-		unhideOverflowDropdown,
-	],
 	include: [
 		pageDetect.hasRepoHeader,
 	],

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -6,10 +6,11 @@ import CodeSquareIcon from 'octicons-plain-react/CodeSquare';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {getCleanPathname} from '../github-helpers/index.js';
+import {getCleanPathname, triggerRepoNavOverflow} from '../github-helpers/index.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';
 import observe from '../helpers/selector-observer.js';
 import GetGistCount from './profile-gists-link.gql';
+import {repoUnderlineNavDropdownUl} from '../github-helpers/selectors.js';
 
 const gistCount = new CachedFunction('gist-count', {
 	async updater(username: string): Promise<number> {
@@ -46,13 +47,14 @@ async function appendTab(navigationBar: Element): Promise<void> {
 	);
 
 	navigationBar.append(link);
-	navigationBar.replaceWith(navigationBar);
 
 	// There are two UnderlineNav items (responsive…) that point to the same dropdown
-	const overflowNav = $('.js-responsive-underlinenav .dropdown-menu ul')!;
+	const overflowNav = $(repoUnderlineNavDropdownUl)!;
 	if (!elementExists('[data-rgh-label="Gists"]', overflowNav)) {
 		overflowNav.append(
-			createDropdownItem('Gists', user.url, CodeSquareIcon),
+			createDropdownItem('Gists', user.url, CodeSquareIcon, {
+				'data-menu-item': 'rgh-gists-item',
+			}),
 		);
 	}
 
@@ -60,6 +62,8 @@ async function appendTab(navigationBar: Element): Promise<void> {
 	if (count > 0) {
 		link.append(<span className="Counter">{count}</span>);
 	}
+
+	triggerRepoNavOverflow();
 }
 
 async function init(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7107


## Test URLs

https://github.com/fregante


## Before

<img width="325" alt="Screenshot 10" src="https://github.com/refined-github/refined-github/assets/1402241/587500a9-80e4-4d52-a492-10a2b646c18b">

## After


<img width="325" alt="Screenshot 11" src="https://github.com/refined-github/refined-github/assets/1402241/db7c0a11-3591-4f57-82c5-584708ca419b">

when overflowing:

<img width="325" alt="Screenshot 12" src="https://github.com/refined-github/refined-github/assets/1402241/15c68014-2af2-497d-b508-a850625c2713">

