### PR TITLE
`cross-deleted-pr-branches` - Restore feature

### DIFF
--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -21,7 +21,7 @@ function init(): void | false {
 	const deletedBranchName = lastBranchAction.textContent.trim();
 	const repoRootUrl = headReferenceLink?.href.split('/', 5).join('/');
 	for (const element of $$('.commit-ref')) {
-		const branchName = element.textContent.trim();
+		const branchName = element.textContent.trim().split(':').pop()!;
 		if (branchName === deletedBranchName) {
 			element.title = 'This branch has been deleted';
 


### PR DESCRIPTION
Closes: #7708 


## Test URLs

- deleted branch: https://github.com/refined-github/refined-github/pull/576
- deleted branch (from fork): https://github.com/refined-github/refined-github/pull/872
- restored branch (on fork): https://github.com/refined-github/refined-github/pull/909
- deleted repository: https://github.com/refined-github/refined-github/pull/271
- deleted repository on open PR: https://github.com/yakov116/TestR/pull/7
- deleted repository with no deleted branch https://github.com/jquery/jquery/pull/769

## Screenshot

https://github.com/user-attachments/assets/841eb449-921c-461d-a777-0ddce12ea689
