### PR TITLE
Fix  handling repo file path got an empty path

### DIFF
--- a/source/github-helpers/github-file-url.ts
+++ b/source/github-helpers/github-file-url.ts
@@ -1,4 +1,4 @@
-import {isRepoRoot} from 'github-url-detection';
+import {isRepoRoot, isSingleFile} from 'github-url-detection';
 
 import getCurrentGitRef from './get-current-git-ref.js';
 
@@ -73,14 +73,14 @@ export default class GitHubFileURL {
 	set pathname(pathname: string) {
 		const [user, repository, route, ...ambiguousReference] = pathname.replaceAll(/^\/|\/$/g, '').split('/');
 		// TODO: `isRepoRoot` uses global state https://github.com/refined-github/refined-github/issues/6637
-		if (isRepoRoot() || (ambiguousReference.length === 2 && ambiguousReference[1].includes('%2F'))) {
+		if (!isSingleFile() && (isRepoRoot() || (ambiguousReference.length === 2 && ambiguousReference[1].includes('%2F')))) {
 			const branch = ambiguousReference.join('/').replaceAll('%2F', '/');
 			this.assign({
 				user,
 				repository,
 				route,
 				branch,
-				filePath: isRepoRoot() ? '' : ambiguousReference[1].replaceAll('%2F', '/'),
+				filePath: '',
 			});
 			return;
 		}

--- a/source/github-helpers/github-file-url.ts
+++ b/source/github-helpers/github-file-url.ts
@@ -80,7 +80,7 @@ export default class GitHubFileURL {
 				repository,
 				route,
 				branch,
-				filePath: '',
+				filePath: isRepoRoot() ? '' : ambiguousReference[1].replaceAll('%2F', '/'),
 			});
 			return;
 		}


### PR DESCRIPTION
Maybe handle it this way for now, and resolve the TODO later.

Close: #8185
Close: #8189


## Test URLs

http://github.com/typescript-eslint/typescript-eslint/blob/86409083167bee4ba1ad3ebba22785b3a4a262ee/packages%2Feslint-plugin%2Fdocs%2Frules%2Fstrict-boolean-expressions.mdx

## Screenshot

https://github.com/user-attachments/assets/540c33f2-1857-4928-9de7-4b694325a788

