### PR TITLE
`locked-issue` - Fix performance issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^2.0.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^8.1.1",
+				"github-url-detection": "^8.2.0",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkedom": "^0.18.0",
@@ -5450,9 +5450,9 @@
 			"integrity": "sha512-9MAoXwjdafN1P2Ve6Y54+buAYRDZLKJcJo12KxMbPe1flaC7S314dS+TleNbNFeh+36s3L00Fgfir7OD4NJ56Q=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-8.1.1.tgz",
-			"integrity": "sha512-x+ZG9ozZ7B1cjP/zgig9+X7X0OWUQ/oHQmvFAPIru3J6QN6U8Mz3OE5oP9JYtD6+FF518a5H19VvuR/zxZ0+Ng==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-8.2.0.tgz",
+			"integrity": "sha512-enyctW9moHeVEZ4vVnO3AWXKiEKIdsPGh5iPBMB34Y8I+MH61RvhogqWGhpMZoe2Ui4Vek5LD5y8m+kDXdYS5A==",
 			"engines": {
 				"node": ">=18"
 			},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"filter-altered-clicks": "^2.0.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^8.1.1",
+		"github-url-detection": "^8.2.0",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkedom": "^0.18.0",

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import LockIcon from 'octicons-plain-react/Lock';
 import * as pageDetect from 'github-url-detection';
-import {isChrome} from 'webext-detect-page';
+import elementReady from 'element-ready';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
@@ -22,20 +22,23 @@ function addLock(element: HTMLElement): void {
 	);
 }
 
-function init(signal: AbortSignal): void {
+async function init(signal: AbortSignal): Promise<void | false> {
 	// If reactions-menu exists, then .js-pick-reaction is the second child
-	// Logged out users never have the menu, so they should be excluded
-	observe(`
-		.logged-in .js-issues-results:has(.js-pick-reaction:first-child) :is(
-			.gh-header-meta > :first-child,
-			.gh-header-sticky .flex-row > :first-child
-		)
-	`, addLock, {signal});
+	const reactions = await elementReady('.js-pick-reaction');
+	if (!reactions?.matches(':first-child')) {
+		return false;
+	}
+
+	observe([
+		'.gh-header-meta > :first-child', // Issue title
+		'.gh-header-sticky .flex-row > :first-child', // Sticky issue title
+	], addLock, {signal});
 }
 
 void features.add(import.meta.url, {
 	asLongAs: [
-		isChrome,
+		// Logged out users never the reactions menu used to determine lock status. This would lead to false positives.
+		pageDetect.isLoggedIn,
 	],
 	include: [
 		pageDetect.isConversation,


### PR DESCRIPTION
- Continues from https://github.com/refined-github/refined-github/pull/7378
- Partially reverts #7315 

That PR reduced the `:has()` subtree size, this PR just drops it.

This means the feature can be re-enabled for all users.


## Test URLs

- Locked issue: https://github.com/refined-github/sandbox/issues/74
- Locked PR: https://github.com/refined-github/sandbox/pull/48

## Screenshot

<img width="616" alt="Screenshot 1" src="https://github.com/refined-github/refined-github/assets/1402241/cfdb48e2-04a4-4fc6-9e0e-e17c7ca6565f">
