### PR TITLE
`fit-textareas` - Enable CSS-native feature where available

### DIFF
--- a/source/features/fit-textareas.css
+++ b/source/features/fit-textareas.css
@@ -1,3 +1,4 @@
 .rgh-fit-textareas {
 	max-height: none !important;
+	field-sizing: content;
 }

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -1,9 +1,12 @@
 import './fit-textareas.css';
+import {isSafari} from 'webext-detect-page';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
+
+const nativeFit = 'fieldSizing' in document.body.style;
 
 function resetListener({target}: Event): void {
 	const field = (target as HTMLFormElement).querySelector('textarea')!;
@@ -18,7 +21,7 @@ function inputListener({target}: Event): void {
 function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
 	// Disable constrained native feature
 	textarea.classList.replace('js-size-to-fit', 'rgh-fit-textareas');
-	if ('fieldSizing' in document.body.style) {
+	if (nativeFit) {
 		return;
 	}
 
@@ -38,6 +41,10 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
+	],
+	exclude: [
+		// Allow Safari only if it supports the native version
+		() => isSafari() && !nativeFit,
 	],
 	init,
 });

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -19,7 +19,7 @@ function inputListener({target}: Event): void {
 }
 
 function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
-	// Disable constrained native feature
+	// Disable constrained GitHub feature
 	textarea.classList.replace('js-size-to-fit', 'rgh-fit-textareas');
 	if (nativeFit) {
 		return;

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -1,5 +1,4 @@
 import './fit-textareas.css';
-import {isSafari} from 'webext-detect-page';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
 
@@ -17,14 +16,17 @@ function inputListener({target}: Event): void {
 }
 
 function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
+	// Disable constrained native feature
+	textarea.classList.replace('js-size-to-fit', 'rgh-fit-textareas');
+	if ('fieldSizing' in document.body.style) {
+		return;
+	}
+
 	textarea.addEventListener('input', inputListener, {signal}); // The user triggers `input` event
 	textarea.addEventListener('focus', inputListener, {signal}); // The user triggers `focus` event
 	textarea.addEventListener('change', inputListener, {signal}); // File uploads trigger `change` events
 	textarea.form?.addEventListener('reset', resetListener, {signal});
 	fitTextarea(textarea);
-
-	// Disable constrained native feature
-	textarea.classList.replace('js-size-to-fit', 'rgh-fit-textareas');
 }
 
 function init(signal: AbortSignal): void {
@@ -36,9 +38,6 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
-	],
-	exclude: [
-		isSafari,
 	],
 	init,
 });


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/7414


After this PR:

- Chrome 123+: uses `field-sizing`
- Firefox and Chrome 122: uses `fit-textarea@2` module
- Safari: enabled only when `field-sizing` will be available
	- Since `fit-textarea` can introduce new performance issues, I'd rather not enabled it

Tracking issues:

- https://bugzilla.mozilla.org/show_bug.cgi?id=1832409
- https://bugs.webkit.org/show_bug.cgi?id=264720

## Test URLs

Here

## Screenshot

See how the field is resized without any changes to the DOM

https://github.com/refined-github/refined-github/assets/1402241/ea600268-3c99-4172-a84d-f363c5ed1e34


