### PR TITLE
Open Welcome page links in new tab in Safari

### DIFF
--- a/source/helpers/target-blank-polyfill.ts
+++ b/source/helpers/target-blank-polyfill.ts
@@ -12,9 +12,9 @@ function isLinkExternal(link: HTMLAnchorElement): boolean {
 // WTF Safari. It opens target="_blank" links in the same tab on extension pages
 if ('window' in globalThis && 'open' in globalThis && isSafari()) {
 	document.addEventListener('click', filterAlteredClicks(event => {
-		const clicked = event.target as HTMLAnchorElement;
-		// Don't use `instaceof` #8135
-		if (clicked.tagName === 'A' && isLinkExternal(clicked)) {
+		// WebComponents support https://stackoverflow.com/a/57963850
+		const clicked = event.composedPath().find(element => element instanceof HTMLAnchorElement);
+		if (clicked && isLinkExternal(clicked)) {
 			event.preventDefault();
 			window.open(clicked.href);
 		}

--- a/source/helpers/target-blank-polyfill.ts
+++ b/source/helpers/target-blank-polyfill.ts
@@ -12,8 +12,8 @@ function isLinkExternal(link: HTMLAnchorElement): boolean {
 // WTF Safari. It opens target="_blank" links in the same tab on extension pages
 if ('window' in globalThis && 'open' in globalThis && isSafari()) {
 	document.addEventListener('click', filterAlteredClicks(event => {
-		const clicked = event.target;
-		if (clicked instanceof HTMLAnchorElement && isLinkExternal(clicked)) {
+		const clicked = event.target as HTMLAnchorElement;
+		if (clicked.tagName === 'A' && isLinkExternal(clicked)) {
 			event.preventDefault();
 			window.open(clicked.href);
 		}

--- a/source/helpers/target-blank-polyfill.ts
+++ b/source/helpers/target-blank-polyfill.ts
@@ -13,6 +13,7 @@ function isLinkExternal(link: HTMLAnchorElement): boolean {
 if ('window' in globalThis && 'open' in globalThis && isSafari()) {
 	document.addEventListener('click', filterAlteredClicks(event => {
 		const clicked = event.target as HTMLAnchorElement;
+		// Don't use `instaceof` #8135
 		if (clicked.tagName === 'A' && isLinkExternal(clicked)) {
 			event.preventDefault();
 			window.open(clicked.href);


### PR DESCRIPTION
- should fix https://github.com/refined-github/refined-github/issues/8058

Reason: `instanceof HTMLAnchorElement` fails across web components. Neat.
