### PR TITLE
Hide copilot from header and search modal

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -303,6 +303,10 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif"
 	},
 	{
+		"id": "hide-copilot",
+		"description": "Hides Copilot from the header and search modal"
+	},
+	{
 		"id": "hide-diff-signs",
 		"description": "Hides diff signs since diffs are color coded already.",
 		"css": true,

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -56,6 +56,7 @@
 	"github-actions-indicators",
 	"global-conversation-list-filters",
 	"hidden-review-comments-indicator",
+	"hide-copilot",
 	"hide-diff-signs",
 	"hide-inactive-deployments",
 	"hide-issue-list-autocomplete",

--- a/source/features/hide-copilot.tsx
+++ b/source/features/hide-copilot.tsx
@@ -1,0 +1,36 @@
+import {$, $optional} from 'select-dom/strict.js';
+
+import {elementExists} from 'select-dom';
+
+import features from '../feature-manager';
+import observe from '../helpers/selector-observer';
+
+async function removeFromAppHeader(): Promise<void> {
+	$optional('.AppHeader-CopilotChat')?.remove();
+}
+
+async function onSearchExpand(): Promise<void> {
+	observe('li:has(> ul > li#query-builder-test-result-ask-copilot)', copilot => {
+		(copilot.previousElementSibling! as HTMLLIElement).remove();
+		copilot!.remove();
+	});
+
+	document.removeEventListener('qbsearch-input:expand', onSearchExpand);
+}
+
+async function removeFromSearch(): Promise<void> {
+	$('qbsearch-input').setAttribute('data-copilot-chat-enabled', 'false');
+	document.addEventListener('qbsearch-input:expand', onSearchExpand);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		() => elementExists('.AppHeader-CopilotChat'),
+	],
+	init: removeFromAppHeader,
+}, {
+	include: [
+		() => elementExists('qbsearch-input'),
+	],
+	init: removeFromSearch,
+});

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -47,6 +47,7 @@ interface GlobalEventHandlersEventMap {
 	'page:loaded': CustomEvent;
 	'turbo:visit': CustomEvent;
 	'session:resume': CustomEvent;
+	'qbsearch-input:expand': CustomEvent;
 	// No input:InputEvent match
 	// https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1174#issuecomment-933042088
 }

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -219,3 +219,4 @@ import './features/linkify-line-numbers.js';
 import './features/sidebar-focus-file.js';
 import './features/rgh-token-user.js';
 import './features/unread-anywhere.js';
+import './features/hide-copilot';


### PR DESCRIPTION
Hides Copilot from the header and search modal


## Test URLs


## Screenshot

### Header

Before:

![Screenshot 2024-12-23 at 08-30-43 refined-github_refined-github octocat Browser extension that simplifies the GitHub interface and adds useful features](https://github.com/user-attachments/assets/ccc44e12-05ae-43a2-aca9-e2f94baedcdc)

After:

![Screenshot 2024-12-23 at 08-31-09 refined-github_refined-github octocat Browser extension that simplifies the GitHub interface and adds useful features](https://github.com/user-attachments/assets/f8996a37-6efc-4f90-b85b-2e24bb5a8865)

### Search modal

Before:

![Screenshot 2024-12-23 at 08-30-58 refined-github_refined-github octocat Browser extension that simplifies the GitHub interface and adds useful features](https://github.com/user-attachments/assets/8ce8b5a9-79bf-404b-9c0c-f9679132a0e1)


After:

![Screenshot 2024-12-23 at 08-31-24 refined-github_refined-github octocat Browser extension that simplifies the GitHub interface and adds useful features](https://github.com/user-attachments/assets/c40b1303-3f56-4f07-918a-b2eda81e30a6)


