### PR TITLE
Avoid uploading source code to AMO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,6 @@ jobs:
     environment: Firefox
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Zip source code
-        run: |
-          git archive --output source.zip HEAD ":!safari" ":!test" ":!.github"
-          zip -ju source.zip build/AMO_BUILD_INSTRUCTIONS
-          unzip -l source.zip
-
       - uses: actions/download-artifact@v4
 
       # Firefox https://github.com/refined-github/refined-github/issues/7477
@@ -84,7 +77,7 @@ jobs:
       - run: npm run manifest artifact 2
 
       - name: Upload build and source code
-        run: npx web-ext@8 sign --channel listed --upload-source-code ../source.zip
+        run: npx web-ext@8 sign --channel listed
         working-directory: artifact
         env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}


### PR DESCRIPTION
- Thanks to https://github.com/refined-github/refined-github/pull/7472
- Related to https://github.com/refined-github/refined-github/issues/7750

The source code is super readable now, no bundler junk. Look at this beauty. We're basically shipping the source code.

<img width="937" alt="Screenshot 6" src="https://github.com/user-attachments/assets/0188f2cc-b3ce-4701-9346-57ec5ae7509d">
