### PR TITLE
Meta: Add more test URLs

### DIFF
--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -33,3 +33,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/sandbox/pull/4
+
+*/

--- a/source/features/rgh-welcome-issue.tsx
+++ b/source/features/rgh-welcome-issue.tsx
@@ -42,3 +42,11 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // Small page
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/issues/3543
+
+*/

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -16,3 +16,12 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // Small page
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/commits/hotfix
+https://github.com/refined-github/refined-github/commits/main/.github
+
+*/

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -21,7 +21,7 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-https://github.com/refined-github/refined-github/commits/hotfix
-https://github.com/refined-github/refined-github/commits/main/.github
+https://github.com/refined-github/sandbox/commits/branch/with/slashes/
+https://github.com/refined-github/sandbox/commits/new/.github
 
 */

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -20,6 +20,5 @@ void features.add(import.meta.url, {
 Test URLs:
 
 https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml
-https://github.com/refined-github/refined-github/pull/6002
 
 */

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -14,3 +14,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml
+https://github.com/refined-github/refined-github/pull/6002
+
+*/

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -55,3 +55,26 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+Collapsed comments:
+- PR conversations: https://github.com/refined-github/refined-github/pull/1694
+- PR files: https://github.com/refined-github/refined-github/pull/1896/files
+- Issue conversations: https://github.com/refined-github/refined-github/issues/4008
+
+Load diff in PR files: https://github.com/parcel-bundler/parcel/pull/2967/files
+Expand all in PR files: https://github.com/refined-github/refined-github/pull/4585/files
+
+Commit messages:
+- isPRConversation: https://github.com/refined-github/refined-github/pull//5324
+- isCommitList: https://github.com/torvalds/linux/commits/master
+
+<details> elements:
+- Issue: https://github.com/yakov116/TestR/issues/34
+- PR description: https://github.com/OpenLightingProject/open-fixture-library/pull/2455
+- PR comment: https://github.com/OpenLightingProject/open-fixture-library/pull/2453#issuecomment-1055672394
+
+*/

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -43,6 +43,6 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-https://github.com/refined-github/refined-github/compare/sandbox/keep-branch...yakov116:upstream
+https://github.com/refined-github/refined-github/compare/main...fregante:refined-github:main
 
 */

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -38,3 +38,11 @@ void features.add(import.meta.url, {
 	deduplicate: 'has-rgh',
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/compare/sandbox/keep-branch...yakov116:upstream
+
+*/


### PR DESCRIPTION
Add test URLs for the `pull-request-hotkeys`, `rgh-welcome-issue`, `same-branch-author-commits`, `tab-to-indent`, `toggle-everything-with-alt` and `warn-pr-from-master` features

Related to the https://github.com/refined-github/refined-github/issues/7656
