### PR TITLE
`clean-conversation-sidebar` - Restore mistakenly-hidden links

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -56,6 +56,7 @@ function cleanSection(selector: string): boolean {
 		'.IssueLabel',
 		'[aria-label="Select milestones"] .Progress-item',
 		'[aria-label="Link issues"] [data-hovercard-type]',
+		'a[href^="https://copilot-workspace.githubnext.com"]',
 		'[aria-label="Select projects"] .Link--primary',
 	];
 
@@ -115,7 +116,8 @@ async function cleanSidebar(): Promise<void> {
 	}
 
 	const createBranchLink = $('button[data-action="click:create-branch#openDialog"]');
-	if (createBranchLink) {
+	const openWorkspaceButton = $('a[href^="https://copilot-workspace.githubnext.com"]');
+	if (createBranchLink && !openWorkspaceButton) {
 		createBranchLink.classList.add('Link--muted', 'Link--inTextBlock');
 		$('[aria-label="Link issues"] summary')!.append(
 			<span style={{fontWeight: 'normal'}}> – {createBranchLink}</span>,

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -114,7 +114,7 @@ async function cleanSidebar(): Promise<void> {
 		removeTextNodeContaining(developmentHint, /No branches or pull requests|Successfully merging/);
 	}
 
-	const createBranchLink = $('button[data-action="click:create-issue-branch#openDialog"]');
+	const createBranchLink = $('button[data-action="click:create-branch#openDialog"]');
 	if (createBranchLink) {
 		createBranchLink.classList.add('Link--muted');
 		$('[aria-label="Link issues"] summary')!.append(

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -116,7 +116,7 @@ async function cleanSidebar(): Promise<void> {
 
 	const createBranchLink = $('button[data-action="click:create-branch#openDialog"]');
 	if (createBranchLink) {
-		createBranchLink.classList.add('Link--muted');
+		createBranchLink.classList.add('Link--muted', 'Link--inTextBlock');
 		$('[aria-label="Link issues"] summary')!.append(
 			<span style={{fontWeight: 'normal'}}> – {createBranchLink}</span>,
 		);


### PR DESCRIPTION
Closes #7235 

* Data action of create branch corrected from `click:create-issue-branch#openDialog` to `click:create-branch#openDialog` so that it will be added to the heading when the section is collapsed
* Section will not be hidden or collapsed if the "Open in Workspace" button is in the Development section (currently a feature in limited technical preview)

## Test URLs

Affects Issues pages

* https://github.com/refined-github/refined-github/issues/7235
* https://github.com/DenverCoder1/readme-typing-svg/issues/295
* https://github.com/DenverCoder1/readme-typing-svg/issues/21

## Screenshot

Not logged in:

![image](https://github.com/refined-github/refined-github/assets/20955511/e9ce24e8-5bef-452c-ac18-553ee9140b90)

----

Logged in, no edit access, no Copilot Workspace access, no linked issues:

![image](https://github.com/refined-github/refined-github/assets/20955511/7a936d6f-9830-45ee-ab95-2876a0d12c48)

----

Logged in, no edit access, no Copilot Workspace access, has linked issues:

![image](https://github.com/refined-github/refined-github/assets/20955511/8261db9e-6ae0-44e2-b4a3-2a9a66349fe2)

----

Logged in, has edit access, no Copilot Workspace access:

![image](https://github.com/refined-github/refined-github/assets/20955511/6f736e53-6b09-4740-8b13-8d3260251ddf)

----

Logged in, no edit access, has Copilot Workspace access:

![image](https://github.com/refined-github/refined-github/assets/20955511/869c250e-be81-492c-8416-f73ae60e7116)

----

Logged in, has edit access, has Copilot Workspace access:

![image](https://github.com/refined-github/refined-github/assets/20955511/747e0786-0a77-48b6-bc89-5df2433b4347)

----