### PR TITLE
Meta: Use `select-dom` more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"pretty-bytes": "^6.1.1",
 				"push-form": "^1.0.1",
 				"regex-join": "^2.1.0",
-				"select-dom": "^9.2.0",
+				"select-dom": "^9.3.0",
 				"shorten-repo-url": "^5.2.1",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^4.1.1",
@@ -9992,9 +9992,9 @@
 			}
 		},
 		"node_modules/select-dom": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-9.2.0.tgz",
-			"integrity": "sha512-/I4nd/t05uUnznlIfmKuh5/npw0L9dnzyjThEqpwbjjd5VkZqN/ffgWl7wq/9RMHf7G/bLsCLatL1PqGfkw+IA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-9.3.0.tgz",
+			"integrity": "sha512-oZkhmrKSdj4pEEpK55P2SK4oVr2ozXhr692kXteqf2d+chwjgjgS57AlUoZaFiwnfZR15aW4+GtGXNYBQgo6yw==",
 			"license": "MIT",
 			"dependencies": {
 				"typed-query-selector": "^2.11.0"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"pretty-bytes": "^6.1.1",
 		"push-form": "^1.0.1",
 		"regex-join": "^2.1.0",
-		"select-dom": "^9.2.0",
+		"select-dom": "^9.3.0",
 		"shorten-repo-url": "^5.2.1",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^4.1.1",

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -21,7 +21,7 @@ function remember(event: DelegateEvent): void {
 }
 
 function isChecked(file: HTMLElement): boolean {
-	return file.querySelector('input.js-reviewed-checkbox')!.checked;
+	return $('input.js-reviewed-checkbox', file).checked;
 }
 
 // A single click is somehow causing two separate trusted `click` events, so it needs to be debounced

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -1,4 +1,5 @@
 import {CachedFunction} from 'webext-storage-cache';
+import {countElements} from 'select-dom';
 import {$, $optional} from 'select-dom/strict.js';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
@@ -56,7 +57,7 @@ const wikiPageCount = new CachedFunction('wiki-page-count', {
 			return looseParseInt(counter);
 		}
 
-		return dom.querySelectorAll('#wiki-content > .Box .Box-row').length;
+		return countElements('#wiki-content > .Box .Box-row', dom);
 	},
 	maxAge: {hours: 1},
 	staleWhileRevalidate: {days: 5},

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,5 +1,5 @@
 import React from 'dom-chef';
-import {$$} from 'select-dom';
+import {countElements} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {type DelegateEvent} from 'delegate-it';
 import {$} from 'select-dom/strict.js';
@@ -61,7 +61,7 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		// Don't clear 1-commit PRs #3140
-		() => $$('.TimelineItem.js-commit').length === 1,
+		() => countElements('.TimelineItem.js-commit') === 1,
 	],
 	awaitDomReady: true, // Appears near the end of the page anyway
 	init,

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -2,6 +2,7 @@ import './fit-textareas.css';
 
 import {isSafari} from 'webext-detect';
 import fitTextarea from 'fit-textarea';
+import {$} from 'select-dom/strict.js';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
@@ -10,7 +11,7 @@ import observe from '../helpers/selector-observer.js';
 const nativeFit = CSS.supports('field-sizing', 'content');
 
 function resetListener({target}: Event): void {
-	const field = (target as HTMLFormElement).querySelector('textarea')!;
+	const field = $('textarea', target as HTMLFormElement);
 	// Delay because the field is still filled while the `reset` event is firing
 	setTimeout(fitTextarea, 0, field);
 }

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -2,7 +2,7 @@ import './hidden-review-comments-indicator.css';
 
 import mem from 'memoize';
 import React from 'dom-chef';
-import {$$} from 'select-dom';
+import {$$, countElements} from 'select-dom';
 import CommentIcon from 'octicons-plain-react/Comment';
 import * as pageDetect from 'github-url-detection';
 import delegate, {type DelegateEvent} from 'delegate-it';
