### PR TITLE
`select-notifications` - Improve spacing and alignment

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -127,7 +127,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 
 const createDropdown = onetime(() => (
 	<details
-		className="details-reset details-overlay position-relative rgh-select-notifications mx-2"
+		className="details-reset details-overlay position-relative rgh-select-notifications mr-2"
 		onToggle={resetFilters}
 	>
 		<summary
@@ -162,7 +162,10 @@ function closeDropdown(): void {
 }
 
 function addDropdown(markAllPrompt: Element): void {
-	markAllPrompt.closest('label')!.after(createDropdown());
+	markAllPrompt.closest('label')!.after(
+		<span className="mx-2">·</span>,
+		createDropdown(),
+	);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -161,15 +161,17 @@ function closeDropdown(): void {
 	$('.rgh-select-notifications')?.removeAttribute('open');
 }
 
-function addDropdown(markAllPrompt: Element): void {
-	markAllPrompt.closest('label')!.after(
-		<span className="mx-2">·</span>,
+function addDropdown(selectAllCheckbox: HTMLInputElement): void {
+	selectAllCheckbox.style.verticalAlign = '-0.2em'; // #7852
+	selectAllCheckbox.closest('label')!.after(
+		// `h6` matches "Select all" style
+		<span className="mx-2 h6">·</span>,
 		createDropdown(),
 	);
 }
 
 function init(signal: AbortSignal): void {
-	observe('.js-notifications-mark-all-prompt', addDropdown, {signal});
+	observe('input.js-notifications-mark-all-prompt', addDropdown, {signal});
 
 	// Close the dropdown when one of the toolbar buttons is clicked
 	delegate(['.js-notifications-mark-selected-actions > *', '.rgh-open-selected-button'], 'click', closeDropdown, {signal});


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7852

This is specifically an iOS issue because the OS' checkbox pushes the "Select all" label a bit lower. Exaggerated example via `vertical-align: super`:

<img width="291" alt="Screenshot 4" src="https://github.com/user-attachments/assets/fc36d418-3bd4-4e09-b354-c79550616155">


`vertical-align` fixes this issue and also aligns it better on Chrome. You can see how this reduces the first box' height:

![regular](https://github.com/user-attachments/assets/44105831-5541-44b0-922e-d213cf418261)


A better solution would be to use `align-items: baseline` on the entire line, but we do want them to be centered. There's no `center baseline` option, apparently.

In this PR I'm also adding a dot to better separate the two buttons.


## Test URLs

https://github.com/notifications

## Screenshot

Safari:

<img width="198" alt="Screenshot 7" src="https://github.com/user-attachments/assets/6ccb34b6-70d1-4384-94a0-3a2693f82340">

Chrome:

<img width="198" alt="Screenshot" src="https://github.com/user-attachments/assets/3b3126df-5cac-4d80-a812-0719b1f4270c">
