### PR TITLE
`collapsible-content-button` - Improve description

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -123,7 +123,7 @@
 	},
 	{
 		"id": "collapsible-content-button",
-		"description": "Adds a button to insert collapsible content (via <code>&lt;details&gt;</code>).",
+		"description": "Adds a button in the text editor to insert collapsible content (via <code>&lt;details&gt;</code>).",
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png"
 	},
 	{

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 ### Writing comments
 
 - [](# "tab-to-indent") 🔥 [Enables <kbd>tab</kbd> and <kbd>shift</kbd> <kbd>tab</kbd> for indentation in comment fields.](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)
-- [](# "collapsible-content-button") [Adds a button to insert collapsible content (via `<details>`).](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png)
+- [](# "collapsible-content-button") [Adds a button in the text editor to insert collapsible content (via `<details>`).](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/260875648-bd495d27-4cd1-4190-bcc5-b8b476f07d39.png)
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [](# "quick-comment-edit") [Lets you edit any comment with one click instead of having to open a dropdown.](https://user-images.githubusercontent.com/46634000/162252055-54750c89-0ddc-487a-b4ad-cec6009d9870.png)
 - [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261155564-e7aabd0e-b14b-4fe6-b379-62e7419c43f8.gif) `[` `` ` `` `'` `"` `*` `~` `_`


### PR DESCRIPTION
It's nice to be able to search the features for a consistent string and see all features that impact it. Since the other 2 features that modify the text editor mention it in their descriptions, I figured this one should as well. Note how it's currently left out of this search:

<img width="776" alt="Screenshot 2025-03-05 at 3 49 29 PM" src="https://github.com/user-attachments/assets/7447f97f-cff1-4fe9-8d30-f62f7d613c59" />
