### PR TITLE
`keyboard-navigation` - Restore navigation without pre-selection

### DIFF
--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -33,6 +33,7 @@ function runShortcuts(event: KeyboardEvent): void {
 
 	// `j` goes to the next comment, `k` goes back a comment
 	const direction = event.key === 'j' ? 1 : -1;
+	// Without `focusedElement`, it will start from -1
 	const currentIndex = items.indexOf(focusedComment!);
 
 	// Start at 0 if nothing is; clamp index

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -1,4 +1,4 @@
-import {$} from 'select-dom/strict.js';
+import {$optional} from 'select-dom/strict.js';
 import {$$, elementExists} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
@@ -19,7 +19,7 @@ function runShortcuts(event: KeyboardEvent): void {
 
 	event.preventDefault();
 
-	const focusedComment = $(':target');
+	const focusedComment = $optional(':target');
 	const items
 		= $$([
 			'.js-targetable-element[id^="diff-"]', // Files in diffs
@@ -33,7 +33,7 @@ function runShortcuts(event: KeyboardEvent): void {
 
 	// `j` goes to the next comment, `k` goes back a comment
 	const direction = event.key === 'j' ? 1 : -1;
-	const currentIndex = items.indexOf(focusedComment);
+	const currentIndex = items.indexOf(focusedComment!);
 
 	// Start at 0 if nothing is; clamp index
 	const chosenCommentIndex = Math.min(


### PR DESCRIPTION
- Close: #8022


## Test URLs

https://github.com/tstirrat/mGB/pull/6/files

## Screenshot

https://github.com/user-attachments/assets/9b9d8897-761c-43df-a2d5-0118214a4deb



