### PR TITLE
`default-branch-button` - Restore feature in sticky header

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -34,7 +34,7 @@ const getUrl = memoize(async (currentUrl: string): Promise<string> => {
 async function add(branchSelector: HTMLElement): Promise<void> {
 	// React issues. Duplicates appear after a color scheme update
 	// https://github.com/refined-github/refined-github/issues/7098
-	if (elementExists('.rgh-default-branch-button')) {
+	if (elementExists('.rgh-default-branch-button', branchSelector)) {
 		return;
 	}
 


### PR DESCRIPTION
close: #7618 


## Screenshot

<img width="1618" alt="image" src="https://github.com/user-attachments/assets/85e94f91-b7ac-44e7-88a8-7e0461e90d1d">
