### PR TITLE
Log broken selectors in the observer

### DIFF
--- a/source/helpers/errors.ts
+++ b/source/helpers/errors.ts
@@ -14,8 +14,8 @@ const {version} = chrome.runtime.getManifest();
 const fineGrainedTokenSuggestion = 'Please use a GitHub App, OAuth App, or a personal access token with fine-grained permissions.';
 const preferredMessage = 'Refined GitHub does not support per-organization fine-grained tokens. https://github.com/refined-github/refined-github/wiki/Security';
 
-// reads from path like assets/features/NAME.js
-function parseFeatureNameFromStack(stack: string): FeatureID | undefined {
+// Reads from path like assets/features/NAME.js
+export function parseFeatureNameFromStack(stack: string = new Error('stack').stack!): FeatureID | undefined {
 	// The stack may show other features due to cross-feature imports, but we want the top-most caller so we need to reverse it
 	const match = stack
 		.split('\n')
@@ -72,15 +72,11 @@ export function logError(error: Error): void {
 		'```',
 	].join('\n'));
 
-	const isObserver = message.startsWith('Selector observer was never');
-
 	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
-	console.group(`${isObserver ? '💡' : '❌'} Refined GitHub: ${id ?? ''}`); // Safari supports only one parameter
+	console.group(`❌ Refined GitHub: ${id ?? 'global'}`); // Safari supports only one parameter
 	console.log(`📕 ${version} ${isEnterprise() ? 'GHE →' : '→'}`, error); // One parameter improves Safari formatting
-	if (!isObserver) {
-		console.log('🔍 Search issue', searchIssueUrl.href);
-		console.log('🚨 Report issue', newIssueUrl.href);
-	}
+	console.log('🔍 Search issue', searchIssueUrl.href);
+	console.log('🚨 Report issue', newIssueUrl.href);
 	console.groupEnd();
 }
 

--- a/source/helpers/errors.ts
+++ b/source/helpers/errors.ts
@@ -72,11 +72,15 @@ export function logError(error: Error): void {
 		'```',
 	].join('\n'));
 
+	const isObserver = message.startsWith('Selector observer was never');
+
 	// Don't change this to `throw Error` because Firefox doesn't show extensions' errors in the console
-	console.group(`❌ Refined GitHub: ${id ?? 'global'}`); // Safari supports only one parameter
+	console.group(`${isObserver ? '💡' : '❌'} Refined GitHub: ${id ?? ''}`); // Safari supports only one parameter
 	console.log(`📕 ${version} ${isEnterprise() ? 'GHE →' : '→'}`, error); // One parameter improves Safari formatting
-	console.log('🔍 Search issue', searchIssueUrl.href);
-	console.log('🚨 Report issue', newIssueUrl.href);
+	if (!isObserver) {
+		console.log('🔍 Search issue', searchIssueUrl.href);
+		console.log('🚨 Report issue', newIssueUrl.href);
+	}
 	console.groupEnd();
 }
 

--- a/source/helpers/event-listener-loop.test.ts
+++ b/source/helpers/event-listener-loop.test.ts
@@ -1,0 +1,74 @@
+import {describe, it, expect} from 'vitest';
+
+import createEventIterator from './event-listener-loop.js';
+
+describe('createEventIterator', () => {
+	it('should yield events when they occur', async () => {
+		const target = new EventTarget();
+		const eventName = 'test-event';
+		const iterator = createEventIterator(target, eventName);
+		const event = new Event(eventName);
+
+		setTimeout(() => target.dispatchEvent(event), 22);
+
+		const result = await iterator.next();
+		expect(result.value).toBe(event);
+		expect(result.done).toBe(false);
+	});
+
+	it('should stop yielding events when signal is aborted', async () => {
+		const target = new EventTarget();
+		const eventName = 'test-event';
+		const controller = new AbortController();
+		const iterator = createEventIterator(target, eventName, {signal: controller.signal});
+		const event = new Event(eventName);
+
+		setTimeout(() => {
+			target.dispatchEvent(event);
+			controller.abort();
+		}, 22);
+
+		const result = await iterator.next();
+		expect(result.value).toBe(event);
+		expect(result.done).toBe(false);
+
+		const abortedResult = await iterator.next();
+		expect(abortedResult.value).toBe(undefined);
+		expect(abortedResult.done).toBe(true);
+	});
+
+	it('should handle multiple events', async () => {
+		const target = new EventTarget();
+		const eventName = 'test-event';
+		const iterator = createEventIterator(target, eventName);
+		const event1 = new Event(eventName);
+		const event2 = new Event(eventName);
+
+		setTimeout(() => {
+			target.dispatchEvent(event1);
+			target.dispatchEvent(event2);
+		}, 22);
+
+		const result1 = await iterator.next();
+		expect(result1.value).toBe(event1);
+		expect(result1.done).toBe(false);
+
+		const result2 = await iterator.next();
+		expect(result2.value).toBe(event2);
+		expect(result2.done).toBe(false);
+	});
+
+	it.skip('should handle synchronous events', async () => {
+		const target = new EventTarget();
+		const eventName = 'test-event';
+		const iterator = createEventIterator(target, eventName);
+		const event = new Event(eventName);
+
+		// This fails because native async generator functions aren't actually executed when called…
+		target.dispatchEvent(event);
+
+		const result = await iterator.next();
+		expect(result.value).toBe(event);
+		expect(result.done).toBe(false);
+	});
+});

