### PR TITLE
`conventional-commits` - Various fixes

### DIFF
--- a/source/features/conventional-commits.css
+++ b/source/features/conventional-commits.css
@@ -3,6 +3,16 @@
 	line-height: 1.5;
 }
 
+/* Default color from `wontfix` label. Also applies to `chore`  because it's the most common and meaningless type of commit */
+[rgh-conventional-commits] {
+	--label-r: 255;
+	--label-g: 255;
+	--label-b: 255;
+	--label-h: 0;
+	--label-s: 0;
+	--label-l: 100;
+}
+
 /* Color from `enhancement` label */
 [rgh-conventional-commits='feat'] {
 	--label-r: 162;
@@ -21,16 +31,6 @@
 	--label-h: 353;
 	--label-s: 66;
 	--label-l: 53;
-}
-
-/* Color from `wontfix` label. Just white because it's the most common and meaningless type of commit */
-[rgh-conventional-commits='chore'] {
-	--label-r: 255;
-	--label-g: 255;
-	--label-b: 255;
-	--label-h: 0;
-	--label-s: 0;
-	--label-l: 100;
 }
 
 /* Color from `documentation` label */

--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -20,8 +20,9 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 		<span className="IssueLabel hx_IssueLabel mr-2" rgh-conventional-commits={commit.rawType}>
 			{commit.type}
 		</span>,
+
 		// Keep scope outside because that's how they're rendered in release notes as well
-		commit.scope ? <span style={{opacity: 0.7}}>{commit.scope}</span> : '',
+		commit.scope ? <span className="color-fg-muted">{commit.scope}</span> : '',
 	);
 
 	removeTextInTextNode(textNode, conventionalCommitRegex);

--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -5,7 +5,8 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {commitTitleInLists} from '../github-helpers/selectors.js';
-import {parseConventionalCommit, removeCommitAndScope} from '../helpers/conventional-commits.js';
+import {conventionalCommitRegex, parseConventionalCommit} from '../helpers/conventional-commits.js';
+import {removeTextInTextNode} from '../helpers/dom-utils.js';
 
 function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 	const textNode = commitTitleElement.firstChild!;
@@ -23,7 +24,7 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 		commit.scope ? <span style={{opacity: 0.7}}>{commit.scope}</span> : '',
 	);
 
-	removeCommitAndScope(textNode);
+	removeTextInTextNode(textNode, conventionalCommitRegex);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/helpers/conventional-commits.ts
+++ b/source/helpers/conventional-commits.ts
@@ -1,12 +1,12 @@
-import {assertNodeContent} from './dom-utils.js';
-
 // Using https://www.conventionalcommits.org/ as a reference.
-const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+)\))?(?<major>!)?: /;
+export const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+)\))?(?<major>!)?: /;
 
 const types = new Map([
 	['feat', 'Feature'],
 	['fix', 'Fix'],
 	['chore', 'Chore'],
+	['revert', 'Revert'],
+	['style', 'Style'],
 	['docs', 'Docs'],
 	['build', 'Build'],
 	['refactor', 'Refactor'],
@@ -38,13 +38,4 @@ export function parseConventionalCommit(commitTitle: string): {
 		scope: scope ? `${scope}: ` : undefined,
 		raw: match[0],
 	};
-}
-
-/**
-Remove the raw commit prefix from the single text node.
-Note: It does not support pre-formatted titles like: fix(#1 `x`)
-*/
-export function removeCommitAndScope(textNode: Text | ChildNode): void {
-	assertNodeContent(textNode, conventionalCommitRegex);
-	textNode.textContent = textNode.textContent.replace(conventionalCommitRegex, '');
 }

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -93,8 +93,8 @@ export const isTextNodeContaining = (node: Nullable<Text | ChildNode>, expectati
 		throw new TypeError(`Expected Text node, received ${String(node?.nodeName)}`);
 	}
 
-	const content = node.textContent.trim();
-	return matchString(expectation, content);
+	// The string/regex may expect spaces, like for `conventional-commits`
+	return matchString(expectation, node.textContent) || matchString(expectation, node.textContent.trim());
 };
 
 export const assertNodeContent = <N extends Text | ChildNode>(node: Nullable<N>, expectation: RegExp | string): N => {
@@ -111,3 +111,8 @@ export const removeTextNodeContaining = (node: Text | ChildNode, expectation: Re
 	assertNodeContent(node, expectation);
 	node.remove();
 };
+
+export function removeTextInTextNode(node: Text | ChildNode, text: RegExp | string): void {
+	assertNodeContent(node, text);
+	node.textContent = node.textContent.replace(text, '');
+}


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/7813
- Will close https://github.com/refined-github/refined-github/issues/7814

## Tasks

- [x] fix support for <code>feat: \`backticks\`</code>
- [x] add support for `style:` and `revert:`

## Test URLs

- https://github.com/refined-github/sandbox/commits/conventional-commits/
- https://github.com/conventional-changelog/standard-version/commits

## Demo

<img width="338" alt="Screenshot 6" src="https://github.com/user-attachments/assets/5acd79e2-2048-4863-bff3-b341ab923dd7">
