### PR TITLE
Fix colors on dark themes 

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,7 +1,10 @@
 :root {
 	--rgh-green: var(--fgColor-success, var(--color-success-fg, #1a7f37));
 	--rgh-red: var(--fgColor-danger, var(--color-danger-fg, #cf222e));
-	--rgh-border-color: var(--borderColor-muted, var(--color-border-muted, #d8dee4));
+	--rgh-border-color: var(
+		--borderColor-muted,
+		var(--color-border-muted, #d8dee4)
+	);
 	--rgh-background: var(--bgColor-default, var(--color-canvas-default, #fff));
 }
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,8 +1,8 @@
 :root {
-	--rgh-green: var(--color-success-fg, #1a7f37);
-	--rgh-red: var(--color-danger-fg, #cf222e);
-	--rgh-border-color: var(--color-border-muted, #d8dee4);
-	--rgh-background: var(--color-canvas-default, #fff);
+	--rgh-green: var(--fgColor-success, #1a7f37);
+	--rgh-red: var(--fgColor-danger, #cf222e);
+	--rgh-border-color: var(--borderColor-muted, #d8dee4);
+	--rgh-background: var(--bgColor-default, #fff);
 }
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,8 +1,8 @@
 :root {
-	--rgh-green: var(--fgColor-success, #1a7f37);
-	--rgh-red: var(--fgColor-danger, #cf222e);
-	--rgh-border-color: var(--borderColor-muted, #d8dee4);
-	--rgh-background: var(--bgColor-default, #fff);
+	--rgh-green: var(--fgColor-success, var(--color-success-fg, #1a7f37));
+	--rgh-red: var(--fgColor-danger, var(--color-danger-fg, #cf222e));
+	--rgh-border-color: var(--borderColor-muted, var(--color-border-muted, #d8dee4));
+	--rgh-background: var(--bgColor-default, var(--color-canvas-default, #fff));
 }
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */


### PR DESCRIPTION
GitHub recently seems to have changed its `--color*` vars to `--fgColor*`/`--bgColor*`. This updates the `--rgh*` color vars to use the new names, as leaving them at defaults causes issues in colorblind/dark themes.

Note that `--fgColor-danger` in Default Light Mode is now `#d1242f` which differs from the previously (still) defined default we have of `#cf222e` (now on `--bgColor-danger-emphasis`, among other vars). I am colorblind so I will need someone else to tell me if this is a significant difference and/or if the default value should also be updated for `--rgh-red`.

Also note that `--borderColor-muted` in Default Light Mode is now `#d0d7deb3` which differs from our default of `#d8dee4`. A var with this color is no longer present in Default Light Mode, but we can consider changing it to `--borderColor-default` instead, which is `#d0d7de` (no alpha).

Fixes #7305 

## Test URLs
https://github.com/notifications, various other pages that rely on rgh* color values.

## Screenshot
Old Light:
<img width="898" alt="Screenshot 2024-03-19 at 5 04 19 PM" src="https://github.com/refined-github/refined-github/assets/2764675/4b334238-3ff7-4c5f-83a3-1aad9dd6c996">

New Light:
<img width="899" alt="Screenshot 2024-03-19 at 5 04 59 PM" src="https://github.com/refined-github/refined-github/assets/2764675/98dafc49-9b71-4f90-bb75-2c3867500836">

Old Dark:
<img width="903" alt="Screenshot 2024-03-19 at 5 05 38 PM" src="https://github.com/refined-github/refined-github/assets/2764675/5bf6c6b4-56c5-4261-b820-dcf5ef899baa">

New Dark:
<img width="890" alt="Screenshot 2024-03-19 at 5 07 06 PM" src="https://github.com/refined-github/refined-github/assets/2764675/c021e828-6869-45fa-98d6-961fce350830">
