### PR TITLE
`unreleased-commits` - Avoid internal wrapping

### DIFF
--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -131,10 +131,14 @@ async function addToHome(branchSelector: HTMLButtonElement): Promise<void> {
 			await createLinkGroup(latestTag, aheadBy) as HTMLElement,
 		);
 	} else {
+		const linkGroup = await createLinkGroup(latestTag, aheadBy) as HTMLElement;
+
+		linkGroup.style.flexShrink = '0';
+
 		wrapAll(
 			<div className="d-flex gap-2"/>,
 			branchSelector,
-			await createLinkGroup(latestTag, aheadBy),
+			linkGroup,
 		);
 	}
 }


### PR DESCRIPTION
Close #7375.

<img width="404" alt="image" src="https://github.com/refined-github/refined-github/assets/15034155/59cedab3-b757-456f-b41d-1d1a049630b3">

Since the branch picker sets the width to 100%, the unreleased commits button group will shrink in a flexbox.

Set `flex-shrink: 0` solves this problem, it will let the width of the button group grow from its min-content.