### PR TITLE
`rgh-netiquette`: Add "Don't comment" banner

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -16,7 +16,7 @@ import {canEditEveryComment} from './quick-comment-edit.js';
 // TODO: Not exact, replace with API
 const isCollaborator = canEditEveryComment;
 
-const isClosedOrMerged = (): boolean => elementExists(closedOrMergedMarkerSelector);
+export const isClosedOrMerged = (): boolean => elementExists(closedOrMergedMarkerSelector);
 
 /** Returns milliseconds passed since `date` */
 function timeAgo(date: Date): number {


### PR DESCRIPTION
In some issues, the author wrote "Please do not leave comments", because those issues are not meant for discussion.

This PR adds a banner to issues with such requests in `rgh-netiquette`.

The `/regex/` may not be perfect, please test if it works on other issues

## Test URLs

- https://github.com/refined-github/refined-github/issues/7404
- https://github.com/refined-github/refined-github/issues/7000
- https://github.com/refined-github/refined-github/issues/6000

## Screenshot

![A lot of cake](https://github.com/refined-github/refined-github/assets/136986257/27f41b96-fea4-4bdf-a1c5-29291fc84b1a)
