### PR TITLE
`linkify-code` - Restore feature

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -72,9 +72,16 @@ void features.add(import.meta.url, {
 - Code Search: https://github.com/search?q=%2F%23%5Cd%7B4%2C%7D%2F+language%3Atypescript&type=code
 - Comment: https://github.com/sindresorhus/linkify-urls/pull/40#pullrequestreview-1593302757
 
-Live tests field:
+Live tests fields:
 
 ```js
+JS:
+issues: // #12, GH-34, fregante#1 and facebook/react#5678
+url: // https://github.com/?q=refined-github
+```
+
+```
+No syntax:
 issues: // #12, GH-34, fregante#1 and facebook/react#5678
 url: // https://github.com/?q=refined-github
 ```

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -70,7 +70,7 @@ void features.add(import.meta.url, {
 - Discussions: https://github.com/File-New-Project/EarTrumpet/discussions/877
 - Code Search: https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code
 - Code Search: https://github.com/search?q=%2F%23%5Cd%7B4%2C%7D%2F+language%3Atypescript&type=code
-- Comment: https://github.com/sindresorhus/linkify-urls/pull/40#pullrequestreview-1593302757
+- Clipped URL that shouldn't be linkified: https://github.com/sindresorhus/linkify-urls/pull/40#pullrequestreview-1593302757
 
 Live tests fields:
 

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -16,8 +16,7 @@ const linkifiedURLSelector = '.rgh-linkified-code';
 export const codeElementsSelector = [
 	// Sometimes formatted diffs are loaded later and discard our formatting #5870
 	'.blob-code-inner:not(deferred-diff-lines.awaiting-highlight *)', // Code lines
-	// TODO: Dropped because it's too broad and causes issues #7951
-	// ':not(.notranslate) > .notranslate', // Code blocks in comments. May be wrapped twice
+	':is(.snippet-clipboard-content, .highlight):not(.notranslate) > pre.notranslate', // Code blocks in comments. May be wrapped twice
 ];
 
 export function shortenLink(link: HTMLAnchorElement): void {

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -16,7 +16,8 @@ const linkifiedURLSelector = '.rgh-linkified-code';
 export const codeElementsSelector = [
 	// Sometimes formatted diffs are loaded later and discard our formatting #5870
 	'.blob-code-inner:not(deferred-diff-lines.awaiting-highlight *)', // Code lines
-	':not(.notranslate) > .notranslate', // Code blocks in comments. May be wrapped twice
+	// TODO: Dropped because it's too broad and causes issues #7951
+	// ':not(.notranslate) > .notranslate', // Code blocks in comments. May be wrapped twice
 ];
 
 export function shortenLink(link: HTMLAnchorElement): void {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7951


## Test URLs

https://github.com/search?q=path%3A.npmrc&type=code


Live tests fields:

```js
JS:
issues: // #12, GH-34, fregante#1 and facebook/react#5678
url: // https://github.com/?q=refined-github
```

```
No syntax:
issues: // #12, GH-34, fregante#1 and facebook/react#5678
url: // https://github.com/?q=refined-github
```


## Before

<img width="828" alt="Screenshot 4" src="https://github.com/user-attachments/assets/71713f19-8585-477a-8208-6762c43fb0f9">


## After

<img width="828" alt="Screenshot" src="https://github.com/user-attachments/assets/f07861c5-58d6-4629-844d-11f2e9902916">
