### PR TITLE
`hide-diff-signs` - Support new commit view

### DIFF
--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -7,5 +7,5 @@
 	)::before,
 	/* React commit page */
 	.diff-text-marker {
-		visibility: hidden;
+	visibility: hidden;
 }

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -2,8 +2,10 @@
 	:is(
 		.diff-text-cell
 		.diff-text, /* Edit page, probably upcoming DOM everywhere */
-		.blob-code-inner,/* Inline review blocks in PRs */
-		.blob-code-marker-cell/* Commit page */
-	)::before {
-	visibility: hidden;
+		.blob-code-inner, /* Inline review blocks in PRs */
+		.blob-code-marker-cell, /* Commit page */
+	)::before,
+	/* React commit page */
+	.diff-text-marker {
+		visibility: hidden;
 }


### PR DESCRIPTION
- Part of #7808

## Test URLs

https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af#r148774860

## Screenshot

<img width="602" alt="image" src="https://github.com/user-attachments/assets/8e1b22fc-d566-4402-8c40-68ef80abc699">
