### PR TITLE
Fix: `repo-age` cache issue when 1st commit is overridden

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -71,6 +71,7 @@ const firstCommit = new CachedFunction('first-commit', {
 		return getRepoAge(commitSha, commitsCount);
 	},
 	cacheKey: cacheByRepo,
+	maxAge: {days: 30},
 });
 
 async function init(): Promise<void> {


### PR DESCRIPTION
Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #7840

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
https://github.com/stephenjason89/bun-pulse/commit/60bc5c1f16e0f19590793169932603d0b5e6931e

3. If applicable, add demonstrative screenshots or gifs
<img width="198" alt="image" src="https://github.com/user-attachments/assets/0b509a48-c5dc-463a-b712-530984045783">

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/bb632905-4b0a-460e-99e5-250df71196e7">

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.