### PR TITLE
Bump TypeScript to v5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
 				"terser-webpack-plugin": "^5.3.10",
 				"tsx": "^4.16.2",
 				"type-fest": "^4.22.0",
-				"typed-query-selector": "^2.11.2",
+				"typed-query-selector": "^2.11.3",
 				"typescript": "^5.5.3",
 				"vitest": "^2.0.3",
 				"webpack": "^5.93.0",
@@ -10308,9 +10308,9 @@
 			}
 		},
 		"node_modules/typed-query-selector": {
-			"version": "2.11.2",
-			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.2.tgz",
-			"integrity": "sha512-6rZP+cG3wPg2w1Zqv2VCOsSqlkGElrLSGeEkyrIU9mHG+JfQZE/6lE3oyQouz42sTS9n8fQXvwQBaVWz6dzpfQ==",
+			"version": "2.11.3",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.3.tgz",
+			"integrity": "sha512-lMG8vpGrthemzydrNhGbpFqLEDEe4ivjNcofh2L2JYC8OBnkIAZLAsNVEkxS8rix2YZhTMqbwwJh91uk31kKTA==",
 			"license": "MIT"
 		},
 		"node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
 				"tsx": "^4.16.2",
 				"type-fest": "^4.22.0",
 				"typed-query-selector": "^2.11.2",
-				"typescript": "5.2.2",
+				"typescript": "^5.5.3",
 				"vitest": "^2.0.3",
 				"webpack": "^5.93.0",
 				"webpack-cli": "^5.1.4",
@@ -10314,9 +10314,9 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -11288,20 +11288,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/typescript": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"tsx": "^4.16.2",
 		"type-fest": "^4.22.0",
 		"typed-query-selector": "^2.11.2",
-		"typescript": "5.2.2",
+		"typescript": "^5.5.3",
 		"vitest": "^2.0.3",
 		"webpack": "^5.93.0",
 		"webpack-cli": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"terser-webpack-plugin": "^5.3.10",
 		"tsx": "^4.16.2",
 		"type-fest": "^4.22.0",
-		"typed-query-selector": "^2.11.2",
+		"typed-query-selector": "^2.11.3",
 		"typescript": "^5.5.3",
 		"vitest": "^2.0.3",
 		"webpack": "^5.93.0",

--- a/source/github-events/on-react-page-update.tsx
+++ b/source/github-events/on-react-page-update.tsx
@@ -5,7 +5,6 @@ export default function onReactPageUpdate(
 	signal: AbortSignal,
 ): void {
 	document.addEventListener('soft-nav:payload', () => {
-		// @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60868
 		const unifiedSignal = AbortSignal.any([
 			signal, // User-provided, likely Turbo page navigation event
 			signalFromEvent(document, 'soft-nav:payload'), // A "React page"-specific page navigation event

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -36,7 +36,7 @@ const registerAnimation = onetime((): void => {
 
 export default function observe<
 	Selector extends string,
-	ExpectedElement extends ParseSelector<Selector, HTMLElement>,
+	ExpectedElement extends ParseSelector<Selector, HTMLElement | SVGElement>,
 >(
 	selectors: Selector | readonly Selector[],
 	listener: ObserverListener<ExpectedElement>,

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -11,7 +11,7 @@ type ObserverListener<ExpectedElement extends Element> = (element: ExpectedEleme
 const animation = 'rgh-selector-observer';
 const getListener = <
 	Selector extends string,
-	ExpectedElement extends ParseSelector<Selector, HTMLElement>,
+	ExpectedElement extends ParseSelector<Selector, HTMLElement | SVGElement>,
 >(
 	seenMark: string,
 	selector: Selector,


### PR DESCRIPTION
We've been having an issue upgrading TS since 5.3. It's failing here:

https://github.com/refined-github/refined-github/blob/f34c0a9c06e94cb82c0724cbe627c0d610ebdc13/source/helpers/fetch-dom.ts#L8


https://github.com/refined-github/refined-github/blob/f34c0a9c06e94cb82c0724cbe627c0d610ebdc13/source/helpers/selector-observer.tsx#L12-L15

```ts
Error: source/helpers/fetch-dom.ts(8,81): error TS2344: Type 'ParseSelector<Selector, HTMLElement>' does not satisfy the constraint 'HTMLElement'.
  Type 'HTMLElement | (ExpandAnd<string & ParseSelectorToTagNames<Selector>, HTMLElement> extends Element ? Element & ExpandAnd<...> : HTMLElement)' is not assignable to type 'HTMLElement'.
    Type 'ExpandAnd<string & ParseSelectorToTagNames<Selector>, HTMLElement> extends Element ? Element & ExpandAnd<...> : HTMLElement' is not assignable to type 'HTMLElement'.
      Type 'HTMLElement | (Element & ExpandAnd<string & ParseSelectorToTagNames<Selector>, HTMLElement>)' is not assignable to type 'HTMLElement'.
        Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 123 more.
Error: source/helpers/selector-observer.tsx(69,76): error TS2345: Argument of type 'ObserverListener<ExpectedElement>' is not assignable to parameter of type 'ObserverListener<HTMLElement>'.
  Type 'HTMLElement' is not assignable to type 'ExpectedElement'.
    'HTMLElement' is assignable to the constraint of type 'ExpectedElement', but 'ExpectedElement' could be instantiated with a different subtype of constraint 'HTMLElement | Element'.
```

cc @g-plane