### PR TITLE
`quick-label-removal` - Don't add button where you can't remove labels

### DIFF
--- a/source/features/quick-label-removal.tsx
+++ b/source/features/quick-label-removal.tsx
@@ -8,7 +8,6 @@ import {assertError} from 'ts-extras';
 import * as pageDetect from 'github-url-detection';
 import delegate, {type DelegateEvent} from 'delegate-it';
 
-import onetime from '../helpers/onetime.js';
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import showToast from '../github-helpers/toast.js';
@@ -16,7 +15,10 @@ import {getConversationNumber} from '../github-helpers/index.js';
 import observe from '../helpers/selector-observer.js';
 import {expectToken} from '../github-helpers/github-token.js';
 
-const canNotEditLabels = onetime((): boolean => !elementExists('.label-select-menu .octicon-gear'));
+// Don't cache: https://github.com/refined-github/refined-github/issues/7283
+function canEditLabels(): boolean {
+	return elementExists('.label-select-menu .octicon-gear');
+}
 
 function getLabelList(): HTMLElement {
 	return $('.label-select-menu [src] .hx_rsm-content');
@@ -82,11 +84,11 @@ async function init(signal: AbortSignal): Promise<void> {
 }
 
 void features.add(import.meta.url, {
-	include: [
+	asLongAs: [
 		pageDetect.isConversation,
+		canEditLabels,
 	],
 	exclude: [
-		canNotEditLabels,
 		pageDetect.isArchivedRepo,
 	],
 	awaitDomReady: true, // The sidebar is near the end of the page


### PR DESCRIPTION
Similar:

- https://github.com/refined-github/refined-github/pull/8067
- https://github.com/refined-github/refined-github/issues/7283


## Before

<img width="365" alt="Screenshot 4" src="https://github.com/user-attachments/assets/c517b357-0969-4254-beb1-c089e275f55f">



