### PR TITLE
`linkify-user-label` - Support new commit view

### DIFF
--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -23,11 +23,13 @@ export default function getCommentAuthor(anyElementInsideComment: Element): stri
 			'.TimelineItem', // PR comments (and pre-issue redesign issue comments)
 			'.review-comment', // PR review comments
 			'.react-issue-comment', // Issue comments
+			'[data-testid="comment-header"]', // Commit comments
 		])!
 		.querySelector([
 			'.TimelineItem-avatar img', // PR comments (and pre-issue redesign issue comments)
 			'img.avatar', // PR review comments
 			'img[data-testid="github-avatar"]', // Issue comments
+			'img[data-component="Avatar"]', // Commit comments
 		])!;
 
 	const name = avatar


### PR DESCRIPTION
Part of #7808 


## Test URLs

https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2

## Screenshot

<img width="1605" alt="image" src="https://github.com/user-attachments/assets/4ab507c5-ee69-40ad-99d9-e2bb057cace8">
