### PR TITLE
Autofix: The pull request description will be empty if we are going to merge a approved PR.

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -13,9 +13,6 @@ import {expectToken} from '../github-helpers/github-token.js';
 const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().base.branch === await getDefaultBranch();
 
 async function clear(messageField: HTMLTextAreaElement): Promise<void | false> {
-	// Only run once so that it doesn't clear the field every time it's opened
-	features.unload(import.meta.url);
-
 	const originalMessage = messageField.value;
 	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch());
 


### PR DESCRIPTION
I have identified the issue in the `clear-pr-merge-commit-message.tsx` file. The problem was that the feature was being unloaded after the first run, preventing it from clearing the commit message field on subsequent openings. I've modified the code to remove the unloading logic, allowing the feature to run every time the merge commit message field is displayed. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission