### PR TITLE
`one-click-diff-options` - Fix sticky header alignment

### DIFF
--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -50,7 +50,7 @@ function attachPRButtons(dropdown: HTMLDetailsElement): void {
 	const Icon = isUnified ? BookIcon : DiffIcon;
 	diffSettingsForm.append(
 		<button
-			className="tooltipped tooltipped-s ml-2 btn-link Link--muted p-2"
+			className="tooltipped tooltipped-s ml-2 btn-link Link--muted px-2"
 			aria-label={`Switch to the ${type} diff view`}
 			name="diff"
 			value={type}
@@ -64,7 +64,7 @@ function attachPRButtons(dropdown: HTMLDetailsElement): void {
 		diffSettingsForm.append(
 			<button
 				data-hotkey="d w"
-				className="tooltipped tooltipped-s btn-link Link--muted p-2"
+				className="tooltipped tooltipped-s btn-link Link--muted px-2"
 				aria-label="Hide whitespace changes"
 				name="w"
 				value="1"


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7542


## Test URLs

https://github.com//refined-github/refined-github/pull/7472/files

## Before


<img width="560" alt="Screenshot 9" src="https://github.com/user-attachments/assets/35578214-3676-4cb0-8d90-e9bfac9108d4">

## After

<img width="560" alt="Screenshot 10" src="https://github.com/user-attachments/assets/323cdd78-ca3a-4fc3-a982-1087ebae13fe">
