### PR TITLE
Increase size of profile picture in user hovercard

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -174,7 +174,8 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	z-index: 5;
 }
 
-/* Increase size of profile picture in user hovercard by 1.5x (default is 48px)  */
+/* Increase size of profile picture in user hovercard by 1.5x (default is 48px) #7695 */
+/* Test: https://github.com/refined-github/refined-github */
 .user-hovercard-avatar > img.d-block.avatar-user {
 	width: 72px;
 	height: 72px;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -173,3 +173,9 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	position: relative;
 	z-index: 5;
 }
+
+/* Increase size of profile picture in user hovercard by 1.5x (default is 48px)  */
+.user-hovercard-avatar > img.d-block.avatar-user {
+	width: 72px;
+	height: 72px;
+}


### PR DESCRIPTION
This PR adds 4 lines of CSS to `refined-github.css`, increasing the size of profile pictures in hovercards by 150%. Closes #7481.

## Test URLs
https://github.com/refined-github/refined-github

## Screenshots
Before:
![refined-github-before](https://github.com/user-attachments/assets/339ecae1-e8bd-4360-8022-6f2d2da8b84d)
After:
![refined-github-after](https://github.com/user-attachments/assets/478b329d-e4a3-43f4-89a5-f224036ba07d)


Opening this PR as a draft, because in rare cases it can cut off the top of the hovercard (reproduce by hovering over the avatar of a user with a two or more line bio, in the first comment of an issue or PR).

![refined-github-cut-off](https://github.com/user-attachments/assets/022324b4-ce16-4b4d-aa93-77c50f57218b)