### PR TITLE
`quick-review` - Restore auto-focus

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -70,7 +70,7 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 
-function focusReviewTextarea(event: DelegateEvent<Event, HTMLDetailsElement>): void {
+function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
 	if (((event as unknown) as ToggleEvent).newState === 'open') {
 		$('textarea', event.delegateTarget)!.focus();
 	}

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -70,9 +70,8 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 
-
 function focusReviewTextarea(event: DelegateEvent<Event, HTMLDetailsElement>): void {
-	if (((event as unknown) as ToggleEvent).newState === "open")  {
+	if (((event as unknown) as ToggleEvent).newState === 'open') {
 		$('textarea', event.delegateTarget)!.focus();
 	}
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -70,14 +70,15 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 
-function focusReviewTextarea({delegateTarget}: DelegateEvent<Event, HTMLDetailsElement>): void {
-	if (delegateTarget.open) {
-		$('textarea', delegateTarget)!.focus();
+
+function focusReviewTextarea(event: DelegateEvent<Event, HTMLDetailsElement>): void {
+	if (((event as unknown) as ToggleEvent).newState === "open")  {
+		$('textarea', event.delegateTarget)!.focus();
 	}
 }
 
 async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> {
-	delegate('.js-reviews-container > details', 'toggle', focusReviewTextarea, {capture: true, signal});
+	delegate('#review-changes-modal', 'toggle', focusReviewTextarea, {capture: true, signal});
 
 	const reviewDropdownButton = await elementReady('.js-reviews-toggle');
 	if (reviewDropdownButton) {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 import delay from 'delay';
-import {$} from 'select-dom';
+import {expectElement as $} from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import delegate, {DelegateEvent} from 'delegate-it';
@@ -49,7 +49,7 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 
 	// Can't approve own PRs and closed PRs
 	// API required for this action
-	if (getUsername() === $('.author')!.textContent || pageDetect.isClosedPR() || !(await getToken())) {
+	if (getUsername() === $('.author').textContent || pageDetect.isClosedPR() || !(await getToken())) {
 		return;
 	}
 
@@ -72,7 +72,7 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 
 function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
 	if ('newState' in event && event.newState === 'open') {
-		$('textarea', event.delegateTarget)!.focus();
+		$('textarea', event.delegateTarget).focus();
 	}
 }
 

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -71,7 +71,7 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 }
 
 function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
-	if (((event as unknown) as ToggleEvent).newState === 'open') {
+	if ('newState' in event && event.newState === 'open') {
 		$('textarea', event.delegateTarget)!.focus();
 	}
 }


### PR DESCRIPTION
## Description
- Closes #7272

## Explain
- GitHub changed to use [Top Layer](https://developer.mozilla.org/en/docs/Glossary/Top_layer) with [Popover API](https://developer.mozilla.org/en/docs/Web/API/Popover_API) on modal elements.
- And the [docs](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API#interfaces) says popover triggers `ToggleEvent` when they called. but `lib.dom.ts` is typed with `Event` maybe for backward compatibility.
- So I hacked the type like `(event as unknown) as ToggleEvent`

## Test URLs
- Open [refined-github/sandbox#12 (files)](https://github.com/refined-github/sandbox/pull/12/files#review-changes-modal)
See the field not being focused

## Screenshot
https://github.com/refined-github/refined-github/assets/50487467/fd653e1b-e25b-4a5c-8ac5-52eddc5c26c5

