### PR TITLE
`small-user-avatars` - Fix own avatar size

### DIFF
--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -1,7 +1,7 @@
 .rgh-mention-avatar::before {
 	content: '';
 	display: inline-block;
-	width: 16px;
+	width: 16px !important;
 	height: 16px;
 	margin-right: 0.2em;
 	border-radius: 50%;

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -12,6 +12,6 @@
 }
 
 .user-mention {
-    margin-left: 0px !important;
-    margin-right: 0px !important;
+	margin-left: 0px !important;
+	margin-right: 0px !important;
 }

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -12,6 +12,6 @@
 }
 
 .user-mention {
-	margin-left: 0px !important;
-	margin-right: 0px !important;
+	margin-left: 0 !important;
+	margin-right: 0 !important;
 }

--- a/source/features/small-user-avatars.css
+++ b/source/features/small-user-avatars.css
@@ -10,3 +10,8 @@
 	background-position: center;
 	vertical-align: middle;
 }
+
+.user-mention {
+    margin-left: 0px !important;
+    margin-right: 0px !important;
+}


### PR DESCRIPTION
## Problem

The avatars shown next to the mentions are squished if it is the logged in user's mention:
> ![1](https://github.com/user-attachments/assets/04c64c01-9e2b-4023-ab2a-bf5641426f76)

## Cause

The following CSS used by GitHub is causing the issue:
```css
.user-mention[href$="/OnkarRuikar"]:before, .user-mention[href$="/OnkarRuikar"]:after {
    content: '';
    display: inline-block;
    width: 2px;
}
```

# Solution 

Force the width from refined-github's side:
```diff
.rgh-mention-avatar::before {
	content: '';
	display: inline-block;
--	width: 16px;
++	width: 16px !important;
	height: 16px;
	margin-right: 0.2em;
	border-radius: 50%;
}
```

## Test URLs

In this case, one URL doesn't work for everyone. Instead I give you steps to reproduce:
1. Add mine and your mention `@OnkarRuikar and @yourname` in the new comment edit box below.
2. Switch to preview tab.
3. Notice my mention gets entire avatar image and yours will be squashed to 2px width.

## Screenshot

Before fix:
![1](https://github.com/user-attachments/assets/8aed6123-db29-4603-a2bb-96366535b110)

After fix:
![2](https://github.com/user-attachments/assets/e7a7b2f7-74ff-4d8d-9fef-eed7efa158a0)

After margin corrected:
![3](https://github.com/user-attachments/assets/d0036c8c-be02-4770-8bd3-27716b83a90c)
