### PR TITLE
Create release as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           FILENAME="$PROJECT_NAME-$DAILY_VERSION-for-local-testing-only.zip"
           zip -r "$FILENAME" ./*
-          gh release create "$DAILY_VERSION" --generate-notes "$FILENAME"
+          # Create as draft to curate it before sending it out
+          gh release create "$DAILY_VERSION" "$FILENAME" --draft --generate-notes
   Chrome:
     if: needs.Version.outputs.created
     needs: Version


### PR DESCRIPTION
For https://github.com/refined-github/refined-github/issues/7763

I always clean up and extend the release notes before sending out a new release, so it's better to hold it before sending out notification emails.