### PR TITLE
`clean-repo-sidebar` - Show packages if not empty

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -4,7 +4,8 @@
 }
 
 /* Hide "Packages" if empty */
-[rgh-clean-repo-sidebar] .BorderGrid-row:has(a[href*="/packages?repo_name"] .Counter[title="0"]) {
+[rgh-clean-repo-sidebar]
+	.BorderGrid-row:has(a[href*='/packages?repo_name'] .Counter[title='0']) {
 	display: none;
 }
 

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -3,6 +3,11 @@
 	display: none;
 }
 
+/* Hide "Packages" if empty */
+[rgh-clean-repo-sidebar] .BorderGrid-row:has(a[href*="/packages?repo_name"] .Counter[title="0"]) {
+	display: none;
+}
+
 /* Align the top of the repo root sidebar with the main page content */
 [rgh-clean-repo-sidebar] .Layout-sidebar .BorderGrid-row:first-child h2 + p.f4 {
 	margin-top: 0 !important;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -29,13 +29,6 @@ async function cleanReleases(): Promise<void> {
 		.classList.add('border-0', 'pb-0');
 }
 
-async function hideEmptyPackages(): Promise<void> {
-	const packagesCounter = await elementReady('.Layout-sidebar .BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false});
-	if (packagesCounter && packagesCounter.textContent === '0') {
-		packagesCounter.closest('.BorderGrid-row')!.hidden = true;
-	}
-}
-
 async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
@@ -76,7 +69,6 @@ void features.add(import.meta.url, {
 	init: [
 		init,
 		cleanReleases,
-		hideEmptyPackages,
 		hideLanguageHeader,
 		hideEmptyMeta,
 		moveReportLink,
@@ -87,6 +79,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-https://github.com/refined-github/refined-github
+- https://github.com/refined-github/refined-github
+- Repo with empty packages section: https://github.com/isaacs/node-glob
+- Repo with 1 package: https://github.com/recyclarr/recyclarr
 
 */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7544
- Replaces and closes https://github.com/refined-github/refined-github/pull/7532


## Test URLs

- https://github.com/refined-github/refined-github
- Repo with packages: https://github.com/recyclarr/recyclarr

## No RGH

<img width="337" alt="Screenshot 2" src="https://github.com/user-attachments/assets/6e33e288-4bc3-49b7-9d5d-7925f1ca3edf">

## RGH

<img width="337" alt="Screenshot 3" src="https://github.com/user-attachments/assets/9667731d-bd15-4c92-8e8f-68fba4c9e219">

## RGH: after this PR

<img width="351" alt="Screenshot" src="https://github.com/user-attachments/assets/f7f88e1c-6264-4bfa-b729-e94105899f09">

