### PR TITLE
`netiquette` - Support new text fields (partial)

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -117,8 +117,13 @@ function makeFieldKinder(field: HTMLParagraphElement): void {
 	}
 }
 
+function makeReactFieldKinder(field: HTMLTextAreaElement): void {
+	field.placeholder = 'Add your comment here, be kind';
+}
+
 function initKindness(signal: AbortSignal): void {
 	observe('p.CommentBox-placeholder', makeFieldKinder, {signal});
+	observe('textarea[placeholder="Use Markdown to format your comment"]', makeReactFieldKinder, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- For #7886 


## Test URLs

- https://togithub.com/eslint/eslint/issues/19013

## Before

<img width="686" alt="Screenshot 8" src="https://github.com/user-attachments/assets/7a03fa6b-f679-48a9-9848-89d5f9ba21ee">

## After

<img width="686" alt="Screenshot 7" src="https://github.com/user-attachments/assets/63fc6c97-6c0c-4e84-84e0-14698b1b37af">

