### PR TITLE
`small-user-avatars` - Don't duplicate native functionality

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -42,9 +42,8 @@ function addMentionAvatar(link: HTMLElement): void {
 function init(): void {
 	// Excludes bots
 	observe([
-		'.js-issue-row [data-hovercard-type="user"]', // `isPRList` + old `isIssueList`
-		'.notification-thread-subscription [data-hovercard-type="user"]', // https://github.com/notifications/subscriptions
-		'[data-testid="created-at"] a[data-hovercard-url*="/users"]', // `isIssueList`
+		'.js-issue-row [data-hovercard-type="user"]',
+		'.notification-thread-subscription [data-hovercard-type="user"]',
 	], addAvatar);
 	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -44,7 +44,7 @@ function init(): void {
 	observe([
 		'.js-issue-row [data-hovercard-type="user"]', // `isPRList` + old `isIssueList`
 		'.notification-thread-subscription [data-hovercard-type="user"]', // https://github.com/notifications/subscriptions
-		'[data-testid="created-at"] a[data-hovercard-url*="/users"]', // `isIssueList`
+		'[data-testid="created-at"] a[data-hovercard-url*="/users"]:first-child', // `isIssueList`. `:first-child` skips links that already include the avatar #7975
 	], addAvatar);
 	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -44,6 +44,7 @@ function init(): void {
 	observe([
 		'.js-issue-row [data-hovercard-type="user"]', // `isPRList` + old `isIssueList`
 		'.notification-thread-subscription [data-hovercard-type="user"]', // https://github.com/notifications/subscriptions
+		'[data-testid="created-at"] a[data-hovercard-url*="/users"]', // `isIssueList`
 	], addAvatar);
 	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -42,8 +42,8 @@ function addMentionAvatar(link: HTMLElement): void {
 function init(): void {
 	// Excludes bots
 	observe([
-		'.js-issue-row [data-hovercard-type="user"]',
-		'.notification-thread-subscription [data-hovercard-type="user"]',
+		'.js-issue-row [data-hovercard-type="user"]', // `isPRList` + old `isIssueList`
+		'.notification-thread-subscription [data-hovercard-type="user"]', // https://github.com/notifications/subscriptions
 	], addAvatar);
 	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }


### PR DESCRIPTION
- Reverts refined-github/refined-github#7924
- For https://github.com/refined-github/refined-github/issues/7856#issuecomment-2440813618

## Test URLs

- Native avatars: https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc+is%3Apr
- Our avatars: https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc