### PR TITLE
`show-whitespace` - Restore feature on Firefox and Safari

### DIFF
--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -1,6 +1,5 @@
 import './show-whitespace.css';
 import * as pageDetect from 'github-url-detection';
-import {isChrome} from 'webext-detect-page';
 
 import features from '../feature-manager.js';
 import {codeElementsSelector} from '../github-helpers/dom-formatters.js';

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -28,9 +28,6 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
-	asLongAs: [
-		isChrome,
-	],
 	include: [
 		pageDetect.hasCode,
 	],


### PR DESCRIPTION
- Partially reverts https://github.com/refined-github/refined-github/pull/7315
- Related to #7404 