### PR TITLE
`pr-approvals-count` - Highlight "Review Required" in yellow

### DIFF
--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -1,3 +1,5 @@
+/* TODO: Drop coloring in July 2025. New PR view renders this defunct and redundant. */
+
 /* Show approvals count in PR list */
 .js-issue-row
 	.color-fg-muted

--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -22,6 +22,12 @@
 	color: var(--rgh-red) !important;
 }
 
+.js-issue-row
+	.color-fg-muted
+	[href$='#partial-pull-merging'][aria-label*='required'] {
+	color: var(--rgh-yellow) !important;
+}
+
 /* Disable now-duplicate tooltip */
 .js-issue-row
 	.color-fg-muted

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,6 +1,7 @@
 :root {
 	--rgh-green: var(--fgColor-success, var(--color-success-fg, #1a7f37));
 	--rgh-red: var(--fgColor-danger, var(--color-danger-fg, #cf222e));
+	--rgh-yellow: var(--fgColor-attention, #c69026);
 	--rgh-border-color: var(
 		--borderColor-muted,
 		var(--color-border-muted, #d8dee4)


### PR DESCRIPTION
An addition to the [Shows color-coded review counts in PR lists.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png) feature. Highlights the 'Review Required' text in yellow so it pops more easily when skimming PR lists.


I would appreciate some guidance on a few things:
1. Existing CSS vars for `--rgh-green` and `--rgh-red` reference `--color-*` vars that I'm unable to find in refined-github or in github's own CSS files, so I cannot apply an applicable one to the `--rgh-yellow` var I've added.
2. I'm not 100% confident I sourced the default color for `--rgh-yellow` from the correct place. I've made the assumption it's meant to be the hex code that the `--fgColor-*` var being used is assigned by github's CSS files.
3. I'm also not 100% confident `--fgColor-attention` is the correct color var to use for this. It was the closest to yellow/amber I could find that looked intended for text colors.


## Test URLs
https://github.com/Baystation12/Baystation12/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen


## Screenshot
### Before
![firefox_2GJiRKlgQV](https://github.com/user-attachments/assets/8082739e-13fc-4c1b-86f7-0a79c154b9cf)

### After
![firefox_Lqavrp3hrx](https://github.com/user-attachments/assets/7785fcf4-6e35-459a-998b-c5d2ea6b1df7)
