### PR TITLE
`clean-converstion-headers` - Support new PR view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^2.1.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^9.0.1",
+				"github-url-detection": "^9.0.2",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkify-issues": "^4.1.0",
@@ -5539,10 +5539,9 @@
 			"license": "MIT"
 		},
 		"node_modules/github-url-detection": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-9.0.1.tgz",
-			"integrity": "sha512-eSgezbnq3HmYOhEHxGc22MJfH64KfgnsoJFuZ741rZR0BWYuBVLmGuj6KUa1nEMVwoevCfHtBEmS4DrJ0figyg==",
-			"license": "MIT",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-9.0.2.tgz",
+			"integrity": "sha512-XyeWaxzYJUyr0+qMaId09wiSlaierP54Ct7pP4aVSK2SeRBhapxSwt6OZh4R4pkO+GDC7QjEAL2M4ExNRyd8mw==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.7"
 			},

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"filter-altered-clicks": "^2.1.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^9.0.1",
+		"github-url-detection": "^9.0.2",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkify-issues": "^4.1.0",

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -42,12 +42,12 @@ a.rgh-clean-conversation-headers-non-default-branch {
 /* Removes on PRs: [octocat] merged 1 commit into master from feature */
 .rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author + .Label, /* #5832 */
 .rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author,
-.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author a[data-hovercard-url]{
+.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author a[data-hovercard-url] {
 	display: none;
 }
 
 .rgh-clean-conversation-headers .commit-ref,
-.rgh-clean-conversation-headers [class^="BranchName"] {
+.rgh-clean-conversation-headers [class^='BranchName'] {
 	font-size: 12px;
 }
 

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -15,7 +15,7 @@ a.rgh-clean-conversation-headers-non-default-branch {
 
 /* Removes: every text (but not icons) */
 .rgh-clean-conversation-headers {
-	font-size: 0;
+	font-size: 0 !important;
 }
 
 /* Shows on issues: [octocat] opened this issue on [1 Jan] · 1 comments */
@@ -63,8 +63,4 @@ a.rgh-clean-conversation-headers-non-default-branch {
 /* Fixes vertical alignment of base branch dropdown #5598 */
 .rgh-clean-conversation-headers .commit-ref-dropdown {
 	margin-top: -2px !important;
-}
-
-.d-flex:has(.rgh-clean-conversation-headers) {
-	align-items: center !important;
 }

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -5,7 +5,8 @@
 	);
 }
 
-.rgh-clean-conversation-headers-non-default-branch a {
+.rgh-clean-conversation-headers-non-default-branch a,
+a.rgh-clean-conversation-headers-non-default-branch {
 	color: var(
 		--control-checked-fgColor-rest,
 		var(--color-state-hover-primary-text, #fff)
@@ -40,11 +41,13 @@
 /* Removes on issues: [octocat] opened this issue on 1 Jan · 1 comments */
 /* Removes on PRs: [octocat] merged 1 commit into master from feature */
 .rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author + .Label, /* #5832 */
-.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author {
+.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author .author,
+.rgh-clean-conversation-headers.rgh-clean-conversation-headers-hide-author a[data-hovercard-url]{
 	display: none;
 }
 
-.rgh-clean-conversation-headers .commit-ref {
+.rgh-clean-conversation-headers .commit-ref,
+.rgh-clean-conversation-headers [class^="BranchName"] {
 	font-size: 12px;
 }
 

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -64,3 +64,7 @@ a.rgh-clean-conversation-headers-non-default-branch {
 .rgh-clean-conversation-headers .commit-ref-dropdown {
 	margin-top: -2px !important;
 }
+
+.d-flex:has(.rgh-clean-conversation-headers) {
+	align-items: center !important;
+}

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -11,6 +11,7 @@ import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import observe from '../helpers/selector-observer.js';
 import {expectToken} from '../github-helpers/github-token.js';
 import {parseReferenceRaw} from '../github-helpers/pr-branches.js';
+import {assertNodeContent} from '../helpers/dom-utils.js';
 
 async function cleanIssueHeader(byline: HTMLElement): Promise<void> {
 	byline.classList.add('rgh-clean-conversation-headers', 'rgh-clean-conversation-headers-hide-author');
@@ -62,14 +63,12 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		base.classList.add('rgh-clean-conversation-headers-non-default-branch');
 	}
 
-	const baseBranchDropdown = $optional('.commit-ref-dropdown', byline);
 	// Shows on PRs: main [←] feature
-	const arrowIcon = <ArrowLeftIcon className="v-align-middle mx-1" />;
-	if (baseBranchDropdown) {
-		baseBranchDropdown.after(<span>{arrowIcon}</span>); // #5598
-	} else {
-		base.after(<span>{arrowIcon}</span>);
-	}
+	const anchor
+		= $optional('.commit-ref-dropdown', byline)?.nextSibling // TODO: Drop old PR layout support
+		?? base.nextSibling?.nextSibling;
+	assertNodeContent(anchor, 'from');
+	anchor!.after(<span><ArrowLeftIcon className="v-align-middle mx-1" /></span>);
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -28,13 +28,19 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 	const shouldHideAuthor
 		= pageDetect.isPRConversation()
 		&& !byline.closest('.gh-header-sticky') // #7802
-		&& $('.author', byline).textContent === (await elementReady('.TimelineItem .author'))!.textContent;
+		&& $([
+			'.author',
+			'a[data-hovercard-url]',
+		], byline).textContent === (await elementReady('.TimelineItem .author'))!.textContent;
 
 	if (shouldHideAuthor) {
 		byline.classList.add('rgh-clean-conversation-headers-hide-author');
 	}
 
-	const base = $('.commit-ref', byline);
+	const base = $([
+		'.commit-ref',
+		'[class^="BranchName"]',
+	], byline);
 	const baseBranchDropdown = $optional('.commit-ref-dropdown', byline);
 
 	// Shows on PRs: main [←] feature
@@ -42,10 +48,10 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 	if (baseBranchDropdown) {
 		baseBranchDropdown.after(<span>{arrowIcon}</span>); // #5598
 	} else {
-		base.nextElementSibling!.replaceChildren(arrowIcon);
+		base.after(<span>{arrowIcon}</span>);
 	}
 
-	const baseBranch = base.title.split(':')[1];
+	const baseBranch = base.textContent.split(':')[1];
 	const wasDefaultBranch = pageDetect.isClosedPR() && baseBranch === 'master';
 	const isDefaultBranch = baseBranch === await getDefaultBranch();
 	if (!isDefaultBranch && !wasDefaultBranch) {
@@ -60,6 +66,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe([
 		'.gh-header-meta > .flex-auto', // Real
 		'.rgh-conversation-activity-filter', // Helper in case it runs first and breaks the `>` selector, because it wraps the .flex-auto element
+		'[class^="StateLabel"] + div > span',
 	], cleanConversationHeader, {signal});
 }
 

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -23,6 +23,11 @@ async function cleanIssueHeader(byline: HTMLElement): Promise<void> {
 async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 	byline.classList.add('rgh-clean-conversation-headers');
 
+	const authorSelector = [
+		'.TimelineItem .author',
+		'.Timeline-Item [data-testid="author-avatar"] a:not([data-testid="github-avatar"])',
+	].join(',');
+
 	// Extra author name is only shown on `isPRConversation`
 	// Hide if it's the same as the opener (always) or merger
 	const shouldHideAuthor
@@ -31,7 +36,7 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		&& $([
 			'.author',
 			'a[data-hovercard-url]',
-		], byline).textContent === (await elementReady('.TimelineItem .author'))!.textContent;
+		], byline).textContent === (await elementReady(authorSelector))!.textContent;
 
 	if (shouldHideAuthor) {
 		byline.classList.add('rgh-clean-conversation-headers-hide-author');
@@ -51,7 +56,8 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		base.after(<span>{arrowIcon}</span>);
 	}
 
-	const baseBranch = base.textContent.split(':')[1];
+	const baseBranchContent = base.textContent.split(':');
+	const baseBranch = baseBranchContent[1] ?? baseBranchContent[0];
 	const wasDefaultBranch = pageDetect.isClosedPR() && baseBranch === 'master';
 	const isDefaultBranch = baseBranch === await getDefaultBranch();
 	if (!isDefaultBranch && !wasDefaultBranch) {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -22,8 +22,9 @@ async function cleanIssueHeader(byline: HTMLElement): Promise<void> {
 
 async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 	byline.classList.add('rgh-clean-conversation-headers');
+	byline.parentElement!.closest('.d-flex')!.classList.add('flex-items-center');
 
-	const authorSelector = [
+	const prCreatorSelector = [
 		'.TimelineItem .author',
 		'.Timeline-Item [data-testid="author-avatar"] a:not([data-testid="github-avatar"])',
 	].join(',');
@@ -36,7 +37,7 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		&& $([
 			'.author',
 			'a[data-hovercard-url]',
-		], byline).textContent === (await elementReady(authorSelector))!.textContent;
+		], byline).textContent === (await elementReady(prCreatorSelector))!.textContent;
 
 	if (shouldHideAuthor) {
 		byline.classList.add('rgh-clean-conversation-headers-hide-author');
@@ -72,7 +73,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe([
 		'.gh-header-meta > .flex-auto', // Real
 		'.rgh-conversation-activity-filter', // Helper in case it runs first and breaks the `>` selector, because it wraps the .flex-auto element
-		'[class^="StateLabel"] + div > span',
+		'[class^="StateLabel"] + div > span:first-child',
 	], cleanConversationHeader, {signal});
 }
 


### PR DESCRIPTION
Part of #7988

## Test URLs

- https://github.com/refined-github/refined-github/pull/7987/commits
- [`32352f7` (#7981)](https://github.com/refined-github/refined-github/pull/7981/commits/32352f73b951779f7e07e15be5fecc4ebe62e664)


## Screenshot

![CleanShot 2024-11-03 at 19 15 26@2x](https://github.com/user-attachments/assets/bed40c47-c1bc-48ca-9ec1-86cdf360179b)


