### PR TITLE
`unreleased-commits` - Only show "Create release" if allowed

### DIFF
--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -98,7 +98,7 @@ async function createLink(
 
 async function createLinkGroup(latestTag: string, aheadBy: number): Promise<HTMLElement> {
 	const link = await createLink(latestTag, aheadBy);
-	if (!userHasPushAccess()) {
+	if (!(await userHasPushAccess())) {
 		return link;
 	}
 


### PR DESCRIPTION
Closes #7919.

Based on testing in browser console on Firefox 130.0.1 on macOS/arm64, and via this Stack Overflow post: https://stackoverflow.com/a/43243161