### PR TITLE
`embed-gist-inline` - Restore feature on the first comment

### DIFF
--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -10,7 +10,7 @@ export const repoUnderlineNavUl_ = [
 ] satisfies UrlMatch[];
 
 export const standaloneGistLinkInMarkdown = css`
-	:is(.js-comment-body, .react-issue-comment) p a:only-child:is(
+	:is(.js-comment-body, .react-issue-comment, .react-issue-body) p a:only-child:is(
 		[href^="https://gist.github.com/"],
 		[href^="${location.origin}/gist/"]
 	)


### PR DESCRIPTION
Close: #8270 

## Test URLs

https://github.com/refined-github/sandbox/issues/77

## Screenshot

<img width="952" alt="image" src="https://github.com/user-attachments/assets/0c451a9c-1fd7-4155-92ab-b65af7d808be" />
