### PR TITLE
`conversation-activity-filter` - Fix position and color

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -164,7 +164,7 @@ async function addWidget(state: State, anchor: HTMLElement): Promise<void> {
 			<summary className="height-full color-fg-muted">
 				<EyeIcon />
 				<EyeClosedIcon className="color-fg-danger" />
-				<span className="text-small color-fg-danger v-align-text-bottom rgh-conversation-events-label"> events</span>
+				<span className="text-small color-fg-danger v-align-text-bottom rgh-conversation-events-label ml-1">events</span>
 				<div className="dropdown-caret ml-1" />
 			</summary>
 			<details-menu

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -161,11 +161,11 @@ async function addWidget(state: State, anchor: HTMLElement): Promise<void> {
 			className={`details-reset details-overlay d-inline-block ml-2 position-relative ${dropdownClass}`}
 			id="rgh-conversation-activity-filter-select-menu"
 		>
-			<summary className="height-full">
-				<EyeIcon className="color-fg-muted" />
+			<summary className="height-full color-fg-muted">
+				<EyeIcon />
 				<EyeClosedIcon className="color-fg-danger" />
 				<span className="text-small color-fg-danger v-align-text-bottom rgh-conversation-events-label"> events</span>
-				<div className="dropdown-caret color-fg-muted ml-1" />
+				<div className="dropdown-caret ml-1" />
 			</summary>
 			<details-menu
 				className={`SelectMenu ${alignment}`}

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -161,11 +161,11 @@ async function addWidget(state: State, anchor: HTMLElement): Promise<void> {
 			className={`details-reset details-overlay d-inline-block ml-2 position-relative ${dropdownClass}`}
 			id="rgh-conversation-activity-filter-select-menu"
 		>
-			<summary>
+			<summary className="height-full">
 				<EyeIcon className="color-fg-muted" />
 				<EyeClosedIcon className="color-fg-danger" />
 				<span className="text-small color-fg-danger v-align-text-bottom rgh-conversation-events-label"> events</span>
-				<div className="dropdown-caret ml-1" />
+				<div className="dropdown-caret color-fg-muted ml-1" />
 			</summary>
 			<details-menu
 				className={`SelectMenu ${alignment}`}


### PR DESCRIPTION
Minor cosmetic fix (that has been in my todo for 6 months)

## Test URLs

https://togithub.com/refined-github/refined-github/pull/8038

## Screenshot

This is the sticky header

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-07 at 00 38 37@2x](https://github.com/user-attachments/assets/d512d1cb-f90d-446c-b41d-0eeaf02f7db6) | ![CleanShot 2025-01-07 at 00 41 39@2x](https://github.com/user-attachments/assets/98ce9165-f753-4810-8822-2eecf4369f3e) |
|![CleanShot 2025-01-07 at 02 38 16@2x](https://github.com/user-attachments/assets/23795242-a029-4c73-983a-b5f94a505de2) | ![CleanShot 2025-01-07 at 02 39 04@2x](https://github.com/user-attachments/assets/4010ec7b-ad87-4bb1-8c5c-5a0c151345ef)|