### PR TITLE
chore: adjust padding

### DIFF
--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -1,7 +1,7 @@
 .rgh-collaborator {
 	border: 1px solid var(--borderColor-default, var(--color-border-default));
 	border-radius: 2em;
-	padding: 2px 5px;
+	padding: 0px 6px;
 
 	.rgh-small-user-avatars {
 		margin-left: -3px;


### PR DESCRIPTION
If vertical padding is used, it will affect the overall height of the DOM, causing layout issues for other elements.

## Test URLs

https://github.com/refined-github/refined-github/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Aupdated-desc

## Screenshot

before:

<img width="639" alt="image" src="https://github.com/refined-github/refined-github/assets/82451257/23bef2c2-c497-4a34-9d6a-cd3fc5b9e10b">

after:

<img width="806" alt="image" src="https://github.com/refined-github/refined-github/assets/82451257/49e82a9e-a147-457d-97da-13c11bb8dfc3">

