### PR TITLE
`collect-commit-comments` - Show all commit comments in the comment section

### DIFF
--- a/source/features/collect-commit-comments.css
+++ b/source/features/collect-commit-comments.css
@@ -1,0 +1,17 @@
+.rgh-comment-header {
+	display: flex;
+	align-items: center;
+	padding-left: 16px;
+	padding-top: 8px;
+	padding-bottom: 8px;
+	color: var(--fgColor-muted, var(--color-fg-muted));
+	border-bottom: 1px solid var(--borderColor-default, var(--color-border-default));
+	border-top-left-radius: 6px;
+	border-top-right-radius: 6px;
+	background-color: var(--bgColor-muted, var(--color-canvas-subtle));
+}
+
+.rgh-comment-header-bolt {
+	color: #FFFF;
+	align-items: center;
+}

--- a/source/features/collect-commit-comments.gql
+++ b/source/features/collect-commit-comments.gql
@@ -1,0 +1,23 @@
+query GetCommentsFromCommit($owner:String!, $name:String!, $commit:String) {
+	repository(owner:$owner, name:$name) {
+		name,
+		object(expression:$commit) {
+			... on Commit {
+				message,
+				comments(first:100) {
+					nodes {
+						author {
+							avatarUrl,
+							login
+						},
+						authorAssociation,
+						bodyHTML,
+						url,
+						position,
+						path
+					}
+				}
+			}
+		}
+	}
+}

--- a/source/features/collect-commit-comments.tsx
+++ b/source/features/collect-commit-comments.tsx
@@ -1,0 +1,69 @@
+import './collect-commit-comments.css';
+import * as pageDetect from 'github-url-detection';
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+import React from 'dom-chef';
+import api from '../github-helpers/api.js';
+import GetCommentsFromCommit from './collect-commit-comments.gql';
+import { CachedFunction } from 'webext-storage-cache';
+
+const getCommitComments = new CachedFunction('get-comments', {
+	async updater(commit: string): Promise<any> {
+		const { repository: { object: { comments } } } = await api.v4(GetCommentsFromCommit, {
+			variables: {
+				commit
+			}
+		});
+
+		return comments;
+	}
+});
+
+async function append(element: HTMLElement): Promise<void> {
+	const commitSha = location.pathname.split('/').pop()!;
+	const comments = await getCommitComments.get(commitSha);
+	console.log(comments.nodes);
+	for (let commentsKey in comments.nodes) {
+		const comment = comments.nodes[commentsKey];
+		if (comment.position === null) continue;
+		const author = comment.author;
+		const body = comment.bodyHTML;
+		const url = comment.url;
+		const pos = comment.position;
+		const path = comment.path;
+
+		element.append(
+			<div className={'js-comment-container TimelineItem d-block'}>
+				<a className={'avatar-parent-child TimelineItem-avatar d-none d-md-block'}>
+					<img className={'avatar rounded-2 avatar-user'} src={author.avatarUrl + '?s=80&v=4'} alt={author.login}
+							 width={40} height={40} />
+				</a>
+				<div
+					className={'timeline-comment-group js-minimizable-comment-group js-targetable-element my-0 comment previewable-edit js-task-list-container js-comment timeline-comment timeline-comment--caret ml-n3 js-minimize-container unminimized-comment'}>
+					<div className={'rgh-comment-header clearfix d-flex'}>
+						<div>
+							<b className={'rgh-comment-header-bolt'}>{author.login}</b> commented on <a href={url}>line {pos}</a> in file {path}</div>
+					</div>
+					<div
+						className={'comment-body markdown-body js-comment-body soft-wrap css-overflow-wrap-anywhere user-select-contain d-block'}>
+						<div dangerouslySetInnerHTML={{ __html: body }}></div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+
+}
+
+async function init(signal: AbortSignal): Promise<void> {
+	observe('div#comments', append, { signal });
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isCommit
+	],
+	init
+});
+

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -222,3 +222,4 @@ import './features/fix-no-pr-search.js';
 import './features/clean-readme-url.js';
 import './features/pr-notification-link.js';
 import './features/click-outside-modal.js';
+import './features/collect-commit-comments.js';


### PR DESCRIPTION

## Notes
This is my first time doing this kind of stuff and I am sure there is a lot of improvements to make. 
I don't think there is an easy way to replicate comments, so I had to create them manually. This is also the reason why it misses several features. The reason why I want to add such a feature is because it's hard to find comments on large commits (See test url). I would like to get feedback about the general idea and maybe some people can give me tips on how to improve things  :)


## Test URLs

https://github.com/PaperMC/DataConverter/commit/31387432cacf86b8e76362c6d7de44c5104afbf1#comments

## Screenshot
### Before
![image](https://github.com/refined-github/refined-github/assets/59799222/000e47d3-1a8b-4335-bfdc-0f08d226cd1c)

### After
![image](https://github.com/refined-github/refined-github/assets/59799222/8b0460a0-0dbc-4895-a8a8-d046ca72df6b)