### PR TITLE
`embed-gist-inline` - Restore feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"push-form": "^1.0.1",
 				"regex-join": "^2.1.0",
 				"select-dom": "^9.0.0",
+				"serialize-error": "^11.0.3",
 				"shorten-repo-url": "^5.2.0",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^4.1.1",
@@ -427,7 +428,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -9009,6 +9010,33 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/serialize-error": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+			"integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^2.12.2"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serialize-error/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"push-form": "^1.0.1",
 		"regex-join": "^2.1.0",
 		"select-dom": "^9.0.0",
+		"serialize-error": "^11.0.3",
 		"shorten-repo-url": "^5.2.0",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^4.1.1",

--- a/source/background.ts
+++ b/source/background.ts
@@ -33,10 +33,6 @@ handleMessages({
 	async closeTab(_: any, {tab}: chrome.runtime.MessageSender) {
 		void chrome.tabs.remove(tab!.id!);
 	},
-	async fetch(url: string) {
-		const response = await fetch(url);
-		return response.text();
-	},
 	async fetchJSON(url: string) {
 		const response = await fetch(url);
 		return response.json();

--- a/source/background.ts
+++ b/source/background.ts
@@ -50,10 +50,16 @@ const messageHandlers = {
 	// They must return a promise to mark the message as handled
 } satisfies Record<string, (...arguments_: any[]) => Promise<any>>;
 
-chrome.runtime.onMessage.addListener((message: typeof messageHandlers, sender): Promise<unknown> | void => {
+chrome.runtime.onMessage.addListener((message: typeof messageHandlers, sender, sendResponse): true | void => {
 	for (const id of objectKeys(message)) {
 		if (id in messageHandlers) {
-			return messageHandlers[id](message[id], sender);
+			messageHandlers[id](message[id], sender).then(sendResponse, error => {
+				sendResponse({error});
+				throw error;
+			});
+
+			// Chrome does not support returning a promise
+			return true;
 		}
 	}
 });

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -24,6 +24,7 @@ import {
 	_,
 } from './helpers/hotfix.js';
 import asyncForEach from './helpers/async-for-each.js';
+import {messageBackground} from './helpers/messaging.js';
 
 type CallerFunction = (callback: VoidFunction, signal: AbortSignal) => void | Promise<void> | Deinit;
 type FeatureInitResult = void | false;
@@ -139,7 +140,7 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 
 	// Request in the background page to avoid showing a 404 request in the console
 	// https://github.com/refined-github/refined-github/issues/6433
-	void chrome.runtime.sendMessage({getStyleHotfixes: true}).then(applyStyleHotfixes);
+	void messageBackground<string>({getStyleHotfixes: true}).then(applyStyleHotfixes);
 
 	if (options.customCSS.trim().length > 0) {
 		// Review #5857 and #5493 before making changes

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -69,8 +69,9 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 			link.parentElement!.after(container);
 			info.remove();
 		}
-	} catch {
+	} catch (error) {
 		info.remove();
+		throw error;
 	}
 }
 

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -7,6 +7,7 @@ import features from '../feature-manager.js';
 import {getCleanPathname} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {standaloneGistLinkInMarkdown} from '../github-helpers/selectors.js';
+import {messageBackground} from '../helpers/messaging.js';
 
 type GistData = {
 	div: string;
@@ -17,7 +18,7 @@ type GistData = {
 // Fetch via background.js due to CORB policies. Also memoize to avoid multiple requests.
 const fetchGist = mem(
 	async (url: string): Promise<GistData> =>
-		chrome.runtime.sendMessage({fetchJSON: `${url}.json`}),
+		messageBackground({fetchJSON: `${url}.json`}),
 );
 
 function parseGistLink(link: HTMLAnchorElement): string | undefined {

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -17,6 +17,7 @@ import looseParseInt from '../helpers/loose-parse-int.js';
 import parseBackticks from '../github-helpers/parse-backticks.js';
 import observe from '../helpers/selector-observer.js';
 import {expectToken, expectTokenScope} from '../github-helpers/github-token.js';
+import {messageBackground} from '../helpers/messaging.js';
 
 function handleToggle(event: DelegateEvent<Event, HTMLDetailsElement>): void {
 	const hasContent = elementExists([
@@ -124,7 +125,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 	$('.application-main')!.remove();
 	if (document.hidden) {
 		// Try closing the tab if in the background. Could fail, so we still update the UI above
-		void chrome.runtime.sendMessage({closeTab: true});
+		void messageBackground({closeTab: true});
 	}
 }
 

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -3,6 +3,7 @@ import onetime from 'onetime';
 
 import features from '../feature-manager.js';
 import {registerHotkey} from '../github-helpers/hotkey.js';
+import {messageBackground} from '../helpers/messaging.js';
 
 function openInNewTab(): void {
 	const selected = $('.navigation-focus a.js-navigation-open[href]');
@@ -10,7 +11,7 @@ function openInNewTab(): void {
 		return;
 	}
 
-	void chrome.runtime.sendMessage({
+	void messageBackground({
 		openUrls: [selected.href],
 	});
 

--- a/source/helpers/messaging.ts
+++ b/source/helpers/messaging.ts
@@ -1,0 +1,31 @@
+import {serializeError, deserializeError} from 'serialize-error';
+
+/** They must return a promise to mark the message as handled */
+export type MessageHandlers = Record<string, (...arguments_: any[]) => Promise<any>>;
+
+export function handleMessages(handlers: MessageHandlers): void {
+	chrome.runtime.onMessage.addListener((message: typeof handlers, sender, sendResponse): true | void => {
+		for (const id of Object.keys(message)) {
+			if (id in handlers) {
+				handlers[id](message[id], sender).then(sendResponse, error => {
+					sendResponse({$$error: serializeError(error)});
+					throw error;
+				});
+
+				// Chrome does not support returning a promise
+				return true;
+			}
+		}
+	});
+}
+
+export async function messageBackground<Return>(message: Record<string, unknown>): Promise<Return> {
+	const response = await chrome.runtime.sendMessage(message);
+	if (response?.$$error) {
+		throw new Error(response.$$error.message, {
+			cause: deserializeError(response.$$error),
+		});
+	}
+
+	return response;
+}

--- a/source/helpers/open-options.ts
+++ b/source/helpers/open-options.ts
@@ -1,4 +1,6 @@
+import {messageBackground} from './messaging.js';
+
 export default function openOptions(event: Event): void {
 	event.preventDefault();
-	void chrome.runtime.sendMessage({openOptionsPage: true});
+	void messageBackground({openOptionsPage: true});
 }

--- a/source/helpers/open-tabs.ts
+++ b/source/helpers/open-tabs.ts
@@ -1,12 +1,13 @@
 import showToast from '../github-helpers/toast.js';
 import pluralize from '../helpers/pluralize.js';
+import {messageBackground} from './messaging.js';
 
 export default async function openTabs(urls: string[]): Promise<boolean> {
 	if (urls.length >= 10 && !confirm(`This will open ${urls.length} new tabs. Continue?`)) {
 		return false;
 	}
 
-	const response = chrome.runtime.sendMessage({
+	const response = messageBackground({
 		openUrls: urls,
 	});
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7781

https://github.com/refined-github/refined-github/pull/7482 in v24.6.25 broke a few features that depended on the background worker, for example style hotfixes (😱) because Chrome is the only browser that _still_ can't handle promises in `onMessage`.


## Tasks

- [x] Restore error handling
- [x] Check what else has been broken

## Demo

<img width="687" alt="Screenshot 6" src="https://github.com/user-attachments/assets/b57de999-859f-4f28-93ad-73a87a083db3">

## Demo error

<img width="494" alt="Screenshot 5" src="https://github.com/user-attachments/assets/51932de2-8943-407a-8209-fb825e6401a2">


