### PR TITLE
`github-actions-indicators` - Restore feature

### DIFF
--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -1,7 +1,6 @@
 import {CachedFunction} from 'webext-storage-cache';
 import React from 'dom-chef';
-import {$, elementExists} from 'select-dom';
-import StopIcon from 'octicons-plain-react/Stop';
+import {$, expectElement} from 'select-dom';
 import PlayIcon from 'octicons-plain-react/Play';
 import {parseCron} from '@cheap-glitch/mi-cron';
 import * as pageDetect from 'github-url-detection';
@@ -69,7 +68,7 @@ const workflowDetails = new CachedFunction('workflows-details', {
 			const workflowYaml = workflowFiles[workflow.name];
 
 			if (workflowYaml === undefined) {
-			// Cannot find workflow yaml; workflow removed.
+				// Cannot find workflow yaml; workflow removed.
 				continue;
 			}
 
@@ -121,7 +120,7 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 	}
 
 	const relativeTime = <relative-time datetime={String(nextTime)}/>;
-	$('.ActionList-item-label', workflowListItem)!.append(
+	expectElement('.ActionListItem-label', workflowListItem).append(
 		<em>
 			({relativeTime})
 		</em>,

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -94,6 +94,9 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 	const workflows = await workflowDetails.get();
 	const workflowName = workflowListItem.href.split('/').pop()!;
 	const workflow = workflows[workflowName];
+	if (!workflow) {
+		return;
+	}
 
 	const svgTrailer = $('.ActionListItem-visual--trailing', workflowListItem)
 	?? <div className="ActionListItem-visual--trailing"/>;
@@ -101,7 +104,7 @@ async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void>
 		workflowListItem.append(svgTrailer);
 	}
 
-	svgTrailer.classList.add('m-auto', 'd-flex', 'gap-2')
+	svgTrailer.classList.add('m-auto', 'd-flex', 'gap-2');
 
 	if (workflow.manuallyDispatchable) {
 		svgTrailer.append(<PlayIcon className="m-auto"/>);
@@ -146,13 +149,10 @@ void features.add(import.meta.url, {
 
 ## Test URLs
 
-Manual:
-https://github.com/fregante/browser-extension-template/actions
-
 Manual + scheduled:
-https://github.com/fregante/eslint-formatters/actions
+https://github.com/sindresorhus/type-fest/actions/workflows/ts-canary.yml
 
-Manually disabled:
-https://github.com/134130/134130/actions
+Manual + disabled + pinned:
+https://github.com/refined-github/sandbox/actions
 
 */

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -73,8 +73,8 @@ const workflowDetails = new CachedFunction('workflows-details', {
 				continue;
 			}
 
-			const cron = /schedule[:\s-]+cron[:\s'"]+([^'"\n]+)/m.exec(workflowYaml);
-
+			// Single-line regex, allows comments around
+			const cron = /^(?: {4}|\t\t)-\s*cron[:\s'"]+([^'"\n]+)/m.exec(workflowYaml);
 			details[workflow.name] = {
 				...workflow,
 				schedule: cron?.[1],

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -90,26 +90,18 @@ const workflowDetails = new CachedFunction('workflows-details', {
 });
 
 async function addIndicators(workflowListItem: HTMLAnchorElement): Promise<void> {
-	// There might be a disabled indicator already
-	if (elementExists('.octicon-stop', workflowListItem)) {
-		return;
-	}
-
 	// Called in `init`, memoized
 	const workflows = await workflowDetails.get();
 	const workflowName = workflowListItem.href.split('/').pop()!;
 	const workflow = workflows[workflowName];
-	if (!workflow) {
-		return;
+
+	const svgTrailer = $('.ActionListItem-visual--trailing', workflowListItem)
+	?? <div className="ActionListItem-visual--trailing"/>;
+	if (!svgTrailer.isConnected) {
+		workflowListItem.append(svgTrailer);
 	}
 
-	const svgTrailer = <div className="ActionListItem-visual--trailing m-auto d-flex gap-2"/>;
-	workflowListItem.append(svgTrailer);
-
-	if (!workflow.isEnabled) {
-		svgTrailer.append(<StopIcon className="m-auto"/>);
-		addTooltip(workflowListItem, 'This workflow is not enabled');
-	}
+	svgTrailer.classList.add('m-auto', 'd-flex', 'gap-2')
 
 	if (workflow.manuallyDispatchable) {
 		svgTrailer.append(<PlayIcon className="m-auto"/>);


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7389


## Test URLs


Manual + scheduled:
https://github.com/sindresorhus/type-fest/actions/workflows/ts-canary.yml

Manual + disabled + pinned:
https://github.com/refined-github/sandbox/actions



## Screenshot

<img width="329" alt="Screenshot 6" src="https://github.com/refined-github/refined-github/assets/1402241/0646761a-62ea-4f8d-9aed-c5f53d9388c7">

<img width="329" alt="Screenshot 7" src="https://github.com/refined-github/refined-github/assets/1402241/9a7bf531-9c0e-4dc1-9258-d1997de8e774">

