### PR TITLE
Improve support for mobile Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 				"webext-detect-page": "^5.0.1",
 				"webext-dynamic-content-scripts": "^10.0.3",
 				"webext-options-sync-per-domain": "^4.2.2",
-				"webext-permission-toggle": "^5.0.1",
+				"webext-permission-toggle": "^5.0.2",
 				"webext-storage-cache": "^6.0.1",
 				"zip-text-nodes": "^1.0.0"
 			},
@@ -11013,9 +11013,10 @@
 			}
 		},
 		"node_modules/webext-permission-toggle": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/webext-permission-toggle/-/webext-permission-toggle-5.0.1.tgz",
-			"integrity": "sha512-7sMgpgdmKhKZr6zYsBR+RmXUfL8Ahr2fRDuGEKomZDUQC5ZhpmdrvfNU5ERnPU6F604FMB3kj71Q+scGJ6thzw==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/webext-permission-toggle/-/webext-permission-toggle-5.0.2.tgz",
+			"integrity": "sha512-PQOfyW1qnE+TKjFtByCduO4uKZhrBZpiGSDWEPRWp9+7cSjw70I2P1NbUZI25I5RaNdYR0nQMVVZbZ6Q2LXUng==",
+			"license": "MIT",
 			"dependencies": {
 				"webext-alert": "^1.0.0",
 				"webext-content-scripts": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"webext-detect-page": "^5.0.1",
 		"webext-dynamic-content-scripts": "^10.0.3",
 		"webext-options-sync-per-domain": "^4.2.2",
-		"webext-permission-toggle": "^5.0.1",
+		"webext-permission-toggle": "^5.0.2",
 		"webext-storage-cache": "^6.0.1",
 		"zip-text-nodes": "^1.0.0"
 	},

--- a/source/background.ts
+++ b/source/background.ts
@@ -15,8 +15,11 @@ import {styleHotfixes} from './helpers/hotfix.js';
 
 const {version} = browser.runtime.getManifest();
 
+if(!doesBrowserActionOpenOptions)
+{
 // GHE support
-addPermissionToggle();
+	addPermissionToggle();
+}
 
 const messageHandlers = {
 	async openUrls(urls: string[], {tab}: Runtime.MessageSender) {

--- a/source/background.ts
+++ b/source/background.ts
@@ -15,11 +15,8 @@ import {styleHotfixes} from './helpers/hotfix.js';
 
 const {version} = browser.runtime.getManifest();
 
-if(!doesBrowserActionOpenOptions)
-{
 // GHE support
-	addPermissionToggle();
-}
+addPermissionToggle();
 
 const messageHandlers = {
 	async openUrls(urls: string[], {tab}: Runtime.MessageSender) {

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,12 +18,11 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-async function isMobile(): Promise<boolean> {
-    const platformInfo = await browser.runtime.getPlatformInfo();
-    return ["android", "ios"].includes(platformInfo.os);
+export function supportsContextMenus(): boolean {
+    return typeof browser.contextMenus !== 'undefined';
 }
 
-export const doesBrowserActionOpenOptions = await isMobile();
+export const doesBrowserActionOpenOptions = !supportsContextMenus();
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = Boolean(!globalThis.chrome?.contextMenus);
+export const doesBrowserActionOpenOptions = !globalThis.chrome?.contextMenus;
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -1,4 +1,3 @@
-import {isMobileSafari} from 'webext-detect-page';
 import {Promisable} from 'type-fest';
 
 import {pEveryFunction, pSomeFunction} from './p-utils.js';
@@ -19,7 +18,13 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = isMobileSafari();
+async function isMobile(): Promise<boolean> {
+    const platformInfo = await browser.runtime.getPlatformInfo();
+	console.log(platformInfo);
+    return ["android", "ios"].includes(platformInfo.os);
+}
+
+export const doesBrowserActionOpenOptions = isMobile();
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -20,11 +20,10 @@ export function isFeaturePrivate(id: string): boolean {
 
 async function isMobile(): Promise<boolean> {
     const platformInfo = await browser.runtime.getPlatformInfo();
-	console.log(platformInfo);
     return ["android", "ios"].includes(platformInfo.os);
 }
 
-export const doesBrowserActionOpenOptions = isMobile();
+export const doesBrowserActionOpenOptions = await isMobile();
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = Boolean(chrome.contextMenus)
+export const doesBrowserActionOpenOptions = Boolean(globalThis.chrome?.contextMenus)
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -1,4 +1,3 @@
-import {isMobileSafari} from 'webext-detect-page';
 import {Promisable} from 'type-fest';
 
 import {pEveryFunction, pSomeFunction} from './p-utils.js';
@@ -19,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = isMobileSafari();
+export const doesBrowserActionOpenOptions = Boolean(chrome.contextMenus)
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -1,3 +1,4 @@
+import {isMobileSafari} from 'webext-detect-page';
 import {Promisable} from 'type-fest';
 
 import {pEveryFunction, pSomeFunction} from './p-utils.js';
@@ -18,11 +19,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export function supportsContextMenus(): boolean {
-    return typeof browser.contextMenus !== 'undefined';
-}
-
-export const doesBrowserActionOpenOptions = !supportsContextMenus();
+export const doesBrowserActionOpenOptions = isMobileSafari();
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = Boolean(globalThis.chrome?.contextMenus)
+export const doesBrowserActionOpenOptions = Boolean(globalThis.chrome?.contextMenus);
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = Boolean(globalThis.chrome?.contextMenus);
+export const doesBrowserActionOpenOptions = !Boolean(globalThis.chrome?.contextMenus);
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */

--- a/source/helpers/feature-utils.ts
+++ b/source/helpers/feature-utils.ts
@@ -18,7 +18,7 @@ export function isFeaturePrivate(id: string): boolean {
 	return id.startsWith('rgh-');
 }
 
-export const doesBrowserActionOpenOptions = !Boolean(globalThis.chrome?.contextMenus);
+export const doesBrowserActionOpenOptions = Boolean(!globalThis.chrome?.contextMenus);
 
 export async function shouldFeatureRun({
 	/** Every condition must be true */


### PR DESCRIPTION
1. No relevant issue found
## Description
This change is made to detect if the user is on a mobile platform (ios or android), instead of just looking for mobile Safari, or explicitly checking for user agents of mobile browsers.

Mobile safari, and other mobile browsers like Kiwi and Firefox for Android do not support context menus. 
This change allows android browsers to access the options page.

`getPlatformInfo` seems to have fairly wide browser support, so it should be fine to use, instead of checking the user agent, like `webext-detect-page` does. 

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo

This method is used, because `webext-detect-page` does not seem to have functions to detect mobile browsers other than Safari.


This has only been tested on Firefox for android, and Firefox on windows. Kiwi on android should behave similarly, but i do not have an ios device to test mobile Safari.




## Test URLs
Affects browser action button on mobile browsers, not URLs.

## Screenshot
![Screenshot 2024-06-23 044312](https://github.com/refined-github/refined-github/assets/10606102/4a48acc3-ebf9-4333-8213-39411c5624bc)