@@ -26,7 +26,7 @@ function handleIndicatorClick({delegateTarget}: DelegateEvent): void {
 
 // `mem` avoids adding the indicator twice to the same thread
 const addIndicator = mem((commentThread: HTMLElement): void => {
-	const commentCount = commentThread.querySelectorAll('.review-comment.js-comment').length;
+	const commentCount = countElements('.review-comment.js-comment', commentThread);
 	commentThread.before(
 		<tr>
 			<td className="rgh-comments-indicator blob-num" colSpan={2}>

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -1,11 +1,6 @@
 [rgh-hide-diff-signs]
-	:is(
-		.diff-text-cell
-		.diff-text, /* Edit page, probably upcoming DOM everywhere */
-		.blob-code-inner, /* Inline review blocks in PRs */
-		.blob-code-marker-cell, /* Commit page */
-	)::before,
-	/* React commit page */
-	.diff-text-marker {
+	:is(.diff-text-cell .diff-text, .blob-code-inner, .blob-code-marker-cell,) 
+	::before,
+.diff-text-marker {
 	visibility: hidden;
 }

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -1,6 +1,11 @@
 [rgh-hide-diff-signs]
-	:is(.diff-text-cell .diff-text, .blob-code-inner, .blob-code-marker-cell,) 
-	::before,
-.diff-text-marker {
+	:is(
+		.diff-text-cell
+		.diff-text, /* Edit page, probably upcoming DOM everywhere */
+		.blob-code-inner, /* Inline review blocks in PRs */
+		.blob-code-marker-cell, /* Commit page */
+	)::before,
+	/* React commit page */
+	.diff-text-marker {
 	visibility: hidden;
 }

--- a/source/features/hide-low-quality-comments.tsx
+++ b/source/features/hide-low-quality-comments.tsx
@@ -2,7 +2,7 @@ import './hide-low-quality-comments.css';
 
 import React from 'dom-chef';
 import {$, $optional} from 'select-dom/strict.js';
-import {$$, elementExists} from 'select-dom';
+import {$$, countElements, elementExists} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import delegate, {type DelegateEvent} from 'delegate-it';
 
@@ -76,7 +76,7 @@ function init(): void {
 		hideComment(comment);
 	}
 
-	const lowQualityCount = $$('.rgh-hidden-comment').length;
+	const lowQualityCount = countElements('.rgh-hidden-comment');
 	if (lowQualityCount > 0) {
 		$('.discussion-timeline-actions').prepend(
 			<p className="rgh-low-quality-comments-note">

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -1,5 +1,7 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
+import {$, $optional} from 'select-dom/strict.js';
+import {$$} from 'select-dom';
 
 import features from '../feature-manager.js';
 import GitHubFileURL from '../github-helpers/github-file-url.js';
@@ -18,15 +20,15 @@ function linkifyQuickPR(element: HTMLElement): void {
 }
 
 function linkifyHovercard(hovercard: HTMLElement): void {
-	const {href} = hovercard.querySelector('a.Link--primary')!;
+	const {href} = $('a.Link--primary', hovercard);
 
-	for (const reference of hovercard.querySelectorAll('.commit-ref')) {
+	for (const reference of $$('.commit-ref', hovercard)) {
 		const url = new GitHubFileURL(href).assign({
 			route: 'tree',
 			branch: reference.title,
 		});
 
-		const user = reference.querySelector('.user');
+		const user = $optional('.user', reference);
 		if (user) {
 			url.user = user.textContent;
 		}

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -3,7 +3,7 @@ import FlameIcon from 'octicons-plain-react/Flame';
 import * as pageDetect from 'github-url-detection';
 import toMilliseconds from '@sindresorhus/to-milliseconds';
 import {$optional} from 'select-dom/strict.js';
-import {$$, elementExists} from 'select-dom';
+import {countElements, elementExists} from 'select-dom';
 import twas from 'twas';
 import InfoIcon from 'octicons-plain-react/Info';
 import GitPullRequestDraftIcon from 'octicons-plain-react/GitPullRequestDraft';
@@ -30,12 +30,12 @@ function getCloseDate(): Date {
 
 function isPopular(): boolean {
 	return (
-		$$('[data-testid="comment-header"]').length > 30
+		countElements('[data-testid="comment-header"]') > 30
 		|| looseParseInt($optional('[aria-label*="other participants"]')?.ariaLabel) > 30
 		|| elementExists('[data-testid="issue-timeline-load-more-count-front"]')
 		// TODO: Drop in April 2025; old conversation style
-		|| $$('.timeline-comment').length > 30
-		|| $$('.participant-avatar').length > 10
+		|| countElements('.timeline-comment') > 30
+		|| countElements('.participant-avatar') > 10
 	);
 }
 

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -4,6 +4,8 @@ import * as pageDetect from 'github-url-detection';
 import CheckIcon from 'octicons-plain-react/Check';
 import FileDiffIcon from 'octicons-plain-react/FileDiff';
 
+import {$} from 'select-dom/strict.js';
+
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
@@ -44,10 +46,10 @@ function replaceCheckboxes(originalSubmitButton: HTMLButtonElement): void {
 			parent.querySelector('label')
 			?? radio.nextSibling! // TODO: Remove after April 2025
 		);
-		const tooltip = parent.querySelector([
+		const tooltip = $([
 			'p', // TODO: Remove after April 2025
 			'.FormControl-caption',
-		])!.textContent.trim().replace(/\.$/, '');
+		], parent).textContent.trim().replace(/\.$/, '');
 		assertNodeContent(labelElement, /^(Approve|Request changes|Comment)$/);
 
 		const classes = ['btn btn-sm'];

--- a/source/features/one-click-review-submission.tsx
+++ b/source/features/one-click-review-submission.tsx
@@ -3,7 +3,6 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import CheckIcon from 'octicons-plain-react/Check';
 import FileDiffIcon from 'octicons-plain-react/FileDiff';
-
 import {$} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -6,6 +6,8 @@ import * as pageDetect from 'github-url-detection';
 import LinkExternalIcon from 'octicons-plain-react/LinkExternal';
 import delegate, {type DelegateEvent} from 'delegate-it';
 
+import {$} from 'select-dom/strict.js';
+
 import features from '../feature-manager.js';
 import openTabs from '../helpers/open-tabs.js';
 import {appendBefore} from '../helpers/dom-utils.js';
@@ -29,7 +31,7 @@ function getUnreadNotifications(container: ParentNode = document): HTMLElement[]
 async function openNotifications(notifications: Element[], markAsDone = false): Promise<void> {
 	const urls = notifications
 		.reverse() // Open oldest first #6755
-		.map(notification => notification.querySelector('a')!.href);
+		.map(notification => $('a', notification).href);
 
 	const openingTabs = openTabs(urls);
 	if (!await openingTabs) {
@@ -38,7 +40,7 @@ async function openNotifications(notifications: Element[], markAsDone = false): 
 
 	for (const notification of notifications) {
 		if (markAsDone) {
-			notification.querySelector('[title="Done"]')!.click();
+			$('[title="Done"]', notification).click();
 		} else {
 			// Mark all as read instead
 			notification.classList.replace('notification-unread', 'notification-read');

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -5,7 +5,6 @@ import {$$, elementExists} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 import LinkExternalIcon from 'octicons-plain-react/LinkExternal';
 import delegate, {type DelegateEvent} from 'delegate-it';
-
 import {$} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -8,6 +8,7 @@ import './release-download-count.css';
 
 import React from 'dom-chef';
 import {$$} from 'select-dom';
+import {$} from 'select-dom/strict.js';
 import DownloadIcon from 'octicons-plain-react/Download';
 import * as pageDetect from 'github-url-detection';
 import {abbreviateNumber} from 'js-abbreviation-number';

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -35,9 +35,8 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 	const container = assetsList.closest('section') // Single-release page
 		?? assetsList.closest('.Box:not(.Box--condensed)')!; // Releases list, excludes the assets list’s own .Box
 
-	const releaseName = container
-		// .octicon-code required by visit-tag feature
-		.querySelector(['.octicon-tag ~ span', '.octicon-code ~ span'])!
+	// .octicon-code required by visit-tag feature
+	const releaseName = $(['.octicon-tag ~ span', '.octicon-code ~ span'], container)
 		.textContent
 		.trim();
 

--- a/source/github-helpers/group-buttons.tsx
+++ b/source/github-helpers/group-buttons.tsx
@@ -1,5 +1,7 @@
 import React from 'dom-chef';
 
+import {$} from 'select-dom/strict.js';
+
 import {wrapAll} from '../helpers/dom-utils.js';
 
 // Wrap a list of elements with BtnGroup + ensure each has BtnGroup-item
@@ -8,7 +10,7 @@ export function groupButtons(buttons: Element[], ...classes: string[]): HTMLElem
 	for (let button of buttons) {
 		if (!button.matches('button, .btn')) {
 			button.classList.add('BtnGroup-parent');
-			button = button.querySelector('.btn')!;
+			button = $('.btn', button);
 		}
 
 		button.classList.add('BtnGroup-item');

--- a/source/github-helpers/group-buttons.tsx
+++ b/source/github-helpers/group-buttons.tsx
@@ -1,5 +1,4 @@
 import React from 'dom-chef';
-
 import {$} from 'select-dom/strict.js';
 
 import {wrapAll} from '../helpers/dom-utils.js';

--- a/source/options/feature-list.tsx
+++ b/source/options/feature-list.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import domify from 'doma';
 import delegate, {type DelegateEvent} from 'delegate-it';
 import {$} from 'select-dom/strict.js';
-import {$$} from 'select-dom';
+import {$$, countElements} from 'select-dom';
 
 import {getLocalHotfixes} from '../helpers/hotfix.js';
 import {createRghIssueLink, getFeatureUrl} from '../helpers/rgh-links.js';
@@ -94,13 +94,13 @@ function featuresFilterHandler(this: HTMLInputElement): void {
 const offCount = new Text();
 
 function updateOffCount(): void {
-	const count = $$('.feature-checkbox:not(:checked)').length;
+	const count = countElements('.feature-checkbox:not(:checked)');
 	switch (count) {
 		case 0: {
 			offCount.nodeValue = '';
 			break;
 		}
-		case $$('.feature-checkbox').length: {
+		case countElements('.feature-checkbox'): {
 			offCount.nodeValue = '(JS off… are you breaking up with me?)';
 			break;
 		}


### PR DESCRIPTION
- Prefer `$()` over `querySelector()!`
- Use new `countElements()` to avoid unnecessary array conversion in `$$()`

I'd block `querySelector` entirely but I still prefer it in traversing sequences like `x.parentElement.querySelector`