### PR TITLE
`table-input` - Support new text fields

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -9,16 +9,14 @@ import {expectElement as $} from 'select-dom';
 import features from '../feature-manager.js';
 import smartBlockWrap from '../helpers/smart-block-wrap.js';
 import observe from '../helpers/selector-observer.js';
-import {triggerActionBarOverflow} from '../github-helpers/index.js';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	// TODO: remove after March 2024
-	const container = square.closest(['form', '[data-testid="comment-composer"]'])!;
+	const container = square.closest('[data-testid="comment-composer"]')!;
 	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #5303 */
-	const field = $([
-		'textarea.js-comment-field', // TODO: remove after March 2024
+	const field = $(
 		'textarea[aria-labelledby="comment-composer-heading"]',
-	], container)!;
+		container,
+	)!;
 	const cursorPosition = field.selectionStart;
 
 	const columns = Number(square.dataset.x);
@@ -91,20 +89,10 @@ function append(container: HTMLElement): void {
 			</details-menu>
 		</details>,
 	);
-
-	if (container.getAttribute('aria-label') === 'Formatting tools')
-		return;
-
-	// Only needed on the old version
-	// TODO: remove after March 2024
-	triggerActionBarOverflow(container);
 }
 
 function init(signal: AbortSignal): void {
-	observe([
-		'[data-target="action-bar.itemContainer"]', // TODO: remove after March 2024
-		'[aria-label="Formatting tools"]',
-	], append, {signal});
+	observe('[aria-label="Formatting tools"]', append, {signal});
 	delegate('.rgh-tic', 'click', addTable, {signal});
 }
 

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -12,6 +12,7 @@ import observe from '../helpers/selector-observer.js';
 import {triggerActionBarOverflow} from '../github-helpers/index.js';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
+	// TODO: remove after March 2024
 	const container = square.closest(['form', '[data-testid="comment-composer"]'])!;
 	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #5303 */
 	const field = $([
@@ -101,7 +102,7 @@ function append(container: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe([
-		'[data-target="action-bar.itemContainer"]',
+		'[data-target="action-bar.itemContainer"]', // TODO: remove after March 2024
 		'[aria-label="Formatting tools"]',
 	], append, {signal});
 	delegate('.rgh-tic', 'click', addTable, {signal});

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -15,7 +15,7 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	const field = $(
 		'textarea[aria-labelledby="comment-composer-heading"]',
 		container,
-	)!;
+	);
 	const cursorPosition = field.selectionStart;
 
 	const columns = Number(square.dataset.x);

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -36,27 +36,10 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 }
 
 function append(container: HTMLElement): void {
-	const wrapperClasses = [
-		'details-reset',
-		'details-overlay',
-		'select-menu',
-		'select-menu-modal-right',
-		'hx_rsm',
-	];
-
-	const buttonClasses = [
-		'Button',
-		'Button--iconOnly',
-		'Button--invisible',
-		'Button--medium',
-	];
-
 	container.append(
-		<details
-			className={wrapperClasses.join(' ')}
-		>
+		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm">
 			<summary
-				className={buttonClasses.join(' ')}
+				className="Button Button--iconOnly Button--invisible Button--medium"
 				role="button"
 				aria-label="Add a table"
 				aria-haspopup="menu"

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -12,7 +12,6 @@ import observe from '../helpers/selector-observer.js';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	const container = square.closest('[data-testid="comment-composer"]')!;
-	/* There's only one rich-text editor even when multiple fields are visible; the class targets it #5303 */
 	const field = $(
 		'textarea[aria-labelledby="comment-composer-heading"]',
 		container,
@@ -43,7 +42,6 @@ function append(container: HTMLElement): void {
 		'select-menu',
 		'select-menu-modal-right',
 		'hx_rsm',
-		'ActionBar-item',
 	];
 
 	const buttonClasses = [
@@ -56,7 +54,6 @@ function append(container: HTMLElement): void {
 	container.append(
 		<details
 			className={wrapperClasses.join(' ')}
-			data-targets="action-bar.items" // Enables automatic hiding when it doesn't fit
 		>
 			<summary
 				className={buttonClasses.join(' ')}


### PR DESCRIPTION
- part of #7856 


## Test URLs

https://github.com/download-directory/download-directory.github.io/issues/141

## Screenshot

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/56752c21-f440-43de-a908-93396eb850e9">
