### PR TITLE
`patch-diff-links` - Restore feature on non-beta issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^2.1.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^9.0.2",
+				"github-url-detection": "^9.0.3",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkify-issues": "^4.1.0",
@@ -396,7 +396,6 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -5557,9 +5556,9 @@
 			"license": "MIT"
 		},
 		"node_modules/github-url-detection": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-9.0.2.tgz",
-			"integrity": "sha512-XyeWaxzYJUyr0+qMaId09wiSlaierP54Ct7pP4aVSK2SeRBhapxSwt6OZh4R4pkO+GDC7QjEAL2M4ExNRyd8mw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-9.0.3.tgz",
+			"integrity": "sha512-OLSOgZdeNZjgqfb9mS7o0ZQGomvM2U2lZIiFw5jTkagNyRmNsDNjkzCHqMfnEbJXuTmMr6vBq+h30spUULmkXw==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.7"
 			},

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"filter-altered-clicks": "^2.1.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^9.0.2",
+		"github-url-detection": "^9.0.3",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkify-issues": "^4.1.0",

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -26,7 +26,7 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe([
-		'.commit-meta > span:last-child', // `isPRCommit` + old `isSingleCommit`
+		'.commit-meta > :is(span, div):last-child', // `isPRCommit` + old `isSingleCommit`
 		'[class*="commit-header-actions"] + div pre',
 	], addPatchDiffLinks, {signal});
 }

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -14,6 +14,7 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 	}
 
 	commitMeta!.classList.remove('no-wrap'); // #5987
+	// TODO: Improve after April 2025
 	const node = (
 		<>
 			<span className="sha-block" data-turbo="false">

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -14,18 +14,14 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 	}
 
 	commitMeta!.classList.remove('no-wrap'); // #5987
-	// TODO: Improve after April 2025
-	const node = (
-		<>
-			<span className="sha-block" data-turbo="false">
-				<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
-				{' '}
-				<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
-			</span>
+	commitMeta!.prepend(
+		<span className="sha-block" data-turbo="false">
+			<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
+			{' '}
+			<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
 			{commitMeta.tagName !== 'DIV' && <span className="px-2">·</span>}
-		</>
+		</span>,
 	);
-	commitMeta!.prepend(node);
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -14,14 +14,17 @@ async function addPatchDiffLinks(commitMeta: HTMLElement): Promise<void> {
 	}
 
 	commitMeta!.classList.remove('no-wrap'); // #5987
-	commitMeta!.prepend(
-		<span className="sha-block" data-turbo="false">
-			<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
-			{' '}
-			<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
-		</span>,
-		<span className="px-2">·</span>,
+	const node = (
+		<>
+			<span className="sha-block" data-turbo="false">
+				<a href={`${commitUrl}.patch`} className="sha color-fg-default">patch</a>
+				{' '}
+				<a href={`${commitUrl}.diff`} className="sha color-fg-default">diff</a>
+			</span>
+			{commitMeta.tagName !== 'DIV' && <span className="px-2">·</span>}
+		</>
 	);
+	commitMeta!.prepend(node);
 }
 
 async function init(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
https://github.com/refined-github/refined-github/pull/7909#issuecomment-2458740998

Test URL:

https://github.com/refined-github/refined-github/commit/132272786fdc058193e089d8c06f2a158844e101

## Screenshot

New view:

<img width="1637" alt="image" src="https://github.com/user-attachments/assets/480dd064-abff-4966-bb6f-db13460208ec">

<img width="1632" alt="image" src="https://github.com/user-attachments/assets/f4f09b1c-2056-4238-93b4-95f2060b0c91">


Old view:

<img width="1607" alt="image" src="https://github.com/user-attachments/assets/e1363469-a6ce-4843-a47a-1f656ef88678">
