### PR TITLE
`clean-repo-sidebar` Wait for package count to load for internal packages

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -30,7 +30,7 @@ async function cleanReleases(): Promise<void> {
 }
 
 async function hideEmptyPackages(): Promise<void> {
-	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false});
+	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter:not([hidden="hidden"])', {waitForChildren: false});
 	if (packagesCounter && packagesCounter.textContent === '0') {
 		packagesCounter.closest('.BorderGrid-row')!.hidden = true;
 	}

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -30,9 +30,22 @@ async function cleanReleases(): Promise<void> {
 }
 
 async function hideEmptyPackages(): Promise<void> {
-	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter:not([hidden="hidden"])', {waitForChildren: false});
-	if (packagesCounter && packagesCounter.textContent === '0') {
-		packagesCounter.closest('.BorderGrid-row')!.hidden = true;
+	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false});
+	if (!packagesCounter || packagesCounter.textContent !== '0') {
+		return;
+	}
+
+	packagesCounter.closest('.BorderGrid-row')!.hidden = true;
+
+	// Github seems to fetch internal packages separately, so if a repo only has internal packages, this makes the panel visible after they've loaded
+	const updatedPackagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter:not([hidden="hidden"])', {
+		waitForChildren: false,
+		stopOnDomReady: false,
+		timeout: 10 * 1000,
+	});
+
+	if (updatedPackagesCounter && updatedPackagesCounter.textContent !== '0') {
+		updatedPackagesCounter.closest('.BorderGrid-row')!.hidden = false;
 	}
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -4,8 +4,9 @@ import domLoaded from 'dom-loaded';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import features from '../feature-manager.js';
 import oneEvent from 'one-event';
+
+import features from '../feature-manager.js';
 // The h2 is to avoid hiding website links that include '/releases' #4424
 // TODO: It's broken
 const releasesSidebarSelector = '.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]';
@@ -35,7 +36,7 @@ async function hideEmptyPackages(): Promise<void> {
 	if (packageLoader) {
 		// 'loadend' captures success and error
 		// https://github.com/github/include-fragment-element/blob/5249243ee1cbdc82ab69c5d7c6318cd61a524b93/src/include-fragment-element.ts#L261
-		await oneEvent(packageLoader, "loadend")
+		await oneEvent(packageLoader, 'loadend');
 	}
 
 	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false});


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

This affects repositories with only internal packages. So inside a Github Organisation.
This affects the repository overview page where `clean-repo-sidebar` runs.


## Copied HTML
```html
<include-fragment src="/my-org/my-repo/packages_list?current_repository=my-repo" aria-busy="true" aria-label="Loading latest packages">
    <h2 class="h4 mb-3">
  <a href="/orgs/my-org/packages?repo_name=my-repo" data-view-component="true" class="Link--primary no-underline Link d-flex flex-items-center">
    Packages
      <span title="0" hidden="hidden" data-view-component="true" class="Counter ml-1">0</span>
</a></h2>


        <div class="mb-2 d-flex flex-items-center">
          <div class="Skeleton mr-2" style="width:20px;height:20px;"></div>
          <div class="Skeleton Skeleton--text flex-auto">&nbsp;</div>
        </div>
        <div class="mb-2 d-flex flex-items-center">
          <div class="Skeleton mr-2" style="width:20px;height:20px;"></div>
          <div class="Skeleton Skeleton--text flex-auto">&nbsp;</div>
        </div>
        <div class="mb-2 d-flex flex-items-center">
          <div class="Skeleton mr-2" style="width:20px;height:20px;"></div>
          <div class="Skeleton Skeleton--text flex-auto">&nbsp;</div>
        </div>
</include-fragment>
```

## Test URLs
* https://github.com/refined-github/refined-github