### PR TITLE
Accept OAuth tokens in the options

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -23,7 +23,7 @@
 		<p>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<!-- https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88 -->
-			<input type="text" name="personalToken" pattern="[\da-f]{40}|ghp_\w{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
+			<input type="text" name="personalToken" pattern="[\da-f]{40}|gh[po]_\w{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
 			<span id="validation"></span>
 		</p>
 		<ul data-token-type="classic">

--- a/source/options.html
+++ b/source/options.html
@@ -23,7 +23,7 @@
 		<p>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<!-- https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88 -->
-			<input type="text" name="personalToken" pattern="[\da-f]{40}|gh[po]_\w{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
+			<input type="text" name="personalToken" placeholder=" " spellcheck="false" autocomplete="off" autocapitalize="off">
 			<span id="validation"></span>
 		</p>
 		<ul data-token-type="classic">


### PR DESCRIPTION
Allow users to use an GitHub OAuth token (`gho_...`). Right now the form validation regex prevent me from even using it.

For example, I am using the one from the GitHub CLI (`gh auth token`). GitHub's OAuth app has as much permissions as one can grant and should be sufficient for refined-github usage.

My organization does not allow PATs (`ghp_...`) to access GH.

Related to:
- https://github.com/refined-github/refined-github/issues/6951
- https://github.com/refined-github/refined-github/issues/6092#issuecomment-1732286938

## Test URLs

n/a

## Screenshot

n/a