### PR TITLE
`release-download-count` - Fix misalignment 

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,5 +1,5 @@
 /* Simulates fixed columns */
-.rgh-release-download-count > span {
+.rgh-release-download-count > span:not(:last-child) {
 	flex-basis: 0 !important;
 	min-width: 6em;
 }

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,10 +1,15 @@
 /* Simulates fixed columns */
 .rgh-release-download-count > span:not(:last-child) {
 	flex-basis: 0 !important;
-	min-width: 6em;
+	min-width: 5em;
 }
 
-/* Makes space for right aligning download count */
+/* Date */
+.rgh-release-download-count > span:last-child {
+	min-width: 7em;
+}
+
+/* Right-align on mobile */
 .rgh-release-download-count [data-rgh-heat] {
 	min-width: 5em;
 }

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -51,11 +51,10 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 			.closest('.Box-row')!
 			.querySelector(':scope > .flex-justify-end > :first-child')!;
 
+		assetSize.classList.replace('text-sm-left', 'text-md-right');
 		assetSize.parentElement!.classList.add('rgh-release-download-count');
 
 		const classes = new Set(assetSize.classList);
-		classes.delete('text-sm-left');
-
 		if (downloadCount === 0) {
 			classes.add('v-hidden');
 		}


### PR DESCRIPTION
Fixes #7579.

## Test URLs
https://github.com/dnicolson/Home-Screen-Layout/releases/tag/v0.1.0
https://github.com/cli/cli/releases/tag/v2.30.0

## Screenshot
| Before | After |
|--------|-------|
| ![PixelSnap 2024-10-09 at 18 52 08@2x](https://github.com/user-attachments/assets/91a92536-091a-48b7-a9c0-9fe8b21a1f33)| ![PixelSnap 2024-10-09 at 18 52 31@2x](https://github.com/user-attachments/assets/0b50dbc3-4438-469f-8738-180c7a425d08) |
| ![PixelSnap 2024-10-09 at 18 51 44@2x](https://github.com/user-attachments/assets/29dad592-cd08-486c-b35a-48c231773ebf) | ![PixelSnap 2024-10-09 at 18 52 38@2x](https://github.com/user-attachments/assets/04412f81-3fe2-4bba-8126-6772ae5de5fa) |

This also fixes timestamps when there are downloads:
| Before | After |
|--------|-------|
| ![PixelSnap 2024-10-09 at 19 50 29@2x](https://github.com/user-attachments/assets/4c7b50cd-eeea-4353-a672-ab64925b973d) | ![PixelSnap 2024-10-09 at 19 50 51@2x](https://github.com/user-attachments/assets/23b50b2b-e5ed-42c3-a88a-ba2b9d72b708) |
