### PR TITLE
`clean-conversation-headers` - Support new PR view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^2.1.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^9.0.3",
+				"github-url-detection": "^10.0.1",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkify-issues": "^4.1.0",
@@ -303,7 +303,6 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -5548,10 +5547,9 @@
 			"license": "MIT"
 		},
 		"node_modules/github-url-detection": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-9.0.3.tgz",
-			"integrity": "sha512-OLSOgZdeNZjgqfb9mS7o0ZQGomvM2U2lZIiFw5jTkagNyRmNsDNjkzCHqMfnEbJXuTmMr6vBq+h30spUULmkXw==",
-			"license": "MIT",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-10.0.1.tgz",
+			"integrity": "sha512-0mCQew9imKutjcEEw4mo9WKOaVFm9h8gH8lWY8kYh2UCKcjWu2gvC4nuGbZOGPN/myIPusbIOaz6sY9cXuwxKQ==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.7"
 			},

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"filter-altered-clicks": "^2.1.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^9.0.3",
+		"github-url-detection": "^10.0.1",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkify-issues": "^4.1.0",

--- a/source/features/actionable-pr-view-file.tsx
+++ b/source/features/actionable-pr-view-file.tsx
@@ -25,7 +25,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		// Editing files doesn't make sense after a PR is closed/merged
-		pageDetect.isClosedPR,
+		pageDetect.isClosedConversation,
 		() => $('.head-ref').title === 'This repository has been deleted',
 		// If you're viewing changes from partial commits, ensure you're on the latest one.
 		() => elementExists('.js-commits-filtered') && !elementExists('[aria-label="You are viewing the latest commit"]'),

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -57,7 +57,7 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		baseBranch = parseReferenceRaw(base.nextElementSibling!.textContent!, base.textContent).branch;
 	}
 
-	const wasDefaultBranch = pageDetect.isClosedPR() && baseBranch === 'master';
+	const wasDefaultBranch = pageDetect.isClosedConversation() && baseBranch === 'master';
 	const isDefaultBranch = baseBranch === await getDefaultBranch();
 	if (!isDefaultBranch && !wasDefaultBranch) {
 		base.classList.add('rgh-clean-conversation-headers-non-default-branch');

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -140,7 +140,7 @@ void features.add(import.meta.url, {
 	// This catches a PR while it's being merged
 	asLongAs: [
 		pageDetect.isPRConversation,
-		pageDetect.isOpenPR,
+		pageDetect.isOpenConversation,
 		userHasPushAccess,
 	],
 	awaitDomReady: true, // Post-load user event, no need to listen earlier

--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -1,20 +1,15 @@
 import React from 'dom-chef';
 import {lastElement} from 'select-dom';
-import {$} from 'select-dom/strict.js';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils.js';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
-export const statusBadge = [
+const statusBadge = [
 	'#partial-discussion-header .State',
-	'[data-testid="issue-viewer-container"] [data-testid="header-state"]',
+	'[class^="StateLabel"]',
 ];
-
-export function isClosedOrMerged(discussionHeader = $(statusBadge)): boolean {
-	return /^Closed|^Merged/.test(discussionHeader.textContent.trim());
-}
 
 export function getLastCloseEvent(): HTMLElement | undefined {
 	return lastElement([
@@ -38,10 +33,6 @@ export function getLastCloseEvent(): HTMLElement | undefined {
 }
 
 function addToConversation(discussionHeader: HTMLElement): void {
-	if (!isClosedOrMerged(discussionHeader)) {
-		return;
-	}
-
 	// Avoid native `title` by disabling pointer events, we have our own `aria-label`. We can't drop the `title` attribute because some features depend on it.
 	discussionHeader.style.pointerEvents = 'none';
 
@@ -66,10 +57,7 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	asLongAs: [
 		pageDetect.isConversation,
-	],
-	include: [
-		pageDetect.isClosedIssue,
-		pageDetect.isClosedPR,
+		pageDetect.isClosedConversation,
 	],
 	awaitDomReady: true, // We're specifically looking for the last event
 	init,

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -12,7 +12,7 @@ import createBanner from '../github-helpers/banner.js';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {buildRepoURL, isAnyRefinedGitHubRepo, isOwnConversation} from '../github-helpers/index.js';
-import {getLastCloseEvent, isClosedOrMerged} from './jump-to-conversation-close-event.js';
+import {getLastCloseEvent} from './jump-to-conversation-close-event.js';
 import {newCommentField} from '../github-helpers/selectors.js';
 import {userIsModerator} from '../github-helpers/get-user-permission.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
@@ -42,7 +42,7 @@ function isPopular(): boolean {
 const threeMonths = toMilliseconds({days: 90});
 
 export function wasClosedLongAgo(): boolean {
-	if (!isClosedOrMerged()) {
+	if (!pageDetect.isClosedConversation()) {
 		return false;
 	}
 

--- a/source/features/pr-base-commit.tsx
+++ b/source/features/pr-base-commit.tsx
@@ -58,7 +58,7 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 	],
 	exclude: [
-		pageDetect.isClosedPR,
+		pageDetect.isClosedConversation,
 		() => $('.head-ref').title === 'This repository has been deleted',
 	],
 	awaitDomReady: true, // DOM-based exclusions

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<void> {
 void features.add(import.meta.url, {
 	asLongAs: [
 		pageDetect.isPRConversation,
-		pageDetect.isOpenPR,
+		pageDetect.isOpenConversation,
 	],
 	awaitDomReady: true, // Post-load user event, no need to listen earlier
 	init(signal: AbortSignal): void {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -58,7 +58,11 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 
 	// Can't approve own PRs and closed PRs
 	// API required for this action
-	if (getUsername() === $('.author').textContent || pageDetect.isClosedPR() || !(await getToken())) {
+	if (
+		getUsername() === $('.author').textContent
+		|| pageDetect.isClosedConversation()
+		|| !(await getToken())
+	) {
 		return;
 	}
 

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -100,7 +100,7 @@ void features.add(import.meta.url, {
 		pageDetect.isPRConversation,
 	],
 	exclude: [
-		pageDetect.isClosedPR,
+		pageDetect.isClosedConversation,
 		() => $('.head-ref').title === 'This repository has been deleted',
 	],
 	awaitDomReady: true, // DOM-based exclusions


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/8001
- Includes https://github.com/refined-github/github-url-detection/pull/202

## Test URLs

- https://github.com/refined-github/refined-github/pull/8001
- https://github.com/refined-github/refined-github/pull/8001/commits
- [`ae164ef` (#8001)](https://github.com/refined-github/refined-github/pull/8001/commits/ae164efc1ed34fc64f4b13bffdb93a534a691622)

## Before

<img width="673" alt="Screenshot 4" src="https://github.com/user-attachments/assets/b108a6eb-d264-48ef-982e-40624cf49d97">


## After

<img width="673" alt="Screenshot 3" src="https://github.com/user-attachments/assets/735c1300-c605-449a-96e0-da2d751ccc67">

