### PR TITLE
`mark-merge-commits-in-list` - Restore feature

### DIFF
--- a/source/feature-data.ts
+++ b/source/feature-data.ts
@@ -1,11 +1,13 @@
 // Run `npm run vitest` to update these files
 import importedFeaturesRaw from '../build/__snapshots__/imported-features.json';
 import featuresMetasRaw from '../build/__snapshots__/features-meta.json';
-
-export {default as renamedFeatures} from './feature-renames.json';
+import renamedFeatures from './feature-renames.json';
 
 export const importedFeatures = importedFeaturesRaw as FeatureID[];
 export const featuresMeta = featuresMetasRaw as FeatureMeta[];
+
+// eslint-disable-next-line unicorn/prefer-export-from -- Webpack silently fails to provide `renamedFeatures` in this scope
+export {renamedFeatures};
 
 export function getNewFeatureName(possibleFeatureName: string): FeatureID | undefined {
 	// @ts-expect-error Useless "no index type" error as usual

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -68,7 +68,7 @@ async function init(signal: AbortSignal): Promise<void> {
 		'[data-testid="commit-row-item"]',
 
 		'.js-commits-list-item', // `isPRCommitList`
-		'.TimelineItem:has(.octicon-git-commit)', // `isPRConversation`
+		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`; "js-timeline-item" excludes "isPRCommitList"
 	], batchedFunction(markCommits, {delay: 100}), {signal});
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -66,7 +66,9 @@ async function markCommits(commits: HTMLElement[]): Promise<void> {
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
 		'[data-testid="commit-row-item"]',
-		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`; "js-timeline-item" excludes "isCommitList"
+
+		'.js-commits-list-item', // `isPRCommitList`
+		'.TimelineItem:has(.octicon-git-commit)', // `isPRConversation`
 	], batchedFunction(markCommits, {delay: 100}), {signal});
 }
 
