### PR TITLE
`show-associated-branch-prs-on-fork` - Restore feature (again)

### DIFF
--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -95,7 +95,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
 	// Memoize because it's being called twice for each. Ideally this should be part of the selector observer
 	// https://github.com/refined-github/refined-github/pull/7194#issuecomment-1894972091
-	observe('react-app[app-name=repos-branches] a[class^=BranchName] div[title]', memoize(addLink), {signal});
+	observe('react-app[app-name=repos-branches] a[class*=BranchName] div[title]', memoize(addLink), {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Was changed yet again, now it just checks for BranchName in the attribute at all.


## Test URLs
https://github.com/bfred-it-org/github-sandbox/branches

## Screenshot
![image](https://github.com/user-attachments/assets/3673ed0e-0513-4920-b18a-368aa50bbccd)
