### PR TITLE
`clean-conversation-filters` - fix token permission error

### DIFF
--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -4,9 +4,10 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import api, {expectTokenScope} from '../github-helpers/api.js';
 import {cacheByRepo} from '../github-helpers/index.js';
 import HasAnyProjects from './clean-conversation-filters.gql';
+import api from '../github-helpers/api.js';
+import {expectTokenScope} from '../github-helpers/github-token.js';
 
 const hasAnyProjects = new CachedFunction('has-projects', {
 	async updater(): Promise<boolean> {

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -8,6 +8,7 @@ import api from '../github-helpers/api.js';
 import {getRepo} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import showToast from '../github-helpers/toast.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 const getReleaseEditLinkSelector = (): 'a' => `a[href^="/${getRepo()!.nameWithOwner}/releases/edit"]` as 'a';
 
@@ -59,7 +60,7 @@ function attachButton(editButton: HTMLAnchorElement): void {
 }
 
 async function init(signal: AbortSignal): Promise<void | false> {
-	await api.expectToken();
+	await expectToken();
 
 	observe(getReleaseEditLinkSelector(), attachButton, {signal});
 	delegate('.rgh-convert-draft', 'click', onConvertClick, {signal});

--- a/source/features/list-prs-for-branch.tsx
+++ b/source/features/list-prs-for-branch.tsx
@@ -6,8 +6,8 @@ import isDefaultBranch from '../github-helpers/is-default-branch.js';
 import {pullRequestsAssociatedWithBranch, stateIcon} from './show-associated-branch-prs-on-fork.js';
 import {addAfterBranchSelector, isPermalink, isRepoCommitListRoot} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
-import api from '../github-helpers/api.js';
 import {branchSelectorParent} from '../github-helpers/selectors.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 // Taken from https://github.com/fregante/github-issue-link-status/blob/98792f2837352bacbf80664f3edbcec8e579ed17/source/github-issue-link-status.js#L10
 const stateColorMap = {
@@ -43,7 +43,7 @@ async function add(branchSelectorParent: HTMLDetailsElement): Promise<void | fal
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	await api.expectToken();
+	await expectToken();
 
 	observe(branchSelectorParent, add, {signal});
 }

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -9,6 +9,7 @@ import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import selectHas from '../helpers/select-has.js';
 import observe from '../helpers/selector-observer.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 const documentation = 'https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#new-repo-disable-projects-and-wikis';
 
@@ -55,7 +56,7 @@ function add(submitButtonLine: HTMLElement): void {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	await api.expectToken();
+	await expectToken();
 	observe('form :has(> [type=submit])', add, {signal});
 	delegate('#new_repository, #new_new_repository', 'submit', setStorage, {signal});
 }

--- a/source/features/pr-base-commit.tsx
+++ b/source/features/pr-base-commit.tsx
@@ -5,13 +5,13 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import api from '../github-helpers/api.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
 import getPrInfo, {PullRequestInfo} from '../github-helpers/get-pr-info.js';
 import pluralize from '../helpers/pluralize.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 import {linkifyCommit} from '../github-helpers/dom-formatters.js';
 import {isTextNodeContaining} from '../helpers/dom-utils.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 function getBaseCommitNotice(prInfo: PullRequestInfo): JSX.Element {
 	const {base} = getBranches();
@@ -49,7 +49,7 @@ async function addInfo(statusMeta: Element): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	await api.expectToken();
+	await expectToken();
 
 	observe('.branch-action-item .status-meta', addInfo, {signal});
 }

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -71,3 +71,12 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // The sidebar is near the end of the page
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/pull/3454
+https://github.com/refined-github/refined-github/issues/3440
+
+*/

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -12,6 +12,7 @@ import api from '../github-helpers/api.js';
 import showToast from '../github-helpers/toast.js';
 import {getConversationNumber} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 const canNotEditLabels = onetime((): boolean => !elementExists('.label-select-menu .octicon-gear'));
 
@@ -52,7 +53,7 @@ function addRemoveLabelButton(label: HTMLElement): void {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	await api.expectToken();
+	await expectToken();
 
 	delegate('.rgh-quick-label-removal:not([disabled])', 'click', removeLabelButtonClickHandler, {signal});
 

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -16,6 +16,7 @@ import addNotice from '../github-widgets/notice-bar.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import parseBackticks from '../github-helpers/parse-backticks.js';
 import observe from '../helpers/selector-observer.js';
+import {expectToken, expectTokenScope} from '../github-helpers/github-token.js';
 
 function handleToggle(event: DelegateEvent<Event, HTMLDetailsElement>): void {
 	const hasContent = elementExists([
@@ -41,7 +42,7 @@ function handleToggle(event: DelegateEvent<Event, HTMLDetailsElement>): void {
 
 async function verifyScopesWhileWaiting(abortController: AbortController): Promise<void> {
 	try {
-		await api.expectTokenScope('delete_repo');
+		await expectTokenScope('delete_repo');
 	} catch (error) {
 		assertError(error);
 		abortController.abort();
@@ -152,7 +153,7 @@ function addButton(header: HTMLElement): void {
 }
 
 async function init(signal: AbortSignal): Promise<void | false> {
-	await api.expectToken();
+	await expectToken();
 
 	observe('.pagehead-actions', addButton, {signal});
 	delegate('.rgh-quick-repo-deletion[open]', 'toggle', handleToggle, {capture: true, signal});

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -11,6 +11,7 @@ import observe from '../helpers/selector-observer.js';
 import showToast from '../github-helpers/toast.js';
 import {getConversationNumber, getUsername} from '../github-helpers/index.js';
 import {randomArrayItem} from '../helpers/math.js';
+import {getToken} from '../github-helpers/github-token.js';
 
 const emojis = [...'🚀✅🐿️⚡️🤌🥳🥰🤩🥸😎🤯🚢🛫🏳️🏁'];
 
@@ -48,7 +49,7 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 
 	// Can't approve own PRs and closed PRs
 	// API required for this action
-	if (getUsername() === $('.author')!.textContent || pageDetect.isClosedPR() || !(await api.getToken())) {
+	if (getUsername() === $('.author')!.textContent || pageDetect.isClosedPR() || !(await getToken())) {
 		return;
 	}
 

--- a/source/features/rgh-improve-new-issue-form.tsx
+++ b/source/features/rgh-improve-new-issue-form.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import openOptions from '../helpers/open-options.js';
 import clearCacheHandler from '../helpers/clear-cache-handler.js';
-import {expectToken, expectTokenScope} from '../github-helpers/api.js';
+import {expectToken, expectTokenScope} from '../github-helpers/github-token.js';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 
 function addNotice(adjective: JSX.Element | string): void {

--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -17,6 +17,7 @@ import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import abbreviateString from '../helpers/abbreviate-string.js';
 import {wrapAll} from '../helpers/dom-utils.js';
 import {groupButtons} from '../github-helpers/group-buttons.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 type RepoPublishState = {
 	latestTag: string | false;
@@ -167,12 +168,12 @@ async function addToReleases(releasesFilter: HTMLInputElement): Promise<void> {
 }
 
 async function initHome(signal: AbortSignal): Promise<void> {
-	await api.expectToken();
+	await expectToken();
 	observe(branchSelector, addToHome, {signal});
 }
 
 async function initReleases(signal: AbortSignal): Promise<void> {
-	await api.expectToken();
+	await expectToken();
 	observe('input#release-filter', addToReleases, {signal});
 }
 

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -15,6 +15,7 @@ import showToast from '../github-helpers/toast.js';
 import {getConversationNumber} from '../github-helpers/index.js';
 import createMergeabilityRow from '../github-widgets/mergeability-row.js';
 import selectHas from '../helpers/select-has.js';
+import {expectToken} from '../github-helpers/github-token.js';
 
 const canMerge = '.merge-pr > .color-fg-muted:first-child';
 const canNativelyUpdate = '.js-update-branch-form';
@@ -92,7 +93,7 @@ async function addButton(mergeBar: Element): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	await api.expectToken();
+	await expectToken()
 
 	delegate('.rgh-update-pr-from-base-branch', 'click', handler, {signal});
 	observe('.merge-message', addButton, {signal});

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -93,7 +93,7 @@ async function addButton(mergeBar: Element): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	await expectToken()
+	await expectToken();
 
 	delegate('.rgh-update-pr-from-base-branch', 'click', handler, {signal});
 	observe('.merge-message', addButton, {signal});

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -31,7 +31,7 @@ import {JsonObject, AsyncReturnType} from 'type-fest';
 
 import features from '../feature-manager.js';
 import {getRepo} from './index.js';
-import optionsStorage from '../options-storage.js';
+import {getToken} from './github-token.js';
 
 type JsonError = {
 	message: string;
@@ -55,30 +55,6 @@ export class RefinedGitHubAPIError extends Error {
 	response: AnyObject = {};
 	constructor(...messages: string[]) {
 		super(messages.join('\n'));
-	}
-}
-
-const settings = optionsStorage.getAll();
-
-export async function getToken(): Promise<string | undefined> {
-	const {personalToken} = await settings;
-	return personalToken;
-}
-
-export async function expectToken(): Promise<string> {
-	const personalToken = await getToken();
-	if (!personalToken) {
-		throw new Error('Personal token required for this feature');
-	}
-
-	return personalToken;
-}
-
-export async function expectTokenScope(scope: string): Promise<void> {
-	const {headers} = await v3('/');
-	const tokenScopes = headers.get('X-OAuth-Scopes')!;
-	if (!tokenScopes.split(', ').includes(scope)) {
-		throw new Error('The token you provided does not have ' + (tokenScopes ? `the \`${scope}\` scope. It only includes \`${tokenScopes}\`.` : 'any scope. You can change the scope of your token at https://github.com/settings/tokens'));
 	}
 }
 
@@ -119,7 +95,7 @@ export const v3 = mem(async (
 	options: GHRestApiOptions = v3defaults,
 ): Promise<RestResponse> => {
 	const {ignoreHTTPStatus, method, body, headers, json} = {...v3defaults, ...options};
-	const {personalToken} = await settings;
+	const personalToken = await getToken();
 
 	if (!query.startsWith('https')) {
 		query = query.startsWith('/') ? query.slice(1) : ['repos', getRepo()!.nameWithOwner, query].filter(Boolean).join('/');
@@ -175,7 +151,7 @@ export const v4uncached = async (
 	query: string,
 	options: GHGraphQLApiOptions = v4defaults,
 ): Promise<AnyObject> => {
-	const personalToken = await expectToken();
+	const personalToken = await getToken();
 
 	// TODO: Remove automatic usage of globals via `getRepo()`
 	// https://github.com/refined-github/refined-github/issues/5821
@@ -252,7 +228,7 @@ export const v4 = mem(v4uncached, {
 });
 
 export async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError> {
-	const {personalToken} = await settings;
+	const personalToken = await getToken();
 
 	if ((apiResponse.message as string)?.includes('API rate limit exceeded')) {
 		return new RefinedGitHubAPIError(

--- a/source/github-helpers/github-token.ts
+++ b/source/github-helpers/github-token.ts
@@ -1,0 +1,40 @@
+import { v3 } from './api.js';
+import optionsStorage from '../options-storage.js';
+
+const settings = optionsStorage.getAll();
+
+export async function getToken(): Promise<string | undefined> {
+	const {personalToken} = await settings;
+	return personalToken;
+}
+
+export async function expectToken(): Promise<string> {
+	const personalToken = await getToken();
+	if (!personalToken) {
+		throw new Error('Personal token required for this feature');
+	}
+	return personalToken;
+}
+
+export async function parseTokenScopes(headers: Headers): Promise<string[]> {
+	// If `X-OAuth-Scopes` is not present, the token may be not a classic token.
+	const scopes = headers.get('X-OAuth-Scopes')?.split(', ') ?? [];
+	scopes.push('valid_token');
+	if (scopes.includes('repo')) {
+		scopes.push('public_repo');
+	}
+
+	if (scopes.includes('project')) {
+		scopes.push('read:project');
+	}
+
+	return scopes;
+}
+
+export async function expectTokenScope(scope: string): Promise<void> {
+	const {headers} = await v3('/');
+	const tokenScopes = await parseTokenScopes(headers);
+	if (!tokenScopes.includes(scope))  {
+		throw new Error('The token you provided does not have ' + (tokenScopes ? `the \`${scope}\` scope. It only includes \`${tokenScopes}\`.` : 'any scope. You can change the scope of your token at https://github.com/settings/tokens'));
+	}
+}

--- a/source/github-helpers/github-token.ts
+++ b/source/github-helpers/github-token.ts
@@ -1,4 +1,4 @@
-import { v3 } from './api.js';
+import {v3} from './api.js';
 import optionsStorage from '../options-storage.js';
 
 const settings = optionsStorage.getAll();
@@ -13,12 +13,18 @@ export async function expectToken(): Promise<string> {
 	if (!personalToken) {
 		throw new Error('Personal token required for this feature');
 	}
+
 	return personalToken;
 }
 
 export async function parseTokenScopes(headers: Headers): Promise<string[]> {
 	// If `X-OAuth-Scopes` is not present, the token may be not a classic token.
-	const scopes = headers.get('X-OAuth-Scopes')?.split(', ') ?? [];
+	const scopesHeader = headers.get('X-OAuth-Scopes');
+	if (!scopesHeader) {
+		return [];
+	}
+
+	const scopes = scopesHeader.split(', ');
 	scopes.push('valid_token');
 	if (scopes.includes('repo')) {
 		scopes.push('public_repo');
@@ -34,7 +40,7 @@ export async function parseTokenScopes(headers: Headers): Promise<string[]> {
 export async function expectTokenScope(scope: string): Promise<void> {
 	const {headers} = await v3('/');
 	const tokenScopes = await parseTokenScopes(headers);
-	if (!tokenScopes.includes(scope))  {
-		throw new Error('The token you provided does not have ' + (tokenScopes ? `the \`${scope}\` scope. It only includes \`${tokenScopes}\`.` : 'any scope. You can change the scope of your token at https://github.com/settings/tokens'));
+	if (!tokenScopes.includes(scope)) {
+		throw new Error('The token you provided does not have ' + (tokenScopes.length > 0 ? `the \`${scope}\` scope. It only includes \`${tokenScopes.join(', ')}\`.` : 'any scope. You can change the scope of your token at https://github.com/settings/tokens'));
 	}
 }

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -21,6 +21,7 @@ import {perDomainOptions} from './options-storage.js';
 import isDevelopmentVersion from './helpers/is-development-version.js';
 import {doesBrowserActionOpenOptions} from './helpers/feature-utils.js';
 import {state as bisectState} from './helpers/bisect.js';
+import {parseTokenScopes} from './github-helpers/github-token.js';
 
 type TokenType = 'classic' | 'fine_grained';
 
@@ -78,18 +79,7 @@ async function getTokenScopes(personalToken: string): Promise<string[]> {
 		throw new Error(details.message);
 	}
 
-	// If `X-OAuth-Scopes` is not present, the token may be not a classic token.
-	const scopes = response.headers.get('X-OAuth-Scopes')?.split(', ') ?? [];
-	scopes.push('valid_token');
-	if (scopes.includes('repo')) {
-		scopes.push('public_repo');
-	}
-
-	if (scopes.includes('project')) {
-		scopes.push('read:project');
-	}
-
-	return scopes;
+	return parseTokenScopes(response.headers);
 }
 
 function expandTokenSection(): void {


### PR DESCRIPTION
## Description
- Closes: #7261
- Centralize token-management helper
  - Previously, github-token management was separated to "for option" and "for features"

## Test URLs
NOTE: Only occurs on my private repositories (SAML required Organization)

[refined-github/refined-github/pulls](https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc)

## Screenshot
![image](https://github.com/refined-github/refined-github/assets/50487467/6bb9977e-8430-420d-9d99-ed1a4b925cec)
