### PR TITLE
`show-names` - Fix comment header cleanup

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -55,7 +55,11 @@ async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise
 
 		// This change is ideal but should not break the feature if it fails
 		// And it should be done before inserting the name
-		dropExtraCopy(usernameElement);
+		try {
+			dropExtraCopy(usernameElement);
+		} catch (error) {
+			features.log.error(import.meta.url, error);
+		}
 
 		insertionPoint.after(
 			' ',

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -9,14 +9,12 @@ import {getUsername, isUsernameAlreadyFullName} from '../github-helpers/index.js
 import observe from '../helpers/selector-observer.js';
 import {removeTextNodeContaining} from '../helpers/dom-utils.js';
 
-function dropExtraCopy(elements: HTMLAnchorElement[]): void {
-	for (const element of elements) {
-		// Drop 'commented' label to shorten the copy
-		const commentedNode = element.parentNode!.nextSibling;
-		if (element.closest('.timeline-comment-header') && commentedNode) {
-			// "left a comment" appears in the main comment of reviews
-			removeTextNodeContaining(commentedNode, /commented|left a comment/);
-		}
+function dropExtraCopy(element: HTMLAnchorElement): void {
+	// Drop 'commented' label to shorten the copy
+	const commentedNode = element.parentNode!.nextSibling;
+	if (element.closest('.timeline-comment-header') && commentedNode) {
+		// "left a comment" appears in the main comment of reviews
+		removeTextNodeContaining(commentedNode, /commented|left a comment/);
 	}
 }
 
@@ -54,6 +52,11 @@ async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise
 		// If it's a regular comment author, add it outside <strong> otherwise it's something like "User added some commits"
 		const {parentElement} = usernameElement;
 		const insertionPoint = parentElement!.tagName === 'STRONG' ? parentElement! : usernameElement;
+
+		// This change is ideal but should not break the feature if it fails
+		// And it should be done before inserting the name
+		dropExtraCopy(usernameElement);
+
 		insertionPoint.after(
 			' ',
 			<span className="color-fg-muted css-truncate d-inline-block">
@@ -62,9 +65,6 @@ async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise
 			' ',
 		);
 	}
-
-	// This change is ideal but should not break the feature if it fails, so leave it for last
-	dropExtraCopy(batchedUsernameElements);
 }
 
 const usernameLinksSelector = [


### PR DESCRIPTION
before:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/a45aeee6-f38f-48d5-8839-ad1df03c9885">

<img width="952" alt="image" src="https://github.com/user-attachments/assets/733b8547-ccce-4bdd-a2e5-10307af63e8b">

after:

<img width="1563" alt="image" src="https://github.com/user-attachments/assets/598fe63c-fc79-4eea-8f59-5227445d4ed8">
