### PR TITLE
`previous-version` - Show in blame page

### DIFF
--- a/source/features/previous-version.tsx
+++ b/source/features/previous-version.tsx
@@ -99,6 +99,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,
+		pageDetect.isBlame,
 	],
 	exclude: [
 		pageDetect.isRepoHome,


### PR DESCRIPTION



## Test URLs

https://github.com/chalk/chalk/blame/f399cd0ff69841e88cca89d43a49f1cc9ba2efd5/readme.md

## Screenshot

https://github.com/user-attachments/assets/260580e4-425b-4065-b36e-efeeba32e28a

