### PR TITLE
Bump minimum Firefox version to 126

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -9,11 +9,11 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "{a4c4eda4-fb84-4a84-b4a1-f7c1cbf2a1ad}",
-			"strict_min_version": "124.0"
+			"strict_min_version": "126.0"
 		},
 		"gecko_android": {
 			"id": "{a4c4eda4-fb84-4a84-b4a1-f7c1cbf2a1ad}",
-			"strict_min_version": "124.0"
+			"strict_min_version": "126.0"
 		}
 	},
 	"permissions": [


### PR DESCRIPTION
I think Firefox won't show a "Preferences" link because `options_page` is not supported until Firefox 126 (🤦‍♂️)

I can't use `options_ui` as a "fallback" because it takes priority over `options_page`

Related:

- https://github.com/refined-github/refined-github/issues/7732