### PR TITLE
`pr-branch-auto-delete` - Restore feature

### DIFF
--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -43,7 +43,7 @@ void features.add(import.meta.url, {
 	additionalListeners: [
 		onPrMerge,
 	],
-	awaitDomReady: true,
+	awaitDomReady: true, // TODO: Remove after https://github.com/refined-github/refined-github/issues/6566
 	onlyAdditionalListeners: true,
 	init,
 });
@@ -52,7 +52,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-https://github.com/USERNAME/REPO_NAME/pull/PR_NUMBER
-https://github.com/ORGANIZATION_NAME/REPO_NAME/pull/PR_NUMBER
+1. Open https://github.com/pulls
+2. Click on any PRs you can merge (in repositories without native auto-delete)
+3. Merge the PR
 
 */

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -43,6 +43,16 @@ void features.add(import.meta.url, {
 	additionalListeners: [
 		onPrMerge,
 	],
+	awaitDomReady: true,
 	onlyAdditionalListeners: true,
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/USERNAME/REPO_NAME/pull/PR_NUMBER
+https://github.com/ORGANIZATION_NAME/REPO_NAME/pull/PR_NUMBER
+
+*/


### PR DESCRIPTION
close: #7646 

We need all conditions in `asLongAs` are true, so that we can successfully get `runFeature` function. So we need to add `awaitDomReady: true` to make `canCreateRelease` to be `true`.

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/cbf3c8b2-f9f7-4a3e-9a76-cb744873caf2">
