### PR TITLE
`repo-avatars` - Fix wrong organization avatar

### DIFF
--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -9,7 +9,7 @@ import observe from '../helpers/selector-observer.js';
 async function add(ownerLabel: HTMLElement): Promise<void> {
 	const username = getRepo()!.owner;
 	const size = 16;
-	const src = getUserAvatar(username, size, true)!;
+	const src = getUserAvatar(username, size)!;
 
 	const avatar = (
 		<img

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -9,7 +9,7 @@ import observe from '../helpers/selector-observer.js';
 async function add(ownerLabel: HTMLElement): Promise<void> {
 	const username = getRepo()!.owner;
 	const size = 16;
-	const src = getUserAvatar(username, size)!;
+	const src = getUserAvatar(username, size, true)!;
 
 	const avatar = (
 		<img

--- a/source/github-helpers/get-user-avatar.ts
+++ b/source/github-helpers/get-user-avatar.ts
@@ -1,14 +1,13 @@
 import {$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-export default function getUserAvatar(username: string, size: number, ignoreBots?: boolean): string | void {
+export default function getUserAvatar(username: string, size: number): string | void {
 	const cleanName = username.replace('[bot]', '');
 
 	// Find image on page. Saves a request and a redirect + add support for bots
-	const existingAvatar = $(`img[alt="@${cleanName}"]`);
-	const isBot = existingAvatar?.parentElement?.getAttribute('href')?.startsWith('/apps/');
+	const existingAvatar = $(`[href="/${cleanName}" i] img`);
 
-	if (existingAvatar && (isBot ? !ignoreBots : true)) {
+	if (existingAvatar) {
 		return existingAvatar.src;
 	}
 

--- a/source/github-helpers/get-user-avatar.ts
+++ b/source/github-helpers/get-user-avatar.ts
@@ -1,12 +1,14 @@
 import {$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
-export default function getUserAvatar(username: string, size: number): string | void {
+export default function getUserAvatar(username: string, size: number, ignoreBots?: boolean): string | void {
 	const cleanName = username.replace('[bot]', '');
 
 	// Find image on page. Saves a request and a redirect + add support for bots
 	const existingAvatar = $(`img[alt="@${cleanName}"]`);
-	if (existingAvatar) {
+	const isBot = existingAvatar?.parentElement?.getAttribute('href')?.startsWith('/apps/');
+
+	if (existingAvatar && (isBot ? !ignoreBots : true)) {
 		return existingAvatar.src;
 	}
 


### PR DESCRIPTION
Closes #7322

I've added a new optional parameter `ignoreBots`, for the `repo-avatars` scene.

## Test URLs

- https://github.com/simple-icons/simple-icons/pull/10728
