### PR TITLE
Options: Change visualization of fine-grained tokens

### DIFF
--- a/source/github-helpers/github-token.ts
+++ b/source/github-helpers/github-token.ts
@@ -96,7 +96,6 @@ function parseTokenScopes(headers: Headers): string[] {
 
 export async function getTokenScopes(apiBase: string, personalToken: string): Promise<string[]> {
 	const response = await baseApiFetch({apiBase, token: personalToken, path: ''});
-	console.log(...response.headers)
 	return parseTokenScopes(response.headers);
 }
 

--- a/source/github-helpers/github-token.ts
+++ b/source/github-helpers/github-token.ts
@@ -76,7 +76,9 @@ function parseTokenScopes(headers: Headers): string[] {
 	// If `X-OAuth-Scopes` is not present, the token may be not a classic token.
 	const scopesHeader = headers.get('X-OAuth-Scopes');
 	if (!scopesHeader) {
-		return [];
+		// If the request succeeded but lacked this header, it's likely a fine-grained token
+		// https://github.com/orgs/community/discussions/25259#discussioncomment-3247158
+		return ['valid_token', 'unknown'];
 	}
 
 	const scopes = scopesHeader.split(', ');
@@ -94,6 +96,7 @@ function parseTokenScopes(headers: Headers): string[] {
 
 export async function getTokenScopes(apiBase: string, personalToken: string): Promise<string[]> {
 	const response = await baseApiFetch({apiBase, token: personalToken, path: ''});
+	console.log(...response.headers)
 	return parseTokenScopes(response.headers);
 }
 

--- a/source/options.html
+++ b/source/options.html
@@ -38,14 +38,11 @@
 				>
 				<span id="validation"></span>
 			</p>
-			<ul data-token-type="classic">
+			<ul>
 				<li data-validation data-scope="valid_token">The token enables <a href="https://github.com/search?q=repo%3Arefined-github%2Frefined-github+%28api.js+OR+does-file-exist.js+OR+get-default-branch.js+OR+get-pr-info.js+OR+pr-ci-status.js%29+path%3A%2F%5Esource%5C%2Ffeatures%5C%2F%2F&type=code">some features</a> to <strong>read</strong> data from public repositories
 				<li data-validation data-scope="public_repo">The <code>public_repo</code> scope lets them <strong>edit</strong> your public repositories
 				<li data-validation data-scope="repo">The <code>repo</code> scope lets them <strong>edit private</strong> repositories as well
 				<li data-validation data-scope="read:project">The <code>read:project</code> scope lets them determine if a repo/org uses projects
-			</ul>
-			<ul data-token-type="fine_grained">
-				<li data-validation data-scope="valid_token">Fine-grained token validated, but some features and organizations might not support them <a href="https://github.com/refined-github/refined-github/issues/6092#issuecomment-1732286938">More info</a></li>
 			</ul>
 		</div>
 	</details>


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/7917
- Kinda reverts https://github.com/refined-github/refined-github/pull/6956

I don't want to support a dedicated UI for a token that is non-supported as per our docs. Easier to mark it as "unknown". Perhaps as part of #7855, more information about the token type can be shown on the list.

## Test URLs

Options page

## Screenshot

<img width="643" alt="Screenshot 6" src="https://github.com/user-attachments/assets/b0d065e8-78f5-47c9-b0e2-83c914201662">
