### PR TITLE
`hide-low-quality-comments` - Fix feature on linked comments

### DIFF
--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -1,7 +1,7 @@
 import './hide-low-quality-comments.css';
 
 import React from 'dom-chef';
-import {$} from 'select-dom/strict.js';
+import {$, $optional} from 'select-dom/strict.js';
 import {$$, elementExists} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {type DelegateEvent} from 'delegate-it';
@@ -39,7 +39,7 @@ function init(): void {
 	}
 
 	const linkedComment = location.hash.startsWith('#issuecomment-')
-		? $(`${location.hash} ${singleParagraphCommentSelector}`)
+		? $optional(`${location.hash} ${singleParagraphCommentSelector}`)
 		: undefined;
 
 	for (const commentText of $$(singleParagraphCommentSelector)) {

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -101,6 +101,10 @@ void features.add(import.meta.url, {
 });
 
 /*
+
 ## Test URLs
-https://github.com/facebook/jest/issues/5311
+
+- 26 hidden comments: https://togithub.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issue-849740710
+- Linked comment should not be collapsed: https://togithub.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issuecomment-821212185
+
 */


### PR DESCRIPTION
The feature stops working when you load a page with a comment link AND the comment link is not "low quality"

```
ElementNotFoundError: Expected element not found: #issuecomment-2413307020 .comment-body > p:only-child
    at expectElement (chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/npm/select-dom.js:21:11)
    at init (chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/features/hide-low-quality-comments.js:38:5)
    at chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/feature-manager.js:100:24
    at chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/helpers/async-for-each.js:6:52
    at Array.map (<anonymous>)
    at asyncForEach (chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/helpers/async-for-each.js:6:34)
    at maybeRun (chrome-extension://jialghbnladbdlhaibaoejjlnihkmemc/assets/feature-manager.js:99:8)
```


## Test URLs


- 26 hidden comments: https://togithub.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issue-849740710
- Linked comment should not be collapsed: https://togithub.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issuecomment-821212185


## Related

- caused by https://github.com/refined-github/refined-github/pull/7966