### PR TITLE
`hide-interaction-limits-warning` - Remove the interaction limits warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,7 @@ Thanks for contributing! 🦋🙌
 - [](# "clean-readme-url") [Drops redundant "readme-ov-file" parameter from repo URLs.](https://github.com/refined-github/refined-github/assets/1402241/73e96411-3314-4501-a9b6-d006af6fcc47)
 - [](# "click-outside-modal") [Closes checks list when clicking outside of modal.](https://github.com/refined-github/refined-github/issues/7157)
 - [](# "linkify-line-numbers") [Linkifies the line numbers where GitHub forgot to add links.](https://github.com/refined-github/refined-github/assets/1402241/d5b67f4e-35c3-45d8-b72c-937b855168c3)
+- [](# "hide-interaction-limits-warning") Removes the temporary interaction limits warning from organization repository homepage.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/hide-interaction-limits-warning.tsx
+++ b/source/features/hide-interaction-limits-warning.tsx
@@ -1,0 +1,28 @@
+import {$} from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+import {getRepo} from '../github-helpers/index.js';
+
+function init(): void {
+	const {owner} = getRepo()!;
+	const settingsLinkElement = $(`[href$="/organizations/${owner}/settings/interaction_limits"]`);
+	settingsLinkElement!.parentElement!.parentElement!.parentElement!.parentElement!.remove();
+}
+
+void features.add(import.meta.url, {
+	include: [pageDetect.isOrganizationRepo, pageDetect.isRepoHome],
+	awaitDomReady: true,
+	init,
+});
+
+/*
+
+Test URLs:
+
+Any organization repository homepage https://github.com/refined-github/refined-github
+
+Only visible to organization maintainers
+Need the feature to be enabled on organization level https://github.com/organizations/refined-github/settings/interaction_limits
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -162,6 +162,7 @@ import './features/esc-to-cancel.js';
 import './features/easy-toggle-files.js';
 import './features/quick-repo-deletion.js';
 import './features/clean-repo-sidebar.js';
+import './features/hide-interaction-limits-warning.js';
 import './features/rgh-feature-descriptions.js';
 import './features/archive-forks-link.js';
 import './features/link-to-changelog-file.js';


### PR DESCRIPTION
## Test URLs

Any organization repository homepage https://github.com/refined-github/refined-github

This warning message is only visible to organization maintainers. Need the feature to be enabled on organization level: https://github.com/organizations/refined-github/settings/interaction_limits
