### PR TITLE
`swap-branches-on-compare` - Show when list is empty

### DIFF
--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -44,7 +44,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		// Disable on Two-dot Git diff comparison #4453
 		isTwoDotDiff,
-
 	],
 	awaitDomReady: true,
 	deduplicate: 'has-rgh',

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -34,7 +34,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		// Disable on Two-dot Git diff comparison #4453
 		isTwoDotDiff,
-		pageDetect.isBlank,
 	],
 	awaitDomReady: true,
 	deduplicate: 'has-rgh',

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -8,8 +8,14 @@ import {buildRepoURL, getRepo} from '../github-helpers/index.js';
 const isTwoDotDiff = (): boolean => /\.\.+/.exec(location.pathname)?.[0]!.length === 2;
 
 function init(): void {
-	const references = getRepo()!
-		.path
+	const {path} = (getRepo()!);
+
+	// `main...main` comparison
+	if (path === 'compare') {
+		return;
+	}
+
+	const references = path
 		.replace('compare/', '')
 		.split('...')
 		.reverse();
@@ -17,6 +23,10 @@ function init(): void {
 	// Compares against the "base" branch if the URL only has one reference
 	if (references.length === 1) {
 		references.unshift($('.branch span')!.textContent);
+	}
+
+	if (references[0] === references[1]) {
+		return;
 	}
 
 	const referencePicker = $('.range-editor .d-inline-block + .range-cross-repo-pair')!;
@@ -34,6 +44,7 @@ void features.add(import.meta.url, {
 	exclude: [
 		// Disable on Two-dot Git diff comparison #4453
 		isTwoDotDiff,
+
 	],
 	awaitDomReady: true,
 	deduplicate: 'has-rgh',
@@ -44,5 +55,6 @@ void features.add(import.meta.url, {
 Test URLs:
 
 - Compare: https://github.com/refined-github/refined-github/compare/23.2.1...main
-- Blank: https://github.com/refined-github/refined-github/compare
+- Blank but valid: https://github.com/refined-github/refined-github/compare/23.11.15.1433...23.11.15
+- Blank but unswappable: https://github.com/refined-github/refined-github/compare
 */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7102


## Test URLs


- Compare: https://github.com/refined-github/refined-github/compare/23.2.1...main
- Blank but valid: https://github.com/refined-github/refined-github/compare/23.11.15.1433...23.11.15
- Blank but unswappable: https://github.com/refined-github/refined-github/compare

## Screenshot

<img width="489" alt="Screenshot 4" src="https://github.com/refined-github/refined-github/assets/1402241/91400912-5bdf-45a3-adfe-4c88ae7c6013">

<img width="489" alt="Screenshot" src="https://github.com/refined-github/refined-github/assets/1402241/9e04d028-1dd0-44f0-9183-1ba2f51fb993">
