### PR TITLE
Work around Firefox bug that causes tab freezes

### DIFF
--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -72,4 +72,3 @@
 .rgh-table-input .sentinel {
 	display: none;
 }
-

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -35,23 +35,23 @@
 }
 
 .rgh-tic:hover div,
-.rgh-tic:is(:nth-of-type(5n + 1)):has(~ :hover:nth-of-type(5n + 1)) div,
+.rgh-tic:is(:nth-of-type(5n + 1)):has(~ .rgh-tic:hover:nth-of-type(5n + 1)) div,
 .rgh-tic:is(:nth-of-type(5n + 1), :nth-of-type(5n + 2)):has(
-		~ :hover:nth-of-type(5n + 2)
+		~ .rgh-tic:hover:nth-of-type(5n + 2)
 	)
 	div,
 .rgh-tic:is(
 		:nth-of-type(5n + 1),
 		:nth-of-type(5n + 2),
 		:nth-of-type(5n + 3)
-	):has(~ :hover:nth-of-type(5n + 3))
+	):has(~ .rgh-tic:hover:nth-of-type(5n + 3))
 	div,
 .rgh-tic:is(
 		:nth-of-type(5n + 1),
 		:nth-of-type(5n + 2),
 		:nth-of-type(5n + 3),
 		:nth-of-type(5n + 4)
-	):has(~ :hover:nth-of-type(5n + 4))
+	):has(~ .rgh-tic:hover:nth-of-type(5n + 4))
 	div,
 .rgh-tic:is(
 		:nth-of-type(5n + 1),
@@ -59,7 +59,7 @@
 		:nth-of-type(5n + 3),
 		:nth-of-type(5n + 4),
 		:nth-of-type(5n + 5)
-	):has(~ :hover:nth-of-type(5n + 5))
+	):has(~ .rgh-tic:hover:nth-of-type(5n + 5))
 	div {
 	border-color: #79b8ff;
 	background-color: var(
@@ -72,3 +72,4 @@
 .rgh-table-input .sentinel {
 	display: none;
 }
+


### PR DESCRIPTION
Make table-input more performant as @fregante discovered in fixes #8039.

It will ensure that firefox does not freeze when opening the labels dialog when you have a large number of labels (somewhere between 500 and 2241).