### PR TITLE
`conventional-commit` - Add support for type `meta`

### DIFF
--- a/source/helpers/conventional-commits.ts
+++ b/source/helpers/conventional-commits.ts
@@ -13,6 +13,7 @@ const types = new Map([
 	['test', 'Test'],
 	['ci', 'CI'],
 	['perf', 'Performance'],
+	['meta', 'Meta'],
 ]);
 
 export function parseConventionalCommit(commitTitle: string): {


### PR DESCRIPTION
This PR adds support for the type `meta` in `conventional-commit`. 
No need for a special color. The default, used for `chore`, `style` and `revert`, will do just fine imo.

## Test URLs

https://github.com/sequelize/sequelize/commits/main/

## Screenshot

Will add later
