### PR TITLE
`netiquette` - Support new commit view

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -138,7 +138,10 @@ function makeReactFieldKinder(field: HTMLTextAreaElement): void {
 
 function initKindness(signal: AbortSignal): void {
 	observe('p.CommentBox-placeholder', makeFieldKinder, {signal});
-	observe('textarea[placeholder="Use Markdown to format your comment"]', makeReactFieldKinder, {signal});
+	observe(`textarea:is(
+		[placeholder="Use Markdown to format your comment"],
+		[placeholder="Leave a comment"]
+	)`, makeReactFieldKinder, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -138,10 +138,10 @@ function makeReactFieldKinder(field: HTMLTextAreaElement): void {
 
 function initKindness(signal: AbortSignal): void {
 	observe('p.CommentBox-placeholder', makeFieldKinder, {signal});
-	observe(`textarea:is(
-		[placeholder="Use Markdown to format your comment"],
-		[placeholder="Leave a comment"]
-	)`, makeReactFieldKinder, {signal});
+	observe([
+		'textarea[placeholder="Use Markdown to format your comment"]', // On issues
+		'textarea[placeholder="Leave a comment"]', // On single commits
+	], makeReactFieldKinder, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
part of #7808

## Test URLs

https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af

## Screenshot

| Before | After |
| ------ | ------ |
| ![CleanShot 2024-11-18 at 08 47 53@2x](https://github.com/user-attachments/assets/97c506e1-cbce-4311-b5b2-c15037a1260d) | ![CleanShot 2024-11-18 at 08 47 40@2x](https://github.com/user-attachments/assets/da2700f5-2588-4038-8e18-88d8371baafa) |
| ![CleanShot 2024-11-18 at 08 48 01@2x](https://github.com/user-attachments/assets/226f9947-b044-4623-bdc9-7462b31c5753) | ![CleanShot 2024-11-18 at 08 47 33@2x](https://github.com/user-attachments/assets/295e5dfe-a4bf-4d9a-8294-f90aa5d0f092) |