### PR TITLE
`conversation-activity-filter` - Restore feature on RGH repo

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -7,6 +7,7 @@ import CheckIcon from 'octicons-plain-react/Check';
 import EyeClosedIcon from 'octicons-plain-react/EyeClosed';
 import EyeIcon from 'octicons-plain-react/Eye';
 import XIcon from 'octicons-plain-react/X';
+import domLoaded from 'dom-loaded';
 
 import {wrap} from '../helpers/dom-utils.js';
 import features from '../feature-manager.js';
@@ -231,6 +232,9 @@ async function init(signal: AbortSignal): Promise<void> {
 	], addWidget.bind(null, initialState), {signal});
 
 	if (initialState !== 'default') {
+		// Wait for the DOM to be ready before applying the initial state
+		// https://github.com/refined-github/refined-github/issues/7086
+		await domLoaded;
 		applyState(initialState);
 	}
 


### PR DESCRIPTION
close: #7086 


## Screenshot

before:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9e498a88-54c0-4a55-876d-0abfbb7665ef">


after:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/009a0597-8091-4136-8e9a-a1e5bfee8f8a">
