### PR TITLE
`conversation-activity-filter` - Don't show in wrong position

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -49,7 +49,10 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	const cleanConversationHeader = pageDetect.isIssue() ? cleanIssueHeader : cleanPrHeader;
-	observe('.gh-header-meta .flex-auto', cleanConversationHeader, {signal});
+	observe([
+		'.gh-header-meta > .flex-auto', // Real
+		'.rgh-conversation-activity-filter', // Helper in case it runs first and breaks the `>` selector, because it wraps the .flex-auto element
+	], cleanConversationHeader, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -227,8 +227,8 @@ async function init(signal: AbortSignal): Promise<void> {
 		: 'default';
 
 	observe([
-		'#partial-discussion-header .gh-header-meta :is(clipboard-copy, .flex-auto)',
-		'#partial-discussion-header .gh-header-sticky :is(clipboard-copy, relative-time)',
+		'#partial-discussion-header .gh-header-meta clipboard-copy',
+		'#partial-discussion-header .gh-header-sticky clipboard-copy',
 	], addWidget.bind(null, initialState), {signal});
 
 	if (initialState !== 'default') {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7545

The original selector was blamed to https://github.com/refined-github/refined-github/pull/4378


## Test URLs

https://github.com/refined-github/sandbox/pull/4


## Screenshot

<img width="412" alt="Screenshot 5" src="https://github.com/user-attachments/assets/f0d05fcf-f3e2-4980-b9f9-3209a28e5edc">
<img width="559" alt="Screenshot 6" src="https://github.com/user-attachments/assets/23d404a7-b21d-4731-847c-c79ce056b333">
<img width="360" alt="Screenshot 4" src="https://github.com/user-attachments/assets/48857c97-63cc-4f87-a34d-e766fb81fe92">

