### PR TITLE
`shorten-links` - Support new commit view

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -7,7 +7,8 @@ import observe from '../helpers/selector-observer.js';
 function initOnce(): void {
 	observe([
 		`.comment-body a[href]:not(.${linkifiedURLClass})`,
-		`.react-issue-comment .markdown-body a[href]:not(.${linkifiedURLClass})`,
+		`.react-issue-comment .markdown-body a[href]:not(.${linkifiedURLClass})`, // Issue comments
+		`[data-testid="review-thread"] .markdown-body a[href]:not(.${linkifiedURLClass})`, // React commit view
 	], shortenLink);
 }
 


### PR DESCRIPTION
Part of #7808 

## Test URLs

https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af#r148774860

## Screenshot

Before: 

![CleanShot 2024-11-20 at 08 30 45@2x](https://github.com/user-attachments/assets/571a7f1a-ab78-483c-b87e-ca16588232a1)

After:

![CleanShot 2024-11-20 at 08 30 28@2x](https://github.com/user-attachments/assets/ebf89145-2799-4368-bfec-a385a05af656)

