### PR TITLE
Add link to app-store-description.txt

### DIFF
--- a/safari/app-store-description.txt
+++ b/safari/app-store-description.txt
@@ -18,7 +18,7 @@ Refined GitHub is a Safari extension that simplifies the GitHub.com interface an
 - Adds possible related pages and alternatives on 404 pages.
 - Displays the age of the repository in the sidebar.
 
-And so much more! 200+ features. See the website for a full list of features.
+And so much more! 200+ features. See <a href="https://github.com/refined-github/refined-github">the website</a> for a full list of features.
 
 
 The GITHUB and REFINED GITHUB trademarks are owned by GitHub, Inc. and used under license.


### PR DESCRIPTION
The description mentions ''the website'', however, the most appropriate website linked is in the information section as ''Developer Website''.