### PR TITLE
Improve options page style 

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -187,6 +187,14 @@ export default antfu(
 			'unicorn/filename-case': 'off',
 		},
 	},
+	{
+		files: [
+			'**/*.svelte',
+		],
+		rules: {
+			'import/prefer-default-export': 'off',
+		},
+	},
 	// https://eslint.org/docs/latest/use/configure/ignore#ignoring-files
 	{
 		ignores: ['safari'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ const rollup = {
 	input: {
 		'options': './source/options.tsx',
 		'welcome': './source/welcome.svelte',
+		'header': './source/options/header.svelte',
 		'background': './source/background.ts',
 		'refined-github': './source/refined-github.ts',
 		'content-script': './source/content-script.ts',

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -43,8 +43,8 @@ function resetFilters({target}: React.SyntheticEvent): void {
 	}
 }
 
-function getFiltersSelector(formData: FormData, category: Category): string {
-	return formData.getAll(category).map(value => filters[value as Filter]).join(',');
+function getFiltersSelector(formData: FormData, category: Category): string[] {
+	return formData.getAll(category).map(value => filters[value as Filter]);
 }
 
 function handleSelection({target}: Event): void {

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -30,7 +30,7 @@ function init(signal: AbortSignal): void {
 	delegate([
 		'#issue_title',
 		'#pull_request_title',
-	].join(', '), 'input', validatePrTitle, {signal, passive: true});
+	], 'input', validatePrTitle, {signal, passive: true});
 }
 
 void features.add(import.meta.url, {

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -52,7 +52,7 @@ export default class SearchQuery {
 	private queryParts: string[];
 
 	constructor(url: string | URL, base?: string) {
-		this.url = new URL(String(url), base);
+		this.url = typeof url === 'string' ? new URL(url, base) : url;
 		this.queryParts = [];
 
 		const currentQuery = this.url.searchParams.get('q');

--- a/source/options.css
+++ b/source/options.css
@@ -4,6 +4,20 @@
 
 :root {
 	--rgh-red: #cf222e;
+	--content-width: 750px;
+	--viewport-margin: 30px;
+
+	max-width: none;
+}
+
+body {
+	margin: 0;
+}
+
+form {
+	max-width: var(--content-width);
+	margin: auto;
+	padding-block: 1em;
 }
 
 html::after {
@@ -23,6 +37,10 @@ html::after {
 
 p {
 	margin-top: 0;
+}
+
+p:last-child {
+	margin-bottom: 0;
 }
 
 ul {
@@ -56,10 +74,12 @@ details[open] {
 summary {
 	--summary-padding: 10px;
 
-	background: #aaa1;
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	background: light-dark(#f9f9f9, #272727);
 	list-style: none;
 	padding: var(--summary-padding);
-	cursor: pointer;
 }
 
 summary::-webkit-details-marker {
@@ -67,7 +87,7 @@ summary::-webkit-details-marker {
 }
 
 summary:hover {
-	background: #aaa4;
+	background: light-dark(#e9e9e9, #353535);
 }
 
 details[open] summary {
@@ -77,10 +97,6 @@ details[open] summary {
 
 details[open] > :not(summary) {
 	margin-left: 10px;
-}
-
-#info summary {
-	font-size: 2em;
 }
 
 [data-validation]::before {

--- a/source/options.html
+++ b/source/options.html
@@ -6,17 +6,19 @@
 <link rel="shortcut icon" href="icon.png">
 <title>Refined GitHub options</title>
 <link rel="stylesheet" href="options.css">
-<script type="module"src="options.js" defer></script>
+<script type="module" src="header.js"></script>
+<script type="module" src="options.js" defer></script>
+<rgh-header title="Refined GitHub">
+	<p>
+		Visit the <a href="https://github.com/refined-github/refined-github/wiki">wiki</a> to learn about updates, debugging, and GitHub Enterprise.
+		You can <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
+		Follow or sponsor <a href="https://github.com/sponsors/fregante">@fregante</a> if Refined GitHub helps you work more efficiently. 🍻
+	</p>
+</rgh-header>
+
 <div id="js-failed">JavaScript failed to load. Your development build failed or your browser has some issue.</div>
+
 <form id="options-form" class="detail-view-container">
-	<details id="info" open>
-		<summary><img src="icon.png" alt="" width="24" height="24"> Refined GitHub</summary>
-		<p>
-			Visit the <a href="https://github.com/refined-github/refined-github/wiki">welcome page</a> to learn about updates, debugging, and GitHub Enterprise.
-			You can <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
-			Follow or sponsor <a href="https://github.com/sponsors/fregante">@fregante</a> if Refined GitHub helps you work more efficiently. 🍻
-		</p>
-	</details>
 
 	<details id="token">
 		<summary><strong>🔑 Personal token</strong></summary>

--- a/source/options/header.css
+++ b/source/options/header.css
@@ -1,0 +1,26 @@
+header {
+	background-color: light-dark(#f6f8fa, #02040a);
+	border-bottom: solid 1px light-dark(#d2d9e0, #3d444d);
+	padding-block: 30px;
+	display: grid;
+	gap: 1em;
+
+	& > * {
+		width: 100%;
+		padding-inline: var(--viewport-margin);
+		max-width: var(--content-width);
+		margin: auto;
+	}
+}
+
+h1 {
+	display: flex;
+	gap: 0.4em;
+	font-size: clamp(1.3em, 5vw, 2em);
+	font-weight: 200;
+
+	img {
+		height: 1.3em;
+		width: 1.3em;
+	}
+}

--- a/source/options/header.svelte
+++ b/source/options/header.svelte
@@ -1,0 +1,22 @@
+<svelte:options customElement={{
+	tag: 'rgh-header',
+	props: {
+		title: {type: 'String', attribute: 'title'},
+	},
+}} />
+
+<link rel='stylesheet' href='header.css'>
+<script>
+	import './header.css';
+
+	export let title;
+</script>
+<header>
+	<h1>
+		<img src='icon.png' alt="" height='32'>
+		{title}
+	</h1>
+	<div>
+		<slot />
+	</div>
+</header>

--- a/source/welcome.css
+++ b/source/welcome.css
@@ -15,32 +15,16 @@ main {
 	margin-bottom: 2em;
 }
 
-header {
-	background-color: light-dark(#f6f8fa, #02040a);
-	border-bottom: solid 1px light-dark(#d2d9e0, #3d444d);
-	padding-block: 30px;
-}
-
 footer {
 	margin-top: 50px;
 }
 
-h1 {
-	font-size: clamp(1.3em, 5vw, 2em);
+h2 {
+	font-size: clamp(1.2em, 4vw, 1.5em);
 	padding-inline: var(--viewport-margin);
 	max-width: var(--content-width);
 	font-weight: 200;
 	margin: auto;
-
-	img {
-		height: 1.3em;
-		width: 1.3em;
-	}
-
-	header & {
-		display: flex;
-		gap: 0.4em;
-	}
 }
 
 ul {

--- a/source/welcome.html
+++ b/source/welcome.html
@@ -15,6 +15,7 @@
 		margin: 0;
 	}
 </style>
+<script type="module" src="header.js"></script>
 <script type="module" src="welcome.js"></script>
 
 <rgh-welcome></rgh-welcome>

--- a/source/welcome.svelte
+++ b/source/welcome.svelte
@@ -72,12 +72,7 @@
 
 <link rel='stylesheet' href='welcome.css'>
 <main class:dimmed={stepValid === 3}>
-	<header>
-		<h1>
-			<img src='icon.png' alt="" height='32'>
-			Welcome to Refined GitHub
-		</h1>
-	</header>
+	<rgh-header title='Welcome to Refined GitHub'></rgh-header>
 	<ul>
 		<li class:valid={stepValid >= 1} class:visible={stepVisible >= 1} class='will-show'>
 			{#if stepValid === 0}
@@ -124,9 +119,9 @@
 	</ul>
 
 	<footer>
-		<h1 class:visible={stepValid === 3} class='will-show'>
+		<h2 class:visible={stepValid === 3} class='will-show'>
 			Setup complete, redirecting to
 			<a class='hidden-link' href='https://github.com/refined-github/refined-github/wiki' target='_self'>GitHub</a>…
-		</h1>
+		</h2>
 	</footer>
 </main>


### PR DESCRIPTION
- Related to #7854 

Now it matches the welcome page, which borrows from GitHub's own header style

<img width="1010" alt="Screenshot 10" src="https://github.com/user-attachments/assets/8939ef9c-4971-4e94-8664-af82e547d472">


<img width="1010" alt="Screenshot 11" src="https://github.com/user-attachments/assets/88fe6b48-213a-47c8-abc7-af2d959d3327">
