### PR TITLE
`tag-changes-link` - Improve reliability 

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -36,6 +36,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 
 function parseTags(element: HTMLElement): TagDetails {
 	// DO NOT change this to `pathname` because it's empty when element is from `getNextPage` function
+	// https://github.com/refined-github/refined-github/pull/7726#discussion_r1727135015
 	const tagUrl = expectElement(['a[href*="/tree/"]', 'a[href*="/tag/"]'], element).href;
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -1,6 +1,8 @@
 import './tag-changes-link.css';
 import React from 'dom-chef';
-import {$, $$, elementExists} from 'select-dom';
+import {
+	$, $$, elementExists, expectElement,
+} from 'select-dom';
 import domLoaded from 'dom-loaded';
 import DiffIcon from 'octicons-plain-react/Diff';
 import * as pageDetect from 'github-url-detection';
@@ -33,15 +35,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
-	let tagUrl = $(['a[href*="/tree/"]', 'a[href*="/tag/"]'], element)!.href;
-
-	// If tagUrl from next page, it is just a pathname not a URL
-	if (tagUrl.startsWith('https://github.com')) {
-		// Safari doesn't correctly parse links if they're loaded via AJAX #3899
-		const {pathname} = new URL(tagUrl);
-		tagUrl = pathname;
-	}
-
+	const tagUrl = expectElement(['a[href*="/tree/"]', 'a[href*="/tag/"]'], element).href;
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 
 	return {

--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -35,6 +35,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
+	// DO NOT change this to `pathname` because it's empty when element is from `getNextPage` function
 	const tagUrl = expectElement(['a[href*="/tree/"]', 'a[href*="/tag/"]'], element).href;
 	const tag = /\/(?:releases\/tag|tree)\/(.*)/.exec(tagUrl)![1];
 


### PR DESCRIPTION
## Test URLs

https://github.com/refined-github/refined-github/releases
https://github.com/refined-github/refined-github/tags
https://github.com/refined-github/refined-github/tags?after=0.5.0

## Screenshot

Sometimes it's all fail.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8a1178dc-6a97-4efa-93f8-d0773ffe72da">

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1bc3888a-e760-405d-9ef9-d7b64d274416">


It's may add the `compareLink` to the end after reloading. But it's still fail for the last tag in this page.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/f1e32717-b0c7-45b6-8440-53f9599e4151">


after:

https://github.com/user-attachments/assets/97694952-2993-43db-b4a0-d18b3bb9443b
