### PR TITLE
fix: ensure 'Open in workspace' option is displayed in conversation sidebar

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -56,6 +56,7 @@ function cleanSection(selector: string): boolean {
 		'.IssueLabel',
 		'[aria-label="Select milestones"] .Progress-item',
 		'[aria-label="Link issues"] [data-hovercard-type]',
+		'[aria-label="Link issues"] svg.octicon-copilot',
 		'[aria-label="Select projects"] .Link--primary',
 	];
 


### PR DESCRIPTION
Related to #7363

Updates the `clean-conversation-sidebar` feature to ensure the "Open in workspace" option is correctly displayed in the GitHub issue pages sidebar.
