### PR TITLE
`default-branch-button` - Restore feature in sidebar

### DIFF
--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,7 +160,7 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	// When the default branch button appears in the sidebar, the closet container is null
+	// In the sidebar the container is not present and this fix is not needed
 	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,7 +160,7 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	// when the default branch button appears in the sidebar, the closet container is null
+	// When the default branch button appears in the sidebar, the closet container is null
 	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,9 +160,9 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	// when the default branch button appears in the sidebar, the closet container is null
-	const container = child.closest('.container')
-	if(container) {
+	// When the default branch button appears in the sidebar, the closet container is null
+	const container = child.closest('.container');
+	if (container) {
 		container.classList.add('rgh-z-index-5');
 	}
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,6 +160,7 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
+	// when the default branch button appears in the sidebar, the closet container is null
 	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,11 +160,7 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	// When the default branch button appears in the sidebar, the closet container is null
-	const container = child.closest('.container');
-	if (container) {
-		container.classList.add('rgh-z-index-5');
-	}
+	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 
 /** Trigger a reflow to push the right-most tab into the overflow dropdown */

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -160,7 +160,11 @@ export function triggerConversationUpdate(): void {
 
 // Fix z-index issue https://github.com/refined-github/refined-github/pull/7430
 export function fixFileHeaderOverlap(child: Element): void {
-	child.closest('.container')!.classList.add('rgh-z-index-5');
+	// when the default branch button appears in the sidebar, the closet container is null
+	const container = child.closest('.container')
+	if(container) {
+		container.classList.add('rgh-z-index-5');
+	}
 }
 
 /** Trigger a reflow to push the right-most tab into the overflow dropdown */


### PR DESCRIPTION
close: #7549 

## Test URLs


## Screenshot

When `default-branch-button` appears in the header, we can find the closet container element so it works fine!

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/b3e8fcae-6160-411a-bf53-5c5f883ddc2b">



But whetn it appears in the sidebar, the closet container element is null. And I think we don't need to add `rgh-z-index-5` class in this situation.

<img width="1601" alt="image" src="https://github.com/user-attachments/assets/4c06eb5e-60f8-4336-b462-076cb7804fa1">
