### PR TITLE
Larger text size in the options

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -25,6 +25,7 @@ html::after {
 /* Use sensible font size in Chrome #7483 */
 body {
 	font-size: 100%;
+	line-height: 1.5;
 }
 
 p {

--- a/source/options.css
+++ b/source/options.css
@@ -22,6 +22,11 @@ html::after {
 	}
 }
 
+/* Use sensible font size in Chrome #7483 */
+body {
+	font-size: 100%;
+}
+
 p {
 	margin-top: 0;
 }


### PR DESCRIPTION
Resolve #7483

I only tested this in (desktop) Chrome since the smaller font seems to be a Chrome only thing. ~~In other browsers the change should make no difference.~~

I do anticipate we need to tweak a few other sizes to make it look perfect (see the logo for example).

## Test URLs

chrome-extension://<RGH>/assets/options.html

## Screenshot


<img width="702" alt="Screenshot 2024-06-27 at 3 37 47 PM" src="https://github.com/refined-github/refined-github/assets/44045911/8098e032-9d7a-43f9-86f6-62defc04ee32">
