### PR TITLE
Meta: Keep build active after syntax error

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,7 +57,12 @@ const rollup = {
 				{find: 'react', replacement: 'dom-chef'},
 			],
 		}),
-		typescript({compilerOptions: {module: 'Node16'}}),
+		typescript({
+			compilerOptions: {
+				noEmitOnError: !process.env.ROLLUP_WATCH,
+				module: 'Node16',
+			},
+		}),
 		resolve({browser: true}),
 		commonjs(),
 		copy({


### PR DESCRIPTION
You can see the first video. I make an error in code and then I fix it. But the `distribution/assets` folder doesn't  generate this time. It means the build failed. So whetever you reload the page or fix the error, extension will not update anymore.

## Screenshot

before:

https://github.com/user-attachments/assets/e08d24ff-670e-46da-89ff-688fe5940e19

after:


https://github.com/user-attachments/assets/a373d4cf-a4d2-4144-8191-05818ba05db1

