### PR TITLE
`conversation-authors` - Avoid border clip on Windows

### DIFF
--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -11,5 +11,5 @@
 
 /* Fix border partially visible in new view #8025 */
 [data-testid='list-view-item-description'] {
-	margin-top: 1px;
+	margin-top: 1.5px;
 }


### PR DESCRIPTION
Follow-up to https://github.com/refined-github/refined-github/pull/8025#issuecomment-2469007955
I noticed that the margin-top value needs to be 1.5px instead of 1px.

## Test URLs

https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc%20is%3Aissue%20state%3Aclosed

## Screenshot

![](https://github.com/user-attachments/assets/f5ae5a0e-4c8c-48d2-b2e7-a556a88e4d0e)

Comparison of 1px vs 1.5px padding:
1px
![2024-11-12_203015](https://github.com/user-attachments/assets/981fd024-b3e4-491a-a2bf-463f9e488a41)

1.5px
![2024-11-12_203039](https://github.com/user-attachments/assets/1a705897-fd24-42e3-8377-7b09ec6f1894)