### PR TITLE
`scrollable-areas` - Remove from new commit conversation view

### DIFF
--- a/source/features/scrollable-areas.css
+++ b/source/features/scrollable-areas.css
@@ -1,6 +1,6 @@
+/* Don't support in React commit view #8100 */
 [rgh-scrollable-areas] {
 	.comment-body,
-	[data-testid='review-thread'] .markdown-body,
 	[data-testid='markdown-body'] {
 		:is(blockquote, pre) {
 			position: relative; /* OctoLinker compat: attach the purple balls to the scroll */

--- a/source/features/scrollable-areas.css
+++ b/source/features/scrollable-areas.css
@@ -1,6 +1,6 @@
 [rgh-scrollable-areas] {
 	.comment-body,
-	[data-testid="review-thread"] .markdown-body,
+	[data-testid='review-thread'] .markdown-body,
 	[data-testid='markdown-body'] {
 		:is(blockquote, pre) {
 			position: relative; /* OctoLinker compat: attach the purple balls to the scroll */

--- a/source/features/scrollable-areas.css
+++ b/source/features/scrollable-areas.css
@@ -1,6 +1,6 @@
 [rgh-scrollable-areas] {
 	.comment-body,
-	.markdown-body,
+	[data-testid="review-thread"] .markdown-body,
 	[data-testid='markdown-body'] {
 		:is(blockquote, pre) {
 			position: relative; /* OctoLinker compat: attach the purple balls to the scroll */


### PR DESCRIPTION
- Fixes #8099 


## Test URLs

- https://github.com/elastio/bon#struct-builder
- https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2

## Screenshot

<img width="1861" alt="image" src="https://github.com/user-attachments/assets/8fc82a67-d558-42f6-84ce-4fe238aefadb">