@@ -83,7 +85,7 @@ void features.add(import.meta.url, {
 
 Test URLs
 
-- isPRConversation: https://github.com/refined-github/refined-github/pull/6194
+- isPRConversation: https://github.com/refined-github/refined-github/pull/6194#event-8016526003
 - isPRCommitList: https://github.com/refined-github/refined-github/pull/6194/commits
 - isCommitList: https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174
 - isCompare: https://github.com/refined-github/sandbox/compare/e8b25d3e...b3d0d992

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,6 +1,6 @@
 import './mark-merge-commits-in-list.css';
 import React from 'dom-chef';
-import {$} from 'select-dom';
+import {expectElement as $} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {objectEntries} from 'ts-extras';
 import GitMergeIcon from 'octicons-plain-react/GitMerge';
@@ -9,6 +9,8 @@ import batchedFunction from 'batched-function';
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
+import {commitHashLinkInLists, commitTitleInLists} from '../github-helpers/selectors.js';
+import {assertCommitHash} from '../github-helpers/index.js';
 
 const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`
@@ -35,23 +37,18 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	return mergeCommits;
 };
 
-function getCommitLink(commit: HTMLElement): HTMLAnchorElement | undefined {
-	return $([
-		'a.markdown-title', // Old view style (before November 2023)
-		'.markdown-title a',
-	], commit);
-}
-
 export function getCommitHash(commit: HTMLElement): string {
-	return getCommitLink(commit)!.pathname.split('/').pop()!;
+	const hash = $(commitHashLinkInLists, commit).pathname.split('/').pop()!;
+	assertCommitHash(hash);
+	return hash;
 }
 
 function updateCommitIcon(commit: HTMLElement, replace: boolean): void {
 	if (replace) {
 		// Align icon to the line; rem used to match the native units
-		$('.octicon-git-commit', commit)!.replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);
+		$('.octicon-git-commit', commit).replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}}/>);
 	} else {
-		getCommitLink(commit)!.before(<GitMergeIcon className="mr-1"/>);
+		$(commitTitleInLists, commit).prepend(<GitMergeIcon className="mr-1"/>);
 	}
 }
 
@@ -68,11 +65,7 @@ async function markCommits(commits: HTMLElement[]): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.list-view-item', // `isCommitList`
-		'.listviewitem', // TODO: Drop in 2025
-
-		// Old view style (before November 2023)
-		'.js-commits-list-item', // `isCommitList`
+		'[data-testid="commit-row-item"]',
 		'.js-timeline-item .TimelineItem:has(.octicon-git-commit)', // `isPRConversation`; "js-timeline-item" excludes "isCommitList"
 	], batchedFunction(markCommits, {delay: 100}), {signal});
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -192,3 +192,9 @@ function getConversationAuthor(): string | undefined {
 export function isOwnConversation(): boolean {
 	return getConversationAuthor() === getUsername();
 }
+
+export function assertCommitHash(hash: string): void {
+	if (!/^[0-9a-f]{40}$/.test(hash)) {
+		throw new Error(`Invalid commit hash: ${hash}`);
+	}
+}

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -135,14 +135,24 @@ export const newCommentField = [
 
 export const newCommentField_ = [] satisfies UrlMatch[];
 
-export const commitHashLinkInLists = '[aria-label="View commit details"] a.text-mono';
+export const commitHashLinkInLists = [
+	'[aria-label="View commit details"] a.text-mono', // `isCommitList`
+	'a[id^="commit-details-"]', // `isPRCommitList`
+	'.js-details-container .text-right code a.Link--secondary', // `isPRConversation`
+] as unknown as 'a';
 export const commitHashLinkInLists_ = [
 	[35, 'https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174'],
+	[4, 'https://github.com/refined-github/refined-github/pull/6194/commits'],
+	[5, 'https://github.com/refined-github/refined-github/pull/6194#event-8016526003'],
 ] satisfies UrlMatch[];
 
-export const commitTitleInLists = '[data-testid="list-view-item-title-container"]';
+export const commitTitleInLists = [
+	'[data-testid="list-view-item-title-container"]', // `isCommitList`
+	'.js-commits-list-item .Details p.mb-1', // `isPRCommitList`,
+];
 export const commitTitleInLists_ = [
 	[35, 'https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174'],
+	[4, 'https://github.com/refined-github/refined-github/pull/6194/commits'],
 ];
 
 const botNames = [

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -135,6 +135,16 @@ export const newCommentField = [
 
 export const newCommentField_ = [] satisfies UrlMatch[];
 
+export const commitHashLinkInLists = '[aria-label="View commit details"] a.text-mono';
+export const commitHashLinkInLists_ = [
+	[35, 'https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174'],
+] satisfies UrlMatch[];
+
+export const commitTitleInLists = '[data-testid="list-view-item-title-container"]';
+export const commitTitleInLists_ = [
+	[35, 'https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174'],
+];
+
 const botNames = [
 	'actions-user',
 	'bors',


### PR DESCRIPTION
- Continues from https://github.com/refined-github/refined-github/pull/7685


## isCompare: https://github.com/refined-github/sandbox/compare/e8b25d3e...b3d0d992

<img width="1005" alt="Screenshot 6" src="https://github.com/user-attachments/assets/1bd1bd4e-5ae2-45c3-90f9-5ff5833bbeb0">


## isPRConversation: https://github.com/refined-github/refined-github/pull/6194#event-8016526003

<img width="627" alt="Screenshot" src="https://github.com/user-attachments/assets/661cb84a-5107-424c-9b9d-a78dfab555e6">


## isPRCommitList: https://github.com/refined-github/refined-github/pull/6194/commits

<img width="1005" alt="Screenshot 5" src="https://github.com/user-attachments/assets/5e5815ff-61c5-4bc6-aeb1-01c9a5edce6a">

## isCommitList: https://github.com/typed-ember/ember-cli-typescript/commits/master?after=5ff0c078a4274aeccaf83382c0d6b46323f57397+174

<img width="1005" alt="Screenshot 4" src="https://github.com/user-attachments/assets/3c2d6070-245c-44c5-8fd0-81e9dd786633">

