### PR TITLE
Completely disable 4 slow features in Firefox/Safari

### DIFF
--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {isHasSelectorSupported} from '../helpers/select-has.js';
-import isBadBrowserOnPrFiles from '../helpers/7116.js';
+import {isChrome} from 'webext-detect-page';
 
 function LockedIndicator(): JSX.Element {
 	return (
@@ -39,6 +39,7 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	asLongAs: [
 		isHasSelectorSupported,
+		isChrome,
 	],
 	include: [
 		pageDetect.isConversation,
@@ -47,8 +48,6 @@ void features.add(import.meta.url, {
 		// TODO: Find alternative detection that works even for GHE that don't have reactions enabled
 		// https://github.com/refined-github/refined-github/issues/7063
 		pageDetect.isEnterprise,
-
-		isBadBrowserOnPrFiles,
 	],
 	init,
 });

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -2,11 +2,11 @@ import './locked-issue.css';
 import React from 'react';
 import LockIcon from 'octicons-plain-react/Lock';
 import * as pageDetect from 'github-url-detection';
+import {isChrome} from 'webext-detect-page';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {isHasSelectorSupported} from '../helpers/select-has.js';
-import {isChrome} from 'webext-detect-page';
 
 function LockedIndicator(): JSX.Element {
 	return (

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -3,11 +3,11 @@ import React from 'dom-chef';
 import {elementExists} from 'select-dom';
 import PencilIcon from 'octicons-plain-react/Pencil';
 import * as pageDetect from 'github-url-detection';
+import {isChrome} from 'webext-detect-page';
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import {isArchivedRepoAsync} from '../github-helpers/index.js';
-import {isChrome} from 'webext-detect-page';
 
 function addQuickEditButton(commentForm: Element): void {
 	const commentBody = commentForm.closest('.js-comment')!;

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -7,7 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import {isArchivedRepoAsync} from '../github-helpers/index.js';
-import isBadBrowserOnPrFiles from '../helpers/7116.js';
+import {isChrome} from 'webext-detect-page';
 
 function addQuickEditButton(commentForm: Element): void {
 	const commentBody = commentForm.closest('.js-comment')!;
@@ -58,11 +58,11 @@ async function init(signal: AbortSignal): Promise<void> {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isChrome,
+	],
 	include: [
 		pageDetect.hasComments,
-	],
-	exclude: [
-		isBadBrowserOnPrFiles,
 	],
 	// The feature is "disabled" via CSS selector when the conversation is locked.
 	// We want the edit buttons to appear while the conversation is loading, but we only know it's locked when the page has finished.

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -3,12 +3,12 @@ import {$} from 'select-dom';
 import TrashIcon from 'octicons-plain-react/Trash';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
+import {isChrome} from 'webext-detect-page';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import loadDetailsMenu from '../github-helpers/load-details-menu.js';
 import showToast from '../github-helpers/toast.js';
-import {isChrome} from 'webext-detect-page';
 
 function onButtonClick({delegateTarget: button}: DelegateEvent): void {
 	try {

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -8,7 +8,7 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import loadDetailsMenu from '../github-helpers/load-details-menu.js';
 import showToast from '../github-helpers/toast.js';
-import isBadBrowserOnPrFiles from '../helpers/7116.js';
+import {isChrome} from 'webext-detect-page';
 
 function onButtonClick({delegateTarget: button}: DelegateEvent): void {
 	try {
@@ -42,12 +42,12 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isChrome,
+	],
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
-	],
-	exclude: [
-		isBadBrowserOnPrFiles,
 	],
 	init,
 });

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -6,7 +6,7 @@ import {codeElementsSelector} from '../github-helpers/dom-formatters.js';
 import showWhiteSpacesOnLine from '../helpers/show-whitespace-on-line.js';
 import onAbort from '../helpers/abort-controller.js';
 import observe from '../helpers/selector-observer.js';
-import isBadBrowserOnPrFiles from '../helpers/7116.js';
+import {isChrome} from 'webext-detect-page';
 
 const viewportObserver = new IntersectionObserver(changes => {
 	for (const {target: line, isIntersecting} of changes) {
@@ -28,11 +28,11 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		isChrome,
+	],
 	include: [
 		pageDetect.hasCode,
-	],
-	exclude: [
-		isBadBrowserOnPrFiles,
 	],
 	init,
 });

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -1,12 +1,12 @@
 import './show-whitespace.css';
 import * as pageDetect from 'github-url-detection';
+import {isChrome} from 'webext-detect-page';
 
 import features from '../feature-manager.js';
 import {codeElementsSelector} from '../github-helpers/dom-formatters.js';
 import showWhiteSpacesOnLine from '../helpers/show-whitespace-on-line.js';
 import onAbort from '../helpers/abort-controller.js';
 import observe from '../helpers/selector-observer.js';
-import {isChrome} from 'webext-detect-page';
 
 const viewportObserver = new IntersectionObserver(changes => {
 	for (const {target: line, isIntersecting} of changes) {

--- a/source/helpers/7116.tsx
+++ b/source/helpers/7116.tsx
@@ -1,7 +1,0 @@
-import {isPRFiles} from 'github-url-detection';
-import {isChrome} from 'webext-detect-page';
-
-// TODO: Bad performance https://github.com/refined-github/refined-github/issues/7116
-export default function isBadBrowserOnPrFiles(): boolean {
-	return !isChrome() && isPRFiles();
-}


### PR DESCRIPTION
- replace `exclude: [isBadBrowserOnPrFiles]` with `asLongAs: [isChrome]` in the `locked-issue`, `quick-comment-edit`, `quick-review-comment-deletion` and `show-whitespace`

Changes according the the proposal in the https://github.com/refined-github/refined-github/issues/7316#issuecomment-2034018693