### PR TITLE
`clean-rich-text-editor` - Restore feature on the first comment

### DIFF
--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -10,11 +10,11 @@
 			[data-md-button='bold'],
 			[data-md-button='italic'],
 			/* React fields */
-			[data-component='IconButton'][aria-label='Add header text'],
-			[data-component='IconButton'][aria-label='Bold (Cmd + B)'],
-			[data-component='IconButton'][aria-label='Italic (Cmd + I)'],
-			[data-component='IconButton'][aria-label='Reference an issue, pull request, or discussion (#)'],
-			[data-component='IconButton'][aria-label='Mention a user or team (@)']
+			[data-component='IconButton']:has(.octicon-heading),
+			[data-component='IconButton']:has(.octicon-bold),
+			[data-component='IconButton']:has(.octicon-italic),
+			[data-component='IconButton']:has(.octicon-cross-reference),
+			[data-component='IconButton']:has(.octicon-mention),
 		):not(:focus) {
 		/* Like GitHub’s `show-on-focus` class. Needed because we target `md-ref` with the observer in `table-input` and `collapsible-content-button` */
 		position: absolute;


### PR DESCRIPTION
Close: #8260 

## Test URLs

https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.ym

## Screenshot

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/25347d9f-bda4-44f5-b0c5-4d6d2e732aca" />
