### PR TITLE
`previous-next-commit-buttons` - Restore feature

### DIFF
--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 
 function init(): false | void {
-	const originalPreviousNext = $('.commit .BtnGroup.float-right');
+	const originalPreviousNext = $('.commit .ButtonGroup.float-right');
 	if (!originalPreviousNext) {
 		return false;
 	}

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -5,7 +5,8 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 
 function init(): false | void {
-	const originalPreviousNext = $('.commit .ButtonGroup.float-right');
+	// TODO: Remove .BtnGroup in June 2024
+	const originalPreviousNext = $('.commit .float-right:is(.BtnGroup, .ButtonGroup)');
 	if (!originalPreviousNext) {
 		return false;
 	}


### PR DESCRIPTION
Fix for #7234 

Tested on Firefox and Chrome.

## Test URLs
[Lundalogik/lime-elements@`9726b8f` (#2739)](https://github.com/Lundalogik/lime-elements/pull/2739/commits/9726b8f50a4d27fb297fda2e6d496a3f109a5c26)

## Screenshot
Before:
![image](https://github.com/refined-github/refined-github/assets/578541/427f6beb-a34c-405a-8c26-0db0988bbbff)


After:
![image](https://github.com/refined-github/refined-github/assets/578541/5ca654f3-ebb5-49b5-97d5-9355b53a9a5d)
