### PR TITLE
`update-pr-from-base-branch` - Don't duplicate native button

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -53,6 +53,7 @@ function createButton(): JSX.Element {
 }
 
 async function addButton(mergeBar: Element): Promise<void> {
+	// TODO: Drop after July 2025
 	if (elementExists(canNativelyUpdate)) {
 		return;
 	}
@@ -74,6 +75,12 @@ async function addButton(mergeBar: Element): Promise<void> {
 		'.branch-action-item:has(.merging-body)', // TODO: Drop after June 2025
 		'[aria-label="Conflicts"] [class^="MergeBoxSectionHeader-module__wrapper"]',
 	]);
+
+	// `canNativelyUpdate` is only working for Old View
+	const nativeButton = $optional('button', mergeabilityRow);
+	if (nativeButton && nativeButton.textContent === 'Update branch') {
+		return;
+	}
 
 	if (mergeabilityRow) {
 		const isOldView = mergeBar.parentElement?.classList.contains('mergeability-details');

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -15,7 +15,10 @@ import {getConversationNumber} from '../github-helpers/index.js';
 import createMergeabilityRow from '../github-widgets/mergeability-row.js';
 import {expectToken} from '../github-helpers/github-token.js';
 
-const canNativelyUpdate = '.js-update-branch-form';
+const canNativelyUpdate = [
+	'.js-update-branch-form',
+	'[aria-label="Update branch options"]',
+];
 
 async function mergeBranches(): Promise<AnyObject> {
 	return api.v3(`pulls/${getConversationNumber()!}/update-branch`, {
@@ -53,7 +56,6 @@ function createButton(): JSX.Element {
 }
 
 async function addButton(mergeBar: Element): Promise<void> {
-	// TODO: Drop after July 2025
 	if (elementExists(canNativelyUpdate)) {
 		return;
 	}
@@ -75,12 +77,6 @@ async function addButton(mergeBar: Element): Promise<void> {
 		'.branch-action-item:has(.merging-body)', // TODO: Drop after June 2025
 		'[aria-label="Conflicts"] [class^="MergeBoxSectionHeader-module__wrapper"]',
 	]);
-
-	// `canNativelyUpdate` is only working for Old View
-	const nativeButton = $optional('button', mergeabilityRow);
-	if (nativeButton && nativeButton.textContent === 'Update branch') {
-		return;
-	}
 
 	if (mergeabilityRow) {
 		const isOldView = mergeBar.parentElement?.classList.contains('mergeability-details');

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -16,7 +16,7 @@ import createMergeabilityRow from '../github-widgets/mergeability-row.js';
 import {expectToken} from '../github-helpers/github-token.js';
 
 const canNativelyUpdate = [
-	'.js-update-branch-form',
+	'.js-update-branch-form', // Old view - TODO: Remove in July 2025
 	'[aria-label="Update branch options"]',
 ];
 


### PR DESCRIPTION
Close: #8247


## Test URLs

[github.com/pulls (is:open archived:false user:@me draft:false)](https://github.com/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+archived%3Afalse+user%3A%40me+draft%3Afalse&rgh-link-date=2025-02-01T07%3A43%3A26.000Z)

## Screenshot

Before:

![CleanShot 2025-02-19 at 11 21 53@2x](https://github.com/user-attachments/assets/e38ca8a6-909c-4425-a994-a1bc860a37b3)

After:

![CleanShot 2025-02-19 at 11 22 10@2x](https://github.com/user-attachments/assets/75ef4d5b-dddc-4921-a559-3270c117589b)

