### PR TITLE
Fix GitHub bug: broken layout with long release assets names

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -95,6 +95,13 @@ div.markdown-body {
 	flex-shrink: 0;
 }
 
+/* Long release asset download links break the layout */
+/* Info: https://github.com/refined-github/refined-github/issues/8065 */
+/* Test: https://github.com/hkint/xiaomi-ax3000t-immortalwrt-hanwckf-firmware-build/releases/tag/ImmortalWrt_2024.11.13-0026 */
+svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
+	white-space: wrap;
+}
+
 /*
 
 Test URLs:


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/8065


## Test URLs
https://github.com/hkint/xiaomi-ax3000t-immortalwrt-hanwckf-firmware-build/releases/tag/ImmortalWrt_2024.11.13-0026

## Before

<img width="847" alt="Screenshot 17" src="https://github.com/user-attachments/assets/e37e7f82-c159-4d1f-836b-946ea51f31cc">

## After

<img width="847" alt="Screenshot 16" src="https://github.com/user-attachments/assets/c59b25f2-09cd-40dd-bda3-4ad174d794a6">




