### PR TITLE
`visit-tag` - Fix duplication after system theme update

### DIFF
--- a/source/features/visit-tag.tsx
+++ b/source/features/visit-tag.tsx
@@ -11,8 +11,13 @@ import {wrapAll} from '../helpers/dom-utils.js';
 import {buildRepoURL} from '../github-helpers/index.js';
 
 async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
-	// If the branch picker is open, do nothing #7491
-	if (elementExists('#selectPanel')) {
+	if (elementExists([
+		// If the branch picker is open, do nothing #7491
+		'#selectPanel',
+
+		// React view deduplication https://github.com/refined-github/refined-github/issues/7601
+		'.rgh-visit-tag',
+	])) {
 		return;
 	}
 
@@ -26,7 +31,7 @@ async function addLink(branchSelector: HTMLButtonElement): Promise<void> {
 		<div className="d-flex gap-2"/>,
 		branchSelector,
 		<a
-			className="btn px-2 tooltipped tooltipped-se"
+			className="btn px-2 tooltipped tooltipped-se rgh-visit-tag"
 			href={buildRepoURL('releases/tag', tag)}
 			aria-label="Visit tag"
 		>


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7601


## Test URLs

https://github.com/fregante/title-to-labels-action/tree/v1.2.1?rgh-link-date=2024-07-26T04%3A58%3A45Z

## Screenshot

The `default-branch-button` duplicate is a regression from https://github.com/refined-github/refined-github/pull/7623


![c](https://github.com/user-attachments/assets/e2bd388b-2321-4f42-afdb-4fd2289c1cd3)
