### PR TITLE
`default-branch-button` - Stop shortening branch name

### DIFF
--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,4 +1,0 @@
-/* Reduce excessive width on long branch names, this is also a GitHub bug */
-.rgh-default-branch-button-group [data-component='text'] {
-	max-width: 80px;
-}

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -1,4 +1,3 @@
-import './default-branch-button.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import ChevronLeftIcon from 'octicons-plain-react/ChevronLeft';

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -100,5 +100,6 @@ Test URLs:
 - isRepoCommitList: https://github.com/refined-github/refined-github/commits/07ecc75/
 - isRepoCommitList (already on default branch): https://github.com/typed-ember/ember-cli-typescript/commits/master
 - isRepoCommitListRoot (no branch selector): https://github.com/refined-github/refined-github/commits/07ecc75/extension
+- `isRepoHome`, long branch name: https://github.com/refined-github/sandbox/tree/very-very-long-long-long-long-branch-name
 
 */


### PR DESCRIPTION
closes: #7681 

I think it doesn't need to set width. Github seem already handle this situation.

## Screenshot

<img width="1620" alt="截屏2024-08-23 10 21 46" src="https://github.com/user-attachments/assets/ab6a353c-b997-442d-b8f1-9fb8b6e600ce">
