### PR TITLE
`repo-stats-spacing` - Drop feature

### DIFF
--- a/source/features/repo-stats-spacing.css
+++ b/source/features/repo-stats-spacing.css
@@ -1,5 +1,0 @@
-.numbers-summary {
-	display: flex;
-	justify-content: space-around;
-	align-items: center;
-}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -10,7 +10,6 @@ import './features/clean-footer.css';
 import './features/pr-approvals-count.css';
 import './features/clean-conversations.css';
 import './features/sticky-conversation-list-toolbar.css';
-import './features/repo-stats-spacing.css';
 import './features/clean-notifications.css';
 import './features/night-not-found.css';
 import './features/sticky-file-header.css';


### PR DESCRIPTION
Added a long time ago: https://github.com/refined-github/refined-github/pull/2560



# Nostalgia

<img width="1058" alt="Screen Shot 2019-11-21 at 3 18 11 AM" src="https://user-images.githubusercontent.com/3848317/69298337-cfe1a080-0c0d-11ea-93b5-e11f21a75efd.png">


