### PR TITLE
`visit-tag` - Work around GitHub tag picker icon bug

### DIFF
--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -30,7 +30,7 @@ async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
 			href={buildRepoURL('releases/tag', tag)}
 			aria-label="Visit tag"
 		>
-			<ArrowUpRightIcon />
+			<ArrowUpRightIcon/>
 		</a>,
 	);
 }

--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -30,7 +30,7 @@ async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
 			href={buildRepoURL('releases/tag', tag)}
 			aria-label="Visit tag"
 		>
-			<ArrowUpRightIcon className="v-align-middle"/>
+			<ArrowUpRightIcon />
 		</a>,
 	);
 }

--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {elementExists} from 'select-dom';
 import ArrowUpRightIcon from 'octicons-plain-react/ArrowUpRight';
 import CodeIcon from 'octicons-plain-react/Code';
 import * as pageDetect from 'github-url-detection';
@@ -10,6 +11,11 @@ import {wrapAll} from '../helpers/dom-utils.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 
 async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
+	// If the branch picker is open, do nothing #7491
+	if (elementExists('#selectPanel')) {
+		return;
+	}
+
 	const tag = branchSelector.getAttribute('aria-label')?.replace(/ tag$/, '');
 	if (!tag) {
 		features.log.error(import.meta.url, 'Tag not found in DOM. The feature needs to be updated');


### PR DESCRIPTION
Fix #7491

I think I still remember how to do RGH PRs 😂 

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

https://github.com/refined-github/refined-github/assets/44045911/5d308061-c452-4fe2-bde2-895fcfd1dd89

