### PR TITLE
`bugs-tab` - Support `issue-bug`

### DIFF
--- a/source/github-helpers/bugs-label.test.ts
+++ b/source/github-helpers/bugs-label.test.ts
@@ -9,10 +9,13 @@ bugfix
 confirmed-bug
 type/bug
 type:bug
+type-bug
 kind/bug
 kind:bug
+kind-bug
 triage/bug
 triage:bug
+Issue-Bug
 :bug:bug
 :bug: bug
 🐛bug

--- a/source/github-helpers/bugs-label.test.ts
+++ b/source/github-helpers/bugs-label.test.ts
@@ -29,8 +29,11 @@ bug-report
 bug-hunt
 bugzilla
 debug
+debugger
 bugatti
+bugia
 ladybug
+not-a-bug
 `;
 
 test('isBugLabel', () => {

--- a/source/github-helpers/bugs-label.ts
+++ b/source/github-helpers/bugs-label.ts
@@ -1,4 +1,4 @@
-const supportedLabels = /^(?:bug|bug-?fix|confirmed-bug|(?:type|kind|triage)[:/]bug|(?::[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(?:bug|bug-?fix|confirmed-bug|(?:type|kind|triage|issue)[:/-]bug|(?::[\w-]+:|\p{Emoji})bug)$/iu;
 export default function isBugLabel(label: string): boolean {
 	return supportedLabels.test(label.replaceAll(/\s/g, ''));
 }


### PR DESCRIPTION
Microsoft PowerToys uses `Issue-Bug` for bug labels. See https://github.com/microsoft/PowerToys/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3AIssue-Bug.

This PR adds support for it. 

This fixes https://github.com/refined-github/refined-github/issues/7991.

## Test URLs

This fixes https://github.com/refined-github/refined-github/issues/7991.

## Screenshot
