### PR TITLE
`unfinished-comments` - Avoid repetition

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -4,8 +4,9 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 
-let documentTitle: string | undefined;
 let submitting: number | undefined;
+
+const prefix = '✏️ Comment - ';
 
 function hasDraftComments(): boolean {
 	// `[id^="convert-to-issue-body"]` excludes the hidden pre-filled textareas created when opening the dropdown menu of review comments
@@ -27,11 +28,9 @@ function updateDocumentTitle(): void {
 	}
 
 	if (document.visibilityState === 'hidden' && hasDraftComments()) {
-		documentTitle = document.title;
 		document.title = '✏️ Comment - ' + document.title;
-	} else if (documentTitle) {
-		document.title = documentTitle;
-		documentTitle = undefined;
+	} else if (document.title.startsWith(prefix) {
+		document.title = document.title.replace(prefix, '');
 	}
 }
 


### PR DESCRIPTION
I don't know what's wrong with the logic, but I see this occasionally





## Test URLs

here

## Before


<img width="336" alt="Screenshot 2" src="https://github.com/user-attachments/assets/71d0eb45-1ef1-4383-b747-cd30e0b4853d">



## After

_untested_