### PR TITLE
`github-actions-indicators` -  Restore feature

### DIFF
--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -139,7 +139,7 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	observe('a.ActionList-content', addIndicators, {signal});
+	observe('a.ActionListContent', addIndicators, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
close: #7282 

## Test URLs
[AlmostReliable/almostunified/actions/workflows/release.yml](https://github.com/AlmostReliable/almostunified/actions/workflows/release.yml)

## Screenshot

<img width="1079" alt="截屏2024-03-13 17 10 13" src="https://github.com/refined-github/refined-github/assets/82451257/bd75241f-e407-4610-8c39-9c8ec585ad32">
