### PR TITLE
`one-key-formatting` - Enable on commit title fields

### DIFF
--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -43,6 +43,7 @@ function init(signal: AbortSignal): void {
 		'input[name="commit_title"]',
 		'input[name="gist[description]"]',
 		'#saved-reply-title-field',
+		'#commit-message-input',
 	], 'keydown', eventHandler, {signal});
 }
 


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/7707


## Test URLs

https://github.com/refined-github/refined-github/edit/main/.git-blame-ignore-revs


## Screenshot

![table](https://github.com/user-attachments/assets/72fcaf98-58bd-4656-a3ba-23f4d5e82c1a)
