### PR TITLE
Improve hotfix loading reliability

### DIFF
--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -23,20 +23,14 @@ function parseCsv(content: string): string[][] {
 }
 
 async function fetchHotfix(path: string): Promise<string> {
-	// The explicit endpoint is necessary because it shouldn't change on GHE
-	// We can't use `https://raw.githubusercontent.com` because of permission issues https://github.com/refined-github/refined-github/pull/3530#issuecomment-691595925
-	const request = await fetch(`https://api.github.com/repos/refined-github/yolo/contents/${path}`, {
-		cache: 'no-store', // Disable caching altogether
-	});
-	const {content} = await request.json();
-
-	// Rate-limit check
-	if (content) {
-		console.log('Probably hit rate-limit');
-		return base64ToString(content).trim();
+	// Use GitHub Pages host because the API is rate-limited
+	const request = await fetch(`https://refined-github.github.io/yolo/${path}`);
+	const response = await request.json();
+	if (!response.content) {
+		throw new Error(`Failed to fetch hotfix: ${JSON.stringify(response, undefined, 2)}`);
 	}
 
-	return '';
+	return base64ToString(response.content).trim();
 }
 
 type HotfixStorage = Array<[FeatureID, string, string]>;

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -24,7 +24,9 @@ function parseCsv(content: string): string[][] {
 
 async function fetchHotfix(path: string): Promise<string> {
 	// Use GitHub Pages host because the API is rate-limited
-	const request = await fetch(`https://refined-github.github.io/yolo/${path}`);
+	const request = await fetch(`https://refined-github.github.io/yolo/${path}`, {
+		cache: 'no-store', // Disable caching altogether
+	});
 	const response = await request.json();
 	if (!response.content) {
 		throw new Error(`Failed to fetch hotfix: ${JSON.stringify(response, undefined, 2)}`);

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -3,7 +3,6 @@ import {CachedFunction} from 'webext-storage-cache';
 import {isEnterprise} from 'github-url-detection';
 import compareVersions from 'tiny-version-compare';
 import {any as concatenateTemplateLiteralTag} from 'code-tag';
-import {base64ToString} from 'uint8array-extras';
 
 import type {RGHOptions} from '../options-storage.js';
 import isDevelopmentVersion from './is-development-version.js';

--- a/source/helpers/hotfix.tsx
+++ b/source/helpers/hotfix.tsx
@@ -27,12 +27,9 @@ async function fetchHotfix(path: string): Promise<string> {
 	const request = await fetch(`https://refined-github.github.io/yolo/${path}`, {
 		cache: 'no-store', // Disable caching altogether
 	});
-	const response = await request.json();
-	if (!response.content) {
-		throw new Error(`Failed to fetch hotfix: ${JSON.stringify(response, undefined, 2)}`);
-	}
 
-	return base64ToString(response.content).trim();
+	const contents = await request.text();
+	return contents.trim();
 }
 
 type HotfixStorage = Array<[FeatureID, string, string]>;


### PR DESCRIPTION
- Should fix https://github.com/refined-github/refined-github/issues/7916

Gotta love no-effort GitHub Pages publishing. I clicked a button and got a CDN-baked URL that _hopefully_ isn't affected by (aggressive) rate-limiting.

e.g. https://refined-github.github.io/yolo/broken-features.csv