### PR TITLE
`patch-diff-links` - Support new commit view

### DIFF
--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -15,7 +15,7 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 
 	commitMeta!.classList.remove('no-wrap'); // #5987
 	commitMeta!.prepend(
-		<span className="sha-block ml-2" data-turbo="false">
+		<span className="sha-block" data-turbo="false">
 			<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
 			{' '}
 			<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
@@ -26,7 +26,7 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.commit-meta > span:last-child', // TODO remove in March 2025
+		'.commit-meta > span:last-child', // `isPRCommit` + old `isSingleCommit`
 		'[class*="commit-header-actions"] + div pre',
 	], addPatchDiffLinks, {signal});
 }

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -25,8 +25,8 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.commit-meta', // It works in PR commit, but not in regular commit
-		'pre:has([data-hovercard-url])', // beta regular commit view
+		'.commit-meta', // TODO remove in March 2025
+		'pre:has([data-hovercard-url])',
 	], addPatchDiffLinks, {signal});
 }
 
@@ -37,7 +37,6 @@ void features.add(import.meta.url, {
 	exclude: [
 		pageDetect.isPRCommit404,
 	],
-	deduplicate: 'has-rgh-inner',
 	init,
 });
 

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -14,19 +14,20 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 	}
 
 	commitMeta!.classList.remove('no-wrap'); // #5987
-	commitMeta!.append(
+	commitMeta!.prepend(
 		<span className="sha-block ml-2" data-turbo="false">
 			<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
 			{' '}
 			<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
 		</span>,
+		<span className="px-2">·</span>,
 	);
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.commit-meta', // TODO remove in March 2025
-		'pre:has([data-hovercard-url])',
+		'.commit-meta > span:last-child', // TODO remove in March 2025
+		'[class*="commit-header-actions"] + div pre',
 	], addPatchDiffLinks, {signal});
 }
 


### PR DESCRIPTION
- part of #7808 


## Test URLs

- Commit:https://github.com/refined-github/refined-github/commit/132272786fdc058193e089d8c06f2a158844e101
- PR Commit: [`07ddf83` (#7751)](https://github.com/refined-github/refined-github/pull/7751/commits/07ddf838c211075701e9a681ab061a158b05ee79)


## Screenshot

<img width="830" alt="image" src="https://github.com/user-attachments/assets/092e6d42-8db5-4b07-ade3-480518191771">

<img width="838" alt="image" src="https://github.com/user-attachments/assets/89a558aa-ea67-465f-8542-01b71cfcba1f">



https://github.com/user-attachments/assets/91528850-34c7-4f0f-be5a-5b663800ccb6

