### PR TITLE
`quick-label-removal` - Don't restore labels when adding some

### DIFF
--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -1,6 +1,6 @@
 import './quick-label-removal.css';
 import React from 'dom-chef';
-import {expectElement as $, elementExists} from 'select-dom';
+import {$, elementExists} from 'select-dom';
 import onetime from 'onetime';
 import XIcon from 'octicons-plain-react/X';
 import {assertError} from 'ts-extras';
@@ -22,14 +22,6 @@ async function removeLabelButtonClickHandler(event: DelegateEvent<MouseEvent, HT
 	const removeLabelButton = event.delegateTarget;
 	const label = removeLabelButton.closest('a')!;
 
-	// Force update of label selector if necessary
-	if (!elementExists('.sidebar-labels include-fragment')) {
-		const deferredContentWrapper = $('.sidebar-labels .hx_rsm-content');
-		const menu = deferredContentWrapper.closest('[src]')!;
-		deferredContentWrapper.textContent = '';
-		deferredContentWrapper.append(<include-fragment src={menu.getAttribute('src')!}/>);
-	}
-
 	label.hidden = true;
 	try {
 		await api.v3(`issues/${getConversationNumber()!}/labels/${removeLabelButton.dataset.name!}`, {
@@ -44,6 +36,15 @@ async function removeLabelButtonClickHandler(event: DelegateEvent<MouseEvent, HT
 	}
 
 	label.remove();
+
+	// Force update of label selector if necessary
+	const deferredContentWrapper = $('.label-select-menu [src] .hx_rsm-content');
+	if (deferredContentWrapper) {
+		const menu = deferredContentWrapper.closest('[src]')!;
+		deferredContentWrapper.replaceChildren(
+			<include-fragment src={menu.getAttribute('src')!}/>,
+		);
+	}
 }
 
 function addRemoveLabelButton(label: HTMLElement): void {
@@ -64,7 +65,6 @@ async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
 
 	delegate('.rgh-quick-label-removal:not([disabled])', 'click', removeLabelButtonClickHandler, {signal});
-
 	observe('.js-issue-labels .IssueLabel', addRemoveLabelButton, {signal});
 }
 

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -60,8 +60,7 @@ function addRemoveLabelButton(label: HTMLElement): void {
 	label.append(
 		<button
 			type="button"
-			aria-label="Remove this label"
-			className="btn-link tooltipped tooltipped-nw rgh-quick-label-removal"
+			className="btn-link rgh-quick-label-removal"
 			data-name={label.dataset.name}
 		>
 			<XIcon/>

--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -1,6 +1,6 @@
 import './quick-label-removal.css';
 import React from 'dom-chef';
-import {elementExists} from 'select-dom';
+import {expectElement as $, elementExists} from 'select-dom';
 import onetime from 'onetime';
 import XIcon from 'octicons-plain-react/X';
 import {assertError} from 'ts-extras';
@@ -21,6 +21,14 @@ async function removeLabelButtonClickHandler(event: DelegateEvent<MouseEvent, HT
 
 	const removeLabelButton = event.delegateTarget;
 	const label = removeLabelButton.closest('a')!;
+
+	// Force update of label selector if necessary
+	if (!elementExists('.sidebar-labels include-fragment')) {
+		const deferredContentWrapper = $('.sidebar-labels .hx_rsm-content');
+		const menu = deferredContentWrapper.closest('[src]')!;
+		deferredContentWrapper.textContent = '';
+		deferredContentWrapper.append(<include-fragment src={menu.getAttribute('src')!}/>);
+	}
 
 	label.hidden = true;
 	try {


### PR DESCRIPTION
- Reverts #4939
- Will fix https://github.com/refined-github/refined-github/issues/6862


## Test URLs

Here

## Demo fast removal


https://github.com/refined-github/refined-github/assets/1402241/4f7f33a4-49b5-49d3-b049-da857396287a


## Demo with broken API


The dropdown is emptied but it still works afterwards

https://github.com/refined-github/refined-github/assets/1402241/fd091eff-636a-4b73-b1e1-f9c63d57657a

