### PR TITLE
Options: expand screenshot inline instead of new tab

### DIFF
--- a/source/helpers/target-blank-polyfill.ts
+++ b/source/helpers/target-blank-polyfill.ts
@@ -1,3 +1,4 @@
+import filterAlteredClicks from 'filter-altered-clicks';
 import {isSafari} from 'webext-detect';
 
 function isLinkExternal(link: HTMLAnchorElement): boolean {
@@ -10,11 +11,11 @@ function isLinkExternal(link: HTMLAnchorElement): boolean {
 
 // WTF Safari. It opens target="_blank" links in the same tab on extension pages
 if ('window' in globalThis && 'open' in globalThis && isSafari()) {
-	document.addEventListener('click', event => {
+	document.addEventListener('click', filterAlteredClicks(event => {
 		const clicked = event.target;
 		if (clicked instanceof HTMLAnchorElement && isLinkExternal(clicked)) {
 			event.preventDefault();
 			window.open(clicked.href);
 		}
-	});
+	}));
 }


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/8059


## Test URLs

Options page

## Screenshot

tested in Chrome (after dropping `isSafari`)