### PR TITLE
`default-branch-button` - Fix Firefox rounded corners bug

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -34,9 +34,11 @@ async function updateUrl(event: React.MouseEvent<HTMLAnchorElement>): Promise<vo
 }
 
 function wrapButtons(buttons: HTMLElement[]): void {
+	groupButtons(buttons, 'd-flex', 'rgh-default-branch-button-group');
+
 	// `rounded-left-0` is for Firefox
 	// https://github.com/refined-github/refined-github/pull/8030
-	groupButtons(buttons, 'd-flex', 'rgh-default-branch-button-group', 'rounded-left-0');
+	buttons.at(-1)!.classList.add('rounded-left-0');
 }
 
 async function add(branchSelector: HTMLElement): Promise<void> {

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -34,7 +34,9 @@ async function updateUrl(event: React.MouseEvent<HTMLAnchorElement>): Promise<vo
 }
 
 function wrapButtons(buttons: HTMLElement[]): void {
-	groupButtons(buttons, 'd-flex', 'rgh-default-branch-button-group');
+	// `rounded-left-0` is for Firefox
+	// https://github.com/refined-github/refined-github/pull/8030
+	groupButtons(buttons, 'd-flex', 'rgh-default-branch-button-group', 'rounded-left-0');
 }
 
 async function add(branchSelector: HTMLElement): Promise<void> {

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -160,12 +160,6 @@ div[data-target='readme-toc.content'] div.blob-wrapper img {
 	margin-right: 20px; /* Push the text farther away from the text so it's cropped out */
 }
 
-/* Add override for CSS-in-JS components that don't use regular .btn styles */
-.BtnGroup-item:last-child:not(:first-child) {
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
-}
-
 .rgh-bg-none {
 	background: none !important;
 }


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7875
- Core issue initially fixed in https://github.com/refined-github/refined-github/pull/6249

For some reason Chrome isn't affected by either bug 🤷‍♂️ 


## Test URLs

https://github.com/refined-github/refined-github/commits/test/safari2/

## Without fix (no CSS)

<img width="242" alt="Screenshot 19" src="https://github.com/user-attachments/assets/3298c211-b45e-4583-9ac1-f18a7240c709">

## With new JS fix

<img width="242" alt="Screenshot" src="https://github.com/user-attachments/assets/d07658fa-35c2-44aa-bd6f-034f8062c549">
