### PR TITLE
feat: add open-notification-external feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -530,6 +530,11 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png"
 	},
 	{
+		"id": "open-notification-external",
+		"description": "Opens notifications in a new tab.",
+		"screenshot": null
+	},
+	{
 		"id": "pagination-hotkey",
 		"description": "Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.",
 		"screenshot": null

--- a/build/__snapshots__/imported-features.txt
+++ b/build/__snapshots__/imported-features.txt
@@ -104,6 +104,7 @@ one-key-formatting
 open-all-conversations
 open-all-notifications
 open-issue-to-latest-comment
+open-notification-external
 pagination-hotkey
 parse-backticks
 patch-diff-links

--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -18,6 +18,7 @@ const noScreenshotExceptions = new Set([
 	'comment-fields-keyboard-shortcuts',
 	'copy-on-y',
 	'create-release-shortcut',
+	'open-notification-external',
 	'pagination-hotkey',
 	'profile-hotkey',
 	'repo-wide-file-finder',

--- a/readme.md
+++ b/readme.md
@@ -351,6 +351,7 @@ Thanks for contributing! 🦋🙌
 - [](# "last-notification-page-button") [Adds a link to the last page of notifications.](https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png)
 - [](# "pr-notification-link") [Points PR notifications to the conversation tabs instead of the commits page, which may be a 404.](https://github.com/refined-github/refined-github/assets/1402241/621f6512-655e-4565-a37b-2b159ea0ffce)
 - [](# "sticky-notifications-actions") [Make the notifications action bar sticky.](https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f)
+- [](# "open-notification-external") Opens notifications in a new tab.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/open-notification-external.tsx
+++ b/source/features/open-notification-external.tsx
@@ -1,0 +1,26 @@
+import {$$} from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+
+function init(): void {
+	for (const link of $$('a.notification-list-item-link')) {
+		link.target = '_blank';
+	}
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isNotifications,
+	],
+	awaitDomReady: true,
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/notifications
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -55,6 +55,7 @@ import './features/linkify-code.js';
 import './features/download-folder-button.js';
 import './features/linkify-branch-references.js';
 import './features/open-all-conversations.js';
+import './features/open-notification-external.js';
 import './features/pagination-hotkey.js';
 import './features/conversation-links-on-repo-lists.js';
 import './features/global-conversation-list-filters.js';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->


After returning from a vacation, we may have a lot of notifications. This time opening the notifications as new tabs will help us to deal with them one by one like a to-do list.

## Test URLs


<https://github.com/notifications>

## Screenshot

N/A
