### PR TITLE
`clean-conversation-filters` - Add support for new beta view

### DIFF
--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -43,25 +43,32 @@ function getCount(element: HTMLElement): number {
 	return Number(element.textContent.trim());
 }
 
-const MILESTONE_SELECTORS = ['#milestones-select-menu', '[data-testid="action-bar-item-milestones"]'];
-const PROJECT_SELECTORS = ['#project-select-menu', '[data-testid="action-bar-item-projects"]'];
+const milestonesSelectors = [
+	'#milestones-select-menu', // TODO: Drop in March 2025
+	'[data-testid="action-bar-item-milestones"]',
+];
+const projectSelectors = [
+	'#project-select-menu', // TODO: Drop in March 2025
+	'[data-testid="action-bar-item-projects"]',
+];
 
 async function hide(container: HTMLElement): Promise<void> {
 	const milestones = $('[data-selected-links^="repo_milestones"] .Counter');
 	if (milestones && getCount(milestones) === 0) {
-		$(MILESTONE_SELECTORS, container)?.remove();
+		$(milestonesSelectors, container)?.remove();
 	}
 
-	if (await hasAnyProjects.get()) {
-		return;
+	if (!await hasAnyProjects.get()) {
+		const projectsDropdown = $(projectSelectors, container);
+		projectsDropdown!.remove();
 	}
-
-	const projectsDropdown = $(PROJECT_SELECTORS, container);
-	projectsDropdown?.remove();
 }
 
 function init(signal: AbortSignal): void {
-	observe(['#js-issues-toolbar', '[data-testid="list-view-metadata"]'], hide, {signal});
+	observe([
+		'#js-issues-toolbar', // TODO: Remove after March 2025
+		'[data-testid="list-view-metadata"]',
+	], hide, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -53,6 +53,8 @@ const projectSelectors = [
 ];
 
 async function hide(container: HTMLElement): Promise<void> {
+	// TODO: Drop in March 2025
+	// The new beta view doesn't have the count selector, maybe we should do it like the projects
 	const milestones = $('[data-selected-links^="repo_milestones"] .Counter');
 	if (milestones && getCount(milestones) === 0) {
 		$(milestonesSelectors, container)?.remove();

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -87,7 +87,7 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Has conversations: https://github.com/refined-github/refined-github/pulls
-- No conversations: https://github.com/fregante/empty/pulls
+- No projects: https://github.com/left-pad/left-pad/issues
+- Projects and milestones (no-op): https://github.com/tc39/ecma402/issues
 
 */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -149,6 +149,7 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 }
 
 /* Hide label on Milestones link if there are zero milestones #5120 */
+/* TODO: Drop in March 2025 if they don't add it to https://github.com/tc39/ecma402/issues */
 [data-selected-links^='repo_milestones ']:has([title='0']) {
 	width: 36px; /* Size it so only the icon is visible */
 	overflow: hidden; /* Crop the text out */


### PR DESCRIPTION
Closes: #7856

## Test URLs

https://github.com/tc39/proposal-await.ops/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen

## Screenshot


<img width="1275" alt="image" src="https://github.com/user-attachments/assets/e61384ed-65d3-4999-abe5-7379647fed7c">

👆 this is the usual page

👇 this is the new view

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/36056f3f-929a-410c-bf20-8d061c6368fc">

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/5dd539c6-dc24-4222-9b8f-58245e028c2b">
