### PR TITLE
`quick-review` - Update the quick review hint to display the key to hold for approving without confirmation on macOS

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -71,7 +71,7 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 		<button
 			type="button"
 			className="btn-link Link--muted Link--inTextBlock rgh-quick-approve tooltipped tooltipped-nw"
-			aria-label="Hold alt to approve without confirmation"
+			aria-label="Hold alt/option to approve without confirmation"
 		>
 			approve now
 		</button>,


### PR DESCRIPTION
$subject

## Test URLs

To be added

## Screenshot

To be added