### PR TITLE
`conversation-links-on-repo-lists` - Improve AJAX support

### DIFF
--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -37,6 +37,9 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
+	// Do not move to `includes` until React AJAX issues are resolved:
+	// https://github.com/refined-github/refined-github/pull/7524#issuecomment-2211692096
+	// https://github.com/refined-github/refined-github/issues/6554
 	if (new URLSearchParams(location.search).get('type') !== 'repositories') {
 		return;
 	}

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -37,6 +37,7 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
+	if (new URLSearchParams(location.search).get('type') !== 'repositories') return
 	// Place before the update date ·
 	repositoryLink
 		.closest('[data-testid="results-list"] > div')!
@@ -84,7 +85,7 @@ void features.add(import.meta.url, {
 	init,
 }, {
 	include: [
-		() => pageDetect.isGlobalSearchResults() && new URLSearchParams(location.search).get('type') === 'repositories',
+		pageDetect.isGlobalSearchResults,
 	],
 	init: initSearch,
 });

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -37,7 +37,10 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
-	if (new URLSearchParams(location.search).get('type') !== 'repositories') return
+	if (new URLSearchParams(location.search).get('type') !== 'repositories') {
+		return;
+	}
+
 	// Place before the update date ·
 	repositoryLink
 		.closest('[data-testid="results-list"] > div')!


### PR DESCRIPTION

Closes https://github.com/refined-github/refined-github/issues/7520

## Test URLs

### Bug1:  It should not be displayed in search "code" panel 

1. open [github.com/search?q=%22webext%22&type=repositories](https://github.com/search?q=%22webext%22&type=repositories)
2. Click "Code" in the sidebar
3. Notice extra links
4. Refresh the page
5. The links are gone

### Bug2: Refresh the page from  search "code" panel , but it does not display after clicking "repositories"

1. open [github.com/search?q=%22webext%22&type=code](https://github.com/search?q=%22webext%22&type=code)
2. Click "Repositories" in the sidebar
3. The links are gone
4. Refresh the page
5.  links show

## Screenshot

Before:

![before](https://github.com/refined-github/refined-github/assets/17134256/4ab9b9bb-a562-49f7-9a36-ed751b6fad54) 

After: 

![after](https://github.com/refined-github/refined-github/assets/17134256/39060554-9401-4e6e-81c3-f0dc956a308d)
|



