### PR TITLE
`fit-textareas` - Avoid conflict with native feature

### DIFF
--- a/source/features/fit-textareas.css
+++ b/source/features/fit-textareas.css
@@ -1,4 +1,5 @@
 .rgh-fit-textareas {
+	min-height: 4.5lh;
 	max-height: none !important;
 	field-sizing: content;
 }

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -20,6 +20,7 @@ function inputListener({target}: Event): void {
 
 function watchTextarea(textarea: HTMLTextAreaElement, {signal}: SignalAsOptions): void {
 	// Disable constrained GitHub feature
+	textarea.classList.remove('size-to-fit');
 	textarea.classList.remove('js-size-to-fit');
 	textarea.classList.remove('issue-form-textarea'); // Remove !important height and min-height
 	textarea.classList.add('rgh-fit-textareas');


### PR DESCRIPTION
- They changed their class name
- In Chrome, the field starts at 30px high, which doesn't look like a textarea


## Test URLs

Here

## Screenshot

<img width="545" alt="Screenshot 9" src="https://github.com/user-attachments/assets/1bb7b3bd-bd01-49b8-b058-3283607ebd39">
