### PR TITLE
fix: restore previous layout

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -127,7 +127,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 
 const createDropdown = onetime(() => (
 	<details
-		className="details-reset details-overlay position-relative rgh-select-notifications mx-2"
+		className="details-reset details-overlay position-relative rgh-select-notifications mx-2 mr-auto"
 		onToggle={resetFilters}
 	>
 		<summary


### PR DESCRIPTION
I remember that the buttons was at the right

## Screenshot
before: 
![CleanShot 2024-05-03 at 17 42 27@2x](https://github.com/refined-github/refined-github/assets/82451257/155de58a-ea8b-4b50-8d5e-f264b2aefb03)

after:
![CleanShot 2024-05-03 at 17 42 10@2x](https://github.com/refined-github/refined-github/assets/82451257/ce0bf321-545b-4c75-a1ef-6d9e53a4f74e)
