### PR TITLE
Meta: Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
-        with:
-          ignore_words_list: eror,usera
-          skip: '*.json'
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           cache: npm
       - run: npm ci
       - run: npm run lint
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          ignore_words_list: eror,usera
+          skip: '*.json'
 
   Types:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          ignore_words_list: eror,usera
+          skip: '*.json'
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,5 +1,5 @@
 /* TODO: Revert https://github.com/refined-github/refined-github/pull/7859 in March 2025 */
-/* The `details` version is for GHE. The `button` in the selector avoids a GHE conflict. `fuchsia` is to higlight broken styles. */
+/* The `details` version is for GHE. The `button` in the selector avoids a GHE conflict. `fuchsia` is to highlight broken styles. */
 button.rgh-highlight-non-default-branch,
 details.rgh-highlight-non-default-branch > summary {
 	background-color: var(

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -112,7 +112,7 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 			> .d-md-block
 				> .js-socket-channel[data-url^='/notifications/beta/recent_notifications_alert']
 		) {
-		/* Substract 16px spacing from both .gap-3 and .ml-3 */
+		/* Subtract 16px spacing from both .gap-3 and .ml-3 */
 		margin-right: -32px;
 	}
 }

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -11,7 +11,7 @@ import observe from '../helpers/selector-observer.js';
 function addLinks(container: HTMLElement): void {
 	const defaultQuery = 'is:open archived:false';
 
-	// Without this, the Issues page also displays PRs, and viceversa
+	// Without this, the Issues page also displays PRs, and vice-versa
 	const isIssues = location.pathname.startsWith('/issues');
 	const typeQuery = isIssues ? 'is:issue' : 'is:pr';
 	const typeName = isIssues ? 'Issues' : 'Pull Requests';


### PR DESCRIPTION
This PR does not close any issue and does not change any pages.

It only fixes typos and adds a GitHub Action step to the Lint job to look for future typos.

% `codespell --ignore-words-list=eror,usera --skip="*.json" --write-changes`
* https://pypi.org/project/codespell
