### PR TITLE
`comment-on-draft-pr-indicator` - Avoid appearing on wrong places

### DIFF
--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -17,7 +17,10 @@ function addDraftBanner(newCommentField: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.CommentBox file-attachment', addDraftBanner, {signal});
+	observe(`.CommentBox file-attachment:is(
+		[input="fc-new_comment_field"],
+		[input^="fc-new_inline_comment_discussion"]
+	)`, addDraftBanner, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import createBanner from '../github-helpers/banner.js';
-import {getDiscussionAuthor, getUsername} from '../github-helpers/index.js';
+import {getConversationAuthor, getUsername} from '../github-helpers/index.js';
 
 function addDraftBanner(newCommentField: HTMLElement): void {
 	newCommentField.before(
@@ -29,7 +29,7 @@ void features.add(import.meta.url, {
 		pageDetect.isDraftPR,
 	],
 	exclude: [
-		() => getDiscussionAuthor() === getUsername(),
+		() => getConversationAuthor() === getUsername(),
 	],
 	awaitDomReady: true,
 	init,

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -22,10 +22,10 @@ function addDraftBanner(newCommentField: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe(`.CommentBox file-attachment:is(
+	observe(`
 		[input="fc-new_comment_field"],
 		[input^="fc-new_inline_comment_discussion"]
-	)`, addDraftBanner, {signal});
+	`, addDraftBanner, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -28,7 +28,7 @@ void features.add(import.meta.url, {
 	asLongAs: [
 		pageDetect.isDraftPR,
 		// Must come after `isDraftPR`
-		() => getDiscussionAuthor() !== getUsername()
+		() => getDiscussionAuthor() !== getUsername(),
 	],
 	awaitDomReady: true,
 	init,

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -5,8 +5,13 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import createBanner from '../github-helpers/banner.js';
+import {getDiscussionAuthor, getUsername} from '../github-helpers/index.js';
 
 function addDraftBanner(newCommentField: HTMLElement): void {
+	if (getDiscussionAuthor() === getUsername()) {
+		return;
+	}
+
 	newCommentField.before(
 		createBanner({
 			icon: <GitPullRequestDraftIcon className="m-0"/>,

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -8,10 +8,6 @@ import createBanner from '../github-helpers/banner.js';
 import {getDiscussionAuthor, getUsername} from '../github-helpers/index.js';
 
 function addDraftBanner(newCommentField: HTMLElement): void {
-	if (getDiscussionAuthor() === getUsername()) {
-		return;
-	}
-
 	newCommentField.before(
 		createBanner({
 			icon: <GitPullRequestDraftIcon className="m-0"/>,
@@ -29,8 +25,10 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
-	include: [
+	asLongAs: [
 		pageDetect.isDraftPR,
+		// Must come after `isDraftPR`
+		() => getDiscussionAuthor() !== getUsername()
 	],
 	awaitDomReady: true,
 	init,

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -18,17 +18,18 @@ function addDraftBanner(newCommentField: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe(`
-		[input="fc-new_comment_field"],
-		[input^="fc-new_inline_comment_discussion"]
-	`, addDraftBanner, {signal});
+	observe([
+		'[input="fc-new_comment_field"]',
+		'[input^="fc-new_inline_comment_discussion"]',
+	], addDraftBanner, {signal});
 }
 
 void features.add(import.meta.url, {
-	asLongAs: [
+	include: [
 		pageDetect.isDraftPR,
-		// Must come after `isDraftPR`
-		() => getDiscussionAuthor() !== getUsername(),
+	],
+	exclude: [
+		() => getDiscussionAuthor() === getUsername(),
 	],
 	awaitDomReady: true,
 	init,

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -185,6 +185,6 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
 
-export function getDiscussionAuthor(): string | undefined {
+export function getConversationAuthor(): string | undefined {
 	return $('#partial-discussion-header .gh-header-meta .author')?.textContent;
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -184,3 +184,7 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	// @ts-expect-error No Firefox support https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
+
+export function getDiscussionAuthor(): string | undefined {
+	return $('#partial-discussion-header .gh-header-meta .author')?.textContent;
+}


### PR DESCRIPTION
Fix #7541


## Test URLs

- https://github.com/refined-github/sandbox/pull/7


## Screenshot

| | Before | After |
|--------|--------|--------|
| Own PR | <img width="404" alt="Screenshot 2024-07-21 at 9 24 56 PM" src="https://github.com/user-attachments/assets/b6fc59e3-b303-4da1-89d1-899ec0ae1322"> | <img width="408" alt="Screenshot 2024-07-21 at 9 24 24 PM" src="https://github.com/user-attachments/assets/6cdc2fb7-ef9e-41e9-8c4c-35fa75571707"> |
| New & edit comment | <img width="788" alt="Screenshot 2024-07-21 at 9 25 30 PM" src="https://github.com/user-attachments/assets/84bbd8a1-462c-4d79-8182-a9383cc62399"> | <img width="789" alt="Screenshot 2024-07-21 at 8 38 16 PM" src="https://github.com/user-attachments/assets/bbcac98f-601d-48c5-b1d2-cd14e3776fe7"> | 