### PR TITLE
`clean-conversation-sidebar` - Don't break the label picker

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -103,10 +103,13 @@ async function cleanSidebar(): Promise<void> {
 	}
 
 	// Labels
-	if (!cleanSection('.js-issue-labels') && !canEditSidebar()) {
-		// Hide heading in any case except `canEditSidebar`
-		$('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading')
-			.remove();
+	if (!cleanSection('.js-issue-labels')) {
+		const heading = $('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading');
+		// If it's a <summary> element, we keep the header because it opens the picker
+		// https://github.com/refined-github/refined-github/issues/7283
+		if (heading.tagName !== 'SUMMARY') {
+			heading.remove();
+		}
 	}
 
 	// Development (linked issues/PRs)

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -103,13 +103,10 @@ async function cleanSidebar(): Promise<void> {
 	}
 
 	// Labels
-	if (!cleanSection('.js-issue-labels')) {
-		const heading = $('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading');
-		// If it's a <summary> element, we keep the header because it opens the picker
-		// https://github.com/refined-github/refined-github/issues/7283
-		if (heading.tagName !== 'SUMMARY') {
-			heading.remove();
-		}
+	if (!cleanSection('.js-issue-labels') && !canEditSidebar()) {
+		// Hide heading in any case except `canEditSidebar`
+		$('.discussion-sidebar-item:has(.js-issue-labels) .discussion-sidebar-heading')
+			.remove();
 	}
 
 	// Development (linked issues/PRs)

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -5,13 +5,12 @@ import {elementExists} from 'select-dom';
 import {$, $optional} from 'select-dom/strict.js';
 import * as pageDetect from 'github-url-detection';
 
-import onetime from '../helpers/onetime.js';
 import features from '../feature-manager.js';
 import onElementRemoval from '../helpers/on-element-removal.js';
 import observe from '../helpers/selector-observer.js';
 import {removeTextNodeContaining} from '../helpers/dom-utils.js';
 
-const canEditSidebar = onetime((): boolean => elementExists('.discussion-sidebar-item [data-hotkey="l"]'));
+const canEditSidebar = (): boolean => elementExists('.discussion-sidebar-item [data-hotkey="l"]');
 
 function getNodesAfter(node: Node): Range {
 	const range = new Range();

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -10,6 +10,7 @@ import onElementRemoval from '../helpers/on-element-removal.js';
 import observe from '../helpers/selector-observer.js';
 import {removeTextNodeContaining} from '../helpers/dom-utils.js';
 
+// Don't cache: https://github.com/refined-github/refined-github/issues/7283
 const canEditSidebar = (): boolean => elementExists('.discussion-sidebar-item [data-hotkey="l"]');
 
 function getNodesAfter(node: Node): Range {


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7283


## Test URLs

1. Visit a conversation you can't moderate, like this https://togithub.com/facebook/react/pull/31542
2. Reach a conversation you can't moderate, via ajaxed link, like via notifications

