### PR TITLE
`esc-to-deselect-line` - Restore feature

### DIFF
--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -27,6 +27,7 @@ function listener({key, target}: KeyboardEvent): void {
 			// Un-focus code block
 			(document.activeElement as HTMLElement).blur();
 		} else {
+			// TODO: Review in December 2025 if old UI is gone. Currently only applies to PRs
 			location.hash = '#no-line'; // Update UI, without `scroll-to-top` behavior
 		}
 

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -1,3 +1,4 @@
+import {$optional} from 'select-dom/strict.js';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
@@ -13,7 +14,22 @@ function isLineSelected(): boolean {
 
 function listener({key, target}: KeyboardEvent): void {
 	if (key === 'Escape' && isLineSelected() && !isEditable(target)) {
-		location.hash = '#no-line'; // Update UI, without `scroll-to-top` behavior
+		const selectedLineNumber = $optional('.react-line-number.highlighted-line');
+
+		if (selectedLineNumber) {
+			// Save and remove line number
+			const {lineNumber} = selectedLineNumber.dataset;
+			selectedLineNumber.dataset.lineNumber = '';
+			// Trigger click to deselect
+			selectedLineNumber.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+			// Restore line number
+			selectedLineNumber.dataset.lineNumber = lineNumber;
+			// Un-focus code block
+			(document.activeElement as HTMLElement).blur();
+		} else {
+			location.hash = '#no-line'; // Update UI, without `scroll-to-top` behavior
+		}
+
 		history.replaceState(undefined, document.title, location.pathname); // Drop remaining # from url
 	}
 }


### PR DESCRIPTION
Fix #7756

Related GitHub source code:

```tsx
// Simplified for demonstration
// https://github.githubassets.com/assets/app/assets/modules/react-code-view/components/blob/BlobContent/Code/LineNumber.tsx

<div onMouseDown={preventClick ? undefined : codeCellClickFunc} />

const codeCellClickFunc = event => {
      const targetedLineNumber = parseInt(event.currentTarget.getAttribute('data-line-number')!, 10)
}
```

## Test URLs

https://github.com/refined-github/refined-github/blob/main/source/features/esc-to-deselect-line.tsx

## Screenshot

https://github.com/user-attachments/assets/eb900534-02a7-49d1-9697-89fd21ed22e6

