### PR TITLE
`open-with-buttons` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -530,6 +530,11 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png"
 	},
 	{
+		"id": "open-with-buttons",
+		"description": "Adds buttons to open a repository in external apps like Visual Studio Code.",
+		"screenshot": "https://github.com/refined-github/refined-github/assets/21111317/13516c22-585f-440e-b4de-53be95995af7"
+	},
+	{
 		"id": "pagination-hotkey",
 		"description": "Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.",
 		"screenshot": null

--- a/build/__snapshots__/imported-features.txt
+++ b/build/__snapshots__/imported-features.txt
@@ -104,6 +104,7 @@ one-key-formatting
 open-all-conversations
 open-all-notifications
 open-issue-to-latest-comment
+open-with-buttons
 pagination-hotkey
 parse-backticks
 patch-diff-links

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ Thanks for contributing! 🦋🙌
 - [](# "html-preview-link") [Adds a link to preview HTML files.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260874191-69d386a0-7c1f-42ae-84fd-4f67f90982da.png)
 - [](# "file-age-color") [Highlights the most-recently-modified items in file lists.](https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png)
 - [](# "previous-version") [Lets you see the previous version of a file in one click.](https://user-images.githubusercontent.com/50487467/236657960-401f3cd7-cc99-494e-b522-1dca76827369.png)
+- [](# "open-with-buttons") [Adds buttons to open a repository in external apps like Visual Studio Code.](https://github.com/refined-github/refined-github/assets/21111317/13516c22-585f-440e-b4de-53be95995af7)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/open-with-buttons.tsx
+++ b/source/features/open-with-buttons.tsx
@@ -1,0 +1,53 @@
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+import GitHubFileURL from '../github-helpers/github-file-url.js';
+
+function addLinkButton(template: Element, text: string, href: string): void {
+	const item = template.cloneNode(true);
+	const link = item.firstElementChild as HTMLAnchorElement;
+	if (link.text === 'Download directory') {
+		return;
+	}
+
+	link.href = href;
+	link.textContent = text;
+	link.ariaKeyShortcuts = 'o'; // Cloned download button is d, other open buttons are o
+
+	template.before(item);
+}
+
+function add({parentElement: downloadZip}: Element): void {
+	const url = new GitHubFileURL(location.href);
+	const root = `https://${location.host}/${url.user}/${url.repository}`;
+
+	// Link to root even if we're on a branch/commit, to match behaviour of other buttons + commandline
+	// However, Codespaces does link to the current branch/commit
+	addLinkButton(downloadZip!, 'Open with VS Code remote', `vscode://ms-vscode.remote-repositories/open?url=${root}`); // ?url doesn't support files, other parameters are unknown
+	addLinkButton(downloadZip!, 'Open with VS Code Dev Container', `vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=${root}`); // Can't open files
+}
+
+function init(signal: AbortSignal): void {
+	observe('a[aria-keyshortcuts="d"]', add, {signal}); // "Download ZIP" button
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepoRoot,
+	],
+	exclude: [
+		pageDetect.isEmptyRepoRoot,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github
+https://github.com/refined-github/refined-github/tree/main
+https://github.com/refined-github/refined-github/tree/ad0054477020c52e7140278200be00fc764cc469
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -222,3 +222,4 @@ import './features/fix-no-pr-search.js';
 import './features/clean-readme-url.js';
 import './features/pr-notification-link.js';
 import './features/click-outside-modal.js';
+import './features/open-with-buttons.js';


### PR DESCRIPTION
The "Code" dropdown in a repository's root has buttons to open the repository in GitHub Desktop or Visual Studio. This feature adds more buttons for other external apps like Visual Studio Code.

To start with, I've added two buttons:
* [Visual Studio Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
* [Visual Studio Code remote repositories](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-repositories)

This feature could lead to requests for other external apps, so an opt-in approach might be useful to avoid overfilling the "Code" dropdown. Not sure of the best way to structure this.

## Test URLs
https://github.com/refined-github/refined-github
https://github.com/refined-github/refined-github/tree/main
https://github.com/refined-github/refined-github/tree/ad0054477020c52e7140278200be00fc764cc469

## Screenshot
![buttons](https://github.com/refined-github/refined-github/assets/21111317/13516c22-585f-440e-b4de-53be95995af7)