### PR TITLE
`hide-inactive-deployments` - Restore feature

### DIFF
--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -6,7 +6,7 @@ import features from '../feature-manager.js';
 // This feature doesn't need an active observer
 function init(): void {
 	// Selects all the deployments first so that we can leave the last one on the page
-	const deployments = $$('.js-socket-channel[data-url*="/partials/deployed_event/"]');
+	const deployments = $$('.js-socket-channel[data-gid^="PR"]:has(.octicon-rocket)');
 	deployments.pop(); // Don't hide the last deployment, even if it is inactive
 
 	for (const deployment of deployments) {


### PR DESCRIPTION
Closes: #7630

## Test URLs

https://github.com/btkostner/btkostner.io/pull/10

if use `.js-socket-channel[data-gid^="PR"]`, you can see there will some dom not what we expected to get.

<img width="1606" alt="image" src="https://github.com/user-attachments/assets/6c5a8507-d85f-4ec7-a4e7-284ad8d3bce8">

after:

everything works fine, and the last deployment still keep on the page. 

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/418d318e-e55d-462d-b887-7a51696d2cee">
