### PR TITLE
Prevent options checkbox position change

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -133,7 +133,7 @@ details[open] > :not(summary) {
 	margin-top: 2px;
 }
 
-.js-features :not(:checked) + .info .feature-name {
+.js-features .feature-checkbox:not(:checked) + .feature-name {
 	text-decoration: line-through;
 }
 
@@ -162,7 +162,7 @@ details[open] > :not(summary) {
 	box-shadow: inset 0 -1px 0 #d1d5da;
 }
 
-.feature-checkbox:disabled + .info > *:not(.hotfix-notice) {
+.info:has(.feature-checkbox:disabled) > *:not(.hotfix-notice) {
 	opacity: 50%;
 }
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -163,8 +163,8 @@ function moveDisabledFeaturesToTop(): void {
 function buildFeatureCheckbox({id, description, screenshot}: FeatureMeta): HTMLElement {
 	return (
 		<div className="feature" data-text={`${id} ${description}`.toLowerCase()}>
-			<input type="checkbox" name={`feature:${id}`} id={id} className="feature-checkbox"/>
 			<div className="info">
+				<input type="checkbox" name={`feature:${id}`} id={id} className="feature-checkbox"/>
 				<label className="feature-name" htmlFor={id}>{id}</label>
 				{' '}
 				<a href={featureLink(id)} className="feature-link">


### PR DESCRIPTION
🚫 NO FUNKY MOVE ALLOWED

## Test URLs

`chrome-extension://<RGH>/assets/options.html`

## Screenshot

<table>
<thead>
<tr>
<td>Before
<td>After
</tr>
</thead>
<tbody>
<tr>
<td>

https://github.com/refined-github/refined-github/assets/44045911/0120e4db-9f35-4536-b3d7-3a47b8ebfce7

<td>

https://github.com/refined-github/refined-github/assets/44045911/e4ea3f9c-2f1c-46d4-b821-eef4bd374d0f

</tobdy>
</table>