### PR TITLE
`default-branch-button` - Fix pink button on GHE

### DIFF
--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,5 +1,5 @@
 /* TODO: Revert https://github.com/refined-github/refined-github/pull/7859 in March 2025 */
-/* The `details` version is for GHE. The `button` in the selector avoids a GHE conflict */
+/* The `details` version is for GHE. The `button` in the selector avoids a GHE conflict. `fuchsia` is to higlight broken styles. */
 button.rgh-highlight-non-default-branch,
 details.rgh-highlight-non-default-branch > summary {
 	background-color: var(

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,11 +1,17 @@
 button.rgh-highlight-non-default-branch,
-details.rgh-highlight-non-default-branch> summary {
-	background-color: var(--bgColor-accent-muted, var(--color-accent-subtle, fuchsia)) !important;
+details.rgh-highlight-non-default-branch > summary {
+	background-color: var(
+		--bgColor-accent-muted,
+		var(--color-accent-subtle, fuchsia)
+	) !important;
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
-	border-color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
+	border-color: var(
+		--fgColor-accent,
+		var(--color-accent-fg, fuchsia)
+	) !important;
 }
 
 button.rgh-highlight-non-default-branch svg,
-details.rgh-highlight-non-default-branch> summary svg {
+details.rgh-highlight-non-default-branch > summary svg {
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,9 +1,9 @@
-.rgh-highlight-non-default-branch {
-	background-color: var(--bgColor-accent-muted, fuchsia) !important;
-	color: var(--fgColor-accent, fuchsia) !important;
-	border-color: var(--fgColor-accent, fuchsia) !important;
+button.rgh-highlight-non-default-branch, details.rgh-highlight-non-default-branch>summary  {
+	background-color: var(--bgColor-accent-muted, var(--color-accent-subtle, fuchsia)) !important ;
+	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
+	border-color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }
 
-.rgh-highlight-non-default-branch svg {
-	color: var(--fgColor-accent, fuchsia) !important;
+button.rgh-highlight-non-default-branch svg, details.rgh-highlight-non-default-branch>summary svg {
+	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,9 +1,11 @@
-button.rgh-highlight-non-default-branch, details.rgh-highlight-non-default-branch>summary  {
-	background-color: var(--bgColor-accent-muted, var(--color-accent-subtle, fuchsia)) !important ;
+button.rgh-highlight-non-default-branch,
+details.rgh-highlight-non-default-branch> summary  {
+	background-color: var(--bgColor-accent-muted, var(--color-accent-subtle, fuchsia)) !important;
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 	border-color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }
 
-button.rgh-highlight-non-default-branch svg, details.rgh-highlight-non-default-branch>summary svg {
+button.rgh-highlight-non-default-branch svg,
+details.rgh-highlight-non-default-branch> summary svg {
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,5 +1,5 @@
 button.rgh-highlight-non-default-branch,
-details.rgh-highlight-non-default-branch> summary  {
+details.rgh-highlight-non-default-branch> summary {
 	background-color: var(--bgColor-accent-muted, var(--color-accent-subtle, fuchsia)) !important;
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 	border-color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,3 +1,5 @@
+/* TODO: Revert https://github.com/refined-github/refined-github/pull/7859 in March 2025 */
+/* The `details` version is for GHE. The `button` in the selector avoids a GHE conflict */
 button.rgh-highlight-non-default-branch,
 details.rgh-highlight-non-default-branch > summary {
 	background-color: var(


### PR DESCRIPTION
Adding old css variables and tweaking the selectors so this doesn't render incorrectly on older GHES platforms.

Fixes #7857

## Test URLs
https://github.com/refined-github/refined-github/tree/sandbox/keep-branch?rgh-link-date=2024-10-04T15%3A40%3A11Z

## Screenshot
https://github.com/refined-github/refined-github/issues/7857#issuecomment-2394150829