### PR TITLE
`rgh-feature-descriptions` - Fix overlap of "Feature disabled"

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -86,7 +86,8 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 }
 
 async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {
-	const classes = ['mb-3 d-inline-block width-full'];
+	// Block and width classes required to avoid margin collapse
+	const classes = ['mb-3', 'd-inline-block', 'width-full'];
 	// Skip dev check present in `getLocalHotfixes`, we want to see this even when developing
 	const hotfixes = await brokenFeatures.get() ?? [];
 	const hotfixed = hotfixes.find(([feature]) => feature === id);

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -135,8 +135,8 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 	// This ID exists whether the feature is documented or not
 	const id = meta?.id ?? filename;
 
-	addDescription(infoBanner, id, meta);
 	await addDisabledBanner(infoBanner, id);
+	addDescription(infoBanner, id, meta);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -86,7 +86,7 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 }
 
 async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {
-	const classes = ['mb-3'];
+	const classes = ['mb-3 d-inline-block width-full'];
 	// Skip dev check present in `getLocalHotfixes`, we want to see this even when developing
 	const hotfixes = await brokenFeatures.get() ?? [];
 	const hotfixed = hotfixes.find(([feature]) => feature === id);
@@ -135,8 +135,8 @@ async function add(infoBanner: HTMLElement): Promise<void> {
 	// This ID exists whether the feature is documented or not
 	const id = meta?.id ?? filename;
 
-	await addDisabledBanner(infoBanner, id);
 	addDescription(infoBanner, id, meta);
+	await addDisabledBanner(infoBanner, id);
 }
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
Closes: #7765 

## Test URL

https://github.com/refined-github/refined-github/blob/main/source/features/table-input.tsx

## Screenshot

before:

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/4235fe3f-cad1-4538-87cc-0776be2b43e7">

after:

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/70ce90d7-ebeb-4fb0-88c0-82954c249c4a">
