### PR TITLE
Fix storage display in options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ const rollup = {
 		'options': './source/options.tsx',
 		'welcome': './source/welcome.svelte',
 		'header': './source/options/header.svelte',
+		'storage-usage': './source/options/storage-usage.svelte',
 		'background': './source/background.ts',
 		'refined-github': './source/refined-github.ts',
 		'content-script': './source/content-script.ts',

--- a/source/helpers/used-storage.ts
+++ b/source/helpers/used-storage.ts
@@ -1,16 +1,25 @@
+export function getTrueSizeOfObject(object: Record<string, any>): number {
+	// Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1385832#c20
+	return new TextEncoder().encode(
+		Object.entries(object)
+			.map(([key, value]) => key + JSON.stringify(value))
+			.join(''),
+	).length;
+}
+
 /** `getBytesInUse` polyfill */
-export default async function getStorageBytesInUse(area: 'local' | 'sync'): Promise<any> {
+export async function getStorageBytesInUse(area: 'local' | 'sync'): Promise<any> {
 	const storage = chrome.storage[area];
 	try {
 		return await storage.getBytesInUse(); // Exists in Safari iOS, but can't be called...
 	} catch {
-		// Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1385832#c20
-		return new TextEncoder().encode(
-			Object.entries(await storage.get())
-				.map(([key, value]) => key + JSON.stringify(value))
-				.join(''),
-		).length;
+		return getTrueSizeOfObject(await storage.get());
 	}
+}
+
+export async function getStoredItemSize(area: chrome.storage.AreaName, item: string): Promise<number> {
+	const storage = chrome.storage[area];
+	return getTrueSizeOfObject(await storage.get(item));
 }
 
 export async function hasUsedStorage(): Promise<boolean> {

--- a/source/options.css
+++ b/source/options.css
@@ -54,7 +54,7 @@ li[data-validation] {
 	margin-bottom: 0.3em;
 }
 
-output {
+storage-usage {
 	font-style: italic;
 }
 

--- a/source/options.html
+++ b/source/options.html
@@ -7,6 +7,7 @@
 <title>Refined GitHub options</title>
 <link rel="stylesheet" href="options.css">
 <script type="module" src="header.js"></script>
+<script type="module" src="storage-usage.js"></script>
 <script type="module" src="options.js" defer></script>
 <rgh-header title="Refined GitHub">
 	<p>
@@ -80,8 +81,8 @@
 		<div>
 			<p>Like a userstyle, useful to undo unwanted style changes</p>
 			<p><textarea name="customCSS" rows="2" spellcheck="false" class="monospace-field"></textarea></p>
-			<p>CSS is limited to 100KB, after which the options <a href="https://github.com/fregante/webext-options-sync/issues/27">will stop being saved</a>.</p>
-			<p>Options storage: <output class="storage-sync">unknown</output></p>
+			<p>Options storage: <storage-usage area="sync" item="options">unknown</storage-usage></p>
+			<p>When the storage is full, the options <a href="https://github.com/fregante/webext-options-sync/issues/27">will stop being saved</a>. If you need to use a lot of CSS, use a dedicated userstyle extension.</p>
 		</div>
 	</details>
 
@@ -110,8 +111,8 @@
 				</label>
 			</p>
 			<p>
-				Options storage: <output class="storage-sync">unknown</output><br>
-				Cache storage: <output class="storage-local">unknown</output><br>
+				Options storage: <storage-usage area="sync" item="options">unknown</storage-usage><br>
+				Cache storage: <storage-usage area="local">unknown</storage-usage><br>
 				Refined Github version: <output id="version">unknown</output>
 			</p>
 			<p>

--- a/source/options/storage-usage.svelte
+++ b/source/options/storage-usage.svelte
@@ -1,0 +1,60 @@
+<svelte:options customElement={{
+	tag: 'storage-usage',
+	props: {
+		area: {type: 'String', attribute: 'area'},
+		item: {type: 'String', attribute: 'item'},
+	},
+}} />
+
+<script lang='ts'>
+	import prettyBytes from 'pretty-bytes';
+
+	import {onMount} from 'svelte';
+
+	import {getStorageBytesInUse, getStoredItemSize, getTrueSizeOfObject} from '../helpers/used-storage.js';
+
+	const {area, item}: {
+		area: 'sync' | 'local';
+		item?: string;
+	} = $props();
+	const storage = chrome.storage[area];
+
+	let used = $state(0);
+	const available = $derived((item ? (storage as chrome.storage.SyncStorageArea).QUOTA_BYTES_PER_ITEM ?? storage.QUOTA_BYTES : storage.QUOTA_BYTES) - used);
+
+	async function getStorageUsage() {
+		used = item ? await getStoredItemSize(area, item) : await getStorageBytesInUse(area);
+	}
+
+	const handleStorageChange = (changes: {[key: string]: chrome.storage.StorageChange}, areaName: chrome.storage.AreaName) => {
+		if (item && changes[item]) {
+			used = getTrueSizeOfObject(changes[item].newValue);
+		}
+
+		if (areaName === area) {
+			getStorageUsage();
+		}
+	};
+
+	$effect(() => {
+		if (item) {
+			used = getTrueSizeOfObject(storage.get(item));
+		}
+	});
+
+	onMount(() => {
+		getStorageUsage();
+
+		chrome.storage.onChanged.addListener(handleStorageChange);
+
+		return () => {
+			chrome.storage.onChanged.removeListener(handleStorageChange);
+		};
+	});
+</script>
+
+<output>
+	{available < 100_000
+		? `Only ${prettyBytes(available)} available`
+		: `${prettyBytes(used)} used`}
+</output>


### PR DESCRIPTION
- extends https://github.com/refined-github/refined-github/pull/6595
 

The label was wrong, we don't have 100KB but only 8KB because `webext-options-sync` stores everything in a single key, which is limited to 8KB https://github.com/fregante/webext-options-sync/issues/80.

## Screenshot

<img width="475" alt="Screenshot" src="https://github.com/user-attachments/assets/2ff5c8f7-1528-460a-a206-70be5563f9e8">


<img width="615" alt="Screenshot 5" src="https://github.com/user-attachments/assets/46e7571e-0e6a-4cac-81f0-d3af779a0d72">
