### PR TITLE
`deep-reblame` - Fix style and tooltip

### DIFF
--- a/source/features/deep-reblame.css
+++ b/source/features/deep-reblame.css
@@ -3,8 +3,3 @@ button.rgh-deep-reblame .octicon-versions {
 	color: var(--color-prettylights-syntax-entity, cyan);
 	opacity: 70%;
 }
-
-.rgh-deep-reblame:hover .octicon-versions {
-	color: var(--color-scale-pink-7, cyan);
-	opacity: 70%;
-}

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -71,7 +71,8 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 function addButton(hunk: HTMLElement): void {
 	const reblameLink = $optional('a[aria-labelledby^="reblame-"]', hunk);
 	if (reblameLink) {
-		reblameLink.setAttribute('aria-label', 'View blame prior to this change. Hold `Alt` to extract commits from this PR first');
+		// Update tooltip
+		reblameLink.nextElementSibling?.append(<br />, 'Hold `Alt` to extract commits from this PR first');
 		reblameLink.classList.add('rgh-deep-reblame');
 	} else {
 		$('.timestamp-wrapper-mobile', hunk).after(


### PR DESCRIPTION
- Drop custom hover style referencing defunct CSS variables, matching native buttons
- Fix extra tooltip copy

## Test URLs

https://github.com/refined-github/refined-github/blame/6b34a590489b728c7e24bcc819aad3d5b023e9ce/source/features/deep-reblame.css

## Screenshot

| | Before | After |
|--------|--------|--------|
| Existing blame link | ![CleanShot 2025-01-09 at 12 27 10@2x](https://github.com/user-attachments/assets/da69810a-8f45-417c-9960-847a2a2c098d) | ![CleanShot 2025-01-09 at 12 27 32@2x](https://github.com/user-attachments/assets/c54b2840-5e81-4a39-91a0-42295adcd225) |
| Added blame link | ![CleanShot 2025-01-09 at 12 36 58@2x](https://github.com/user-attachments/assets/9f27a45c-9119-4219-bb65-c6d7ccd009f3) | TBD | 