--- a/source/helpers/event-listener-loop.ts
+++ b/source/helpers/event-listener-loop.ts
@@ -1,0 +1,39 @@
+import pDefer from 'p-defer';
+
+async function* createEventIterator<T extends Event>(
+	element: EventTarget,
+	eventName: string,
+	{signal, once}: {
+		signal?: AbortSignal;
+		once?: boolean;
+	} = {},
+): AsyncGenerator<T> {
+	const queue: T[] = [];
+	let deferred = pDefer<void>();
+
+	const handler = (event: Event): void => {
+		queue.push(event as T);
+		deferred.resolve();
+		deferred = pDefer();
+	};
+
+	try {
+		element.addEventListener(eventName, handler, {once});
+
+		while (!signal?.aborted) {
+			if (queue.length === 0) {
+				// eslint-disable-next-line no-await-in-loop
+				await deferred.promise;
+			}
+			yield queue.shift()!;
+
+			if (once) {
+				break;
+			}
+		}
+	} finally {
+		element.removeEventListener(eventName, handler);
+	}
+}
+
+export default createEventIterator;

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -5,9 +5,10 @@ import {ParseSelector} from 'typed-query-selector/parser.js';
 import delay from 'delay';
 import domLoaded from 'dom-loaded';
 import {signalFromPromise} from 'abort-utils';
-import optionsStorage from '../options-storage.js';
 
+import optionsStorage from '../options-storage.js';
 import getCallerID from './caller-id.js';
+import {parseFeatureNameFromStack} from './errors.js';
 
 type ObserverListener<ExpectedElement extends Element> = (element: ExpectedElement, options: SignalAsOptions) => void;
 
@@ -68,7 +69,7 @@ export default function observe<
 
 	let called = false;
 	// Capture stack outside
-	const error = new Error('Selector observer was never found:' + selector);
+	const currentFeature = parseFeatureNameFromStack();
 	(async () => {
 		const {logging} = await optionsStorage.getAll();
 		if (!logging) {
@@ -78,7 +79,7 @@ export default function observe<
 		await domLoaded;
 		await delay(1000);
 		if (!called && !signal?.aborted) {
-			throw error;
+			console.warn(currentFeature, '→ Selector not found on page:', selector);
 		}
 	})();
 	globalThis.addEventListener('animationstart', (event: AnimationEvent) => {

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -5,6 +5,7 @@ import {ParseSelector} from 'typed-query-selector/parser.js';
 import delay from 'delay';
 import domLoaded from 'dom-loaded';
 import {signalFromPromise} from 'abort-utils';
+import optionsStorage from '../options-storage.js';
 
 import getCallerID from './caller-id.js';
 
@@ -69,6 +70,11 @@ export default function observe<
 	// Capture stack outside
 	const error = new Error('Selector observer was never found:' + selector);
 	(async () => {
+		const {logging} = await optionsStorage.getAll();
+		if (!logging) {
+			return;
+		}
+
 		await domLoaded;
 		await delay(1000);
 		if (!called && !signal?.aborted) {


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/6096

It's quite noisy because many of these features are "optional", for example on issues often you won't be able to edit _any_ comments, but that doesn't mean that the feature is broken.

It might be a way to detect broken features in 7856 #7886 #7808, but it's probably just noise.

I added it temporarily behind the `logging` flag, let's see how it works.


## Screenshot

<img width="830" alt="Screenshot 23" src="https://github.com/user-attachments/assets/7f502ae0-c73d-42ad-be12-86ef44ee283a">

