### PR TITLE
`unfinished-comments` - Drop "Draft" from the tab title prefix

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -28,7 +28,7 @@ function updateDocumentTitle(): void {
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
-		document.title = '✏️ Draft Comment - ' + document.title;
+		document.title = '✏️ Comment - ' + document.title;
 	} else if (documentTitle) {
 		document.title = documentTitle;
 		documentTitle = undefined;

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -28,7 +28,7 @@ function updateDocumentTitle(): void {
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
 		documentTitle = document.title;
-		document.title = '✏️ Draft - ' + document.title;
+		document.title = '✏️ Draft Comment - ' + document.title;
 	} else if (documentTitle) {
 		document.title = documentTitle;
 		documentTitle = undefined;


### PR DESCRIPTION
With GitHub having both 'Pull-Requests' and 'Draft Pull Requests', it may be confusing for users to understand that the 'Draft' in the document title refers to a unfinished comment rather than a Draft PR.
