### PR TITLE
`pr-branch-auto-delete` - Preserve more `release` branches

### DIFF
--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -22,7 +22,7 @@ const exceptions = [
 	'stage',
 	'staging',
 	/production/,
-	/^release\//,
+	/^release\/?/,
 	/^v\d/,
 ];
 

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -22,7 +22,7 @@ const exceptions = [
 	'stage',
 	'staging',
 	/production/,
-	/^release\/?/,
+	/^release/,
 	/^v\d/,
 ];
 


### PR DESCRIPTION
We use a single release branch named `release` that I'd like to protect from auto-deletion.

The current functionality is to protect branches named `release/*`. This PR would change that to protect branches named `release*`.