### PR TITLE
`conversation-authors` - Fix border partially visible in new view

### DIFF
--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -9,6 +9,6 @@
 	}
 }
 
-[data-testid="list-view-item-description"] {
+[data-testid='list-view-item-description'] {
 	margin-top: 1px;
 }

--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -9,6 +9,7 @@
 	}
 }
 
+/* Fix border partially visible in new view #8025 */
 [data-testid='list-view-item-description'] {
 	margin-top: 1px;
 }

--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -8,3 +8,7 @@
 		margin-right: 2px !important;
 	}
 }
+
+[data-testid="list-view-item-description"] {
+	margin-top: 1px;
+}


### PR DESCRIPTION
## Test URLs

https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc%20is%3Aissue%20state%3Aclosed

## Screenshot

Before:

<img width="551" alt="image" src="https://github.com/user-attachments/assets/6c243c0d-c61b-4336-aa8b-f4a611a9b371">

After:

<img width="723" alt="image" src="https://github.com/user-attachments/assets/cf26a075-a313-429f-ba16-d09d8b4fe968">
