### PR TITLE
`embed-gist-inline` - Support new view

### DIFF
--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -4,7 +4,6 @@ import * as pageDetect from 'github-url-detection';
 import mem from 'memoize';
 
 import features from '../feature-manager.js';
-import {getCleanPathname} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {standaloneGistLinkInMarkdown} from '../github-helpers/selectors.js';
 import {messageBackground} from '../helpers/messaging.js';
@@ -20,23 +19,6 @@ const fetchGist = mem(
 	async (url: string): Promise<GistData> =>
 		messageBackground({fetchJSON: `${url}.json`}),
 );
-
-function parseGistLink(link: HTMLAnchorElement): string | undefined {
-	if (link.host === 'gist.github.com') {
-		return getCleanPathname(link);
-	}
-
-	if (link.host === location.host && link.pathname.startsWith('gist/')) {
-		return link.pathname.replace('/gist', '').replace(/\/$/, '');
-	}
-
-	return undefined;
-}
-
-// TODO: Replace with updated github-url-detection: isGistFile(link)
-function isGist(link: HTMLAnchorElement): boolean {
-	return parseGistLink(link)?.replace(/[^/]/g, '').length === 1; // Exclude user links and file links
-}
 
 const isOnlyChild = (link: HTMLAnchorElement): boolean => link.textContent.trim() === link.parentElement!.textContent.trim();
 
@@ -78,7 +60,7 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 
 function init(signal: AbortSignal): void {
 	observe(standaloneGistLinkInMarkdown, link => {
-		if (isGist(link) && isOnlyChild(link)) {
+		if (pageDetect.isGist(link) && isOnlyChild(link)) {
 			void embedGist(link);
 		}
 	}, {signal});

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -9,12 +9,20 @@ export const repoUnderlineNavUl_ = [
 	[1, 'https://github.com/refined-github/refined-github/releases'],
 ] satisfies UrlMatch[];
 
-export const standaloneGistLinkInMarkdown = css`
-	.js-comment-body p a:only-child:is(
-		[href^="https://gist.github.com/"],
-		[href^="${location.origin}/gist/"]
-	)
-` as 'a'; // TODO: Drop after https://github.com/fregante/code-tag/issues/12
+export const standaloneGistLinkInMarkdown = [
+	css`
+		.js-comment-body p a:only-child:is(
+			[href^="https://gist.github.com/"],
+			[href^="${location.origin}/gist/"]
+		)
+	` as 'a',
+	css`
+		.react-issue-comment p a:only-child:is(
+			[href^="https://gist.github.com/"],
+			[href^="${location.origin}/gist/"]
+		)
+	` as 'a',
+]; // TODO: Drop after https://github.com/fregante/code-tag/issues/12
 export const standaloneGistLinkInMarkdown_ = [
 	[3, 'https://github.com/refined-github/sandbox/issues/77'],
 ] satisfies UrlMatch[];


### PR DESCRIPTION
- part of #7856 


## Test URLs

https://github.com/download-directory/download-directory.github.io/issues/141


## Screenshot

https://github.com/user-attachments/assets/2eb5d186-b203-4885-850a-b0a7bb0e5735

