### PR TITLE
Add "Reload without Refined GitHub" action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"ts-extras": "^0.13.0",
 				"twas": "^2.1.3",
 				"uint8array-extras": "^1.4.0",
-				"webext-alert": "^1.0.2",
+				"webext-alert": "^1.0.3",
 				"webext-base-css": "^2.0.1",
 				"webext-detect": "^5.3.1",
 				"webext-dynamic-content-scripts": "^10.0.4",
@@ -11756,9 +11756,9 @@
 			}
 		},
 		"node_modules/webext-alert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webext-alert/-/webext-alert-1.0.2.tgz",
-			"integrity": "sha512-dyVZn6w3A5b8Bi/SDX5NSQOpjeAtT5YZksWV1GdvftaHlvK+WBAGPtbrYjR47vEqrpyxgSsyWtBbatmykPtjLw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/webext-alert/-/webext-alert-1.0.3.tgz",
+			"integrity": "sha512-5qJ8hTRsVwthmf61NA5Lfw9K9HjZE1Ukn6wmhxvho7Ay4Pwrvgrnl47iEcDbZaA1i5jOzn/E97I4vWCe5/fiCw==",
 			"license": "MIT",
 			"dependencies": {
 				"webext-detect": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"ts-extras": "^0.13.0",
 		"twas": "^2.1.3",
 		"uint8array-extras": "^1.4.0",
-		"webext-alert": "^1.0.2",
+		"webext-alert": "^1.0.3",
 		"webext-base-css": "^2.0.1",
 		"webext-detect": "^5.3.1",
 		"webext-dynamic-content-scripts": "^10.0.4",

--- a/source/background.ts
+++ b/source/background.ts
@@ -11,6 +11,7 @@ import isDevelopmentVersion from './helpers/is-development-version.js';
 import {doesBrowserActionOpenOptions} from './helpers/feature-utils.js';
 import {styleHotfixes} from './helpers/hotfix.js';
 import {fetchText} from './helpers/isomorphic-fetch.js';
+import addReloadWithoutContentScripts from './options/reload-without.js';
 
 const {version} = chrome.runtime.getManifest();
 
@@ -21,6 +22,9 @@ addPermissionToggle();
 
 // Firefox/Safari polyfill
 addOptionsContextMenu();
+
+// Add "Reload without content scripts" functionality
+addReloadWithoutContentScripts();
 
 handleMessages({
 	async openUrls(urls: string[], {tab}: chrome.runtime.MessageSender) {

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -26,6 +26,7 @@ import {
 import asyncForEach from './helpers/async-for-each.js';
 import {catchErrors, disableErrorLogging} from './helpers/errors.js';
 import {getFeatureID, listenToAjaxedLoad, log, shortcutMap} from './helpers/feature-helpers.js';
+import {contentScript} from './options/reload-without.js';
 
 type FeatureInitResult = void | false;
 type FeatureInit = (signal: AbortSignal) => Promisable<FeatureInitResult>;
@@ -57,12 +58,21 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 
 	listenToAjaxedLoad();
 
-	const [options, localHotfixes, bisectedFeatures] = await Promise.all([
+	const [options, contentScripts, localHotfixes, bisectedFeatures] = await Promise.all([
 		optionsStorage.getAll(),
+		contentScript.get(),
 		getLocalHotfixesAsOptions(),
 		bisectFeatures(),
 		preloadSyncLocalStrings(),
 	]);
+
+	if (!contentScripts) {
+		await contentScript.remove();
+		const message = 'Refined GitHub: scripts were disabled for this load, but CSS can’t be disabled this way.';
+		console.warn(message);
+		alert(message);
+		return;
+	}
 
 	log.setup(options);
 

--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -26,7 +26,7 @@ import {
 import asyncForEach from './helpers/async-for-each.js';
 import {catchErrors, disableErrorLogging} from './helpers/errors.js';
 import {getFeatureID, listenToAjaxedLoad, log, shortcutMap} from './helpers/feature-helpers.js';
-import {contentScript} from './options/reload-without.js';
+import {contentScriptToggle} from './options/reload-without.js';
 
 type FeatureInitResult = void | false;
 type FeatureInit = (signal: AbortSignal) => Promisable<FeatureInitResult>;
@@ -60,14 +60,14 @@ const globalReady = new Promise<RGHOptions>(async resolve => {
 
 	const [options, contentScripts, localHotfixes, bisectedFeatures] = await Promise.all([
 		optionsStorage.getAll(),
-		contentScript.get(),
+		contentScriptToggle.get(),
 		getLocalHotfixesAsOptions(),
 		bisectFeatures(),
 		preloadSyncLocalStrings(),
 	]);
 
 	if (!contentScripts) {
-		await contentScript.remove();
+		await contentScriptToggle.remove();
 		const message = 'Refined GitHub: scripts were disabled for this load, but CSS can’t be disabled this way.';
 		console.warn(message);
 		alert(message);

--- a/source/options/reload-without.ts
+++ b/source/options/reload-without.ts
@@ -7,7 +7,7 @@ import {isFirefox} from 'webext-detect';
 // Always Firefox… https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/setAccessLevel
 const area = isFirefox() ? 'local' : 'session';
 
-export const contentScript = new StorageItem('contentScript', {
+export const contentScriptToggle = new StorageItem('contentScript', {
 	area,
 	defaultValue: true,
 });
@@ -37,7 +37,7 @@ export default function addReloadWithoutContentScripts(): void {
 		if (tab.url && isScriptableUrl(tab.url) && await chromeP.permissions.contains({
 			origins: [tab.url],
 		})) {
-			await contentScript.set(false);
+			await contentScriptToggle.set(false);
 			chrome.tabs.reload(tab.id);
 		} else {
 			// TODO: Use https://github.com/fregante/webext-tools/issues/11 to disable the item instead

--- a/source/options/reload-without.ts
+++ b/source/options/reload-without.ts
@@ -1,22 +1,47 @@
 import {StorageItem} from 'webext-storage';
+import webextAlert from 'webext-alert';
+import chromeP from 'webext-polyfill-kinda';
+import {isScriptableUrl} from 'webext-content-scripts';
+import {isFirefox} from 'webext-detect';
+
+// Always Firefox… https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/setAccessLevel
+const area = isFirefox() ? 'local' : 'session';
 
 export const contentScript = new StorageItem('contentScript', {
-	area: 'session',
+	area,
 	defaultValue: true,
 });
 
+const id = 'reload-without-content-scripts';
+
 export default function addReloadWithoutContentScripts(): void {
-	chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' });
+	if (!chrome.contextMenus) {
+		// Silently ignore if the API is not available, like in Firefox Android
+		// https://github.com/fregante/webext-permission-toggle/pull/53
+		return;
+	}
+
+	chrome.storage.session.setAccessLevel?.({accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS'});
 
 	chrome.contextMenus.create({
-		id: 'reload-without-content-scripts',
+		id,
 		title: 'Reload without Refined GitHub',
-		contexts: ['action'],
+		contexts: 'action' in chrome ? ['action'] : ['browser_action'],
 	});
+
 	chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-		if (info.menuItemId === 'reload-without-content-scripts' && tab?.id) {
+		if (!tab?.id || info.menuItemId !== id) {
+			return;
+		}
+
+		if (tab.url && isScriptableUrl(tab.url) && await chromeP.permissions.contains({
+			origins: [tab.url],
+		})) {
 			await contentScript.set(false);
 			chrome.tabs.reload(tab.id);
+		} else {
+			// TODO: Use https://github.com/fregante/webext-tools/issues/11 to disable the item instead
+			webextAlert('Refined GitHub is already not running on this page');
 		}
 	});
 }

--- a/source/options/reload-without.ts
+++ b/source/options/reload-without.ts
@@ -1,0 +1,22 @@
+import {StorageItem} from 'webext-storage';
+
+export const contentScript = new StorageItem('contentScript', {
+	area: 'session',
+	defaultValue: true,
+});
+
+export default function addReloadWithoutContentScripts(): void {
+	chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' });
+
+	chrome.contextMenus.create({
+		id: 'reload-without-content-scripts',
+		title: 'Reload without Refined GitHub',
+		contexts: ['action'],
+	});
+	chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+		if (info.menuItemId === 'reload-without-content-scripts' && tab?.id) {
+			await contentScript.set(false);
+			chrome.tabs.reload(tab.id);
+		}
+	});
+}


### PR DESCRIPTION
- Includes https://github.com/fregante/webext-alert/pull/14
- Closes #7562 


## Test URLs

Here or any page, including `about:blank`

## Screenshots


<img width="875" alt="Screenshot 4" src="https://github.com/user-attachments/assets/f14f0b1b-8fab-4f0d-aecb-1d88ab33fb8e" />

## Screenshot when clicked on unrelated hosts

<img width="420" alt="Screenshot 5" src="https://github.com/user-attachments/assets/3a1fba99-3841-4ea0-b46c-ba360b64ca1a" />


### Firefox


<img width="420" alt="Screenshot 7" src="https://github.com/user-attachments/assets/c9fef7c9-7d94-47b9-a8b2-53a0e974d8fb" />