### PR TITLE
`comments-time-machine-links` - Support new view

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -65,8 +65,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 	);
 }
 
-function addInlineLinks(menu: HTMLElement, timestamp: string): void {
-	const comment = menu.closest('.js-comment')!;
+function addInlineLinks(comment: HTMLElement, timestamp: string): void {
 	const links = $$(`
 		a[href^="${location.origin}"][href*="/blob/"]:not(.${linkifiedURLClass}),
 		a[href^="${location.origin}"][href*="/tree/"]:not(.${linkifiedURLClass})
@@ -117,8 +116,16 @@ async function init(signal: AbortSignal): Promise<void> {
 			.datetime
 			.value;
 
-		addInlineLinks(menu, timestamp);
+		addInlineLinks(menu.closest('.js-comment')!, timestamp);
 		addDropdownLink(menu, timestamp);
+	}, {signal});
+
+	observe([
+		'div.react-issue-comment',
+		'[data-testid="review-thread"] > div',
+	], comment => {
+		const timestamp = comment.querySelector('relative-time')!.attributes.datetime.value;
+		addInlineLinks(comment, timestamp);
 	}, {signal});
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -124,7 +124,7 @@ async function init(signal: AbortSignal): Promise<void> {
 		'div.react-issue-comment',
 		'[data-testid="review-thread"] > div',
 	], comment => {
-		const timestamp = comment.querySelector('relative-time')!.attributes.datetime.value;
+		const timestamp = $('relative-time', comment).attributes.datetime.value;
 		addInlineLinks(comment, timestamp);
 	}, {signal});
 }


### PR DESCRIPTION
Part of 
- #7808
- #7856


## Test URLs

https://github.com/refined-github/sandbox/commit/54c10fe670779eab43b6a18b7fb06e51dd7050af#r149853192

https://github.com/download-directory/download-directory.github.io/issues/143

## Screenshot

<img width="1631" alt="image" src="https://github.com/user-attachments/assets/bdf41f79-ef79-4722-bd17-2cdc679d3efc">

<img width="996" alt="image" src="https://github.com/user-attachments/assets/4a4f6816-39e1-4f6b-9a2a-0fe784bdaee5">

