### PR TITLE
`batch-mark-files-as-viewed` - Don't select excluded files

### DIFF
--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -39,7 +39,13 @@ const batchToggle = debounceFn((event: DelegateEvent<MouseEvent, HTMLFormElement
 	runningBatch = true;
 	const selectedFiles = getItemsBetween(files, previousFile, thisFile);
 	for (const file of selectedFiles) {
-		if (file !== thisFile && isChecked(file) !== isThisBeingFileChecked) {
+		if (
+			file !== thisFile
+			// `checkVisibility` excludes filtered-out files
+			// https://github.com/refined-github/refined-github/issues/7819
+			&& file.checkVisibility()
+			&& isChecked(file) !== isThisBeingFileChecked
+		) {
 			$('.js-reviewed-checkbox', file).click();
 		}
 	}
@@ -52,7 +58,9 @@ const batchToggle = debounceFn((event: DelegateEvent<MouseEvent, HTMLFormElement
 
 function markAsViewedSelector(target: HTMLElement): string {
 	const checked = isChecked(target) ? ':not([checked])' : '[checked]';
-	return '.js-reviewed-checkbox' + checked;
+	// The `hidden` attribute excludes filtered-out files
+	// https://github.com/refined-github/refined-github/issues/7819
+	return '.file:not([hidden]) .js-reviewed-checkbox' + checked;
 }
 
 const markAsViewed = clickAll(markAsViewedSelector);


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7819


## Test URLs

https://github.com/refined-github/refined-github/pull/6006/files

## Shift-click

![shift](https://github.com/user-attachments/assets/41360fd2-e941-45c9-aee7-1078498dd914)



## Alt-click


![alt](https://github.com/user-attachments/assets/367e7d82-41e3-4ee6-9167-047917f4f0fd)
