### PR TITLE
`small-user-avatars` - Fix misalignment 

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -11,7 +11,7 @@ function addAvatar(link: HTMLElement): void {
 	const username = link.textContent;
 	const size = 14;
 
-	link.classList.add('d-inline-block');
+	link.classList.add('d-inline-block', 'lh-condensed-ultra');
 	link.prepend(
 		<img
 			className="avatar avatar-user v-align-text-bottom mr-1 rgh-small-user-avatars"


### PR DESCRIPTION

 Closes #7509

## Test URLs

https://github.com/refined-github/refined-github/issues

## Screenshot

small-user-avatars disabled:
|Before|After|
|---|---|
| <img width="672" alt="SCR-20240701-rctj" src="https://github.com/refined-github/refined-github/assets/17134256/2fb3148f-6732-4b55-8b37-7cc275c2cae4"> |<img width="685" alt="SCR-20240701-rcwp" src="https://github.com/refined-github/refined-github/assets/17134256/ec8c729c-ffbd-48be-aad5-1dd108228465"> |

small-user-avatars enabled:

|Before|After|
|---|---|
| <img width="739" alt="SCR-20240701-rcjn" src="https://github.com/refined-github/refined-github/assets/17134256/2a649bd2-b2bd-4dbf-9522-68cfd6543a00"> |<img width="719" alt="SCR-20240701-rcct" src="https://github.com/refined-github/refined-github/assets/17134256/c1aa09d3-4e52-4a74-8728-5feea65d39a2"> |


