### PR TITLE
`pull-request-hotkeys` - Restore feature

### DIFF
--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -1,4 +1,4 @@
-import {$$} from 'select-dom';
+import {$$} from 'select-dom/strict.js';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
@@ -6,8 +6,14 @@ import features from '../feature-manager.js';
 import {addHotkey} from '../github-helpers/hotkey.js';
 
 async function init(): Promise<void> {
-	const tabnav = await elementReady('#partial-discussion-header + .tabnav');
-	const tabs = $$('a.tabnav-tab', tabnav);
+	const tabnav = await elementReady([
+		'[aria-label="Pull request tabs"]',
+		'[aria-label="Pull request navigation tabs"]', // Commits list tab
+	].join(', '));
+	const tabs = $$([
+		'a.tabnav-tab',
+		'a[role="tab"]', // Commits list tab
+	], tabnav);
 	const lastTab = tabs.length - 1;
 	const selectedIndex = tabs.findIndex(tab => tab.classList.contains('selected'));
 


### PR DESCRIPTION
- Fixes #7369 pull-request-hotkeys

Each tab has its own tabs component… so it wasn't finding any tabs.

Using the new `select-dom/strict` would have made this immediately	 visible.


## Test URLs


Here

