### PR TITLE
`shorten-links` - Support more links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"push-form": "^1.0.1",
 				"regex-join": "^2.0.0",
 				"select-dom": "^9.0.0",
-				"shorten-repo-url": "^4.0.1",
+				"shorten-repo-url": "^5.0.0",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^4.1.1",
 				"tiny-version-compare": "^4.0.0",
@@ -8881,14 +8881,15 @@
 			}
 		},
 		"node_modules/shorten-repo-url": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-4.0.1.tgz",
-			"integrity": "sha512-5LZelptySMVGBvPIqWpmWrPHf6kd6ZpRreQdSAUehI3d8ZZWVNbDe6p0zF3xluaHgqQOUMCPOQHxxxudD5MTGw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-5.0.0.tgz",
+			"integrity": "sha512-XMHv2xAe6SuRbRHWfAg18rmJBIEVuztTXPwaqtptplu9cGDFl/CsHkmJMSLZH9DEL1BtKdicL0BYV1MY0m1Omg==",
+			"license": "MIT",
 			"dependencies": {
 				"github-reserved-names": "^2.0.5"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"push-form": "^1.0.1",
 		"regex-join": "^2.0.0",
 		"select-dom": "^9.0.0",
-		"shorten-repo-url": "^4.0.1",
+		"shorten-repo-url": "^5.0.0",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^4.1.1",
 		"tiny-version-compare": "^4.0.0",


### PR DESCRIPTION
Includes https://github.com/refined-github/shorten-repo-url/releases/tag/v5.0.0


- https://github.com/refined-github/shorten-repo-url/pull/50
- https://github.com/refined-github/shorten-repo-url/pull/49
- [Wiki URLs: Remove empty parens on same-repo](https://github.com/refined-github/shorten-repo-url/commit/07f3216e98f03677f5987e72c28cc8ea0be2e45d)