### PR TITLE
`netiquette` - Hide banners in preview tab

### DIFF
--- a/source/features/draft-pr-notice.tsx
+++ b/source/features/draft-pr-notice.tsx
@@ -9,7 +9,7 @@ import {isOwnConversation} from '../github-helpers/index.js';
 import {newCommentField} from '../github-helpers/selectors.js';
 
 function addDraftBanner(newCommentField: HTMLElement): void {
-	newCommentField.before(
+	newCommentField.prepend(
 		createBanner({
 			icon: <GitPullRequestDraftIcon className="m-0"/>,
 			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -58,7 +58,7 @@ export function getNoticeText(): JSX.Element {
 }
 
 function addConversationBanner(newCommentField: HTMLElement): void {
-	newCommentField.before(
+	newCommentField.prepend(
 		createBanner({
 			icon: <InfoIcon className="m-0"/>,
 			classes: 'p-2 m-2 text-small color-fg-muted border-0'.split(' '),
@@ -68,7 +68,7 @@ function addConversationBanner(newCommentField: HTMLElement): void {
 }
 
 function addPopularBanner(newCommentField: HTMLElement): void {
-	newCommentField.before(
+	newCommentField.prepend(
 		createBanner({
 			icon: <FlameIcon className="m-0"/>,
 			classes: 'p-2 m-2 text-small color-fg-muted border-0'.split(' '),


### PR DESCRIPTION
Fix #7612


## Test URLs

- Draft PR: https://github.com//refined-github/sandbox/pull/7
- Old PR: https://github.com//facebook/react/pull/209

## Screenshot

`draft-pr-notice`

https://github.com/user-attachments/assets/840956f9-6427-4823-a2eb-a502c4be0df8

`netiquette`

https://github.com/user-attachments/assets/0c63ad0c-8a89-49d6-bfba-0701277517de

