### PR TITLE
Improve `has`-selector performance

### DIFF
--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,3 +1,0 @@
-.js-issues-results:has(.js-pick-reaction:not(:first-child)) .rgh-locked-issue {
-	display: none !important;
-}

--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,3 +1,3 @@
-:has(.js-pick-reaction:not(:first-child)) .rgh-locked-issue {
+.js-issues-results:has(.js-pick-reaction:not(:first-child)) .rgh-locked-issue {
 	display: none !important;
 }

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -17,22 +17,21 @@ function LockedIndicator(): JSX.Element {
 }
 
 function addLock(element: HTMLElement): void {
+	const classes = (element.closest('.gh-header-sticky') ? 'mr-2 ' : '') + 'mb-2 rgh-locked-issue';
 	element.after(
-		<LockedIndicator className="mb-2 rgh-locked-issue"/>,
-	);
-}
-
-function addStickyLock(element: HTMLElement): void {
-	element.after(
-		<LockedIndicator className="mr-2 mb-2 rgh-locked-issue"/>,
+		<LockedIndicator className={classes}/>,
 	);
 }
 
 function init(signal: AbortSignal): void {
 	// If reactions-menu exists, then .js-pick-reaction is the second child
 	// Logged out users never have the menu, so they should be excluded
-	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-meta > :first-child', addLock, {signal});
-	observe('.logged-in:has(.js-pick-reaction:first-child) .gh-header-sticky .flex-row > :first-child', addStickyLock, {signal});
+	observe(`
+		.logged-in .js-issues-results:has(.js-pick-reaction:first-child) :is(
+			.gh-header-meta > :first-child,
+			.gh-header-sticky .flex-row > :first-child
+		)
+	`, addLock, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -1,4 +1,3 @@
-import './locked-issue.css';
 import React from 'react';
 import LockIcon from 'octicons-plain-react/Lock';
 import * as pageDetect from 'github-url-detection';

--- a/source/features/quick-comment-edit.css
+++ b/source/features/quick-comment-edit.css
@@ -1,5 +1,5 @@
 /* Re-hide buttons when you can't leave a new comment (locked conversation or user blocked you) */
-html:has(.previewable-comment-form .octicon-lock.blankslate-icon)
+.js-quote-selection-container:has(.previewable-comment-form .octicon-lock.blankslate-icon)
 	.rgh-quick-comment-edit-button {
 	display: none;
 }

--- a/source/features/quick-comment-edit.css
+++ b/source/features/quick-comment-edit.css
@@ -1,5 +1,7 @@
 /* Re-hide buttons when you can't leave a new comment (locked conversation or user blocked you) */
-.js-quote-selection-container:has(.previewable-comment-form .octicon-lock.blankslate-icon)
+.js-quote-selection-container:has(
+		.previewable-comment-form .octicon-lock.blankslate-icon
+	)
 	.rgh-quick-comment-edit-button {
 	display: none;
 }

--- a/source/features/quick-comment-edit.css
+++ b/source/features/quick-comment-edit.css
@@ -1,0 +1,7 @@
+/* Re-hide buttons when you can't leave a new comment (locked conversation or user blocked you) */
+.js-quote-selection-container:has(
+		.previewable-comment-form .octicon-lock.blankslate-icon
+	)
+	.rgh-quick-comment-edit-button {
+	display: none;
+}

--- a/source/features/quick-comment-edit.css
+++ b/source/features/quick-comment-edit.css
@@ -1,7 +1,0 @@
-/* Re-hide buttons when you can't leave a new comment (locked conversation or user blocked you) */
-.js-quote-selection-container:has(
-		.previewable-comment-form .octicon-lock.blankslate-icon
-	)
-	.rgh-quick-comment-edit-button {
-	display: none;
-}

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -1,4 +1,3 @@
-import './quick-comment-edit.css';
 import React from 'dom-chef';
 import {elementExists} from 'select-dom';
 import PencilIcon from 'octicons-plain-react/Pencil';

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -18,14 +18,14 @@ function addQuickEditButton(commentDropdown: HTMLDetailsElement): void {
 		return;
 	}
 
-	if (elementExists([
-		// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
-		'.rgh-quick-comment-edit-button',
+	// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
+	if (elementExists('.rgh-quick-comment-edit-button', commentBody)) {
+		return;
+	}
 
-		// If .js-pick-reaction is the first child, `reaction-menu` doesn't exist, which means that the conversation is locked
-		'.js-pick-reaction:first-child',
-	], commentBody)) {
-		console.log('Comment is locked');
+	// If .js-pick-reaction is the first child, `reaction-menu` doesn't exist, which means that the conversation is locked.
+	// However, if you can edit every comment, you can still edit the comment
+	if (elementExists('.js-pick-reaction:first-child', commentBody) && !canEditEveryComment()) {
 		return;
 	}
 

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -1,3 +1,4 @@
+import './quick-comment-edit.css';
 import React from 'dom-chef';
 import {elementExists} from 'select-dom';
 import PencilIcon from 'octicons-plain-react/Pencil';

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -1,4 +1,3 @@
-import './quick-comment-edit.css';
 import React from 'dom-chef';
 import {elementExists} from 'select-dom';
 import PencilIcon from 'octicons-plain-react/Pencil';
@@ -9,25 +8,37 @@ import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import {isArchivedRepoAsync} from '../github-helpers/index.js';
 
-function addQuickEditButton(commentForm: Element): void {
-	const commentBody = commentForm.closest('.js-comment')!;
-	// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
-	if (elementExists('.rgh-quick-comment-edit-button', commentBody)) {
+function addQuickEditButton(commentDropdown: HTMLDetailsElement): void {
+	const commentBody = commentDropdown.closest('.js-comment')!;
+
+	// TODO: Potentially move to :has selector
+	// The comment is definitely not editable
+	if (!elementExists('.js-comment-update', commentBody)) {
+		console.log('Comment is not editable');
 		return;
 	}
 
-	commentBody
-		.querySelector('.timeline-comment-actions details.position-relative')! // The dropdown
-		.before(
-			<button
-				type="button"
-				role="menuitem"
-				className="timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button"
-				aria-label="Edit comment"
-			>
-				<PencilIcon/>
-			</button>,
-		);
+	if (elementExists([
+		// We can't rely on a class for deduplication because the whole comment might be replaced by GitHub #5572
+		'.rgh-quick-comment-edit-button',
+
+		// If .js-pick-reaction is the first child, `reaction-menu` doesn't exist, which means that the conversation is locked
+		'.js-pick-reaction:first-child',
+	], commentBody)) {
+		console.log('Comment is locked');
+		return;
+	}
+
+	commentDropdown.before(
+		<button
+			type="button"
+			role="menuitem"
+			className="timeline-comment-action btn-link js-comment-edit-button rgh-quick-comment-edit-button"
+			aria-label="Edit comment"
+		>
+			<PencilIcon/>
+		</button>,
+	);
 }
 
 export function canEditEveryComment(): boolean {
@@ -52,9 +63,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	// If true then the resulting selector will match all comments, otherwise it will only match those made by you
 	const preSelector = canEditEveryComment() ? '' : '.current-user';
 
-	// Find editable comments first, then traverse to the correct position
-	// TODO: Replace with :has selector
-	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update', addQuickEditButton, {signal});
+	observe(preSelector + '.js-comment.unminimized-comment .timeline-comment-actions details.position-relative', addQuickEditButton, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -77,3 +77,11 @@ void features.add(import.meta.url, {
 	// We want the edit buttons to appear while the conversation is loading, but we only know it's locked when the page has finished.
 	init,
 });
+
+/*
+Test URLs:
+
+- Locked issue (own repo): https://github.com/refined-github/sandbox/issues/74
+- Locked issue (other repo): https://github.com/eslint/eslint/issues/8213
+
+*/

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -93,8 +93,9 @@ async function init(signal: AbortSignal): Promise<void> {
 	// The hovercard attribute avoids `highest-rated-comment`
 	// Avatars next to review events aren't wrapped in a <div> #4844
 	// :has(fieldSelector) enables the feature only when/after the "mention" button can actually work
+	// .js-quote-selection-container selects the closest parent that contains both the new comment field and the avatar #7378
 	observe(`
-		.js-discussion:has(${fieldSelector})
+		.js-quote-selection-container:has(${fieldSelector})
 		:is(
 			div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child,
 			a.TimelineItem-avatar

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -94,7 +94,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	// Avatars next to review events aren't wrapped in a <div> #4844
 	// :has(fieldSelector) enables the feature only when/after the "mention" button can actually work
 	observe(`
-		body:has(${fieldSelector})
+		.js-discussion:has(${fieldSelector})
 		:is(
 			div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child,
 			a.TimelineItem-avatar

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -119,4 +119,7 @@ https://github.com/refined-github/sandbox/pull/10
 No-comment reviews shouldn't have it:
 https://github.com/NixOS/nixpkgs/pull/147010#pullrequestreview-817111882
 
+- Locked issue (own repo): https://github.com/refined-github/sandbox/issues/74
+- Locked issue (other repo): https://github.com/eslint/eslint/issues/8213
+
 */

--- a/source/features/readable-title-change-events.css
+++ b/source/features/readable-title-change-events.css
@@ -12,11 +12,6 @@
 	word-break: break-word !important;
 }
 
-/* TODO: Drop this whole rule when :has() is crossbrowser */
-.TimelineItem[id^='event-'] .TimelineItem-body :is(ins, del) {
-	display: block !important;
-}
-
 /*
 Test URLs
 https://github.com/refined-github/refined-github/pull/4030#event-4385348325


### PR DESCRIPTION
- Follows the advice in https://github.com/refined-github/refined-github/issues/7331#issuecomment-2120464245
- Part of https://github.com/refined-github/refined-github/issues/5797
- Reverts https://github.com/refined-github/refined-github/pull/7075


## Demo for `locked-issue`

URL: https://github.com/refined-github/sandbox/issues/74

GitHub seems to be reloading the whole page when locked/unlocked, so I dropped the additional CSS rule.


https://github.com/refined-github/refined-github/assets/1402241/bdcb2dd4-0ba8-4a99-85bb-abdc96841379

## Demo for `quick-mention`

URL: https://github.com/refined-github/sandbox/pull/10

Alignment but must be reported/fixed separately

<img width="159" alt="Screenshot 2024-06-02 at 14 54 06" src="https://github.com/refined-github/refined-github/assets/1402241/9d9e9475-cd14-4bf6-ab49-007296265585">


## Demo for `readable-title-change-events`

URL: Below

<img width="324" alt="Screenshot 2024-06-02 at 14 51 09" src="https://github.com/refined-github/refined-github/assets/1402241/f1e7f0cf-a9ea-42eb-ac3b-194ec465f6db">

