### PR TITLE
`comments-time-machine-links` - Preserve hash on link

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -53,7 +53,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 	}
 
 	const link = (
-		<a className="rgh-link-date" href={url.href} data-turbo-frame="repo-content-turbo-frame">
+		<a className="rgh-link-date" href={url.href}>
 			view this object as it appeared at the time of the comment
 		</a>
 	);


### PR DESCRIPTION
- Appears to fix https://github.com/refined-github/refined-github/issues/7620

Not yet tested


## Test

1. Open https://togithub.com/acomagu/fish-async-prompt/issues/51
2. Click `__async_prompt.fish#L2` link
3. Click "view this object as it appeared at the time of the comment"
4. Expect `#L2` hash to still be there