### PR TITLE
`comments-time-machine-links` - Add support for all "Code" links

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -66,13 +66,13 @@ async function showTimeMachineBar(): Promise<void | false> {
 }
 
 function addInlineLinks(comment: HTMLElement, timestamp: string): void {
-	const links = $$(`
-		a[href^="${location.origin}"][href*="/blob/"]:not(.${linkifiedURLClass}),
-		a[href^="${location.origin}"][href*="/tree/"]:not(.${linkifiedURLClass})
-	`, comment);
-
-	for (const link of links) {
+	for (const link of $$(`a[href^="${location.origin}"]:not(.${linkifiedURLClass})`, comment)) {
 		const linkParts = link.pathname.split('/');
+		// Skip non-git-object links. `undefined` covers links to the repo home #4979
+		if ([undefined, 'blob', 'tree', 'blame'].includes(linkParts[3])) {
+			continue;
+		}
+
 		// Skip permalinks
 		if (/^[\da-f]{40}$/.test(linkParts[4])) {
 			continue;


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/4979

I think all links appearing in the "Code" tab should be covered, except irrelevant ones like `/edit/`


## Test URLs
1. On this page
2. Click on any of:
	- https://github.com/refined-github/refined-github
	- https://github.com/refined-github/refined-github/tree/main
	- https://github.com/refined-github/refined-github/blob/main/readme.md
	- https://github.com/refined-github/refined-github/tree/main/test

Or visit this:

```js
// https://github.com/refined-github/refined-github?rgh-link-date=2024-12-08T06%3A15%3A26Z
```


## Screenshot
