### PR TITLE
`action-pr-link` - Restore feature on Actions tab

### DIFF
--- a/source/features/action-pr-link.tsx
+++ b/source/features/action-pr-link.tsx
@@ -13,7 +13,7 @@ function setSearchParameter(anchorElement: HTMLAnchorElement, name: string, valu
 async function addForRepositoryActions(prLink: HTMLAnchorElement): Promise<void> {
 	const prNumber = prLink.textContent.slice(1);
 
-	const runLink = prLink.closest('.Box-row')!.querySelector('a[href*="actions/runs"]')!;
+	const runLink = prLink.closest('.Box-row')!.querySelector('a:has(.Link--primary)')!;
 	setSearchParameter(runLink, 'pr', prNumber);
 }
 

--- a/source/features/action-pr-link.tsx
+++ b/source/features/action-pr-link.tsx
@@ -13,7 +13,7 @@ function setSearchParameter(anchorElement: HTMLAnchorElement, name: string, valu
 async function addForRepositoryActions(prLink: HTMLAnchorElement): Promise<void> {
 	const prNumber = prLink.textContent.slice(1);
 
-	const runLink = prLink.closest('.Box-row')!.querySelector('a.Link--primary')!;
+	const runLink = prLink.closest('.Box-row')!.querySelector('a[href*="actions/runs"]')!;
 	setSearchParameter(runLink, 'pr', prNumber);
 }
 


### PR DESCRIPTION
Closes #7534

Fix `action-pr-link` runLink element null

## Test URLs

https://github.com/refined-github/refined-github/actions

## Screenshot

Before

<img width="400" alt="SCR-20240709-osbe" src="https://github.com/refined-github/refined-github/assets/17134256/28a2df05-bbf7-464a-b9c6-8beeff806c01">

After

<img width="400" alt="SCR-20240709-ortl" src="https://github.com/refined-github/refined-github/assets/17134256/b4c1cc00-891c-485e-9cb0-799b693fed85">

