### PR TITLE
`netiquette` - Support review comments

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -75,12 +75,14 @@ function addPopularBanner(newCommentField: HTMLElement): void {
 	);
 }
 
+const commentFieldSelector = '.CommentBox file-attachment';
+
 function initBanner(signal: AbortSignal): void | false {
 	// Do not move to `asLongAs` because those conditions are run before `isConversation`
 	if (wasClosedLongAgo()) {
-		observe('#issuecomment-new file-attachment', addConversationBanner, {signal});
+		observe(commentFieldSelector, addConversationBanner, {signal});
 	} else if (isPopular() && !isCollaborator()) {
-		observe('#issuecomment-new file-attachment', addPopularBanner, {signal});
+		observe(commentFieldSelector, addPopularBanner, {signal});
 	} else {
 		return false;
 	}


### PR DESCRIPTION
Use the same selector as in #7514. Unfortunately this currently only works with inline comments on the Conversation page since `wasClosedLongAgo()` etc. only works there.

## Test URLs

https://github.com//nodejs/node/pull/43689#discussion_r915109802


## Screenshot
 
<img width="802" alt="Screenshot 2024-06-30 at 7 38 27 PM" src="https://github.com/refined-github/refined-github/assets/44045911/6ee2e617-5152-4b98-9f17-4a98a025801c">
