### PR TITLE
`rgh-feature-description` - Add link to css file

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -2,142 +2,170 @@
 	{
 		"id": "action-pr-link",
 		"description": "Adds a link back to the PR that ran the workflow.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png",
+		"css": false
 	},
 	{
 		"id": "action-used-by-link",
 		"description": "Lets you see how others are using the current Action in the Marketplace.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258552390-7d2cd013-c167-4fe5-9731-33622b8607e9.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258552390-7d2cd013-c167-4fe5-9731-33622b8607e9.png",
+		"css": false
 	},
 	{
 		"id": "actionable-pr-view-file",
 		"description": "Points the \"View file\" on PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the \"View file\" page.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png",
+		"css": false
 	},
 	{
 		"id": "align-issue-labels",
 		"description": "In issue/PR lists, aligns the labels to the left, below each title.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png",
+		"css": true
 	},
 	{
 		"id": "archive-forks-link",
 		"description": "Helps you find forks on archived repos.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/230362566-12493c80-bffe-4c7a-b9ba-4a11b1358ab0.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/230362566-12493c80-bffe-4c7a-b9ba-4a11b1358ab0.png",
+		"css": false
 	},
 	{
 		"id": "avoid-accidental-submissions",
 		"description": "Disables the <kbd>enter</kbd>-to-submit shortcut in some commit/PR/issue title fields to avoid accidental submissions. Use <kbd>ctrl</kbd> <kbd>enter</kbd> instead.",
-		"screenshot": "https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif"
+		"screenshot": "https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif",
+		"css": false
 	},
 	{
 		"id": "batch-mark-files-as-viewed",
 		"description": "Mark/unmark multiple files as “Viewed” in the PR Files tab. Click on the first checkbox you want to mark/unmark and then <code>shift</code>-click another one; all the files between the two checkboxes will be marked/unmarked as “Viewed”.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257009611-17249bee-d2e2-42ac-bdf0-ebc90029544e.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257009611-17249bee-d2e2-42ac-bdf0-ebc90029544e.gif",
+		"css": false
 	},
 	{
 		"id": "bugs-tab",
 		"description": "Adds a \"Bugs\" tab to repos, if there are any open issues with the \"bug\" label.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/156766081-f2ea100b-a9f3-472b-bddc-a984a88ddcd3.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/156766081-f2ea100b-a9f3-472b-bddc-a984a88ddcd3.png",
+		"css": false
 	},
 	{
 		"id": "ci-link",
 		"description": "Adds a build/CI status icon next to the repo’s name.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/237923995-5e14a272-0bf2-4fe4-b409-8c05378aa4fd.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/237923995-5e14a272-0bf2-4fe4-b409-8c05378aa4fd.png",
+		"css": true
 	},
 	{
 		"id": "clean-conversation-filters",
 		"description": "Hides <code>Projects</code> and <code>Milestones</code> filters in issue/PR lists if they are empty.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262557246-4ef1c702-eece-4701-9000-0aad21c54c1b.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262557246-4ef1c702-eece-4701-9000-0aad21c54c1b.png",
+		"css": false
 	},
 	{
 		"id": "clean-conversation-headers",
 		"description": "Removes duplicate information in the header of issues and PRs (\"User wants to merge X commits from Y into Z\")",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png",
+		"css": true
 	},
 	{
 		"id": "clean-conversation-sidebar",
 		"description": "Hides empty sections (or just their \"empty\" label) in the issue/PR sidebar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png",
+		"css": true
 	},
 	{
 		"id": "clean-pinned-issues",
 		"description": "Changes the layout of pinned issues from side-by-side to a standard list.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258224321-e8ee8c70-6952-4a42-8626-6b5f31d167a3.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258224321-e8ee8c70-6952-4a42-8626-6b5f31d167a3.png",
+		"css": true
 	},
 	{
 		"id": "clean-readme-url",
 		"description": "Drops redundant \"readme-ov-file\" parameter from repo URLs.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/73e96411-3314-4501-a9b6-d006af6fcc47"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/73e96411-3314-4501-a9b6-d006af6fcc47",
+		"css": false
 	},
 	{
 		"id": "clean-repo-filelist-actions",
 		"description": "Makes some buttons on repository lists more compact to make room for other features.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/108955170-52d48080-7633-11eb-8979-67e0d3a53f16.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/108955170-52d48080-7633-11eb-8979-67e0d3a53f16.png",
+		"css": false
 	},
 	{
 		"id": "clean-repo-sidebar",
 		"description": "Removes unnecessary or redundant information from the repository sidebar.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png",
+		"css": true
 	},
 	{
 		"id": "clean-repo-tabs",
 		"description": "Moves the \"Security\" and \"Insights\"  to the repository navigation dropdown. Also moves the \"Projects\", \"Actions\" and \"Wiki\" tabs if they're empty/unused.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png",
+		"css": false
 	},
 	{
 		"id": "clean-rich-text-editor",
 		"description": "Hides unnecessary comment field tooltips and toolbar items (each one has a keyboard shortcut.)",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/158201651-7364aba7-f9d0-4a51-89c4-2ced0cc34e48.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/158201651-7364aba7-f9d0-4a51-89c4-2ced0cc34e48.png",
+		"css": true
 	},
 	{
 		"id": "clear-pr-merge-commit-message",
 		"description": "Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png",
+		"css": false
 	},
 	{
 		"id": "click-outside-modal",
 		"description": "Closes checks list when clicking outside of modal.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "close-as-unplanned",
 		"description": "Lets you \"close issue as unplanned\" in one click instead of three.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png",
+		"css": false
 	},
 	{
 		"id": "close-out-of-view-modals",
 		"description": "Automatically closes dropdown menus when they’re no longer visible.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif",
+		"css": false
 	},
 	{
 		"id": "closing-remarks",
 		"description": "Shows the first Git tag a merged PR was included in or suggests creating a release if not yet released.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/169497171-85d4a97f-413a-41b4-84ba-885dca2b51cf.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/169497171-85d4a97f-413a-41b4-84ba-885dca2b51cf.png",
+		"css": false
 	},
 	{
 		"id": "collapsible-content-button",
 		"description": "Adds a button to insert collapsible content (via <code>&lt;details&gt;</code>).",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png",
+		"css": false
 	},
 	{
 		"id": "command-palette-navigation-shortcuts",
 		"description": "Adds keyboard shortcuts to select items in command palette using <kbd>ctrl</kbd> <kbd>n</kbd> and <kbd>ctrl</kbd> <kbd>p</kbd> (macOS only).",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "comment-excess",
 		"description": "Informs you that there are hidden comments in the header of long issues. Also scrolls down to the hidden comments when pressing Cmd+F or Ctrl+F.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/4e4660f9-c987-4b0d-82ca-56ef29952c31"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/4e4660f9-c987-4b0d-82ca-56ef29952c31",
+		"css": false
 	},
 	{
 		"id": "comments-time-machine-links",
 		"description": "Adds links to browse the repository and linked files at the time of each comment.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252749373-9313f1d9-3d92-44a2-a1d1-2b49a29e6a5c.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252749373-9313f1d9-3d92-44a2-a1d1-2b49a29e6a5c.png",
+		"css": false
 	},
 	{
 		"id": "conflict-marker",
 		"description": "Shows which PRs have conflicts in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png",
+		"css": true
 	},
 	{
 		"id": "conversation-activity-filter",
@@ -147,37 +175,44 @@
 	{
 		"id": "conversation-links-on-repo-lists",
 		"description": "Adds a link to the issues and pulls on the user profile repository tab and global search.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png",
+		"css": false
 	},
 	{
 		"id": "convert-pr-to-draft-improvements",
 		"description": "Moves the \"Convert PR to Draft\" button to the mergeability box and adds visual feedback to its confirm button.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif",
+		"css": false
 	},
 	{
 		"id": "convert-release-to-draft",
 		"description": "Adds a button to convert a release to draft.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png",
+		"css": false
 	},
 	{
 		"id": "copy-on-y",
 		"description": "Enhances the <kbd>y</kbd> hotkey to also copy the permalink.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "create-release-shortcut",
 		"description": "Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "cross-deleted-pr-branches",
 		"description": "Adds a line-through to the deleted branches in PRs.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/256963526-646ac7d0-3e7f-40c6-ba39-014b49bc0063.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/256963526-646ac7d0-3e7f-40c6-ba39-014b49bc0063.png",
+		"css": true
 	},
 	{
 		"id": "deep-reblame",
 		"description": "When exploring blames, <code>Alt</code>-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png",
+		"css": true
 	},
 	{
 		"id": "default-branch-button",
@@ -187,367 +222,440 @@
 	{
 		"id": "dim-bots",
 		"description": "Dims commits and PRs by bots to reduce noise.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif",
+		"css": true
 	},
 	{
 		"id": "download-folder-button",
 		"description": "Adds a button to download entire folders, via https://download-directory.github.io.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png",
+		"css": false
 	},
 	{
 		"id": "easy-toggle-commit-messages",
 		"description": "Enables toggling commit messages by clicking on the commit box.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif",
+		"css": false
 	},
 	{
 		"id": "easy-toggle-files",
 		"description": "Enables toggling file diffs by clicking on their header bar.",
-		"screenshot": "https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif"
+		"screenshot": "https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif",
+		"css": false
 	},
 	{
 		"id": "embed-gist-inline",
 		"description": "Embeds short gists when linked in comments on their own lines.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152117903-80d784d5-4f43-4786-bc4c-d4993aec5c79.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152117903-80d784d5-4f43-4786-bc4c-d4993aec5c79.png",
+		"css": false
 	},
 	{
 		"id": "embed-gist-via-iframe",
 		"description": "Adds a menu item to embed a gist via <code>&lt;iframe&gt;</code>.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553891-a55a3bc0-f244-421b-a24c-6f1d4a92552e.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553891-a55a3bc0-f244-421b-a24c-6f1d4a92552e.png",
+		"css": false
 	},
 	{
 		"id": "emphasize-draft-pr-label",
 		"description": "Makes it easier to distinguish draft PR in lists.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png",
+		"css": true
 	},
 	{
 		"id": "esc-to-cancel",
 		"description": "Adds a shortcut to cancel editing a issue/PR title: <kbd>esc</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif"
+		"screenshot": "https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif",
+		"css": false
 	},
 	{
 		"id": "esc-to-deselect-line",
 		"description": "Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "expand-all-hidden-comments",
 		"description": "On long conversations where GitHub hides comments under a \"N hidden items. Load more...\", alt-clicking it will load up to 200 comments at once instead of 60.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160123-9c4f894b-38c0-446f-af50-9beca7ff1f74.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160123-9c4f894b-38c0-446f-af50-9beca7ff1f74.png",
+		"css": false
 	},
 	{
 		"id": "extend-conversation-status-filters",
 		"description": "Lets you toggle between is:open/is:closed/is:merged filters in searches.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif",
+		"css": false
 	},
 	{
 		"id": "extend-diff-expander",
 		"description": "Widens the <code>Expand diff</code> button to be clickable across the screen.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif",
+		"css": true
 	},
 	{
 		"id": "file-age-color",
 		"description": "Highlights the most-recently-modified items in file lists.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png",
+		"css": false
 	},
 	{
 		"id": "fit-textareas",
 		"description": "Auto-resizes comment fields to fit their content and no longer show scroll bars.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif",
+		"css": true
 	},
 	{
 		"id": "fix-no-pr-search",
 		"description": "Redirect to repo issue list when the search doesn‘t include <code>is:pr</code>.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/286579939-50122f02-dcfd-4510-b9e1-03d9985da2cd.gif"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/286579939-50122f02-dcfd-4510-b9e1-03d9985da2cd.gif",
+		"css": false
 	},
 	{
 		"id": "github-actions-indicators",
 		"description": "In the workflows sidebar, shows an indicator that a workflow can be triggered manually, and its next scheduled time if relevant.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252181237-a1d809b1-e5d4-4747-9654-7dde5ab5c61a.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252181237-a1d809b1-e5d4-4747-9654-7dde5ab5c61a.png",
+		"css": false
 	},
 	{
 		"id": "global-conversation-list-filters",
 		"description": "Adds filters for issues/PRs <em>in your repos</em> and <em>commented on by you</em> in the global issue/PR search.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png",
+		"css": true
 	},
 	{
 		"id": "hidden-review-comments-indicator",
 		"description": "Adds comment indicators when comments are hidden in PR review.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif",
+		"css": true
 	},
 	{
 		"id": "hide-diff-signs",
 		"description": "Hides diff signs since diffs are color coded already.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png",
+		"css": true
 	},
 	{
 		"id": "hide-inactive-deployments",
 		"description": "Hides inactive deployments in PRs.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "hide-issue-list-autocomplete",
 		"description": "Removes the autocomplete on search fields.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png",
+		"css": false
 	},
 	{
 		"id": "hide-low-quality-comments",
 		"description": "Hides reaction comments (\"+1\", \"👍\", …) (except the maintainers’) but they can still be shown.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258220965-4743b9b9-2aef-41b3-a905-ccf8d7beb74e.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258220965-4743b9b9-2aef-41b3-a905-ccf8d7beb74e.png",
+		"css": true
 	},
 	{
 		"id": "hide-navigation-hover-highlight",
 		"description": "Removes the file hover effect in the repo file browser.",
-		"screenshot": null
+		"screenshot": null,
+		"css": true
 	},
 	{
 		"id": "hide-newsfeed-noise",
 		"description": "Hides other inutile newsfeed events (commits, forks, new followers).",
-		"screenshot": null
+		"screenshot": null,
+		"css": true
 	},
 	{
 		"id": "hide-user-forks",
 		"description": "Hides forks and archived repos from profiles (but they can still be shown.)",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263195425-85cf0951-c6ed-45fe-8cfc-e447e3ed2a25.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263195425-85cf0951-c6ed-45fe-8cfc-e447e3ed2a25.png",
+		"css": false
 	},
 	{
 		"id": "highest-rated-comment",
 		"description": "Highlights the most useful comment in issues.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png",
+		"css": true
 	},
 	{
 		"id": "highlight-collaborators-and-own-conversations",
 		"description": "Highlights issues/PRs opened by you or the current repo’s collaborators.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png",
+		"css": true
 	},
 	{
 		"id": "highlight-non-default-base-branch",
 		"description": "Shows the base branch in PR lists if it’s not the default branch.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png",
+		"css": false
 	},
 	{
 		"id": "html-preview-link",
 		"description": "Adds a link to preview HTML files.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260874191-69d386a0-7c1f-42ae-84fd-4f67f90982da.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260874191-69d386a0-7c1f-42ae-84fd-4f67f90982da.png",
+		"css": false
 	},
 	{
 		"id": "improve-shortcut-help",
 		"description": "Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).",
-		"screenshot": "https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png"
+		"screenshot": "https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png",
+		"css": false
 	},
 	{
 		"id": "infinite-scroll",
 		"description": "Automagically expands the newsfeed when you scroll down.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "jump-to-change-requested-comment",
 		"description": "Adds a link to jump to the latest changed requested comment.",
-		"screenshot": "https://user-images.githubusercontent.com/19198931/98718312-418b9f00-23c9-11eb-8da2-dfb616e95eb6.gif"
+		"screenshot": "https://user-images.githubusercontent.com/19198931/98718312-418b9f00-23c9-11eb-8da2-dfb616e95eb6.gif",
+		"css": false
 	},
 	{
 		"id": "jump-to-conversation-close-event",
 		"description": "Adds a link to jump to the latest close event of a issue/PR.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif",
+		"css": false
 	},
 	{
 		"id": "keyboard-navigation",
 		"description": "Adds shortcuts to issues, PRs conversations, and PR file lists: <kbd>j</kbd> focuses the comment/file below; <kbd>k</kbd> focuses the comment/file above.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/86573176-48665900-bf74-11ea-8996-a5c46cb7bdfd.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/86573176-48665900-bf74-11ea-8996-a5c46cb7bdfd.gif",
+		"css": false
 	},
 	{
 		"id": "last-notification-page-button",
 		"description": "Adds a link to the last page of notifications.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png",
+		"css": false
 	},
 	{
 		"id": "link-to-changelog-file",
 		"description": "Adds a button to view the changelog file from the releases page.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png",
+		"css": false
 	},
 	{
 		"id": "link-to-compare-diff",
 		"description": "Linkifies the \"X files changed\" text on compare pages to allow jumping to the diff.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png",
+		"css": true
 	},
 	{
 		"id": "link-to-github-io",
 		"description": "Adds a link to visit the user’s github.io website from its repo.",
-		"screenshot": "https://user-images.githubusercontent.com/34235681/152473104-c4723999-9239-48fd-baee-273b01c4eb87.png"
+		"screenshot": "https://user-images.githubusercontent.com/34235681/152473104-c4723999-9239-48fd-baee-273b01c4eb87.png",
+		"css": false
 	},
 	{
 		"id": "linkify-branch-references",
 		"description": "Linkifies branch references in \"Quick PR\" pages.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553554-e1711be0-d5ce-4edc-aaf8-72d659c881bc.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553554-e1711be0-d5ce-4edc-aaf8-72d659c881bc.png",
+		"css": false
 	},
 	{
 		"id": "linkify-code",
 		"description": "Linkifies issue/PR references and URLs in code and issue/PR titles.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png"
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png",
+		"css": false
 	},
 	{
 		"id": "linkify-commit-sha",
 		"description": "Adds a link to the non-PR commit when visiting a PR commit.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164635-b3caa3fa-3bb6-41a5-90d3-4aba84517da6.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164635-b3caa3fa-3bb6-41a5-90d3-4aba84517da6.png",
+		"css": false
 	},
 	{
 		"id": "linkify-line-numbers",
 		"description": "Linkifies the line numbers where GitHub forgot to add links.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/d5b67f4e-35c3-45d8-b72c-937b855168c3"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/d5b67f4e-35c3-45d8-b72c-937b855168c3",
+		"css": false
 	},
 	{
 		"id": "linkify-notification-repository-header",
 		"description": "Linkifies the header of each notification group (when grouped by repository).",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png",
+		"css": false
 	},
 	{
 		"id": "linkify-symbolic-links",
 		"description": "Linkifies symbolic links files.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png",
+		"css": false
 	},
 	{
 		"id": "linkify-user-edit-history-popup",
 		"description": "Linkifies the username in the edit history popup.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png",
+		"css": false
 	},
 	{
 		"id": "linkify-user-labels",
 		"description": "Links the \"Contributor\" and \"Member\" labels on comments to the author’s commits on the repo.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png",
+		"css": false
 	},
 	{
 		"id": "linkify-user-location",
 		"description": "Linkifies the user location in their hovercard and profile page.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262554067-43bea584-cdb4-41c7-b0fa-f487e7ef8807.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262554067-43bea584-cdb4-41c7-b0fa-f487e7ef8807.png",
+		"css": false
 	},
 	{
 		"id": "list-prs-for-branch",
 		"description": "On branch commit lists, shows the PR that touches the current branch.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/119760295-b8751a80-be77-11eb-87da-91d0c403bb49.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/119760295-b8751a80-be77-11eb-87da-91d0c403bb49.png",
+		"css": false
 	},
 	{
 		"id": "list-prs-for-file",
 		"description": "Alerts you if the current file is altered by an open PR.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/234559302-b9911ac2-a1bb-4f8a-8e88-078d631cde18.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/234559302-b9911ac2-a1bb-4f8a-8e88-078d631cde18.png",
+		"css": false
 	},
 	{
 		"id": "locked-issue",
 		"description": "Show a label on locked issues and PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png",
+		"css": false
 	},
 	{
 		"id": "mark-merge-commits-in-list",
 		"description": "Marks merge commits in commit lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285106996-9bdbc938-69c4-4692-8d47-11e30676de62.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285106996-9bdbc938-69c4-4692-8d47-11e30676de62.png",
+		"css": true
 	},
 	{
 		"id": "mark-private-orgs",
 		"description": "Marks private organizations on your own profile.",
-		"screenshot": "https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png"
+		"screenshot": "https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png",
+		"css": true
 	},
 	{
 		"id": "mobile-tabs",
 		"description": "Makes the tabs more compact on mobile so more of them can be seen.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png",
+		"css": true
 	},
 	{
 		"id": "more-conversation-filters",
 		"description": "Adds <code>Everything you’re involved in</code> and <code>Everything you subscribed to</code> filters in the search box dropdown.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253043952-cfb99cea-1c7b-43ad-9144-9d84bda8206f.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253043952-cfb99cea-1c7b-43ad-9144-9d84bda8206f.png",
+		"css": false
 	},
 	{
 		"id": "more-dropdown-links",
 		"description": "Adds useful links to the repository navigation dropdown",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png",
+		"css": true
 	},
 	{
 		"id": "more-file-links",
 		"description": "Adds links to view the raw version, the blame, and the history of files in PRs and commits.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png",
+		"css": false
 	},
 	{
 		"id": "netiquette",
 		"description": "Adds unobtrusive netiquette reminders (old closed issues, highly-active issues, draft PRs, …).",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png",
+		"css": false
 	},
 	{
 		"id": "new-or-deleted-file",
 		"description": "Indicates with an icon whether files in commits and PRs are being added or removed.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png",
+		"css": false
 	},
 	{
 		"id": "new-repo-disable-projects-and-wikis",
 		"description": "Automatically disables projects and wikis when creating a repository.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177040449-73fde2a5-98e2-4583-8f32-905d1c4bfd20.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177040449-73fde2a5-98e2-4583-8f32-905d1c4bfd20.png",
+		"css": false
 	},
 	{
 		"id": "no-duplicate-list-update-time",
 		"description": "Hides the update time of issues/PRs in lists when it matches the open/closed/merged time.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png",
+		"css": false
 	},
 	{
 		"id": "no-unnecessary-split-diff-view",
 		"description": "Always uses unified diffs on files where split diffs aren’t useful.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png",
+		"css": true
 	},
 	{
 		"id": "one-click-diff-options",
 		"description": "Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: <kbd>d</kbd> <kbd>w</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png",
+		"css": false
 	},
 	{
 		"id": "one-click-pr-or-gist",
 		"description": "Lets you create draft PRs and public gists in one click.",
-		"screenshot": "https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png"
+		"screenshot": "https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png",
+		"css": true
 	},
 	{
 		"id": "one-click-review-submission",
 		"description": "Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/236627732-df341ff7-cd98-4cd0-a579-722d1fffa5cf.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/236627732-df341ff7-cd98-4cd0-a579-722d1fffa5cf.png",
+		"css": false
 	},
 	{
 		"id": "one-key-formatting",
 		"description": "Wraps selected text when pressing one of Markdown symbols instead of replacing it: <code>[</code> `<code> </code> `<code> </code>'<code> </code>\"<code> </code><em><code> </code>~<code> </code><em>`</em></em>",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261155564-e7aabd0e-b14b-4fe6-b379-62e7419c43f8.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261155564-e7aabd0e-b14b-4fe6-b379-62e7419c43f8.gif",
+		"css": false
 	},
 	{
 		"id": "open-all-conversations",
 		"description": "Lets you open all visible issues/PRs at once.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/110980658-5face000-8366-11eb-88f9-0cc94f75ce57.gif"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/110980658-5face000-8366-11eb-88f9-0cc94f75ce57.gif",
+		"css": false
 	},
 	{
 		"id": "open-all-notifications",
 		"description": "Adds a button to open all your unread notifications at once.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png",
+		"css": true
 	},
 	{
 		"id": "open-issue-to-latest-comment",
 		"description": "Makes the \"comment\" icon in issue lists link to the latest comment of the issue.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png",
+		"css": false
 	},
 	{
 		"id": "pagination-hotkey",
 		"description": "Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "parse-backticks",
 		"description": "GitHub renders `<code> </code>text in backticks<code> </code>` in some places but not others; this features fills in where forgotten.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262555091-df31aa17-e7a2-4c16-91ca-fb077ba6134a.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262555091-df31aa17-e7a2-4c16-91ca-fb077ba6134a.png",
+		"css": true
 	},
 	{
 		"id": "patch-diff-links",
 		"description": "Adds links to <code>.patch</code> and <code>.diff</code> files in commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png",
+		"css": false
 	},
 	{
 		"id": "pinned-issues-update-time",
 		"description": "Replaces the \"opened\" time with the \"updated\" time on pinned issues.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/240707405-e416be14-5ab5-4869-b33c-f43aab7afcb6.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/240707405-e416be14-5ab5-4869-b33c-f43aab7afcb6.png",
+		"css": false
 	},
 	{
 		"id": "pr-approvals-count",
 		"description": "Shows color-coded review counts in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png",
+		"css": true
 	},
 	{
 		"id": "pr-base-commit",
@@ -557,177 +665,212 @@
 	{
 		"id": "pr-branch-auto-delete",
 		"description": "Automatically deletes the branch right after merging a PR, if possible.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png",
+		"css": false
 	},
 	{
 		"id": "pr-commit-lines-changed",
 		"description": "Adds diff stats on PR commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253130044-494cd822-c460-42dc-8f65-44454a9d18e3.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253130044-494cd822-c460-42dc-8f65-44454a9d18e3.png",
+		"css": false
 	},
 	{
 		"id": "pr-filters",
 		"description": "Adds Checks and Draft PR dropdown filters in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253068868-6afb4656-4ef5-4846-89c5-24dc6ee7f839.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253068868-6afb4656-4ef5-4846-89c5-24dc6ee7f839.png",
+		"css": false
 	},
 	{
 		"id": "pr-first-commit-title",
 		"description": "Uses the first commit for a new PR’s title and description.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif",
+		"css": false
 	},
 	{
 		"id": "pr-jump-to-first-non-viewed-file",
 		"description": "Jumps to first non-viewed file in a PR when clicking on the progress bar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011208-764f509d-fed9-424b-84e9-c01cf2fd428b.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011208-764f509d-fed9-424b-84e9-c01cf2fd428b.gif",
+		"css": false
 	},
 	{
 		"id": "pr-notification-link",
 		"description": "Points PR notifications to the Conversation tabs instead of the commits page, which may be a 404.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/621f6512-655e-4565-a37b-2b159ea0ffce"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/621f6512-655e-4565-a37b-2b159ea0ffce",
+		"css": false
 	},
 	{
 		"id": "prevent-comment-loss",
 		"description": "While writing/editing comments, open the preview links in new tab instead of navigating away from the page.",
-		"screenshot": "https://user-images.githubusercontent.com/17681399/282616531-2befcabe-5c80-4b9a-bfb5-7b9917847bb5.gif"
+		"screenshot": "https://user-images.githubusercontent.com/17681399/282616531-2befcabe-5c80-4b9a-bfb5-7b9917847bb5.gif",
+		"css": false
 	},
 	{
 		"id": "prevent-duplicate-pr-submission",
 		"description": "Avoids creating duplicate PRs when mistakenly clicking \"Create pull request\" more than once.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif",
+		"css": false
 	},
 	{
 		"id": "prevent-link-loss",
 		"description": "Suggests fixing links that are wrongly shortened by GitHub.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260087535-a0f19995-5f4a-44e9-87d8-cf742b9bfeed.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260087535-a0f19995-5f4a-44e9-87d8-cf742b9bfeed.gif",
+		"css": false
 	},
 	{
 		"id": "prevent-pr-merge-panel-opening",
 		"description": "Prevents the merge panel from automatically opening on every page load after it’s been opened once.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "preview-hidden-comments",
 		"description": "Previews hidden comments inline.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262556553-ca04b870-9adb-4a8c-a6d0-6238863948be.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262556553-ca04b870-9adb-4a8c-a6d0-6238863948be.png",
+		"css": true
 	},
 	{
 		"id": "previous-next-commit-buttons",
 		"description": "Adds duplicate commit navigation buttons at the bottom of the <code>Commits</code> tab page.",
-		"screenshot": "https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png"
+		"screenshot": "https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png",
+		"css": false
 	},
 	{
 		"id": "previous-version",
 		"description": "Lets you see the previous version of a file in one click.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/bc82cc77-bde2-4683-98a6-012c87b4a319"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/bc82cc77-bde2-4683-98a6-012c87b4a319",
+		"css": false
 	},
 	{
 		"id": "profile-gists-link",
 		"description": "Adds a link to the user’s public gists on their profile.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png",
+		"css": false
 	},
 	{
 		"id": "profile-hotkey",
 		"description": "Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "pull-request-hotkeys",
 		"description": "Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd>, and <kbd>g</kbd> <kbd>4</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png"
+		"screenshot": "https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png",
+		"css": false
 	},
 	{
 		"id": "quick-comment-edit",
 		"description": "Lets you edit any comment with one click instead of having to open a dropdown.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png",
+		"css": false
 	},
 	{
 		"id": "quick-comment-hiding",
 		"description": "Simplifies the UI to hide comments.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif",
+		"css": false
 	},
 	{
 		"id": "quick-file-edit",
 		"description": "Adds a button to edit files from the repo file list.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252182890-081975f4-f041-4ba5-ae48-d52cb0796543.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252182890-081975f4-f041-4ba5-ae48-d52cb0796543.png",
+		"css": true
 	},
 	{
 		"id": "quick-label-removal",
 		"description": "Adds one-click buttons to remove labels in issues/PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif"
+		"screenshot": "https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif",
+		"css": true
 	},
 	{
 		"id": "quick-mention",
 		"description": "Adds a button to <code>@mention</code> a user in issues and PRs.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261158402-5a79cc3e-4331-475f-8063-5ed81fefcf10.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261158402-5a79cc3e-4331-475f-8063-5ed81fefcf10.gif",
+		"css": true
 	},
 	{
 		"id": "quick-new-issue",
 		"description": "Adds a link to create issues from anywhere in a repository.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/274816033-820ec518-049d-4248-9f8a-27b9423e350b.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/274816033-820ec518-049d-4248-9f8a-27b9423e350b.png",
+		"css": false
 	},
 	{
 		"id": "quick-repo-deletion",
 		"description": "Lets you delete your repos in a click, if they have no stars, issues, or PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif",
+		"css": true
 	},
 	{
 		"id": "quick-review",
 		"description": "Adds quick-review buttons to the PR sidebar, automatically focuses the review textarea, and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/f11039c4-c9d1-4adc-9a65-cfe1f2027ec3"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/f11039c4-c9d1-4adc-9a65-cfe1f2027ec3",
+		"css": false
 	},
 	{
 		"id": "quick-review-comment-deletion",
 		"description": "Adds a button to delete review comments in one click when editing them.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/115445792-9fdd6900-a216-11eb-9ba3-6dab4d2f9d32.png"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/115445792-9fdd6900-a216-11eb-9ba3-6dab4d2f9d32.png",
+		"css": false
 	},
 	{
 		"id": "reactions-avatars",
 		"description": "Adds reaction avatars showing <em>who</em> reacted to a comment.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/236628453-8b646178-b838-44a3-9541-0a9b5f54a84a.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/236628453-8b646178-b838-44a3-9541-0a9b5f54a84a.png",
+		"css": true
 	},
 	{
 		"id": "refined-github.css",
 		"description": "Reduces tabs’ size to 4 spaces instead of 8 where GitHub doesn't follow the user’s preferences.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png"
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png",
+		"css": false
 	},
 	{
 		"id": "release-download-count",
 		"description": "Adds a download count next to release assets.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png",
+		"css": true
 	},
 	{
 		"id": "releases-dropdown",
 		"description": "Adds a tags dropdown/search on tag/release pages.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png",
+		"css": false
 	},
 	{
 		"id": "releases-tab",
 		"description": "Adds a <code>Releases</code> tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png"
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png",
+		"css": false
 	},
 	{
 		"id": "reload-failed-proxied-images",
 		"description": "Retries downloading images that failed downloading due to GitHub limited proxying.",
-		"screenshot": "https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png"
+		"screenshot": "https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png",
+		"css": false
 	},
 	{
 		"id": "repo-age",
 		"description": "Displays the age of the repository in the sidebar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252176778-f8260312-d0dc-41b5-a4d1-ca680208d347.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252176778-f8260312-d0dc-41b5-a4d1-ca680208d347.png",
+		"css": false
 	},
 	{
 		"id": "repo-avatars",
 		"description": "Adds the profile picture to the header of public repositories.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/255323568-aee4d90e-844e-41e8-880a-ce466826516c.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/255323568-aee4d90e-844e-41e8-880a-ce466826516c.png",
+		"css": false
 	},
 	{
 		"id": "repo-header-info",
 		"description": "Shows whether a repo is a fork and adds the number of stars to its header.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png",
+		"css": false
 	},
 	{
 		"id": "repo-wide-file-finder",
 		"description": "Enables the File Finder keyboard shortcut (<kbd>t</kbd>) on entire repository.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "resolve-conflicts",
@@ -742,17 +885,20 @@
 	{
 		"id": "same-branch-author-commits",
 		"description": "Preserves current branch and path when viewing all commits by an author.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png",
+		"css": false
 	},
 	{
 		"id": "scrollable-areas",
 		"description": "Limits the height of tall code blocks and quotes.",
-		"screenshot": null
+		"screenshot": null,
+		"css": true
 	},
 	{
 		"id": "select-all-notifications-shortcut",
 		"description": "Adds a shortcut to select all visible notifications: <kbd>a</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "select-notifications",
@@ -762,32 +908,38 @@
 	{
 		"id": "selection-in-new-tab",
 		"description": "Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "shorten-links",
 		"description": "Shortens URLs and repo URLs to readable references like \"<em>user/repo/.file@<code>d71718d</code>\".</em>",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png",
+		"css": false
 	},
 	{
 		"id": "show-associated-branch-prs-on-fork",
 		"description": "Shows the associated PRs on branches for forked repositories.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260873542-2a7fc7a2-231f-4f2e-9c7e-272d894de4c6.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260873542-2a7fc7a2-231f-4f2e-9c7e-272d894de4c6.png",
+		"css": true
 	},
 	{
 		"id": "show-names",
 		"description": "Adds the real name of users by their usernames.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252756294-94785dc2-423e-498c-939a-359a012036e0.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252756294-94785dc2-423e-498c-939a-359a012036e0.png",
+		"css": true
 	},
 	{
 		"id": "show-open-prs-of-forks",
 		"description": "In your forked repos, shows number of your open PRs to the original repo.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252177140-94165582-628b-45b6-9a62-faf0c7fc2335.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252177140-94165582-628b-45b6-9a62-faf0c7fc2335.png",
+		"css": false
 	},
 	{
 		"id": "show-user-top-repositories",
 		"description": "Adds a link to the user’s most starred repositories.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png",
+		"css": false
 	},
 	{
 		"id": "show-whitespace",
@@ -797,12 +949,14 @@
 	{
 		"id": "small-user-avatars",
 		"description": "Shows a small avatar next to the username in issue/PR lists and mentions.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/271184107-24ec471e-54d1-434a-a5f2-615902d2cad9.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/271184107-24ec471e-54d1-434a-a5f2-615902d2cad9.png",
+		"css": false
 	},
 	{
 		"id": "sort-conversations-by-update-time",
 		"description": "Changes the default sort order of issues/PRs to <code>Recently updated</code>.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "status-subscription",
@@ -812,131 +966,157 @@
 	{
 		"id": "sticky-conversation-list-toolbar",
 		"description": "Makes the issue/PR list’s filters toolbar sticky.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif",
+		"css": true
 	},
 	{
 		"id": "sticky-notifications-actions",
 		"description": "Make the notifications action bar sticky.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f",
+		"css": true
 	},
 	{
 		"id": "sticky-sidebar",
 		"description": "Makes sidebars sticky in repositories, issues, and PRs, if they fit the viewport.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252179311-ea6d42dc-1525-401a-bc4d-404cf8fa1785.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252179311-ea6d42dc-1525-401a-bc4d-404cf8fa1785.gif",
+		"css": true
 	},
 	{
 		"id": "stop-redirecting-in-notification-bar",
 		"description": "Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png"
+		"screenshot": "https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png",
+		"css": false
 	},
 	{
 		"id": "submission-via-ctrl-enter-everywhere",
 		"description": "Enables submission via <kbd>ctrl</kbd> <kbd>enter</kbd> on every page possible.",
-		"screenshot": null
+		"screenshot": null,
+		"css": false
 	},
 	{
 		"id": "suggest-commit-title-limit",
 		"description": "Suggests limiting commit and PR titles to 72 characters.",
-		"screenshot": "https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif"
+		"screenshot": "https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif",
+		"css": true
 	},
 	{
 		"id": "swap-branches-on-compare",
 		"description": "Adds a link to swap branches in the branch compare view.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/230370539-ebc94246-864f-48f2-85fa-7318fc1f6d71.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/230370539-ebc94246-864f-48f2-85fa-7318fc1f6d71.png",
+		"css": false
 	},
 	{
 		"id": "sync-pr-commit-title",
 		"description": "Uses the PR’s title as the default squash commit title and updates the PR’s title to match the commit title, if changed.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011579-25332762-b25f-407b-b6d2-bbfc13de2be7.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011579-25332762-b25f-407b-b6d2-bbfc13de2be7.png",
+		"css": false
 	},
 	{
 		"id": "tab-to-indent",
 		"description": "Enables <kbd>tab</kbd> and <kbd>shift</kbd> <kbd>tab</kbd> for indentation in comment fields.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif",
+		"css": false
 	},
 	{
 		"id": "table-input",
 		"description": "Adds a button in the text editor to quickly insert a simplified HTML table.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif"
+		"screenshot": "https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif",
+		"css": true
 	},
 	{
 		"id": "tag-changes-link",
 		"description": "Adds a link to changes since last tag/release for each tag/release.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png",
+		"css": true
 	},
 	{
 		"id": "tags-on-commits-list",
 		"description": "Displays the corresponding tags next to commits.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/285106537-3c882cb2-6847-4098-9e51-cf2951dee818.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/285106537-3c882cb2-6847-4098-9e51-cf2951dee818.png",
+		"css": false
 	},
 	{
 		"id": "toggle-everything-with-alt",
 		"description": "Adds a shortcut to toggle all similar items (minimized comments, deferred diffs, etc) at once: <kbd>alt</kbd> <kbd>click</kbd> on each button or checkbox.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253063446-6f556e7d-2ac5-439d-92f0-0c6d719fc86f.gif"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253063446-6f556e7d-2ac5-439d-92f0-0c6d719fc86f.gif",
+		"css": false
 	},
 	{
 		"id": "toggle-files-button",
 		"description": "Adds a button to toggle the repo file list.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/69465a92-5548-40d2-bf90-9f7834d26ef2"
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/69465a92-5548-40d2-bf90-9f7834d26ef2",
+		"css": true
 	},
 	{
 		"id": "unfinished-comments",
 		"description": "Notifies the user of unfinished comments in hidden tabs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif",
+		"css": false
 	},
 	{
 		"id": "unreleased-commits",
 		"description": "Tells you whether you're looking at the latest version of a repository, or if there are any unreleased commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267236196-8564c193-a3c7-4248-9735-54749c1990c7.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267236196-8564c193-a3c7-4248-9735-54749c1990c7.png",
+		"css": false
 	},
 	{
 		"id": "unwrap-unnecessary-dropdowns",
 		"description": "Makes some dropdowns 1-click instead of unnecessarily 2-click.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258554504-97d4079a-2aae-4aea-a870-653a267494a8.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258554504-97d4079a-2aae-4aea-a870-653a267494a8.png",
+		"css": false
 	},
 	{
 		"id": "update-pr-from-base-branch",
 		"description": "Adds an \"Update branch\" button to every PR. GitHub has the same feature, but it must be manually configured with protected branches.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/234483592-4867cb2e-21cb-436d-9ea0-aedadf834f19.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/234483592-4867cb2e-21cb-436d-9ea0-aedadf834f19.png",
+		"css": false
 	},
 	{
 		"id": "useful-not-found-page",
 		"description": "Adds possible related pages and alternatives on 404 pages.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png",
+		"css": false
 	},
 	{
 		"id": "user-local-time",
 		"description": "Shows the user local time in their hovercard (based on their last commit).",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257039621-132bd789-e213-4a89-83ff-e1266215c60d.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257039621-132bd789-e213-4a89-83ff-e1266215c60d.png",
+		"css": true
 	},
 	{
 		"id": "user-profile-follower-badge",
 		"description": "On profiles, it shows whether the user follows you.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263206287-c8e1b94c-ec80-4394-bbb3-1cf6fb08b807.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263206287-c8e1b94c-ec80-4394-bbb3-1cf6fb08b807.png",
+		"css": false
 	},
 	{
 		"id": "vertical-front-matter",
 		"description": "Shows Markdown front matter as vertical table.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png",
+		"css": true
 	},
 	{
 		"id": "view-last-pr-deployment",
 		"description": "Adds a link to open the latest deployment from the header of a PR.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png"
+		"screenshot": "https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png",
+		"css": false
 	},
 	{
 		"id": "visit-tag",
 		"description": "When navigating a repo's file on a specific tag, it adds a link to see the release/tag itself.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png"
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png",
+		"css": false
 	},
 	{
 		"id": "warn-pr-from-master",
 		"description": "Warns you when creating a PR from the default branch, as it’s an anti-pattern.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png",
+		"css": false
 	},
 	{
 		"id": "warning-for-disallow-edits",
 		"description": "Warns you when unchecking <code>Allow edits from maintainers</code>, as it’s maintainer-hostile.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif"
+		"screenshot": "https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif",
+		"css": true
 	}
 ]

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -16,8 +16,8 @@
 	},
 	{
 		"id": "align-issue-labels",
-		"css": true,
 		"description": "In issue/PR lists, aligns the labels to the left, below each title.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png"
 	},
 	{
@@ -42,8 +42,8 @@
 	},
 	{
 		"id": "ci-link",
-		"css": true,
 		"description": "Adds a build/CI status icon next to the repo’s name.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/237923995-5e14a272-0bf2-4fe4-b409-8c05378aa4fd.png"
 	},
 	{
@@ -53,20 +53,20 @@
 	},
 	{
 		"id": "clean-conversation-headers",
-		"css": true,
 		"description": "Removes duplicate information in the header of issues and PRs (\"User wants to merge X commits from Y into Z\")",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png"
 	},
 	{
 		"id": "clean-conversation-sidebar",
-		"css": true,
 		"description": "Hides empty sections (or just their \"empty\" label) in the issue/PR sidebar.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png"
 	},
 	{
 		"id": "clean-pinned-issues",
-		"css": true,
 		"description": "Changes the layout of pinned issues from side-by-side to a standard list.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258224321-e8ee8c70-6952-4a42-8626-6b5f31d167a3.png"
 	},
 	{
@@ -81,8 +81,8 @@
 	},
 	{
 		"id": "clean-repo-sidebar",
-		"css": true,
 		"description": "Removes unnecessary or redundant information from the repository sidebar.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png"
 	},
 	{
@@ -92,8 +92,8 @@
 	},
 	{
 		"id": "clean-rich-text-editor",
-		"css": true,
 		"description": "Hides unnecessary comment field tooltips and toolbar items (each one has a keyboard shortcut.)",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/46634000/158201651-7364aba7-f9d0-4a51-89c4-2ced0cc34e48.png"
 	},
 	{
@@ -143,8 +143,8 @@
 	},
 	{
 		"id": "conflict-marker",
-		"css": true,
 		"description": "Shows which PRs have conflicts in PR lists.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png"
 	},
 	{
@@ -179,14 +179,14 @@
 	},
 	{
 		"id": "cross-deleted-pr-branches",
-		"css": true,
 		"description": "Adds a line-through to the deleted branches in PRs.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/256963526-646ac7d0-3e7f-40c6-ba39-014b49bc0063.png"
 	},
 	{
 		"id": "deep-reblame",
-		"css": true,
 		"description": "When exploring blames, <code>Alt</code>-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png"
 	},
 	{
@@ -196,8 +196,8 @@
 	},
 	{
 		"id": "dim-bots",
-		"css": true,
 		"description": "Dims commits and PRs by bots to reduce noise.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif"
 	},
 	{
@@ -227,8 +227,8 @@
 	},
 	{
 		"id": "emphasize-draft-pr-label",
-		"css": true,
 		"description": "Makes it easier to distinguish draft PR in lists.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png"
 	},
 	{
@@ -253,8 +253,8 @@
 	},
 	{
 		"id": "extend-diff-expander",
-		"css": true,
 		"description": "Widens the <code>Expand diff</code> button to be clickable across the screen.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif"
 	},
 	{
@@ -264,8 +264,8 @@
 	},
 	{
 		"id": "fit-textareas",
-		"css": true,
 		"description": "Auto-resizes comment fields to fit their content and no longer show scroll bars.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif"
 	},
 	{
@@ -280,20 +280,20 @@
 	},
 	{
 		"id": "global-conversation-list-filters",
-		"css": true,
 		"description": "Adds filters for issues/PRs <em>in your repos</em> and <em>commented on by you</em> in the global issue/PR search.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png"
 	},
 	{
 		"id": "hidden-review-comments-indicator",
-		"css": true,
 		"description": "Adds comment indicators when comments are hidden in PR review.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif"
 	},
 	{
 		"id": "hide-diff-signs",
-		"css": true,
 		"description": "Hides diff signs since diffs are color coded already.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png"
 	},
 	{
@@ -308,20 +308,20 @@
 	},
 	{
 		"id": "hide-low-quality-comments",
-		"css": true,
 		"description": "Hides reaction comments (\"+1\", \"👍\", …) (except the maintainers’) but they can still be shown.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258220965-4743b9b9-2aef-41b3-a905-ccf8d7beb74e.png"
 	},
 	{
 		"id": "hide-navigation-hover-highlight",
-		"css": true,
 		"description": "Removes the file hover effect in the repo file browser.",
+		"css": true,
 		"screenshot": null
 	},
 	{
 		"id": "hide-newsfeed-noise",
-		"css": true,
 		"description": "Hides other inutile newsfeed events (commits, forks, new followers).",
+		"css": true,
 		"screenshot": null
 	},
 	{
@@ -331,14 +331,14 @@
 	},
 	{
 		"id": "highest-rated-comment",
-		"css": true,
 		"description": "Highlights the most useful comment in issues.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png"
 	},
 	{
 		"id": "highlight-collaborators-and-own-conversations",
-		"css": true,
 		"description": "Highlights issues/PRs opened by you or the current repo’s collaborators.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png"
 	},
 	{
@@ -388,8 +388,8 @@
 	},
 	{
 		"id": "link-to-compare-diff",
-		"css": true,
 		"description": "Linkifies the \"X files changed\" text on compare pages to allow jumping to the diff.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png"
 	},
 	{
@@ -459,20 +459,20 @@
 	},
 	{
 		"id": "mark-merge-commits-in-list",
-		"css": true,
 		"description": "Marks merge commits in commit lists.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285106996-9bdbc938-69c4-4692-8d47-11e30676de62.png"
 	},
 	{
 		"id": "mark-private-orgs",
-		"css": true,
 		"description": "Marks private organizations on your own profile.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png"
 	},
 	{
 		"id": "mobile-tabs",
-		"css": true,
 		"description": "Makes the tabs more compact on mobile so more of them can be seen.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png"
 	},
 	{
@@ -482,8 +482,8 @@
 	},
 	{
 		"id": "more-dropdown-links",
-		"css": true,
 		"description": "Adds useful links to the repository navigation dropdown",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png"
 	},
 	{
@@ -513,8 +513,8 @@
 	},
 	{
 		"id": "no-unnecessary-split-diff-view",
-		"css": true,
 		"description": "Always uses unified diffs on files where split diffs aren’t useful.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png"
 	},
 	{
@@ -524,8 +524,8 @@
 	},
 	{
 		"id": "one-click-pr-or-gist",
-		"css": true,
 		"description": "Lets you create draft PRs and public gists in one click.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png"
 	},
 	{
@@ -545,8 +545,8 @@
 	},
 	{
 		"id": "open-all-notifications",
-		"css": true,
 		"description": "Adds a button to open all your unread notifications at once.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png"
 	},
 	{
@@ -561,8 +561,8 @@
 	},
 	{
 		"id": "parse-backticks",
-		"css": true,
 		"description": "GitHub renders `<code> </code>text in backticks<code> </code>` in some places but not others; this features fills in where forgotten.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262555091-df31aa17-e7a2-4c16-91ca-fb077ba6134a.png"
 	},
 	{
@@ -577,8 +577,8 @@
 	},
 	{
 		"id": "pr-approvals-count",
-		"css": true,
 		"description": "Shows color-coded review counts in PR lists.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png"
 	},
 	{
@@ -638,8 +638,8 @@
 	},
 	{
 		"id": "preview-hidden-comments",
-		"css": true,
 		"description": "Previews hidden comments inline.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262556553-ca04b870-9adb-4a8c-a6d0-6238863948be.png"
 	},
 	{
@@ -679,20 +679,20 @@
 	},
 	{
 		"id": "quick-file-edit",
-		"css": true,
 		"description": "Adds a button to edit files from the repo file list.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252182890-081975f4-f041-4ba5-ae48-d52cb0796543.png"
 	},
 	{
 		"id": "quick-label-removal",
-		"css": true,
 		"description": "Adds one-click buttons to remove labels in issues/PRs.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif"
 	},
 	{
 		"id": "quick-mention",
-		"css": true,
 		"description": "Adds a button to <code>@mention</code> a user in issues and PRs.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261158402-5a79cc3e-4331-475f-8063-5ed81fefcf10.gif"
 	},
 	{
@@ -702,8 +702,8 @@
 	},
 	{
 		"id": "quick-repo-deletion",
-		"css": true,
 		"description": "Lets you delete your repos in a click, if they have no stars, issues, or PRs.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif"
 	},
 	{
@@ -718,8 +718,8 @@
 	},
 	{
 		"id": "reactions-avatars",
-		"css": true,
 		"description": "Adds reaction avatars showing <em>who</em> reacted to a comment.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/236628453-8b646178-b838-44a3-9541-0a9b5f54a84a.png"
 	},
 	{
@@ -729,8 +729,8 @@
 	},
 	{
 		"id": "release-download-count",
-		"css": true,
 		"description": "Adds a download count next to release assets.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png"
 	},
 	{
@@ -785,8 +785,8 @@
 	},
 	{
 		"id": "scrollable-areas",
-		"css": true,
 		"description": "Limits the height of tall code blocks and quotes.",
+		"css": true,
 		"screenshot": null
 	},
 	{
@@ -811,14 +811,14 @@
 	},
 	{
 		"id": "show-associated-branch-prs-on-fork",
-		"css": true,
 		"description": "Shows the associated PRs on branches for forked repositories.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260873542-2a7fc7a2-231f-4f2e-9c7e-272d894de4c6.png"
 	},
 	{
 		"id": "show-names",
-		"css": true,
 		"description": "Adds the real name of users by their usernames.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252756294-94785dc2-423e-498c-939a-359a012036e0.png"
 	},
 	{
@@ -853,20 +853,20 @@
 	},
 	{
 		"id": "sticky-conversation-list-toolbar",
-		"css": true,
 		"description": "Makes the issue/PR list’s filters toolbar sticky.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif"
 	},
 	{
 		"id": "sticky-notifications-actions",
-		"css": true,
 		"description": "Make the notifications action bar sticky.",
+		"css": true,
 		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f"
 	},
 	{
 		"id": "sticky-sidebar",
-		"css": true,
 		"description": "Makes sidebars sticky in repositories, issues, and PRs, if they fit the viewport.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252179311-ea6d42dc-1525-401a-bc4d-404cf8fa1785.gif"
 	},
 	{
@@ -881,8 +881,8 @@
 	},
 	{
 		"id": "suggest-commit-title-limit",
-		"css": true,
 		"description": "Suggests limiting commit and PR titles to 72 characters.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif"
 	},
 	{
@@ -902,14 +902,14 @@
 	},
 	{
 		"id": "table-input",
-		"css": true,
 		"description": "Adds a button in the text editor to quickly insert a simplified HTML table.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif"
 	},
 	{
 		"id": "tag-changes-link",
-		"css": true,
 		"description": "Adds a link to changes since last tag/release for each tag/release.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png"
 	},
 	{
@@ -924,8 +924,8 @@
 	},
 	{
 		"id": "toggle-files-button",
-		"css": true,
 		"description": "Adds a button to toggle the repo file list.",
+		"css": true,
 		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/69465a92-5548-40d2-bf90-9f7834d26ef2"
 	},
 	{
@@ -955,8 +955,8 @@
 	},
 	{
 		"id": "user-local-time",
-		"css": true,
 		"description": "Shows the user local time in their hovercard (based on their last commit).",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257039621-132bd789-e213-4a89-83ff-e1266215c60d.png"
 	},
 	{
@@ -966,8 +966,8 @@
 	},
 	{
 		"id": "vertical-front-matter",
-		"css": true,
 		"description": "Shows Markdown front matter as vertical table.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png"
 	},
 	{
@@ -987,8 +987,8 @@
 	},
 	{
 		"id": "warning-for-disallow-edits",
-		"css": true,
 		"description": "Warns you when unchecking <code>Allow edits from maintainers</code>, as it’s maintainer-hostile.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif"
 	}
 ]

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -16,9 +16,9 @@
 	},
 	{
 		"id": "align-issue-labels",
+		"css": true,
 		"description": "In issue/PR lists, aligns the labels to the left, below each title.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png"
 	},
 	{
 		"id": "archive-forks-link",
@@ -42,9 +42,9 @@
 	},
 	{
 		"id": "ci-link",
+		"css": true,
 		"description": "Adds a build/CI status icon next to the repo’s name.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/237923995-5e14a272-0bf2-4fe4-b409-8c05378aa4fd.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/237923995-5e14a272-0bf2-4fe4-b409-8c05378aa4fd.png"
 	},
 	{
 		"id": "clean-conversation-filters",
@@ -53,21 +53,21 @@
 	},
 	{
 		"id": "clean-conversation-headers",
+		"css": true,
 		"description": "Removes duplicate information in the header of issues and PRs (\"User wants to merge X commits from Y into Z\")",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png"
 	},
 	{
 		"id": "clean-conversation-sidebar",
+		"css": true,
 		"description": "Hides empty sections (or just their \"empty\" label) in the issue/PR sidebar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png"
 	},
 	{
 		"id": "clean-pinned-issues",
+		"css": true,
 		"description": "Changes the layout of pinned issues from side-by-side to a standard list.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258224321-e8ee8c70-6952-4a42-8626-6b5f31d167a3.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258224321-e8ee8c70-6952-4a42-8626-6b5f31d167a3.png"
 	},
 	{
 		"id": "clean-readme-url",
@@ -81,9 +81,9 @@
 	},
 	{
 		"id": "clean-repo-sidebar",
+		"css": true,
 		"description": "Removes unnecessary or redundant information from the repository sidebar.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png"
 	},
 	{
 		"id": "clean-repo-tabs",
@@ -92,9 +92,9 @@
 	},
 	{
 		"id": "clean-rich-text-editor",
+		"css": true,
 		"description": "Hides unnecessary comment field tooltips and toolbar items (each one has a keyboard shortcut.)",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/158201651-7364aba7-f9d0-4a51-89c4-2ced0cc34e48.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/46634000/158201651-7364aba7-f9d0-4a51-89c4-2ced0cc34e48.png"
 	},
 	{
 		"id": "clear-pr-merge-commit-message",
@@ -143,9 +143,9 @@
 	},
 	{
 		"id": "conflict-marker",
+		"css": true,
 		"description": "Shows which PRs have conflicts in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png"
 	},
 	{
 		"id": "conversation-activity-filter",
@@ -179,15 +179,15 @@
 	},
 	{
 		"id": "cross-deleted-pr-branches",
+		"css": true,
 		"description": "Adds a line-through to the deleted branches in PRs.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/256963526-646ac7d0-3e7f-40c6-ba39-014b49bc0063.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/256963526-646ac7d0-3e7f-40c6-ba39-014b49bc0063.png"
 	},
 	{
 		"id": "deep-reblame",
+		"css": true,
 		"description": "When exploring blames, <code>Alt</code>-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png"
 	},
 	{
 		"id": "default-branch-button",
@@ -196,9 +196,9 @@
 	},
 	{
 		"id": "dim-bots",
+		"css": true,
 		"description": "Dims commits and PRs by bots to reduce noise.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif"
 	},
 	{
 		"id": "download-folder-button",
@@ -227,9 +227,9 @@
 	},
 	{
 		"id": "emphasize-draft-pr-label",
+		"css": true,
 		"description": "Makes it easier to distinguish draft PR in lists.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/218252438-062a1ab3-4437-436d-9140-87bee23aaefb.png"
 	},
 	{
 		"id": "esc-to-cancel",
@@ -253,9 +253,9 @@
 	},
 	{
 		"id": "extend-diff-expander",
+		"css": true,
 		"description": "Widens the <code>Expand diff</code> button to be clickable across the screen.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif"
 	},
 	{
 		"id": "file-age-color",
@@ -264,9 +264,9 @@
 	},
 	{
 		"id": "fit-textareas",
+		"css": true,
 		"description": "Auto-resizes comment fields to fit their content and no longer show scroll bars.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif"
 	},
 	{
 		"id": "fix-no-pr-search",
@@ -280,21 +280,21 @@
 	},
 	{
 		"id": "global-conversation-list-filters",
+		"css": true,
 		"description": "Adds filters for issues/PRs <em>in your repos</em> and <em>commented on by you</em> in the global issue/PR search.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png"
 	},
 	{
 		"id": "hidden-review-comments-indicator",
+		"css": true,
 		"description": "Adds comment indicators when comments are hidden in PR review.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif"
 	},
 	{
 		"id": "hide-diff-signs",
+		"css": true,
 		"description": "Hides diff signs since diffs are color coded already.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png"
 	},
 	{
 		"id": "hide-inactive-deployments",
@@ -308,21 +308,21 @@
 	},
 	{
 		"id": "hide-low-quality-comments",
+		"css": true,
 		"description": "Hides reaction comments (\"+1\", \"👍\", …) (except the maintainers’) but they can still be shown.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258220965-4743b9b9-2aef-41b3-a905-ccf8d7beb74e.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258220965-4743b9b9-2aef-41b3-a905-ccf8d7beb74e.png"
 	},
 	{
 		"id": "hide-navigation-hover-highlight",
+		"css": true,
 		"description": "Removes the file hover effect in the repo file browser.",
-		"screenshot": null,
-		"css": true
+		"screenshot": null
 	},
 	{
 		"id": "hide-newsfeed-noise",
+		"css": true,
 		"description": "Hides other inutile newsfeed events (commits, forks, new followers).",
-		"screenshot": null,
-		"css": true
+		"screenshot": null
 	},
 	{
 		"id": "hide-user-forks",
@@ -331,15 +331,15 @@
 	},
 	{
 		"id": "highest-rated-comment",
+		"css": true,
 		"description": "Highlights the most useful comment in issues.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252763905-a0c3b074-b032-4d97-946e-328e8a6fb2da.png"
 	},
 	{
 		"id": "highlight-collaborators-and-own-conversations",
+		"css": true,
 		"description": "Highlights issues/PRs opened by you or the current repo’s collaborators.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png"
 	},
 	{
 		"id": "highlight-non-default-base-branch",
@@ -388,9 +388,9 @@
 	},
 	{
 		"id": "link-to-compare-diff",
+		"css": true,
 		"description": "Linkifies the \"X files changed\" text on compare pages to allow jumping to the diff.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png"
 	},
 	{
 		"id": "link-to-github-io",
@@ -459,21 +459,21 @@
 	},
 	{
 		"id": "mark-merge-commits-in-list",
+		"css": true,
 		"description": "Marks merge commits in commit lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285106996-9bdbc938-69c4-4692-8d47-11e30676de62.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285106996-9bdbc938-69c4-4692-8d47-11e30676de62.png"
 	},
 	{
 		"id": "mark-private-orgs",
+		"css": true,
 		"description": "Marks private organizations on your own profile.",
-		"screenshot": "https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png"
 	},
 	{
 		"id": "mobile-tabs",
+		"css": true,
 		"description": "Makes the tabs more compact on mobile so more of them can be seen.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/245446231-28f44b59-0151-4986-8cb9-05b5645592d8.png"
 	},
 	{
 		"id": "more-conversation-filters",
@@ -482,9 +482,9 @@
 	},
 	{
 		"id": "more-dropdown-links",
+		"css": true,
 		"description": "Adds useful links to the repository navigation dropdown",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/16872793/124681432-856e6f80-de96-11eb-89c9-6d78e8ae4329.png"
 	},
 	{
 		"id": "more-file-links",
@@ -513,9 +513,9 @@
 	},
 	{
 		"id": "no-unnecessary-split-diff-view",
+		"css": true,
 		"description": "Always uses unified diffs on files where split diffs aren’t useful.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/46634000/121495005-89af8600-c9d9-11eb-822d-77e0b987e3b1.png"
 	},
 	{
 		"id": "one-click-diff-options",
@@ -524,9 +524,9 @@
 	},
 	{
 		"id": "one-click-pr-or-gist",
+		"css": true,
 		"description": "Lets you create draft PRs and public gists in one click.",
-		"screenshot": "https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/34235681/152473201-868ad7c1-e06f-4826-b808-d90bca7f08b3.png"
 	},
 	{
 		"id": "one-click-review-submission",
@@ -545,9 +545,9 @@
 	},
 	{
 		"id": "open-all-notifications",
+		"css": true,
 		"description": "Adds a button to open all your unread notifications at once.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png"
 	},
 	{
 		"id": "open-issue-to-latest-comment",
@@ -561,9 +561,9 @@
 	},
 	{
 		"id": "parse-backticks",
+		"css": true,
 		"description": "GitHub renders `<code> </code>text in backticks<code> </code>` in some places but not others; this features fills in where forgotten.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262555091-df31aa17-e7a2-4c16-91ca-fb077ba6134a.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262555091-df31aa17-e7a2-4c16-91ca-fb077ba6134a.png"
 	},
 	{
 		"id": "patch-diff-links",
@@ -577,9 +577,9 @@
 	},
 	{
 		"id": "pr-approvals-count",
+		"css": true,
 		"description": "Shows color-coded review counts in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png"
 	},
 	{
 		"id": "pr-base-commit",
@@ -638,9 +638,9 @@
 	},
 	{
 		"id": "preview-hidden-comments",
+		"css": true,
 		"description": "Previews hidden comments inline.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262556553-ca04b870-9adb-4a8c-a6d0-6238863948be.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262556553-ca04b870-9adb-4a8c-a6d0-6238863948be.png"
 	},
 	{
 		"id": "previous-next-commit-buttons",
@@ -679,21 +679,21 @@
 	},
 	{
 		"id": "quick-file-edit",
+		"css": true,
 		"description": "Adds a button to edit files from the repo file list.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252182890-081975f4-f041-4ba5-ae48-d52cb0796543.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252182890-081975f4-f041-4ba5-ae48-d52cb0796543.png"
 	},
 	{
 		"id": "quick-label-removal",
+		"css": true,
 		"description": "Adds one-click buttons to remove labels in issues/PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif"
 	},
 	{
 		"id": "quick-mention",
+		"css": true,
 		"description": "Adds a button to <code>@mention</code> a user in issues and PRs.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261158402-5a79cc3e-4331-475f-8063-5ed81fefcf10.gif",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261158402-5a79cc3e-4331-475f-8063-5ed81fefcf10.gif"
 	},
 	{
 		"id": "quick-new-issue",
@@ -702,9 +702,9 @@
 	},
 	{
 		"id": "quick-repo-deletion",
+		"css": true,
 		"description": "Lets you delete your repos in a click, if they have no stars, issues, or PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif"
 	},
 	{
 		"id": "quick-review",
@@ -718,9 +718,9 @@
 	},
 	{
 		"id": "reactions-avatars",
+		"css": true,
 		"description": "Adds reaction avatars showing <em>who</em> reacted to a comment.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/236628453-8b646178-b838-44a3-9541-0a9b5f54a84a.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/236628453-8b646178-b838-44a3-9541-0a9b5f54a84a.png"
 	},
 	{
 		"id": "refined-github.css",
@@ -729,9 +729,9 @@
 	},
 	{
 		"id": "release-download-count",
+		"css": true,
 		"description": "Adds a download count next to release assets.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/197958719-1577bc1b-1f4d-44a8-98c2-2645b7b14d31.png"
 	},
 	{
 		"id": "releases-dropdown",
@@ -785,9 +785,9 @@
 	},
 	{
 		"id": "scrollable-areas",
+		"css": true,
 		"description": "Limits the height of tall code blocks and quotes.",
-		"screenshot": null,
-		"css": true
+		"screenshot": null
 	},
 	{
 		"id": "select-all-notifications-shortcut",
@@ -811,15 +811,15 @@
 	},
 	{
 		"id": "show-associated-branch-prs-on-fork",
+		"css": true,
 		"description": "Shows the associated PRs on branches for forked repositories.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260873542-2a7fc7a2-231f-4f2e-9c7e-272d894de4c6.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260873542-2a7fc7a2-231f-4f2e-9c7e-272d894de4c6.png"
 	},
 	{
 		"id": "show-names",
+		"css": true,
 		"description": "Adds the real name of users by their usernames.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252756294-94785dc2-423e-498c-939a-359a012036e0.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252756294-94785dc2-423e-498c-939a-359a012036e0.png"
 	},
 	{
 		"id": "show-open-prs-of-forks",
@@ -853,21 +853,21 @@
 	},
 	{
 		"id": "sticky-conversation-list-toolbar",
+		"css": true,
 		"description": "Makes the issue/PR list’s filters toolbar sticky.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif"
 	},
 	{
 		"id": "sticky-notifications-actions",
+		"css": true,
 		"description": "Make the notifications action bar sticky.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f",
-		"css": true
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/5b370430-2319-4c78-88e7-c2c06cd1c30f"
 	},
 	{
 		"id": "sticky-sidebar",
+		"css": true,
 		"description": "Makes sidebars sticky in repositories, issues, and PRs, if they fit the viewport.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252179311-ea6d42dc-1525-401a-bc4d-404cf8fa1785.gif",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252179311-ea6d42dc-1525-401a-bc4d-404cf8fa1785.gif"
 	},
 	{
 		"id": "stop-redirecting-in-notification-bar",
@@ -881,9 +881,9 @@
 	},
 	{
 		"id": "suggest-commit-title-limit",
+		"css": true,
 		"description": "Suggests limiting commit and PR titles to 72 characters.",
-		"screenshot": "https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif"
 	},
 	{
 		"id": "swap-branches-on-compare",
@@ -902,15 +902,15 @@
 	},
 	{
 		"id": "table-input",
+		"css": true,
 		"description": "Adds a button in the text editor to quickly insert a simplified HTML table.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif"
 	},
 	{
 		"id": "tag-changes-link",
+		"css": true,
 		"description": "Adds a link to changes since last tag/release for each tag/release.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png"
 	},
 	{
 		"id": "tags-on-commits-list",
@@ -924,9 +924,9 @@
 	},
 	{
 		"id": "toggle-files-button",
+		"css": true,
 		"description": "Adds a button to toggle the repo file list.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/69465a92-5548-40d2-bf90-9f7834d26ef2",
-		"css": true
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/69465a92-5548-40d2-bf90-9f7834d26ef2"
 	},
 	{
 		"id": "unfinished-comments",
@@ -955,9 +955,9 @@
 	},
 	{
 		"id": "user-local-time",
+		"css": true,
 		"description": "Shows the user local time in their hovercard (based on their last commit).",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257039621-132bd789-e213-4a89-83ff-e1266215c60d.png",
-		"css": true
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257039621-132bd789-e213-4a89-83ff-e1266215c60d.png"
 	},
 	{
 		"id": "user-profile-follower-badge",
@@ -966,9 +966,9 @@
 	},
 	{
 		"id": "vertical-front-matter",
+		"css": true,
 		"description": "Shows Markdown front matter as vertical table.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png"
 	},
 	{
 		"id": "view-last-pr-deployment",
@@ -987,8 +987,8 @@
 	},
 	{
 		"id": "warning-for-disallow-edits",
+		"css": true,
 		"description": "Warns you when unchecking <code>Allow edits from maintainers</code>, as it’s maintainer-hostile.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif",
-		"css": true
+		"screenshot": "https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif"
 	}
 ]

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -2,20 +2,17 @@
 	{
 		"id": "action-pr-link",
 		"description": "Adds a link back to the PR that ran the workflow.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/50487467/241645264-076a0137-36a2-4fd0-a66e-735ef3b3a563.png"
 	},
 	{
 		"id": "action-used-by-link",
 		"description": "Lets you see how others are using the current Action in the Marketplace.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258552390-7d2cd013-c167-4fe5-9731-33622b8607e9.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258552390-7d2cd013-c167-4fe5-9731-33622b8607e9.png"
 	},
 	{
 		"id": "actionable-pr-view-file",
 		"description": "Points the \"View file\" on PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the \"View file\" page.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png"
 	},
 	{
 		"id": "align-issue-labels",
@@ -26,26 +23,22 @@
 	{
 		"id": "archive-forks-link",
 		"description": "Helps you find forks on archived repos.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/230362566-12493c80-bffe-4c7a-b9ba-4a11b1358ab0.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/230362566-12493c80-bffe-4c7a-b9ba-4a11b1358ab0.png"
 	},
 	{
 		"id": "avoid-accidental-submissions",
 		"description": "Disables the <kbd>enter</kbd>-to-submit shortcut in some commit/PR/issue title fields to avoid accidental submissions. Use <kbd>ctrl</kbd> <kbd>enter</kbd> instead.",
-		"screenshot": "https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif"
 	},
 	{
 		"id": "batch-mark-files-as-viewed",
 		"description": "Mark/unmark multiple files as “Viewed” in the PR Files tab. Click on the first checkbox you want to mark/unmark and then <code>shift</code>-click another one; all the files between the two checkboxes will be marked/unmarked as “Viewed”.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257009611-17249bee-d2e2-42ac-bdf0-ebc90029544e.gif",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257009611-17249bee-d2e2-42ac-bdf0-ebc90029544e.gif"
 	},
 	{
 		"id": "bugs-tab",
 		"description": "Adds a \"Bugs\" tab to repos, if there are any open issues with the \"bug\" label.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/156766081-f2ea100b-a9f3-472b-bddc-a984a88ddcd3.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/156766081-f2ea100b-a9f3-472b-bddc-a984a88ddcd3.png"
 	},
 	{
 		"id": "ci-link",
@@ -56,8 +49,7 @@
 	{
 		"id": "clean-conversation-filters",
 		"description": "Hides <code>Projects</code> and <code>Milestones</code> filters in issue/PR lists if they are empty.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262557246-4ef1c702-eece-4701-9000-0aad21c54c1b.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262557246-4ef1c702-eece-4701-9000-0aad21c54c1b.png"
 	},
 	{
 		"id": "clean-conversation-headers",
@@ -80,14 +72,12 @@
 	{
 		"id": "clean-readme-url",
 		"description": "Drops redundant \"readme-ov-file\" parameter from repo URLs.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/73e96411-3314-4501-a9b6-d006af6fcc47",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/73e96411-3314-4501-a9b6-d006af6fcc47"
 	},
 	{
 		"id": "clean-repo-filelist-actions",
 		"description": "Makes some buttons on repository lists more compact to make room for other features.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/108955170-52d48080-7633-11eb-8979-67e0d3a53f16.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/108955170-52d48080-7633-11eb-8979-67e0d3a53f16.png"
 	},
 	{
 		"id": "clean-repo-sidebar",
@@ -98,8 +88,7 @@
 	{
 		"id": "clean-repo-tabs",
 		"description": "Moves the \"Security\" and \"Insights\"  to the repository navigation dropdown. Also moves the \"Projects\", \"Actions\" and \"Wiki\" tabs if they're empty/unused.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/124681343-4a6c3c00-de96-11eb-9055-a8fc551e6eb8.png"
 	},
 	{
 		"id": "clean-rich-text-editor",
@@ -110,56 +99,47 @@
 	{
 		"id": "clear-pr-merge-commit-message",
 		"description": "Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png"
 	},
 	{
 		"id": "click-outside-modal",
 		"description": "Closes checks list when clicking outside of modal.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "close-as-unplanned",
 		"description": "Lets you \"close issue as unplanned\" in one click instead of three.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png"
 	},
 	{
 		"id": "close-out-of-view-modals",
 		"description": "Automatically closes dropdown menus when they’re no longer visible.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif"
 	},
 	{
 		"id": "closing-remarks",
 		"description": "Shows the first Git tag a merged PR was included in or suggests creating a release if not yet released.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/169497171-85d4a97f-413a-41b4-84ba-885dca2b51cf.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/169497171-85d4a97f-413a-41b4-84ba-885dca2b51cf.png"
 	},
 	{
 		"id": "collapsible-content-button",
 		"description": "Adds a button to insert collapsible content (via <code>&lt;details&gt;</code>).",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png"
 	},
 	{
 		"id": "command-palette-navigation-shortcuts",
 		"description": "Adds keyboard shortcuts to select items in command palette using <kbd>ctrl</kbd> <kbd>n</kbd> and <kbd>ctrl</kbd> <kbd>p</kbd> (macOS only).",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "comment-excess",
 		"description": "Informs you that there are hidden comments in the header of long issues. Also scrolls down to the hidden comments when pressing Cmd+F or Ctrl+F.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/4e4660f9-c987-4b0d-82ca-56ef29952c31",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/4e4660f9-c987-4b0d-82ca-56ef29952c31"
 	},
 	{
 		"id": "comments-time-machine-links",
 		"description": "Adds links to browse the repository and linked files at the time of each comment.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252749373-9313f1d9-3d92-44a2-a1d1-2b49a29e6a5c.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252749373-9313f1d9-3d92-44a2-a1d1-2b49a29e6a5c.png"
 	},
 	{
 		"id": "conflict-marker",
@@ -175,32 +155,27 @@
 	{
 		"id": "conversation-links-on-repo-lists",
 		"description": "Adds a link to the issues and pulls on the user profile repository tab and global search.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png"
 	},
 	{
 		"id": "convert-pr-to-draft-improvements",
 		"description": "Moves the \"Convert PR to Draft\" button to the mergeability box and adds visual feedback to its confirm button.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif"
 	},
 	{
 		"id": "convert-release-to-draft",
 		"description": "Adds a button to convert a release to draft.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png"
 	},
 	{
 		"id": "copy-on-y",
 		"description": "Enhances the <kbd>y</kbd> hotkey to also copy the permalink.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "create-release-shortcut",
 		"description": "Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "cross-deleted-pr-branches",
@@ -228,32 +203,27 @@
 	{
 		"id": "download-folder-button",
 		"description": "Adds a button to download entire folders, via https://download-directory.github.io.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png"
 	},
 	{
 		"id": "easy-toggle-commit-messages",
 		"description": "Enables toggling commit messages by clicking on the commit box.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif"
 	},
 	{
 		"id": "easy-toggle-files",
 		"description": "Enables toggling file diffs by clicking on their header bar.",
-		"screenshot": "https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif"
 	},
 	{
 		"id": "embed-gist-inline",
 		"description": "Embeds short gists when linked in comments on their own lines.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/152117903-80d784d5-4f43-4786-bc4c-d4993aec5c79.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/152117903-80d784d5-4f43-4786-bc4c-d4993aec5c79.png"
 	},
 	{
 		"id": "embed-gist-via-iframe",
 		"description": "Adds a menu item to embed a gist via <code>&lt;iframe&gt;</code>.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553891-a55a3bc0-f244-421b-a24c-6f1d4a92552e.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553891-a55a3bc0-f244-421b-a24c-6f1d4a92552e.png"
 	},
 	{
 		"id": "emphasize-draft-pr-label",
@@ -264,26 +234,22 @@
 	{
 		"id": "esc-to-cancel",
 		"description": "Adds a shortcut to cancel editing a issue/PR title: <kbd>esc</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif"
 	},
 	{
 		"id": "esc-to-deselect-line",
 		"description": "Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "expand-all-hidden-comments",
 		"description": "On long conversations where GitHub hides comments under a \"N hidden items. Load more...\", alt-clicking it will load up to 200 comments at once instead of 60.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160123-9c4f894b-38c0-446f-af50-9beca7ff1f74.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160123-9c4f894b-38c0-446f-af50-9beca7ff1f74.png"
 	},
 	{
 		"id": "extend-conversation-status-filters",
 		"description": "Lets you toggle between is:open/is:closed/is:merged filters in searches.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif"
 	},
 	{
 		"id": "extend-diff-expander",
@@ -294,8 +260,7 @@
 	{
 		"id": "file-age-color",
 		"description": "Highlights the most-recently-modified items in file lists.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png"
 	},
 	{
 		"id": "fit-textareas",
@@ -306,14 +271,12 @@
 	{
 		"id": "fix-no-pr-search",
 		"description": "Redirect to repo issue list when the search doesn‘t include <code>is:pr</code>.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/286579939-50122f02-dcfd-4510-b9e1-03d9985da2cd.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/286579939-50122f02-dcfd-4510-b9e1-03d9985da2cd.gif"
 	},
 	{
 		"id": "github-actions-indicators",
 		"description": "In the workflows sidebar, shows an indicator that a workflow can be triggered manually, and its next scheduled time if relevant.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252181237-a1d809b1-e5d4-4747-9654-7dde5ab5c61a.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252181237-a1d809b1-e5d4-4747-9654-7dde5ab5c61a.png"
 	},
 	{
 		"id": "global-conversation-list-filters",
@@ -336,14 +299,12 @@
 	{
 		"id": "hide-inactive-deployments",
 		"description": "Hides inactive deployments in PRs.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "hide-issue-list-autocomplete",
 		"description": "Removes the autocomplete on search fields.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png"
 	},
 	{
 		"id": "hide-low-quality-comments",
@@ -366,8 +327,7 @@
 	{
 		"id": "hide-user-forks",
 		"description": "Hides forks and archived repos from profiles (but they can still be shown.)",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263195425-85cf0951-c6ed-45fe-8cfc-e447e3ed2a25.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263195425-85cf0951-c6ed-45fe-8cfc-e447e3ed2a25.png"
 	},
 	{
 		"id": "highest-rated-comment",
@@ -384,56 +344,47 @@
 	{
 		"id": "highlight-non-default-base-branch",
 		"description": "Shows the base branch in PR lists if it’s not the default branch.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png"
 	},
 	{
 		"id": "html-preview-link",
 		"description": "Adds a link to preview HTML files.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260874191-69d386a0-7c1f-42ae-84fd-4f67f90982da.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260874191-69d386a0-7c1f-42ae-84fd-4f67f90982da.png"
 	},
 	{
 		"id": "improve-shortcut-help",
 		"description": "Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).",
-		"screenshot": "https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png"
 	},
 	{
 		"id": "infinite-scroll",
 		"description": "Automagically expands the newsfeed when you scroll down.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "jump-to-change-requested-comment",
 		"description": "Adds a link to jump to the latest changed requested comment.",
-		"screenshot": "https://user-images.githubusercontent.com/19198931/98718312-418b9f00-23c9-11eb-8da2-dfb616e95eb6.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/19198931/98718312-418b9f00-23c9-11eb-8da2-dfb616e95eb6.gif"
 	},
 	{
 		"id": "jump-to-conversation-close-event",
 		"description": "Adds a link to jump to the latest close event of a issue/PR.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif"
 	},
 	{
 		"id": "keyboard-navigation",
 		"description": "Adds shortcuts to issues, PRs conversations, and PR file lists: <kbd>j</kbd> focuses the comment/file below; <kbd>k</kbd> focuses the comment/file above.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/86573176-48665900-bf74-11ea-8996-a5c46cb7bdfd.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/86573176-48665900-bf74-11ea-8996-a5c46cb7bdfd.gif"
 	},
 	{
 		"id": "last-notification-page-button",
 		"description": "Adds a link to the last page of notifications.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png"
 	},
 	{
 		"id": "link-to-changelog-file",
 		"description": "Adds a button to view the changelog file from the releases page.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png"
 	},
 	{
 		"id": "link-to-compare-diff",
@@ -444,80 +395,67 @@
 	{
 		"id": "link-to-github-io",
 		"description": "Adds a link to visit the user’s github.io website from its repo.",
-		"screenshot": "https://user-images.githubusercontent.com/34235681/152473104-c4723999-9239-48fd-baee-273b01c4eb87.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/34235681/152473104-c4723999-9239-48fd-baee-273b01c4eb87.png"
 	},
 	{
 		"id": "linkify-branch-references",
 		"description": "Linkifies branch references in \"Quick PR\" pages.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553554-e1711be0-d5ce-4edc-aaf8-72d659c881bc.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258553554-e1711be0-d5ce-4edc-aaf8-72d659c881bc.png"
 	},
 	{
 		"id": "linkify-code",
 		"description": "Linkifies issue/PR references and URLs in code and issue/PR titles.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png",
-		"css": false
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png"
 	},
 	{
 		"id": "linkify-commit-sha",
 		"description": "Adds a link to the non-PR commit when visiting a PR commit.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164635-b3caa3fa-3bb6-41a5-90d3-4aba84517da6.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164635-b3caa3fa-3bb6-41a5-90d3-4aba84517da6.png"
 	},
 	{
 		"id": "linkify-line-numbers",
 		"description": "Linkifies the line numbers where GitHub forgot to add links.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/d5b67f4e-35c3-45d8-b72c-937b855168c3",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/d5b67f4e-35c3-45d8-b72c-937b855168c3"
 	},
 	{
 		"id": "linkify-notification-repository-header",
 		"description": "Linkifies the header of each notification group (when grouped by repository).",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png"
 	},
 	{
 		"id": "linkify-symbolic-links",
 		"description": "Linkifies symbolic links files.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png"
 	},
 	{
 		"id": "linkify-user-edit-history-popup",
 		"description": "Linkifies the username in the edit history popup.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png"
 	},
 	{
 		"id": "linkify-user-labels",
 		"description": "Links the \"Contributor\" and \"Member\" labels on comments to the author’s commits on the repo.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png"
 	},
 	{
 		"id": "linkify-user-location",
 		"description": "Linkifies the user location in their hovercard and profile page.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262554067-43bea584-cdb4-41c7-b0fa-f487e7ef8807.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/262554067-43bea584-cdb4-41c7-b0fa-f487e7ef8807.png"
 	},
 	{
 		"id": "list-prs-for-branch",
 		"description": "On branch commit lists, shows the PR that touches the current branch.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/119760295-b8751a80-be77-11eb-87da-91d0c403bb49.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/119760295-b8751a80-be77-11eb-87da-91d0c403bb49.png"
 	},
 	{
 		"id": "list-prs-for-file",
 		"description": "Alerts you if the current file is altered by an open PR.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/234559302-b9911ac2-a1bb-4f8a-8e88-078d631cde18.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/234559302-b9911ac2-a1bb-4f8a-8e88-078d631cde18.png"
 	},
 	{
 		"id": "locked-issue",
 		"description": "Show a label on locked issues and PRs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png"
 	},
 	{
 		"id": "mark-merge-commits-in-list",
@@ -540,8 +478,7 @@
 	{
 		"id": "more-conversation-filters",
 		"description": "Adds <code>Everything you’re involved in</code> and <code>Everything you subscribed to</code> filters in the search box dropdown.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253043952-cfb99cea-1c7b-43ad-9144-9d84bda8206f.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253043952-cfb99cea-1c7b-43ad-9144-9d84bda8206f.png"
 	},
 	{
 		"id": "more-dropdown-links",
@@ -552,32 +489,27 @@
 	{
 		"id": "more-file-links",
 		"description": "Adds links to view the raw version, the blame, and the history of files in PRs and commits.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png"
 	},
 	{
 		"id": "netiquette",
 		"description": "Adds unobtrusive netiquette reminders (old closed issues, highly-active issues, draft PRs, …).",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/226551766-0e1b6b15-65a3-427e-8bb5-9ea7873993be.png"
 	},
 	{
 		"id": "new-or-deleted-file",
 		"description": "Indicates with an icon whether files in commits and PRs are being added or removed.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png"
 	},
 	{
 		"id": "new-repo-disable-projects-and-wikis",
 		"description": "Automatically disables projects and wikis when creating a repository.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177040449-73fde2a5-98e2-4583-8f32-905d1c4bfd20.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177040449-73fde2a5-98e2-4583-8f32-905d1c4bfd20.png"
 	},
 	{
 		"id": "no-duplicate-list-update-time",
 		"description": "Hides the update time of issues/PRs in lists when it matches the open/closed/merged time.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png"
 	},
 	{
 		"id": "no-unnecessary-split-diff-view",
@@ -588,8 +520,7 @@
 	{
 		"id": "one-click-diff-options",
 		"description": "Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: <kbd>d</kbd> <kbd>w</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png"
 	},
 	{
 		"id": "one-click-pr-or-gist",
@@ -600,20 +531,17 @@
 	{
 		"id": "one-click-review-submission",
 		"description": "Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/236627732-df341ff7-cd98-4cd0-a579-722d1fffa5cf.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/236627732-df341ff7-cd98-4cd0-a579-722d1fffa5cf.png"
 	},
 	{
 		"id": "one-key-formatting",
 		"description": "Wraps selected text when pressing one of Markdown symbols instead of replacing it: <code>[</code> `<code> </code> `<code> </code>'<code> </code>\"<code> </code><em><code> </code>~<code> </code><em>`</em></em>",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261155564-e7aabd0e-b14b-4fe6-b379-62e7419c43f8.gif",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261155564-e7aabd0e-b14b-4fe6-b379-62e7419c43f8.gif"
 	},
 	{
 		"id": "open-all-conversations",
 		"description": "Lets you open all visible issues/PRs at once.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/110980658-5face000-8366-11eb-88f9-0cc94f75ce57.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/110980658-5face000-8366-11eb-88f9-0cc94f75ce57.gif"
 	},
 	{
 		"id": "open-all-notifications",
@@ -624,14 +552,12 @@
 	{
 		"id": "open-issue-to-latest-comment",
 		"description": "Makes the \"comment\" icon in issue lists link to the latest comment of the issue.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261159396-0610574b-ab1f-42fb-813f-ee7310a1e5b6.png"
 	},
 	{
 		"id": "pagination-hotkey",
 		"description": "Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "parse-backticks",
@@ -642,14 +568,12 @@
 	{
 		"id": "patch-diff-links",
 		"description": "Adds links to <code>.patch</code> and <code>.diff</code> files in commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png"
 	},
 	{
 		"id": "pinned-issues-update-time",
 		"description": "Replaces the \"opened\" time with the \"updated\" time on pinned issues.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/240707405-e416be14-5ab5-4869-b33c-f43aab7afcb6.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/240707405-e416be14-5ab5-4869-b33c-f43aab7afcb6.png"
 	},
 	{
 		"id": "pr-approvals-count",
@@ -665,62 +589,52 @@
 	{
 		"id": "pr-branch-auto-delete",
 		"description": "Automatically deletes the branch right after merging a PR, if possible.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/177067141-eabc7494-38a2-45b5-aef9-ac33cc0da370.png"
 	},
 	{
 		"id": "pr-commit-lines-changed",
 		"description": "Adds diff stats on PR commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253130044-494cd822-c460-42dc-8f65-44454a9d18e3.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253130044-494cd822-c460-42dc-8f65-44454a9d18e3.png"
 	},
 	{
 		"id": "pr-filters",
 		"description": "Adds Checks and Draft PR dropdown filters in PR lists.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253068868-6afb4656-4ef5-4846-89c5-24dc6ee7f839.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253068868-6afb4656-4ef5-4846-89c5-24dc6ee7f839.png"
 	},
 	{
 		"id": "pr-first-commit-title",
 		"description": "Uses the first commit for a new PR’s title and description.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif"
 	},
 	{
 		"id": "pr-jump-to-first-non-viewed-file",
 		"description": "Jumps to first non-viewed file in a PR when clicking on the progress bar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011208-764f509d-fed9-424b-84e9-c01cf2fd428b.gif",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011208-764f509d-fed9-424b-84e9-c01cf2fd428b.gif"
 	},
 	{
 		"id": "pr-notification-link",
 		"description": "Points PR notifications to the Conversation tabs instead of the commits page, which may be a 404.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/621f6512-655e-4565-a37b-2b159ea0ffce",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/621f6512-655e-4565-a37b-2b159ea0ffce"
 	},
 	{
 		"id": "prevent-comment-loss",
 		"description": "While writing/editing comments, open the preview links in new tab instead of navigating away from the page.",
-		"screenshot": "https://user-images.githubusercontent.com/17681399/282616531-2befcabe-5c80-4b9a-bfb5-7b9917847bb5.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/17681399/282616531-2befcabe-5c80-4b9a-bfb5-7b9917847bb5.gif"
 	},
 	{
 		"id": "prevent-duplicate-pr-submission",
 		"description": "Avoids creating duplicate PRs when mistakenly clicking \"Create pull request\" more than once.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif"
 	},
 	{
 		"id": "prevent-link-loss",
 		"description": "Suggests fixing links that are wrongly shortened by GitHub.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260087535-a0f19995-5f4a-44e9-87d8-cf742b9bfeed.gif",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260087535-a0f19995-5f4a-44e9-87d8-cf742b9bfeed.gif"
 	},
 	{
 		"id": "prevent-pr-merge-panel-opening",
 		"description": "Prevents the merge panel from automatically opening on every page load after it’s been opened once.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "preview-hidden-comments",
@@ -731,44 +645,37 @@
 	{
 		"id": "previous-next-commit-buttons",
 		"description": "Adds duplicate commit navigation buttons at the bottom of the <code>Commits</code> tab page.",
-		"screenshot": "https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png"
 	},
 	{
 		"id": "previous-version",
 		"description": "Lets you see the previous version of a file in one click.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/bc82cc77-bde2-4683-98a6-012c87b4a319",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/bc82cc77-bde2-4683-98a6-012c87b4a319"
 	},
 	{
 		"id": "profile-gists-link",
 		"description": "Adds a link to the user’s public gists on their profile.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png"
 	},
 	{
 		"id": "profile-hotkey",
 		"description": "Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "pull-request-hotkeys",
 		"description": "Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd>, and <kbd>g</kbd> <kbd>4</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png"
 	},
 	{
 		"id": "quick-comment-edit",
 		"description": "Lets you edit any comment with one click instead of having to open a dropdown.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png"
 	},
 	{
 		"id": "quick-comment-hiding",
 		"description": "Simplifies the UI to hide comments.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif"
 	},
 	{
 		"id": "quick-file-edit",
@@ -791,8 +698,7 @@
 	{
 		"id": "quick-new-issue",
 		"description": "Adds a link to create issues from anywhere in a repository.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/274816033-820ec518-049d-4248-9f8a-27b9423e350b.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/274816033-820ec518-049d-4248-9f8a-27b9423e350b.png"
 	},
 	{
 		"id": "quick-repo-deletion",
@@ -803,14 +709,12 @@
 	{
 		"id": "quick-review",
 		"description": "Adds quick-review buttons to the PR sidebar, automatically focuses the review textarea, and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.",
-		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/f11039c4-c9d1-4adc-9a65-cfe1f2027ec3",
-		"css": false
+		"screenshot": "https://github.com/refined-github/refined-github/assets/1402241/f11039c4-c9d1-4adc-9a65-cfe1f2027ec3"
 	},
 	{
 		"id": "quick-review-comment-deletion",
 		"description": "Adds a button to delete review comments in one click when editing them.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/115445792-9fdd6900-a216-11eb-9ba3-6dab4d2f9d32.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/46634000/115445792-9fdd6900-a216-11eb-9ba3-6dab4d2f9d32.png"
 	},
 	{
 		"id": "reactions-avatars",
@@ -821,8 +725,7 @@
 	{
 		"id": "refined-github.css",
 		"description": "Reduces tabs’ size to 4 spaces instead of 8 where GitHub doesn't follow the user’s preferences.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png",
-		"css": false
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png"
 	},
 	{
 		"id": "release-download-count",
@@ -833,44 +736,37 @@
 	{
 		"id": "releases-dropdown",
 		"description": "Adds a tags dropdown/search on tag/release pages.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/231678527-f0a96112-9c30-4b49-8205-efa472bd880e.png"
 	},
 	{
 		"id": "releases-tab",
 		"description": "Adds a <code>Releases</code> tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.",
-		"screenshot": "https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png",
-		"css": false
+		"screenshot": "https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png"
 	},
 	{
 		"id": "reload-failed-proxied-images",
 		"description": "Retries downloading images that failed downloading due to GitHub limited proxying.",
-		"screenshot": "https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png"
 	},
 	{
 		"id": "repo-age",
 		"description": "Displays the age of the repository in the sidebar.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252176778-f8260312-d0dc-41b5-a4d1-ca680208d347.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252176778-f8260312-d0dc-41b5-a4d1-ca680208d347.png"
 	},
 	{
 		"id": "repo-avatars",
 		"description": "Adds the profile picture to the header of public repositories.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/255323568-aee4d90e-844e-41e8-880a-ce466826516c.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/255323568-aee4d90e-844e-41e8-880a-ce466826516c.png"
 	},
 	{
 		"id": "repo-header-info",
 		"description": "Shows whether a repo is a fork and adds the number of stars to its header.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png"
 	},
 	{
 		"id": "repo-wide-file-finder",
 		"description": "Enables the File Finder keyboard shortcut (<kbd>t</kbd>) on entire repository.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "resolve-conflicts",
@@ -885,8 +781,7 @@
 	{
 		"id": "same-branch-author-commits",
 		"description": "Preserves current branch and path when viewing all commits by an author.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png"
 	},
 	{
 		"id": "scrollable-areas",
@@ -897,8 +792,7 @@
 	{
 		"id": "select-all-notifications-shortcut",
 		"description": "Adds a shortcut to select all visible notifications: <kbd>a</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "select-notifications",
@@ -908,14 +802,12 @@
 	{
 		"id": "selection-in-new-tab",
 		"description": "Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "shorten-links",
 		"description": "Shortens URLs and repo URLs to readable references like \"<em>user/repo/.file@<code>d71718d</code>\".</em>",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png"
 	},
 	{
 		"id": "show-associated-branch-prs-on-fork",
@@ -932,14 +824,12 @@
 	{
 		"id": "show-open-prs-of-forks",
 		"description": "In your forked repos, shows number of your open PRs to the original repo.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252177140-94165582-628b-45b6-9a62-faf0c7fc2335.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252177140-94165582-628b-45b6-9a62-faf0c7fc2335.png"
 	},
 	{
 		"id": "show-user-top-repositories",
 		"description": "Adds a link to the user’s most starred repositories.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png"
 	},
 	{
 		"id": "show-whitespace",
@@ -949,14 +839,12 @@
 	{
 		"id": "small-user-avatars",
 		"description": "Shows a small avatar next to the username in issue/PR lists and mentions.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/271184107-24ec471e-54d1-434a-a5f2-615902d2cad9.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/271184107-24ec471e-54d1-434a-a5f2-615902d2cad9.png"
 	},
 	{
 		"id": "sort-conversations-by-update-time",
 		"description": "Changes the default sort order of issues/PRs to <code>Recently updated</code>.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "status-subscription",
@@ -984,14 +872,12 @@
 	{
 		"id": "stop-redirecting-in-notification-bar",
 		"description": "Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png"
 	},
 	{
 		"id": "submission-via-ctrl-enter-everywhere",
 		"description": "Enables submission via <kbd>ctrl</kbd> <kbd>enter</kbd> on every page possible.",
-		"screenshot": null,
-		"css": false
+		"screenshot": null
 	},
 	{
 		"id": "suggest-commit-title-limit",
@@ -1002,20 +888,17 @@
 	{
 		"id": "swap-branches-on-compare",
 		"description": "Adds a link to swap branches in the branch compare view.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/230370539-ebc94246-864f-48f2-85fa-7318fc1f6d71.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/44045911/230370539-ebc94246-864f-48f2-85fa-7318fc1f6d71.png"
 	},
 	{
 		"id": "sync-pr-commit-title",
 		"description": "Uses the PR’s title as the default squash commit title and updates the PR’s title to match the commit title, if changed.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011579-25332762-b25f-407b-b6d2-bbfc13de2be7.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011579-25332762-b25f-407b-b6d2-bbfc13de2be7.png"
 	},
 	{
 		"id": "tab-to-indent",
 		"description": "Enables <kbd>tab</kbd> and <kbd>shift</kbd> <kbd>tab</kbd> for indentation in comment fields.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif"
 	},
 	{
 		"id": "table-input",
@@ -1032,14 +915,12 @@
 	{
 		"id": "tags-on-commits-list",
 		"description": "Displays the corresponding tags next to commits.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/285106537-3c882cb2-6847-4098-9e51-cf2951dee818.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/285106537-3c882cb2-6847-4098-9e51-cf2951dee818.png"
 	},
 	{
 		"id": "toggle-everything-with-alt",
 		"description": "Adds a shortcut to toggle all similar items (minimized comments, deferred diffs, etc) at once: <kbd>alt</kbd> <kbd>click</kbd> on each button or checkbox.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253063446-6f556e7d-2ac5-439d-92f0-0c6d719fc86f.gif",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253063446-6f556e7d-2ac5-439d-92f0-0c6d719fc86f.gif"
 	},
 	{
 		"id": "toggle-files-button",
@@ -1050,32 +931,27 @@
 	{
 		"id": "unfinished-comments",
 		"description": "Notifies the user of unfinished comments in hidden tabs.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif"
 	},
 	{
 		"id": "unreleased-commits",
 		"description": "Tells you whether you're looking at the latest version of a repository, or if there are any unreleased commits.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267236196-8564c193-a3c7-4248-9735-54749c1990c7.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267236196-8564c193-a3c7-4248-9735-54749c1990c7.png"
 	},
 	{
 		"id": "unwrap-unnecessary-dropdowns",
 		"description": "Makes some dropdowns 1-click instead of unnecessarily 2-click.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258554504-97d4079a-2aae-4aea-a870-653a267494a8.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/258554504-97d4079a-2aae-4aea-a870-653a267494a8.png"
 	},
 	{
 		"id": "update-pr-from-base-branch",
 		"description": "Adds an \"Update branch\" button to every PR. GitHub has the same feature, but it must be manually configured with protected branches.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/234483592-4867cb2e-21cb-436d-9ea0-aedadf834f19.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/234483592-4867cb2e-21cb-436d-9ea0-aedadf834f19.png"
 	},
 	{
 		"id": "useful-not-found-page",
 		"description": "Adds possible related pages and alternatives on 404 pages.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png"
 	},
 	{
 		"id": "user-local-time",
@@ -1086,8 +962,7 @@
 	{
 		"id": "user-profile-follower-badge",
 		"description": "On profiles, it shows whether the user follows you.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263206287-c8e1b94c-ec80-4394-bbb3-1cf6fb08b807.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/263206287-c8e1b94c-ec80-4394-bbb3-1cf6fb08b807.png"
 	},
 	{
 		"id": "vertical-front-matter",
@@ -1098,20 +973,17 @@
 	{
 		"id": "view-last-pr-deployment",
 		"description": "Adds a link to open the latest deployment from the header of a PR.",
-		"screenshot": "https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/44045911/232313171-b54ac9cc-ebb1-43ef-bd41-5d81ec9f9588.png"
 	},
 	{
 		"id": "visit-tag",
 		"description": "When navigating a repo's file on a specific tag, it adds a link to see the release/tag itself.",
-		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png",
-		"css": false
+		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png"
 	},
 	{
 		"id": "warn-pr-from-master",
 		"description": "Warns you when creating a PR from the default branch, as it’s an anti-pattern.",
-		"screenshot": "https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png",
-		"css": false
+		"screenshot": "https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png"
 	},
 	{
 		"id": "warning-for-disallow-edits",

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -40,7 +40,8 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 		description: parseMarkdown(linkLessMarkdownDescription),
 		// `null` makes the keys visible in the JSON file
 		screenshot: urls.find(url => screenshotRegex.test(url)) ?? null,
-		css: existsSync(`source/features/${simpleId}.css`),
+		// `undefined` hides the key when CSS is missing
+		css: existsSync(`source/features/${simpleId}.css`) || undefined,
 	};
 }
 

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -37,11 +37,11 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 	const linkLessMarkdownDescription = simpleDescription.replaceAll(/\[(.+?)]\((.+?)\)/g, urlExtracter);
 	return {
 		id: simpleId as FeatureID,
+		css: existsSync(`source/features/${simpleId}.css`) || undefined,
 		description: parseMarkdown(linkLessMarkdownDescription),
 		// `null` makes the keys visible in the JSON file
 		screenshot: urls.find(url => screenshotRegex.test(url)) ?? null,
 		// `undefined` hides the key when CSS is missing
-		css: existsSync(`source/features/${simpleId}.css`) || undefined,
 	};
 }
 

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -1,7 +1,7 @@
 /// <reference types="../source/globals.js" />
 
 import regexJoin from 'regex-join';
-import {readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import parseMarkdown from 'snarkdown';
 
 // Group names must be unique because they will be merged
@@ -40,6 +40,7 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 		description: parseMarkdown(linkLessMarkdownDescription),
 		// `null` makes the keys visible in the JSON file
 		screenshot: urls.find(url => screenshotRegex.test(url)) ?? null,
+		css: existsSync(`source/features/${simpleId}.css`),
 	};
 }
 

--- a/build/readme-parser.ts
+++ b/build/readme-parser.ts
@@ -37,11 +37,11 @@ function extractDataFromMatch(match: RegExpMatchArray): FeatureMeta {
 	const linkLessMarkdownDescription = simpleDescription.replaceAll(/\[(.+?)]\((.+?)\)/g, urlExtracter);
 	return {
 		id: simpleId as FeatureID,
-		css: existsSync(`source/features/${simpleId}.css`) || undefined,
 		description: parseMarkdown(linkLessMarkdownDescription),
+		// `undefined` hides the key when CSS is missing
+		css: existsSync(`source/features/${simpleId}.css`) || undefined,
 		// `null` makes the keys visible in the JSON file
 		screenshot: urls.find(url => screenshotRegex.test(url)) ?? null,
-		// `undefined` hides the key when CSS is missing
 	};
 }
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -4,8 +4,6 @@ import AlertIcon from 'octicons-plain-react/Alert';
 import CopyIcon from 'octicons-plain-react/Copy';
 import InfoIcon from 'octicons-plain-react/Info';
 
-import {$} from 'select-dom';
-
 import features from '../feature-manager.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import {featuresMeta, getNewFeatureName} from '../feature-data.js';
@@ -18,14 +16,13 @@ import {isFeaturePrivate} from '../helpers/feature-utils.js';
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
 	const isCss = location.pathname.endsWith('.css');
-	const isCssOnly = isCss ? !$(`li[id="source/features/${id}.tsx-item"]`) : false;
 
 	const description = meta?.description // Regular feature?
 	?? (
 		isFeaturePrivate(id)
 			? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
 			: (
-				isCssOnly
+				isCss
 					? 'This feature is CSS-only and cannot be disabled.'
 					: undefined // The heck!?
 			)
@@ -66,9 +63,9 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						{
 							meta && isCss
 								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
-								: isCssOnly
-									? undefined
-									: <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
+								: meta?.css
+									? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
+									: undefined
 						}
 					</div>
 				</div>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -18,13 +18,15 @@ import {isFeaturePrivate} from '../helpers/feature-utils.js';
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
 	const isCss = location.pathname.endsWith('.css');
+	const cssElement = $(`li[id="source/features/${id}.css-item"]`);
+	const isCssOnly = cssElement && cssElement.getAttribute('aria-current') === 'true';
 
 	const description = meta?.description // Regular feature?
 	?? (
 		isFeaturePrivate(id)
 			? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
 			: (
-				isCss
+				isCssOnly
 					? 'This feature is CSS-only and cannot be disabled.'
 					: undefined // The heck!?
 			)
@@ -37,8 +39,6 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
 	newIssueUrl.searchParams.set('title', `\`${id}\`: `);
 	newIssueUrl.searchParams.set('labels', 'bug, help wanted');
-
-	const hasCss = $(`li[id="source/features/${id}.css-item"]`);
 
 	infoBanner.before(
 		// Block and width classes required to avoid margin collapse
@@ -67,7 +67,7 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						{
 							meta && isCss
 								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
-								: hasCss
+								: cssElement && !isCssOnly
 									? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
 									: undefined
 						}

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -4,6 +4,8 @@ import AlertIcon from 'octicons-plain-react/Alert';
 import CopyIcon from 'octicons-plain-react/Copy';
 import InfoIcon from 'octicons-plain-react/Info';
 
+import {$} from 'select-dom';
+
 import features from '../feature-manager.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import {featuresMeta, getNewFeatureName} from '../feature-data.js';
@@ -36,6 +38,8 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 	newIssueUrl.searchParams.set('title', `\`${id}\`: `);
 	newIssueUrl.searchParams.set('labels', 'bug, help wanted');
 
+	const hasCss = $(`li[id="source/features/${id}.css-item"]`);
+
 	infoBanner.before(
 		// Block and width classes required to avoid margin collapse
 		<div className="Box mb-3 d-inline-block width-full">
@@ -63,7 +67,9 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						{
 							meta && isCss
 								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
-								: undefined
+								: hasCss
+									? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
+									: undefined
 						}
 					</div>
 				</div>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -18,8 +18,7 @@ import {isFeaturePrivate} from '../helpers/feature-utils.js';
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
 	const isCss = location.pathname.endsWith('.css');
-	const cssElement = $(`li[id="source/features/${id}.css-item"]`);
-	const isCssOnly = cssElement && cssElement.getAttribute('aria-current') === 'true';
+	const isCssOnly = isCss ? !$(`li[id="source/features/${id}.tsx-item"]`) : false;
 
 	const description = meta?.description // Regular feature?
 	?? (
@@ -67,9 +66,9 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						{
 							meta && isCss
 								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
-								: cssElement && !isCssOnly
-									? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
-									: undefined
+								: isCssOnly
+									? undefined
+									: <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
 						}
 					</div>
 				</div>

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -11,6 +11,7 @@ interface FeatureMeta {
 	id: FeatureID;
 	description: string;
 	screenshot: string | null; // eslint-disable-line @typescript-eslint/ban-types -- We use `null` in the JSON file
+	css?: boolean;
 }
 
 // These types are unnecessarily loose

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -11,7 +11,7 @@ interface FeatureMeta {
 	id: FeatureID;
 	description: string;
 	screenshot: string | null; // eslint-disable-line @typescript-eslint/ban-types -- We use `null` in the JSON file
-	css?: boolean;
+	css?: true;
 }
 
 // These types are unnecessarily loose


### PR DESCRIPTION
Closes: #7724 

## Test URLs

- Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
- CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.css
- RGH feature: https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
- CSS-only feature: https://github.com/refined-github/refined-github/blob/main/source/features/center-reactions-popup.css

## Screenshot

![CleanShot 2024-08-23 at 09 13 48@2x](https://github.com/user-attachments/assets/ffedbea5-1b60-45e6-8c04-ce605901cc34)

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/1f0f9cbc-e04d-44de-91e9-2cd602e1884d">
