### PR TITLE
Fix GitHub bug: Notification buttons overlap on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -82,6 +82,13 @@ div.markdown-body {
 	padding: 0;
 }
 
+/* Notifications "Unread" dropdown  overlap (Safari, Mobile) */
+/* Info: https://github.com/refined-github/refined-github/issues/7959 */
+/* Test: https://github.com/notifications */
+#dialog-show-notifications-tabs-nav ~ action-menu {
+	flex-shrink: 0;
+}
+
 /*
 
 Test URLs:


### PR DESCRIPTION
- Closes #7959

## Test URLs
https://github.com/notifications

## Before
<img width="487" alt="Screenshot 3" src="https://github.com/user-attachments/assets/a7a5dbb5-a5c6-4350-88e4-e4999e2f58c1">

## After

<img width="487" alt="Screenshot 2" src="https://github.com/user-attachments/assets/eede70da-a9a5-405a-b363-b50010b23da4">


