### PR TITLE
`open-all-notifications` - Add keyboard shortcut: P

### DIFF
--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -13,6 +13,7 @@ import showToast from '../github-helpers/toast.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import observe from '../helpers/selector-observer.js';
 import GetPullRequestBlameCommit from './deep-reblame.gql';
+import {multilineAriaLabel} from '../github-helpers/index.js';
 
 const getPullRequestBlameCommit = mem(async (commit: string, prNumbers: number[], currentFilename: string): Promise<string> => {
 	const {repository} = await api.v4(GetPullRequestBlameCommit, {
@@ -73,7 +74,10 @@ function addButton(hunk: HTMLElement): void {
 		$('.timestamp-wrapper-mobile', hunk)!.after(
 			<button
 				type="button"
-				aria-label="View blame prior to this change (extracts commits from this PR first)"
+				aria-label={multilineAriaLabel(
+					'View blame prior to this change',
+					'(extracts commits from this PR first)',
+				)}
 				className="rgh-deep-reblame Button Button--iconOnly Button--invisible Button--small d-flex"
 			>
 				<VersionsIcon/>

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -9,6 +9,7 @@ import features from '../feature-manager.js';
 import openTabs from '../helpers/open-tabs.js';
 import {appendBefore} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
+import {multilineAriaLabel} from '../github-helpers/index.js';
 
 // Selector works on:
 // https://github.com/notifications (Grouped by date)
@@ -73,7 +74,10 @@ function addSelectedButton(selectedActionsGroup: HTMLElement): void {
 			type="button"
 			className={'btn btn-sm mr-2 tooltipped tooltipped-s ' + openSelected.class}
 			data-hotkey="p"
-			aria-label="Open selected (keyboard shortcut: P)"
+			aria-label={multilineAriaLabel(
+				'Open selected notifications',
+				'Hotkey: P',
+			)}
 		>
 			<LinkExternalIcon className="mr-1"/>Open
 		</button>

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -69,7 +69,12 @@ function removeOpenUnreadButtons(container: ParentNode = document): void {
 
 function addSelectedButton(selectedActionsGroup: HTMLElement): void {
 	const button = (
-		<button className={'btn btn-sm mr-2 ' + openSelected.class} type="button">
+		<button
+			type="button"
+			className={'btn btn-sm mr-2 tooltipped tooltipped-s ' + openSelected.class}
+			data-hotkey="p"
+			aria-label="Open selected (keyboard shortcut: P)"
+		>
 			<LinkExternalIcon className="mr-1"/>Open
 		</button>
 	);
@@ -122,6 +127,9 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isNotifications,
 	],
+	shortcuts: {
+		p: 'Open selected notifications',
+	},
 	init,
 });
 

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -6,6 +6,7 @@ import IssueReopenedIcon from 'octicons-plain-react/IssueReopened';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
+import {multilineAriaLabel} from '../github-helpers/index.js';
 
 // Make the element look selected, not disabled, but effectively disable clicks/focus
 const disableAttributes = {
@@ -76,7 +77,10 @@ function addButton(subscriptionButton: HTMLButtonElement): void {
 			<SubButton
 				// @ts-expect-error I don't remember how to fix this
 				value="subscribe_to_custom_notifications"
-				aria-label="Subscribe just to status changes&#10;(closing, reopening, merging)"
+				aria-label={multilineAriaLabel(
+					'Subscribe just to status changes',
+					'(closing, reopening, merging)',
+				)}
 				{...(status === 'status' && disableAttributes)}
 			>
 				<IssueReopenedIcon/> Status

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -162,3 +162,7 @@ export function triggerActionBarOverflow(child: Element): void {
 	parent.replaceWith(placeholder);
 	placeholder.replaceWith(parent);
 }
+
+export function multilineAriaLabel(...lines: string[]): string {
+	return lines.join('\n');
+}


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6273

I picked P because it's near O (the one used to open the focused item). Alt-Shift-O would have been an alternative too, but unnecessary at this point since P seems unused.


## Test URLs

https://github.com/notifications

## Screenshot

<img width="583" alt="Screenshot 11" src="https://github.com/refined-github/refined-github/assets/1402241/2ef88f6b-e33f-4541-923b-3950c7d2f81f">
