### PR TITLE
`same-branch-author-commits` - Restore feature

### DIFF
--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -1,22 +1,21 @@
+import {$$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import observe from '../helpers/selector-observer.js';
 
 const authorLinkSelector = 'a[aria-label^="commits by"]';
 
-function changePath(authorLink: HTMLAnchorElement): void {
-	authorLink.pathname = location.pathname;
-}
-
-function init(signal: AbortSignal): void {
-	observe(authorLinkSelector, changePath, {signal});
+function init(): void {
+	for (const author of $$(authorLinkSelector)) {
+		author.pathname = location.pathname;
+	}
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoCommitList,
 	],
+	awaitDomReady: true, // Small page
 	init,
 });
 

--- a/source/features/same-branch-author-commits.tsx
+++ b/source/features/same-branch-author-commits.tsx
@@ -1,19 +1,22 @@
-import {$$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
 
-function init(): void {
-	for (const author of $$('.js-navigation-container a.commit-author')) {
-		author.pathname = location.pathname;
-	}
+const authorLinkSelector = 'a[aria-label^="commits by"]';
+
+function changePath(authorLink: HTMLAnchorElement): void {
+	authorLink.pathname = location.pathname;
+}
+
+function init(signal: AbortSignal): void {
+	observe(authorLinkSelector, changePath, {signal});
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoCommitList,
 	],
-	awaitDomReady: true, // Small page
 	init,
 });
 


### PR DESCRIPTION
At the moment the `same-branch-author-commits` doesn't work correctly as the current selector no longer matches the author link element

## Test URLs

https://github.com/refined-github/sandbox/commits/branch/with/slashes/

## Screenshot

![same-branch-author-restore](https://github.com/user-attachments/assets/40d1dd57-3b3a-400d-8c56-40a94bbe0fb1)
