### PR TITLE
`list-prs-for-file` - Prevent symbols panel overlapping

### DIFF
--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -29,6 +29,7 @@ function getDropdown(prs: number[]): HTMLElement {
 		? <AlertIcon className="v-align-middle color-fg-attention"/>
 		: <GitPullRequestIcon className="v-align-middle"/>;
 	// Markup copied from https://primer.style/css/components/dropdown
+	// TODO: use Popover API when hovercards become compatible #7496
 	return (
 		<details className="dropdown details-reset details-overlay flex-self-center rgh-list-prs-for-file">
 			<summary className="btn btn-sm">

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,7 +160,7 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	child.closest('.container')!.classList.add('rgh-z-index-1');
+	child.closest('.container')!.classList.add('rgh-z-index-5');
 }
 
 /** Trigger a reflow to push the right-most tab into the overflow dropdown */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -174,7 +174,7 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	background: none !important;
 }
 
-.rgh-z-index-1 {
+.rgh-z-index-5 {
 	position: relative;
-	z-index: 1;
+	z-index: 5;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #7468

## Test URLs

https://github.com/pypi/warehouse/blob/main/warehouse/packaging/models.py

## Screenshot
<img width="335" alt="Screenshot 2024-06-30 at 12 30 49 PM" src="https://github.com/refined-github/refined-github/assets/44045911/0b628924-e8f1-4c89-a959-4b64ccb210b6">
