### PR TITLE
`toggle-everything-with-alt` - Restore for commit message

### DIFF
--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -55,11 +55,3 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
-
-/*
-
-Test URLs
-
-https://github.com/torvalds/linux/commits/master
-
-*/

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -55,3 +55,11 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs
+
+https://github.com/torvalds/linux/commits/master
+
+*/

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -19,7 +19,7 @@ const expandSelector = '.js-file .js-expand-full';
 
 const collapseSelector = '.js-file .js-collapse-diff';
 
-const commitMessageSelector = '.TimelineItem .ellipsis-expander';
+const commitMessageSelector = 'button[data-testid="commit-row-show-description-button"]';
 
 function markdownCommentSelector(clickedItem: HTMLElement): string {
 	const {id} = clickedItem.closest('.TimelineItem-body[id]')!;


### PR DESCRIPTION
Closes: #7671 


## Test URLs

https://github.com/torvalds/linux/commits/master

## Screenshot

https://github.com/user-attachments/assets/cf4b2550-099b-4691-9b56-4487f0e3f5e1

