### PR TITLE
Avoid "Permission needed" bug on Firefox for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
+      - run: npm install dot-json@1
       - run: npm run manifest artifact 3
       - run: npx chrome-webstore-upload-cli@3
         working-directory: artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
+      - run: npm run manifest artifact 3
       - run: npx chrome-webstore-upload-cli@3
         working-directory: artifact
         env:
@@ -66,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
+      - run: npm install dot-json@1
+      - run: npm run manifest artifact 2
       - run: npx web-ext@8 sign --channel listed
         working-directory: artifact
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
-      - run: npm install dot-json@1
-      - run: npm run manifest artifact 3 # Kiwi browser https://github.com/kiwibrowser/src.next/issues/1138
+
+      # Kiwi browser https://github.com/kiwibrowser/src.next/issues/1138
+      - run: npm install dot-json@1 -g
+      - run: npm run manifest artifact 3
+
       - run: npx chrome-webstore-upload-cli@3
         working-directory: artifact
         env:
@@ -68,8 +71,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
+
+      # Firefox https://github.com/refined-github/refined-github/issues/7477
       - run: npm install dot-json@1
-      - run: npm run manifest artifact 2 # Firefox https://github.com/refined-github/refined-github/issues/7477
+      - run: npm run manifest artifact 2
+
       - run: npx web-ext@8 sign --channel listed
         working-directory: artifact
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - run: npm install dot-json@1
-      - run: npm run manifest artifact 3
+      - run: npm run manifest artifact 3 # Kiwi browser https://github.com/kiwibrowser/src.next/issues/1138
       - run: npx chrome-webstore-upload-cli@3
         working-directory: artifact
         env:
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - run: npm install dot-json@1
-      - run: npm run manifest artifact 2
+      - run: npm run manifest artifact 2 # Firefox https://github.com/refined-github/refined-github/issues/7477
       - run: npx web-ext@8 sign --channel listed
         working-directory: artifact
         env:

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -17,6 +17,8 @@ if (!existsSync(manifestPath)) {
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
 if (manifestVersion === '2') {
+	// Avoid bad Firefox UX with manifest v3
+	// TODO: Drop after https://bugzilla.mozilla.org/show_bug.cgi?id=1851083
 	manifest.manifest_version = 2;
 	manifest.web_accessible_resources = ['assets/resolve-conflicts.js'];
 	delete manifest.background.service_worker;
@@ -31,6 +33,8 @@ if (manifestVersion === '2') {
 	manifest.browser_action = manifest.action;
 	delete manifest.action;
 } else {
+	// Kiwi browser support
+	// TODO: Drop after https://github.com/kiwibrowser/src.next/issues/1138
 	delete manifest.background.scripts;
 }
 

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -1,0 +1,37 @@
+/* eslint-disable camelcase */
+import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+const [extensionPath, manifestVersion] = process.argv.slice(2);
+
+if (!extensionPath || !manifestVersion) {
+	throw new Error('Please provide a path to the extension and a manifest version, like: npm run manifest distribution 2');
+}
+
+const manifestPath = join(extensionPath, 'manifest.json');
+
+if (!existsSync(manifestPath)) {
+	throw new Error(`No manifest found in: ${extensionPath}`);
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+if (manifestVersion === '2') {
+	manifest.manifest_version = 2;
+	manifest.web_accessible_resources = ['assets/resolve-conflicts.js'];
+	delete manifest.background.service_worker;
+
+	manifest.permissions = [
+		...(manifest.permissions || []),
+		...(manifest.host_permissions || []),
+	];
+	delete manifest.host_permissions;
+	delete manifest.optional_host_permissions;
+
+	manifest.browser_action = manifest.action;
+	delete manifest.action;
+} else {
+	delete manifest.background.scripts;
+}
+
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -24,8 +24,8 @@ if (manifestVersion === '2') {
 	delete manifest.background.service_worker;
 
 	manifest.permissions = [
-		...(manifest.permissions || []),
-		...(manifest.host_permissions || []),
+		...manifest.permissions,
+		...manifest.host_permissions,
 	];
 	delete manifest.host_permissions;
 	delete manifest.optional_host_permissions;

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -23,10 +23,7 @@ if (manifestVersion === '2') {
 	manifest.web_accessible_resources = ['assets/resolve-conflicts.js'];
 	delete manifest.background.service_worker;
 
-	manifest.permissions = [
-		...manifest.permissions,
-		...manifest.host_permissions,
-	];
+	manifest.permissions.push(...manifest.host_permissions);
 	delete manifest.host_permissions;
 	delete manifest.optional_host_permissions;
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"build": "run-p build:* --continue-on-error",
 		"build:typescript": "tsc --noEmit",
 		"build:webpack": "npm run x:webpack -- --mode=production",
+		"manifest": "node build/manifest.js",
 		"fix": "run-p \"lint:css -- --fix\" \"lint:js -- --fix\" fix:prettier \"vitest -- --update\" --continue-on-error",
 		"fix:prettier": "prettier . --write",
 		"lint": "run-p lint:* --continue-on-error",


### PR DESCRIPTION
- Fixes #7477 
- Related https://github.com/refined-github/refined-github/pull/7480

This should work, assuming AMO doesn't block manifest downgrades.

The manifest.json in `source` will continue to work in both browsers.


cc @INSANEMODE @HanabishiRecca