### PR TITLE
`default-branch-button` - Various fixes

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -15,7 +15,6 @@ import isDefaultBranch from '../github-helpers/is-default-branch.js';
 import {isRepoCommitListRoot} from '../github-helpers/index.js';
 
 async function updateUrl(event: React.MouseEvent<HTMLAnchorElement>): Promise<void> {
-	console.log('updateUrl');
 	event.currentTarget.href = await getUrl(location.href);
 }
 
@@ -88,6 +87,6 @@ Test URLs:
 - isSingleFile, 410 Gone from default branch https://github.com/refined-github/refined-github/blob/07ecc75/extension/content.js
 - isRepoCommitList: https://github.com/refined-github/refined-github/commits/07ecc75/
 - isRepoCommitList (already on default branch): https://github.com/typed-ember/ember-cli-typescript/commits/master
-- isRepoCommitListRoot (no branchs selector): https://github.com/refined-github/refined-github/commits/07ecc75/extension
+- isRepoCommitListRoot (no branch selector): https://github.com/refined-github/refined-github/commits/07ecc75/extension
 
 */

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -2,6 +2,8 @@ import './default-branch-button.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import ChevronLeftIcon from 'octicons-plain-react/ChevronLeft';
+import {elementExists} from 'select-dom';
+import memoize from 'memoize';
 
 import features from '../feature-manager.js';
 import GitHubFileURL from '../github-helpers/github-file-url.js';
@@ -10,24 +12,44 @@ import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import observe from '../helpers/selector-observer.js';
 import {branchSelector} from '../github-helpers/selectors.js';
 import isDefaultBranch from '../github-helpers/is-default-branch.js';
-import {isRepoCommitListRoot, isUrlReachable} from '../github-helpers/index.js';
+import {isRepoCommitListRoot} from '../github-helpers/index.js';
 
-async function add(branchSelector: HTMLElement): Promise<void> {
-	const url = new GitHubFileURL(location.href);
+async function updateUrl(event: React.MouseEvent<HTMLAnchorElement>): Promise<void> {
+	console.log('updateUrl');
+	event.currentTarget.href = await getUrl(location.href);
+}
+
+const getUrl = memoize(async (currentUrl: string): Promise<string> => {
+	const defaultUrl = new GitHubFileURL(currentUrl);
 	if (pageDetect.isRepoRoot()) {
 		// The default branch of the root directory is just /user/repo/
-		url.route = '';
-		url.branch = '';
+		defaultUrl.route = '';
+		defaultUrl.branch = '';
 	} else {
-		url.branch = await getDefaultBranch();
+		defaultUrl.branch = await getDefaultBranch();
+	}
+
+	return defaultUrl.href;
+});
+
+async function add(branchSelector: HTMLElement): Promise<void> {
+	// React issues. Duplicates appear after a color scheme update
+	// https://github.com/refined-github/refined-github/issues/7098
+	if (elementExists('.rgh-default-branch-button')) {
+		return;
 	}
 
 	const defaultLink = (
 		<a
-			className="btn tooltipped tooltipped-se px-2"
-			href={url.href}
-			data-turbo-frame="repo-content-turbo-frame"
+			className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
+			href={await getUrl(location.href)}
 			aria-label="See this view on the default branch"
+			// Update on hover because the URL may change without a DOM refresh
+			// https://github.com/refined-github/refined-github/issues/6554
+			// Inlined listener because `mouseenter` is too heavy for `delegate`
+			onMouseEnter={updateUrl}
+			// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
+			// data-turbo-frame="repo-content-turbo-frame"
 		>
 			<ChevronLeftIcon/>
 		</a>
@@ -40,12 +62,6 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 
 	selectorWrapper.before(defaultLink);
 	groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
-
-	// Only request it later to avoid slowing down the page load
-	if (!await isUrlReachable(url.href)) {
-		defaultLink.classList.add('disabled');
-		defaultLink.setAttribute('aria-label', 'Object not found on the default branch');
-	}
 }
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7098
- Fixes part of https://github.com/refined-github/refined-github/issues/6554


## Test URLs

- https://github.com/refined-github/sandbox/tree/locked/.github/workflows

## Screenshot

Changing the theme now no longer duplicates the button, but since React rebuilds the branch selector, it no longer has a "button group" class. For #6554 we'll likely have to just track the React element removal and remove the attached element.

![Untitled](https://github.com/refined-github/refined-github/assets/1402241/7e4a3c20-2606-4c98-be80-fde5bb28fa68)

