### PR TITLE
Stop allowing "all urls" as a permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"ts-extras": "^0.11.0",
 				"twas": "^2.1.3",
 				"uint8array-extras": "^1.1.0",
+				"webext-alert": "^1.0.0",
 				"webext-base-css": "^1.4.4",
 				"webext-detect-page": "^5.0.1",
 				"webext-dynamic-content-scripts": "^10.0.1",
@@ -10840,15 +10841,29 @@
 			}
 		},
 		"node_modules/webext-alert": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/webext-alert/-/webext-alert-0.9.0.tgz",
-			"integrity": "sha512-/aWI4MlJWxO4pH7NVRZ+McXomQUAJIMOE7dqpTOc7UDPV44HlZth/VH3CLm5O9y+u0h6mYbIja2GFWa0og5CGw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/webext-alert/-/webext-alert-1.0.0.tgz",
+			"integrity": "sha512-8jf2LF8lsGOqS7uk0O/RP1awje3Fm7J5JENvG661g6k3ttFTsWrPTAvkrKF/RZykZeg9PjfnaOYeidse5LcvEg==",
 			"dependencies": {
-				"webext-detect-page": "^5.0.0",
-				"webext-events": "^2.0.0"
+				"webext-detect-page": "^5.0.1",
+				"webext-events": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
+		"node_modules/webext-alert/node_modules/webext-events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/webext-events/-/webext-events-3.0.0.tgz",
+			"integrity": "sha512-RlqJXJV0zxn3rhuCv4l8fFddLvOCIyQACu+hVTSvL/AiC+bGvU7aaXZiTJ+WCqPcWFH8iu6SPPVJgvnCCtSlhg==",
+			"dependencies": {
+				"webext-detect-page": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
@@ -11003,6 +11018,21 @@
 			},
 			"engines": {
 				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
+		"node_modules/webext-permission-toggle/node_modules/webext-alert": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/webext-alert/-/webext-alert-0.9.0.tgz",
+			"integrity": "sha512-/aWI4MlJWxO4pH7NVRZ+McXomQUAJIMOE7dqpTOc7UDPV44HlZth/VH3CLm5O9y+u0h6mYbIja2GFWa0og5CGw==",
+			"dependencies": {
+				"webext-detect-page": "^5.0.0",
+				"webext-events": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"ts-extras": "^0.11.0",
 		"twas": "^2.1.3",
 		"uint8array-extras": "^1.1.0",
+		"webext-alert": "^1.0.0",
 		"webext-base-css": "^1.4.4",
 		"webext-detect-page": "^5.0.1",
 		"webext-dynamic-content-scripts": "^10.0.1",

--- a/source/background.ts
+++ b/source/background.ts
@@ -5,6 +5,7 @@ import {globalCache} from 'webext-storage-cache'; // Also needed to regularly cl
 import {isSafari} from 'webext-detect-page';
 import {objectKeys} from 'ts-extras';
 import addPermissionToggle from 'webext-permission-toggle';
+import webextAlert from 'webext-alert';
 
 import optionsStorage from './options-storage.js';
 import isDevelopmentVersion from './helpers/is-development-version.js';
@@ -98,5 +99,16 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 
 	if (isDevelopmentVersion()) {
 		await globalCache.clear();
+	}
+});
+
+browser.permissions.onAdded.addListener(async permissions => {
+	if (permissions.origins?.includes('*://*/*')) {
+		await browser.permissions.remove({
+			origins: [
+				'*://*/*',
+			],
+		});
+		await webextAlert('Refined GitHub is not meant to run on every website. If you’re looking to enable it on GitHub Enterprise, follow the instructions in the Options page.');
 	}
 });

--- a/source/background.ts
+++ b/source/background.ts
@@ -100,6 +100,15 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 	if (isDevelopmentVersion()) {
 		await globalCache.clear();
 	}
+
+	if (await browser.permissions.contains({origins: ['*://*/*']})) {
+		console.warn('Refined GitHub was granted the `*://*/*` permission and it’s now been removed.');
+		await browser.permissions.remove({
+			origins: [
+				'*://*/*',
+			],
+		});
+	}
 });
 
 browser.permissions.onAdded.addListener(async permissions => {


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/7381
- includes https://github.com/fregante/webext-alert/pull/4

I also tried to follow the removal with `.request(GitHub.com)` but that didn't work.


