### PR TITLE
`default-branch-button` - Restore feature in sticky header

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -34,8 +34,8 @@ const getUrl = memoize(async (currentUrl: string): Promise<string> => {
 async function add(branchSelector: HTMLElement): Promise<void> {
 	// The DOM varies between details-based DOM and React-based one
 	const selectorWrapper = branchSelector.tagName === 'SUMMARY'
-			? branchSelector.parentElement!
-			: branchSelector;
+		? branchSelector.parentElement!
+		: branchSelector;
 
 	let defaultLink = $('.rgh-default-branch-button', branchSelector.parentElement!);
 

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -31,19 +31,23 @@ const getUrl = memoize(async (currentUrl: string): Promise<string> => {
 	return defaultUrl.href;
 });
 
+function wrapButtons(buttons: HTMLElement[]): void {
+	groupButtons(buttons).classList.add('d-flex', 'rgh-default-branch-button-group');
+}
+
 async function add(branchSelector: HTMLElement): Promise<void> {
 	// The DOM varies between details-based DOM and React-based one
 	const selectorWrapper = branchSelector.tagName === 'SUMMARY'
 		? branchSelector.parentElement!
 		: branchSelector;
 
-	let defaultLink = $('.rgh-default-branch-button', branchSelector.parentElement!);
+	const existingLink = $('.rgh-default-branch-button', branchSelector.parentElement!);
 
 	// React issues. Duplicates appear after a color scheme update
 	// https://github.com/refined-github/refined-github/issues/7098
-	if (defaultLink) {
+	if (existingLink) {
 		// Border radius style is removed by the color scheme update
-		groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
+		wrapButtons([existingLink, selectorWrapper]);
 		return;
 	}
 
@@ -51,7 +55,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 		fixFileHeaderOverlap(branchSelector);
 	}
 
-	defaultLink = (
+	const defaultLink = (
 		<a
 			className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
 			href={await getUrl(location.href)}
@@ -60,6 +64,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 			// https://github.com/refined-github/refined-github/issues/6554
 			// Inlined listener because `mouseenter` is too heavy for `delegate`
 			onMouseEnter={updateUrl}
+
 			// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
 			// data-turbo-frame="repo-content-turbo-frame"
 		>
@@ -68,7 +73,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 	);
 
 	selectorWrapper.before(defaultLink);
-	groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
+	wrapButtons([defaultLink, selectorWrapper]);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -39,30 +39,35 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 
 	let defaultLink = $('.rgh-default-branch-button', branchSelector.parentElement!);
 
-	if (!defaultLink) {
-		if (pageDetect.isSingleFile()) {
-			fixFileHeaderOverlap(branchSelector);
-		}
-
-		defaultLink = (
-			<a
-				className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
-				href={await getUrl(location.href)}
-				aria-label="See this view on the default branch"
-				// Update on hover because the URL may change without a DOM refresh
-				// https://github.com/refined-github/refined-github/issues/6554
-				// Inlined listener because `mouseenter` is too heavy for `delegate`
-				onMouseEnter={updateUrl}
-				// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
-				// data-turbo-frame="repo-content-turbo-frame"
-			>
-				<ChevronLeftIcon/>
-			</a>
-		);
-
-		selectorWrapper.before(defaultLink);
+	// React issues. Duplicates appear after a color scheme update
+	// https://github.com/refined-github/refined-github/issues/7098
+	if (defaultLink) {
+		// Border radius style is removed by the color scheme update
+		groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
+		return;
 	}
 
+	if (pageDetect.isSingleFile()) {
+		fixFileHeaderOverlap(branchSelector);
+	}
+
+	defaultLink = (
+		<a
+			className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
+			href={await getUrl(location.href)}
+			aria-label="See this view on the default branch"
+			// Update on hover because the URL may change without a DOM refresh
+			// https://github.com/refined-github/refined-github/issues/6554
+			// Inlined listener because `mouseenter` is too heavy for `delegate`
+			onMouseEnter={updateUrl}
+			// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
+			// data-turbo-frame="repo-content-turbo-frame"
+		>
+			<ChevronLeftIcon/>
+		</a>
+	);
+
+	selectorWrapper.before(defaultLink);
 	groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
 }
 

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -2,7 +2,7 @@ import './default-branch-button.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import ChevronLeftIcon from 'octicons-plain-react/ChevronLeft';
-import {elementExists} from 'select-dom';
+import {$} from 'select-dom';
 import memoize from 'memoize';
 
 import features from '../feature-manager.js';
@@ -32,38 +32,37 @@ const getUrl = memoize(async (currentUrl: string): Promise<string> => {
 });
 
 async function add(branchSelector: HTMLElement): Promise<void> {
-	// React issues. Duplicates appear after a color scheme update
-	// https://github.com/refined-github/refined-github/issues/7098
-	if (elementExists('.rgh-default-branch-button')) {
-		return;
-	}
-
-	if (pageDetect.isSingleFile()) {
-		fixFileHeaderOverlap(branchSelector);
-	}
-
-	const defaultLink = (
-		<a
-			className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
-			href={await getUrl(location.href)}
-			aria-label="See this view on the default branch"
-			// Update on hover because the URL may change without a DOM refresh
-			// https://github.com/refined-github/refined-github/issues/6554
-			// Inlined listener because `mouseenter` is too heavy for `delegate`
-			onMouseEnter={updateUrl}
-			// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
-			// data-turbo-frame="repo-content-turbo-frame"
-		>
-			<ChevronLeftIcon/>
-		</a>
-	);
-
 	// The DOM varies between details-based DOM and React-based one
 	const selectorWrapper = branchSelector.tagName === 'SUMMARY'
-		? branchSelector.parentElement!
-		: branchSelector;
+			? branchSelector.parentElement!
+			: branchSelector;
 
-	selectorWrapper.before(defaultLink);
+	let defaultLink = $('.rgh-default-branch-button', branchSelector.parentElement!);
+
+	if (!defaultLink) {
+		if (pageDetect.isSingleFile()) {
+			fixFileHeaderOverlap(branchSelector);
+		}
+
+		defaultLink = (
+			<a
+				className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button"
+				href={await getUrl(location.href)}
+				aria-label="See this view on the default branch"
+				// Update on hover because the URL may change without a DOM refresh
+				// https://github.com/refined-github/refined-github/issues/6554
+				// Inlined listener because `mouseenter` is too heavy for `delegate`
+				onMouseEnter={updateUrl}
+				// Don't enable AJAX on this behavior because we need a full page reload to drop the button, same reason as above #6554
+				// data-turbo-frame="repo-content-turbo-frame"
+			>
+				<ChevronLeftIcon/>
+			</a>
+		);
+
+		selectorWrapper.before(defaultLink);
+	}
+
 	groupButtons([defaultLink, selectorWrapper]).classList.add('d-flex', 'rgh-default-branch-button-group');
 }
 


### PR DESCRIPTION
close: #7618 

this pr fix two problem
1. #7618 
2. when switch the theme, the default branch button lost its radius style.

<img width="191" alt="image" src="https://github.com/user-attachments/assets/c58d3574-9f0d-4894-98eb-3c794d07ce86">


## Screenshot

👇 here is the video that test all test urls.
[Google Chrome.mp4.zip](https://github.com/user-attachments/files/16504827/Google.Chrome.mp4.zip)
