### PR TITLE
`conventional-commits` - Fix grouping on commits with parens

### DIFF
--- a/source/helpers/conventional-commits.test.ts
+++ b/source/helpers/conventional-commits.test.ts
@@ -43,6 +43,14 @@ test('parseConventionalCommit', () => {
 		  "type": "Feature!",
 		}
 	`);
+	expect(parseConventionalCommit('revert(scope): Revert "feat(scope): Commit message"')).toMatchInlineSnapshot(`
+		{
+		  "raw": "revert(scope): ",
+		  "rawType": "revert",
+		  "scope": "scope: ",
+		  "type": "Revert",
+		}
+	`);
 	expect(parseConventionalCommit('feat(sco pe): Commit message')).toMatchInlineSnapshot(`
 		{
 		  "raw": "feat(sco pe): ",

--- a/source/helpers/conventional-commits.ts
+++ b/source/helpers/conventional-commits.ts
@@ -1,5 +1,5 @@
 // Using https://www.conventionalcommits.org/ as a reference.
-export const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+)\))?(?<major>!)?: */;
+export const conventionalCommitRegex = /^(?<type>\w+)(?:\((?<scope>.+?)\))?(?<major>!)?: */;
 
 // Do not send PRs for types not listed here: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#rules
 // No more types will be added nor do we accept options.


### PR DESCRIPTION
The problem:

![image](https://github.com/user-attachments/assets/97c0605b-194f-4f9f-9913-55db8da30e9f)

Before fix: https://regex101.com/r/XZIg7M/1
After fix: https://regex101.com/r/j85oEo/1

## Test URLs

https://github.com/renovatebot/renovate/commits/4214048e713096f58005658e104c09e881d4b933/

## Screenshot