### PR TITLE
`close-out-of-view-modals` - Fix conflict with Development menu

### DIFF
--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -57,3 +57,12 @@ function init(): void {
 void features.add(import.meta.url, {
 	init: onetime(init),
 });
+
+/*
+
+Test URLs
+
+- Dropdowns in conversation sidebar: https://github.com/refined-github/sandbox/issues/3
+- Star/Watch dropdowns: https://github.com/refined-github/sandbox
+
+*/

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -41,6 +41,7 @@ function menuActivatedHandler(event: DelegateEvent): void {
 	const modals = $$([
 		':scope > details-menu', // "Watch repo" dropdown
 		':scope > details-dialog', // "Watch repo" dropdown
+		':scope > modal-dialog', // "Development" dropdown #7093
 		':scope > div > .dropdown-menu', // "Clone or download" and "Repo nav overflow"
 	], details);
 


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/7093


## Test URLs



- Dropdowns in conversation sidebar: https://github.com/refined-github/sandbox/issues/3
- Star/Watch dropdowns: https://github.com/refined-github/sandbox


## Screenshot

![Untitled](https://github.com/refined-github/refined-github/assets/1402241/c1823d95-b64d-4c0c-946a-41570b01a07b)

