### PR TITLE
Fix typo

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -31,7 +31,7 @@ const fresh = [
 	'Smells fresh',
 	'Just a baby',
 	'It’s my birthday',
-	'Brand spanking new',
+	'Brand sparkling new',
 	'It’s a new world ✨',
 	'Certified Fresh Repo™',
 	'So it begins, the great battle of our time',


### PR DESCRIPTION
Let's say I was a bit surprised to see this description of a repository's age
![image](https://github.com/user-attachments/assets/5adcc224-7a8b-42d2-aae7-6f1327ddbe0e)

So, here's a fix of an (assumed) typo introduced by 4a60549174fc9a3848936c087491ef09d9e736ae.