### PR TITLE
`tags-on-commits` - Improve GitHub Enterprise compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"pretty-bytes": "^6.1.1",
 				"push-form": "^1.0.1",
 				"regex-join": "^2.1.0",
-				"select-dom": "^9.1.1",
+				"select-dom": "^9.2.0",
 				"shorten-repo-url": "^5.2.0",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^4.1.1",
@@ -10002,9 +10002,9 @@
 			}
 		},
 		"node_modules/select-dom": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-9.1.1.tgz",
-			"integrity": "sha512-WCLqWaJrUoosGihRvxBFYwNXJQ1MI2iXDim1D725MFjkJiEQ+kn4C75xnRdGEq3J83HdyWvxZDh8cwW2kOqyxg==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-9.2.0.tgz",
+			"integrity": "sha512-/I4nd/t05uUnznlIfmKuh5/npw0L9dnzyjThEqpwbjjd5VkZqN/ffgWl7wq/9RMHf7G/bLsCLatL1PqGfkw+IA==",
 			"license": "MIT",
 			"dependencies": {
 				"typed-query-selector": "^2.11.0"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"pretty-bytes": "^6.1.1",
 		"push-form": "^1.0.1",
 		"regex-join": "^2.1.0",
-		"select-dom": "^9.1.1",
+		"select-dom": "^9.2.0",
 		"shorten-repo-url": "^5.2.0",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^4.1.1",


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/7954
- Replaces https://github.com/refined-github/refined-github/pull/7987
- Includes https://github.com/fregante/select-dom/pull/31


## Test URLs

Like this, but on GHE https://github.com/microsoft/vscode/commits/release/1.25/

## Screenshot

_Untested_