### PR TITLE
`rgh-token-user` - Fix token button style

### DIFF
--- a/source/features/rgh-token-user.tsx
+++ b/source/features/rgh-token-user.tsx
@@ -24,7 +24,7 @@ async function verify(header: HTMLButtonElement): Promise<void> {
 			icon: <AlertIcon />,
 			classes: ['mx-3', 'mt-3', 'mb-0', 'py-2'],
 			text: [
-				<>Your <OptionsLink className="Link--muted">Refined GitHub token</OptionsLink> is for a different user, the extension will act on behalf of <code>{currentTokenUser}</code></>,
+				<>Your <OptionsLink className="btn-link">Refined GitHub token</OptionsLink> is for a different user, the extension will act on behalf of <code>{currentTokenUser}</code></>,
 			],
 		},
 		));


### PR DESCRIPTION
- Follows https://github.com/refined-github/refined-github/pull/8002

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

Before:

<img width="353" alt="image" src="https://github.com/user-attachments/assets/f9083c92-49c6-476c-8430-94b1bc300308">


After:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/530402c6-3118-4700-a04a-08cc3b4583ca">
