### PR TITLE
`release-download-count` - Prevent time overflow

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -4,6 +4,11 @@
 	min-width: 6em;
 }
 
+/* <relative-time> can occupy more space #7579 */
+.rgh-release-download-count > span:last-child {
+	min-width: 8em;
+}
+
 /* Makes space for right aligning download count */
 .rgh-release-download-count [data-rgh-heat] {
 	min-width: 5em;

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -5,7 +5,7 @@
 }
 
 /* <relative-time> can occupy more space #7579 */
-.rgh-release-download-count > span:last-child {
+.rgh-release-download-count > span:has(relative-time) {
 	min-width: 8em;
 }
 


### PR DESCRIPTION
Fix #7579


## Test URLs

https://github.com/cli/cli/releases/tag/v2.30.0

## Screenshot

Note: time is simulated

| Before | After |
|--------|--------|
| <img width="370" alt="Screenshot 2024-07-23 at 12 02 20 PM" src="https://github.com/user-attachments/assets/14346321-c1d5-4751-bbaf-9d2338afa89e"> | <img width="360" alt="Screenshot 2024-07-23 at 12 02 24 PM" src="https://github.com/user-attachments/assets/af32dd07-3569-432e-a2ca-12780430cee1"> |


