### PR TITLE
`unreleased-commits` - Fix icon alignment

### DIFF
--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -91,8 +91,8 @@ async function createLink(
 			href={buildRepoURL('compare', `${latestTag}...${await getDefaultBranch()}`)}
 			aria-label={label}
 		>
-			<TagIcon className="v-align-middle"/>
-			{aheadBy === undeterminableAheadBy || <sup className="ml-n2"> +{aheadBy}</sup>}
+			<TagIcon/>
+			{aheadBy === undeterminableAheadBy || <sup className="ml-n1"> +{aheadBy}</sup>}
 		</a>
 	);
 }


### PR DESCRIPTION
Small cosmetic tweak

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

| Before | After |
|--------|--------|
| <img width="183" alt="Screenshot 2024-06-30 at 1 58 47 PM" src="https://github.com/refined-github/refined-github/assets/44045911/9a7b92d2-b432-4700-9f89-ce783e629461"> | <img width="180" alt="Screenshot 2024-06-30 at 2 04 30 PM" src="https://github.com/refined-github/refined-github/assets/44045911/650b7869-1641-4304-a4e8-fec0e690d7c2"> | 


