### PR TITLE
`more-conversation-filters` - Fix error on new beta view

### DIFF
--- a/source/features/more-conversation-filters.tsx
+++ b/source/features/more-conversation-filters.tsx
@@ -7,9 +7,9 @@ import SearchQuery from '../github-helpers/search-query.js';
 
 function init(): void {
 	const sourceItem = $('#filters-select-menu a:nth-last-child(2)');
-
-	if (!sourceItem)
+	if (!sourceItem) {
 		return;
+	}
 
 	// "Involved" filter
 	const commentsLink = sourceItem.cloneNode(true);

--- a/source/features/more-conversation-filters.tsx
+++ b/source/features/more-conversation-filters.tsx
@@ -1,13 +1,15 @@
 import {$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {stringToBase64} from 'uint8array-extras';
-import elementReady from 'element-ready';
 
 import features from '../feature-manager.js';
 import SearchQuery from '../github-helpers/search-query.js';
 
 function init(): void {
-	const sourceItem = $('#filters-select-menu a:nth-last-child(2)')!;
+	const sourceItem = $('#filters-select-menu a:nth-last-child(2)');
+
+	if (!sourceItem)
+		return;
 
 	// "Involved" filter
 	const commentsLink = sourceItem.cloneNode(true);
@@ -33,16 +35,7 @@ function init(): void {
 	commentsLink.after(subscriptionsLink);
 }
 
-// The page below doesn't have the filters menu
-// https://github.com/tc39/proposal-await.ops/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen
-async function hasFilters(): Promise<boolean> {
-	return Boolean(await elementReady('#filters-select-menu', {waitForChildren: false}));
-}
-
 void features.add(import.meta.url, {
-	asLongAs: [
-		hasFilters,
-	],
 	include: [
 		pageDetect.isRepoIssueOrPRList,
 	],

--- a/source/features/more-conversation-filters.tsx
+++ b/source/features/more-conversation-filters.tsx
@@ -1,6 +1,7 @@
 import {$} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import {stringToBase64} from 'uint8array-extras';
+import elementReady from 'element-ready';
 
 import features from '../feature-manager.js';
 import SearchQuery from '../github-helpers/search-query.js';
@@ -32,7 +33,16 @@ function init(): void {
 	commentsLink.after(subscriptionsLink);
 }
 
+// The page below doesn't have the filters menu
+// https://github.com/tc39/proposal-await.ops/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen
+async function hasFilters(): Promise<boolean> {
+	return Boolean(await elementReady('#filters-select-menu', {waitForChildren: false}));
+}
+
 void features.add(import.meta.url, {
+	asLongAs: [
+		hasFilters,
+	],
 	include: [
 		pageDetect.isRepoIssueOrPRList,
 	],


### PR DESCRIPTION
Closes: #7856 

Because our test page doesn't have `#filters-select-menu`, so it throws an error.

## Test URLs

https://github.com/tc39/proposal-await.ops/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen

## Screenshot

<img width="843" alt="image" src="https://github.com/user-attachments/assets/483e7f67-80a8-4132-a26a-5d02d12dd4cf">

<img width="574" alt="image" src="https://github.com/user-attachments/assets/28a94571-4eaa-4efc-95cc-1bf39ec7e74a">
