### PR TITLE
`ci-link` - Add explanatory tooltip

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -29,7 +29,7 @@ async function add(anchor: HTMLElement): Promise<void> {
 
 	const endpoint = buildRepoURL('commits/checks-statuses-rollups');
 	anchor.parentElement!.append(
-		<span className="rgh-ci-link ml-1">
+		<span className="rgh-ci-link ml-1" title="CI status of latest commit">
 			<batch-deferred-content hidden data-url={endpoint}>
 				<input
 					name="oid"


### PR DESCRIPTION
- Closes #7938 

## Test URLs

Here

## Screenshot

<img width="326" alt="Screenshot 20" src="https://github.com/user-attachments/assets/b7f30d02-5bf6-4736-9ee5-4bfd525d5e4d">

