### PR TITLE
show-names - Handle missing textContent

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -21,7 +21,14 @@ function dropExtraCopy(element: HTMLAnchorElement): void {
 // The selector observer calls this function several times, but we want to batch them into a single GraphQL API call
 async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise<void> {
 	const myUsername = getUsername();
-	batchedUsernameElements = batchedUsernameElements.filter(({textContent: name}) => name !== myUsername && name !== 'ghost');
+	batchedUsernameElements = batchedUsernameElements.filter((element) => {
+		const name = element.textContent;
+		if (!name) {
+			console.warn('Error', element)
+			throw new Error('Failed to get textContent in the element');
+		}
+		return name !== myUsername && name !== 'ghost'
+	});
 	const usernames = new Set(batchedUsernameElements.map(element => element.textContent));
 
 	if (usernames.size === 0) {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -21,13 +21,15 @@ function dropExtraCopy(element: HTMLAnchorElement): void {
 // The selector observer calls this function several times, but we want to batch them into a single GraphQL API call
 async function updateLink(batchedUsernameElements: HTMLAnchorElement[]): Promise<void> {
 	const myUsername = getUsername();
-	batchedUsernameElements = batchedUsernameElements.filter((element) => {
+	batchedUsernameElements = batchedUsernameElements.filter(element => {
 		const name = element.textContent;
+
 		if (!name) {
-			console.warn('Error', element)
+			console.warn('Error', element);
 			throw new Error('Failed to get textContent in the element');
 		}
-		return name !== myUsername && name !== 'ghost'
+
+		return name !== myUsername && name !== 'ghost';
 	});
 	const usernames = new Set(batchedUsernameElements.map(element => element.textContent));
 


### PR DESCRIPTION
Fixes: #7699

```tsx
const names = await api.v4(
	[...usernames].map(user =>
		api.escapeKey(user) + `: user(login: "${user}") {name}`,
	).join(','),
);
```

```
refined-github.js:3397 Uncaught (in promise) Error: GraphQL:
Could not resolve to a User with the login of 'undefined'.
    at Object.v4uncached (refined-github.js:3397:60)
    at async show_names_updateLink (refined-github.js:6239:21)
```

The reason cause this error is `user` is `undefined`, it means `usernames` set contains `undefined` data.