### PR TITLE
`tags-on-commits-list` - Restore feature

### DIFF
--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -86,7 +86,7 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 async function init(): Promise<void | false> {
 	const cacheKey = `tags:${getRepo()!.nameWithOwner}`;
 
-	const commitsOnPage = $$('.listviewitem');
+	const commitsOnPage = $$('.list-view-item');
 
 	const lastCommitOnPage = getCommitHash(commitsOnPage.at(-1)!);
 	let cached = await cache.get<Record<string, string[]>>(cacheKey) ?? {};
@@ -102,10 +102,10 @@ async function init(): Promise<void | false> {
 		}
 
 		if (!targetTags) {
-			// There was no tags for this commit, save that info to the cache
+			// There was no tag for this commit, save that info to the cache
 			commitsWithNoTags.push(targetCommit);
 		} else if (targetTags.length > 0) {
-			const commitMeta = $('div[data-testid="listview-item-description"]', commit)!;
+			const commitMeta = $('div[data-testid="list-view-item-description"]', commit)!;
 
 			commitMeta.append(
 				<span className="d-flex flex-items-center gap-1">


### PR DESCRIPTION
Fix #7459

I only updated the selector. Further work may include moving them to `selectors.ts` (which is a new thing to me) and also migrate from the deprecated `cache` function.

## Test URLs

https://github.com/refined-github/refined-github/commits/main/

## Screenshot

<img width="412" alt="Screenshot 2024-06-27 at 6 03 18 PM" src="https://github.com/refined-github/refined-github/assets/44045911/e8778e79-ecb1-42ed-aa0b-798d1f325a82">
