### PR TITLE
`safer-destructive-actions` - Restore feature

### DIFF
--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -29,7 +29,7 @@ async function preloadDropdown({delegateTarget: button}: DelegateEvent): Promise
 
 function addDeleteButton(cancelButton: Element): void {
 	cancelButton.after(
-		<button className="btn btn-danger float-left rgh-review-comment-delete-button" type="button">
+		<button className="btn btn-danger float-left mr-auto rgh-review-comment-delete-button" type="button">
 			<TrashIcon />
 		</button>,
 	);

--- a/source/features/safer-destructive-actions.css
+++ b/source/features/safer-destructive-actions.css
@@ -1,27 +1,17 @@
 /* Move "close issue" and "cancel" buttons on authoring comments to the left */
 
 /* ...in issue comment form */
-#issuecomment-new #partial-new-comment-form-actions > .d-flex {
-	justify-content: space-between !important;
-}
+#issuecomment-new #partial-new-comment-form-actions > .d-flex,
 
 /* ...in comment edit form */
-div.previewable-edit .previewable-comment-form .form-actions {
-	margin-left: 10px;
+div.previewable-edit .d-flex:has(>.js-comment-cancel-button) {
+	justify-content: space-between !important;
+	width: 100%; /* https://github.com/refined-github/refined-github/issues/7711 */
+}
+
+/* ...in PR review comment form */
+button.js-hide-inline-comment-form {
 	float: none !important;
-}
-
-.previewable-edit
-	.previewable-comment-form
-	.form-actions
-	.btn.js-comment-cancel-button {
-	float: left !important;
-}
-
-/* ...in inline comment form */
-div.inline-comment-form .form-actions,
-.inline-comment-form .form-actions .js-hide-inline-comment-form {
-	float: none;
 }
 
 /* ...in the merge confirmation form */

--- a/source/features/safer-destructive-actions.css
+++ b/source/features/safer-destructive-actions.css
@@ -2,15 +2,16 @@
 
 /* ...in issue comment form */
 #issuecomment-new #partial-new-comment-form-actions > .d-flex,
-
 /* ...in comment edit form */
 div.previewable-edit .d-flex:has(>.js-comment-cancel-button) {
 	justify-content: space-between !important;
 	width: 100%; /* https://github.com/refined-github/refined-github/issues/7711 */
 }
 
-/* ...in PR review comment form */
-button.js-hide-inline-comment-form {
+/* ...in PR review form */
+button.js-hide-inline-comment-form,
+/* ... in PR review add comment form */
+.float-right:has(>button.js-hide-inline-comment-form) {
 	float: none !important;
 }
 


### PR DESCRIPTION
- Fixes #7711 
- Doesn't cover #7856 

## Test URLs

- Here
- Files tab: https://github.com/refined-github/refined-github/pull/8134/files

## PR Reviews

<img width="805" alt="Screenshot 4" src="https://github.com/user-attachments/assets/8c0d1941-05e9-4a7f-9e0e-0491d5c2168d">

## Regular comments

<img width="685" alt="Screenshot" src="https://github.com/user-attachments/assets/8ef1ebe3-fc30-4387-a0cc-0a59a3ac0dac">


## PR review box

Unchanged, still works

<img width="805" alt="Screenshot 4" src="https://github.com/user-attachments/assets/11a4287d-7c68-4c0f-a7fe-9d6193746b54">

