### PR TITLE
`pr-branch-auto-delete` - Exclude `staging`

### DIFF
--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -24,6 +24,7 @@ const exceptions = [
 	'pre',
 	'prod',
 	'stage',
+	'staging',
 	/production/,
 	/^release\//,
 	/^v\d/,


### PR DESCRIPTION
I am adding `staging` as a common branch type for the pr-auto-delete exception branch list. Like `production` `staging` is also similarly used for the branch before prod. 