### PR TITLE
Faster CSS hotfixes

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -21,6 +21,10 @@ addPermissionToggle();
 // Firefox/Safari polyfill
 addOptionsContextMenu();
 
+// The background page is restarted regularly, so we rely on that to update it and re-register it.
+// The getter has a side-effect: it automatically registers the value after it fetches it.
+void styleHotfixes.get(version);
+
 handleMessages({
 	async openUrls(urls: string[], {tab}: chrome.runtime.MessageSender) {
 		for (const [index, url] of urls.entries()) {
@@ -40,9 +44,6 @@ handleMessages({
 	},
 	async openOptionsPage() {
 		return chrome.runtime.openOptionsPage();
-	},
-	async getStyleHotfixes() {
-		return styleHotfixes.get(version);
 	},
 });
 

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -5,7 +5,6 @@ import stripIndent from 'strip-indent';
 import type {Promisable} from 'type-fest';
 import * as pageDetect from 'github-url-detection';
 import {isWebPage} from 'webext-detect';
-import {messageRuntime} from 'webext-msg';
 import oneEvent from 'one-event';
 
 import waitFor from './helpers/wait-for.js';
@@ -19,7 +18,6 @@ import {
 } from './helpers/feature-utils.js';
 import optionsStorage, {isFeatureDisabled, type RGHOptions} from './options-storage.js';
 import {
-	applyStyleHotfixes,
 	getLocalHotfixesAsOptions,
 	preloadSyncLocalStrings,
 	brokenFeatures,
@@ -86,10 +84,6 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 	}
 
 	document.documentElement.setAttribute('refined-github', '');
-
-	// Request in the background page to avoid showing a 404 request in the console
-	// https://github.com/refined-github/refined-github/issues/6433
-	void messageRuntime<string>({getStyleHotfixes: true}).then(applyStyleHotfixes);
 
 	if (options.customCSS.trim().length > 0) {
 		// Review #5857 and #5493 before making changes

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -3,7 +3,6 @@ import {isEnterprise} from 'github-url-detection';
 import compareVersions from 'tiny-version-compare';
 import {any as concatenateTemplateLiteralTag} from 'code-tag';
 import {base64ToString} from 'uint8array-extras';
-import {queryAdditionalPermissions} from 'webext-permissions';
 
 import type {RGHOptions} from '../options-storage.js';
 import isDevelopmentVersion from './is-development-version.js';
@@ -75,12 +74,10 @@ async function registerStyleHotfixes(css: string): Promise<void> {
 	}
 
 	const id = 'style-hotfixes';
-	// TODO: Replace with https://github.com/fregante/webext-options-sync-per-domain/issues/11
-	const {origins} = await queryAdditionalPermissions({strictOrigins: false});
 	await chrome.scripting.unregisterContentScripts({ids: [id]});
 	await chrome.scripting.registerContentScripts([{
 		id,
-		matches: ['https://github.com', ...origins],
+		matches: ['https://github.com'],
 		css: [css],
 	}]);
 }

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -70,14 +70,15 @@ export const styleHotfixes = new CachedFunction('style-hotfixes', {
 
 async function registerStyleHotfixes(css: string): Promise<void> {
 	if (isDevelopmentVersion()) {
+	const id = 'style-hotfixes';
+	await chrome.scripting.unregisterContentScripts({ids: [id]}).catch(() => {});
+	if (!css ) {
 		return;
 	}
 
-	const id = 'style-hotfixes';
-	await chrome.scripting.unregisterContentScripts({ids: [id]});
 	await chrome.scripting.registerContentScripts([{
 		id,
-		matches: ['https://github.com'],
+		matches: ['https://github.com/*'],
 		css: [css],
 	}]);
 }

--- a/source/options.html
+++ b/source/options.html
@@ -141,6 +141,7 @@
 			<p>In order to address severe issues as quickly as possible, Refined GitHub loads a list of disabled features and temporary CSS fixes. <a href="https://github.com/refined-github/yolo">More info.</a></p>
 			<p>This is the latest CSS fetched from the server (if any):</p>
 			<p><textarea id="hotfixes-field" rows="2" disabled></textarea></p>
+			<button type="button" id="update-style-hotfixes">Fetch new style hotfixes</button>
 		</div>
 	</details>
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -71,11 +71,10 @@ function isEnterprise(): boolean {
 async function showStoredCssHotfixes(): Promise<void> {
 	const cachedCSS = await styleHotfixes.getCached(version);
 	$('#hotfixes-field').textContent
-		= isDevelopmentVersion()
-			? 'Hotfixes are not applied in the development version.'
-			: isEnterprise()
-				? 'Hotfixes are not applied on GitHub Enterprise.'
-				: cachedCSS ?? 'No CSS found in cache.';
+		= (isDevelopmentVersion() ? 'Hotfixes are not applied in the development version:\n\n' : '')
+		+ isEnterprise()
+			? 'Hotfixes are not applied on GitHub Enterprise.'
+			: cachedCSS ?? 'No CSS found in cache.';
 }
 
 function enableToggleAll(this: HTMLButtonElement): void {


### PR DESCRIPTION
- Part of https://github.com/refined-github/refined-github/issues/8054

Pros:

- This will avoid the FOUC on Slow browsers (Safari…) because the hotfix no longer depends on the JS content script
- It should fix injection on GitHub Enterprise (not sure how it was broken)
	- https://github.com/refined-github/refined-github/issues/8091#issuecomment-2511308547

Edit: well, it seems that it was intentional:

https://github.com/refined-github/refined-github/blob/aff10c3ec47f0062c908bc089212e235c7cae9ea/source/options.tsx#L76-L78