### PR TITLE
`linkify-user-labels` - Support new issue view

### DIFF
--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -21,6 +21,8 @@ function init(signal: AbortSignal): void {
 	observe([
 		'.tooltipped[aria-label*="a member of the"]',
 		'.tooltipped[aria-label^="This user has previously committed"]',
+		'span[data-testid=comment-author-association][aria-label*="a member of the"]',
+		'span[data-testid=comment-author-association][aria-label^="This user has previously committed"]',
 	], linkify, {signal});
 }
 

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -19,10 +19,11 @@ function linkify(label: Element): void {
 
 function init(signal: AbortSignal): void {
 	observe([
+		'span[data-testid="comment-author-association"][aria-label*="a member of the"]',
+		'span[data-testid="comment-author-association"][aria-label^="This user has previously committed"]',
+		// PRs and pre-issue redesign 2024
 		'.tooltipped[aria-label*="a member of the"]',
 		'.tooltipped[aria-label^="This user has previously committed"]',
-		'span[data-testid=comment-author-association][aria-label*="a member of the"]',
-		'span[data-testid=comment-author-association][aria-label^="This user has previously committed"]',
 	], linkify, {signal});
 }
 

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -19,8 +19,8 @@ Note: Bots are used as `name[bot]`, `app/name`, or `apps/name` depending on the 
 */
 export default function getCommentAuthor(anyElementInsideComment: Element): string {
 	const avatar: HTMLImageElement = anyElementInsideComment
-		.closest(['.TimelineItem', '.review-comment'])!
-		.querySelector(['.TimelineItem-avatar img', 'img.avatar'])!;
+		.closest(['.TimelineItem', '.review-comment', '.react-issue-comment'])!
+		.querySelector(['.TimelineItem-avatar img', 'img.avatar', 'img[data-testid=github-avatar]'])!;
 
 	const name = avatar
 		.alt // Occasionally ends with `[bot]`

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -19,8 +19,16 @@ Note: Bots are used as `name[bot]`, `app/name`, or `apps/name` depending on the 
 */
 export default function getCommentAuthor(anyElementInsideComment: Element): string {
 	const avatar: HTMLImageElement = anyElementInsideComment
-		.closest(['.TimelineItem', '.review-comment', '.react-issue-comment'])!
-		.querySelector(['.TimelineItem-avatar img', 'img.avatar', 'img[data-testid=github-avatar]'])!;
+		.closest([
+			'.TimelineItem', // PR comments (and pre-issue redesign issue comments)
+			'.review-comment', // PR review comments
+			'.react-issue-comment', // Issue comments
+		])!
+		.querySelector([
+			'.TimelineItem-avatar img', // PR comments (and pre-issue redesign issue comments)
+			'img.avatar', // PR review comments
+			'img[data-testid="github-avatar"]', // Issue comments
+		])!;
 
 	const name = avatar
 		.alt // Occasionally ends with `[bot]`


### PR DESCRIPTION
part of #7856 

## Test URLs

https://github.com/download-directory/download-directory.github.io/issues/141

---

This PR fixes the `linkify-user-labels` feature in the new issue view.

The new Ui doesn't seem to have a lot of usable classes or IDs so I used `data-testid` but I  am not sure how much sense this makes. 

I really like this project and would like to contribute a bit more, so please let me know what I can improve!