### PR TITLE
`conventional-commits` - Support links following the type

### DIFF
--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -23,6 +23,11 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 		return;
 	}
 
+	// Skip commits that are _only_ "ci:" without anything else. Rare but would be confusing to show just the label
+	if (commit.raw === textNode.textContent && !commitTitleElement.nextElementSibling) {
+		return;
+	}
+
 	commitTitleElement.prepend(
 		<span className="IssueLabel hx_IssueLabel mr-2" rgh-conventional-commits={commit.rawType}>
 			{commit.type}

--- a/source/helpers/conventional-commits.test.ts
+++ b/source/helpers/conventional-commits.test.ts
@@ -59,8 +59,15 @@ test('parseConventionalCommit', () => {
 		  "type": "Feature",
 		}
 	`);
+	expect(parseConventionalCommit('fix:')).toMatchInlineSnapshot(`
+		{
+		  "raw": "fix:",
+		  "rawType": "fix",
+		  "scope": undefined,
+		  "type": "Fix",
+		}
+	`);
 
-	expect(parseConventionalCommit('feat:')).toBeUndefined();
 	expect(parseConventionalCommit('idk(label): not recognized')).toBeUndefined();
 	expect(parseConventionalCommit('Commit message')).toBeUndefined();
 	expect(parseConventionalCommit('feat(): Commit message')).toBeUndefined();

--- a/source/helpers/conventional-commits.ts
+++ b/source/helpers/conventional-commits.ts
@@ -1,5 +1,5 @@
 // Using https://www.conventionalcommits.org/ as a reference.
-export const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+)\))?(?<major>!)?: /;
+export const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+)\))?(?<major>!)?: */;
 
 // Do not send PRs for types not listed here: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#rules
 // No more types will be added nor do we accept options.


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/8066


## Notes

- ✅ `ci: #1` is now formatted
- ⚠️ `ci: #1` has a little extra padding after the type because a space character appears _between_ the two elements
- ✅ `ci:` is still skipped
- ℹ️ `fix: #1` has custom formatting already so it's not detected as conventional commit

<img width="323" alt="Screenshot 14" src="https://github.com/user-attachments/assets/a793cb53-628c-46f4-a4f5-34c9e32b13b1">


## Test URLs

https://github.com/refined-github/sandbox/commits/conventional-commits/


## Screenshot
<img width="330" alt="Screenshot" src="https://github.com/user-attachments/assets/fa563e43-d244-4361-b8a5-11a31c3edd5f">
