### PR TITLE
`comment-on-draft-pr-indicator` - Create `netiquette`-like banner

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -137,7 +137,7 @@
 	{
 		"id": "comment-on-draft-pr-indicator",
 		"description": "Reminds you you’re commenting on a draft PR by changing the submit button’s label.",
-		"screenshot": "https://user-images.githubusercontent.com/34235681/152473140-22b6eb86-3ef4-4104-af10-4a659d878f91.png"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/44045911/988a6ec1-5faa-4500-baa9-0c3713468ca9"
 	},
 	{
 		"id": "comments-time-machine-links",

--- a/readme.md
+++ b/readme.md
@@ -373,7 +373,7 @@ Thanks for contributing! 🦋🙌
 - [](# "netiquette") [Adds unobtrusive netiquette reminders.](https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png)
 - [](# "warn-pr-from-master") [Warns you when creating a PR from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
-- [](# "comment-on-draft-pr-indicator") [Reminds you you’re commenting on a draft PR by changing the submit button’s label.](https://user-images.githubusercontent.com/34235681/152473140-22b6eb86-3ef4-4104-af10-4a659d878f91.png)
+- [](# "comment-on-draft-pr-indicator") [Reminds you you’re commenting on a draft PR by changing the submit button’s label.](https://github.com/refined-github/refined-github/assets/44045911/988a6ec1-5faa-4500-baa9-0c3713468ca9)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -27,3 +27,11 @@ void features.add(import.meta.url, {
 	awaitDomReady: true,
 	init,
 });
+
+/*
+
+Test URL:
+
+https://github.com/refined-github/sandbox/pull/7
+
+*/

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -1,28 +1,29 @@
+import React from 'dom-chef';
+import InfoIcon from 'octicons-plain-react/Info';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
+import createBanner from '../github-helpers/banner.js';
 
-function addIndicator(button: HTMLElement): void {
-	const preposition = button.textContent.includes('Add') ? ' to ' : ' on ';
-	button.textContent += preposition + 'draft PR';
+function addDraftBanner(newCommentField: HTMLElement): void {
+	newCommentField.before(
+		createBanner({
+			icon: <InfoIcon className="m-0"/>,
+			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
+			text: <>This is a <strong>draft PR</strong>. Make sure you would like to comment.</>,
+		}),
+	);
 }
 
 function init(signal: AbortSignal): void {
-	observe([
-		'.review-simple-reply-button', // "Add single comment" button
-		'.add-comment-label', // "Add review comment" button
-		'.start-review-label', // "Start a review" button
-	], addIndicator, {signal});
+	observe('.CommentBox file-attachment', addDraftBanner, {signal});
 }
 
 void features.add(import.meta.url, {
-	asLongAs: [
+	include: [
 		pageDetect.isDraftPR,
 	],
-	include: [
-		pageDetect.isPRConversation,
-		pageDetect.isPRFiles,
-	],
+	awaitDomReady: true,
 	init,
 });

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -11,7 +11,7 @@ function addDraftBanner(newCommentField: HTMLElement): void {
 		createBanner({
 			icon: <InfoIcon className="m-0"/>,
 			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
-			text: <>This is a <strong>draft PR</strong>. Make sure you would like to comment.</>,
+			text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
 		}),
 	);
 }

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -1,5 +1,5 @@
 import React from 'dom-chef';
-import InfoIcon from 'octicons-plain-react/Info';
+import GitPullRequestDraftIcon from 'octicons-plain-react/GitPullRequestDraft';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
@@ -9,7 +9,7 @@ import createBanner from '../github-helpers/banner.js';
 function addDraftBanner(newCommentField: HTMLElement): void {
 	newCommentField.before(
 		createBanner({
-			icon: <InfoIcon className="m-0"/>,
+			icon: <GitPullRequestDraftIcon className="m-0"/>,
 			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
 			text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
 		}),


### PR DESCRIPTION
Resolve #7438

## Test URLs

https://github.com/refined-github/sandbox/pull/7

## Screenshot

Regular

<img width="865" alt="Screenshot 2024-06-30 at 7 11 03 PM" src="https://github.com/refined-github/refined-github/assets/44045911/988a6ec1-5faa-4500-baa9-0c3713468ca9">


Inline

<img width="800" alt="Screenshot 2024-06-30 at 7 11 57 PM" src="https://github.com/refined-github/refined-github/assets/44045911/c5d8d2cb-c9c8-490e-b187-b70f69848ba6">

