### PR TITLE
Meta: Fix RelativeCI setup on PRs from forks

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -1,0 +1,17 @@
+name: RelativeCI
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types:
+      - completed
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send bundle stats and build information to RelativeCI
+        uses: relative-ci/agent-action@v2.2.0
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,13 +96,11 @@ jobs:
       - run: npm run build:bundle
         env:
           RELATIVE_CI_STATS: true
-      - name: Send build stats to RelativeCI
+      - name: Upload bundle stats artifact
         if: matrix.os == 'ubuntu-latest'
-        uses: relative-ci/agent-action@v2
+        uses: relative-ci/agent-upload-artifact-action@v2
         with:
-          token: ${{ github.token }}
           webpackStatsFile: ./distribution/assets/webpack-stats.json
-          key: ${{ secrets.RELATIVE_CI_KEY }}
       - uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:


### PR DESCRIPTION
Run relative-ci/agent-action during `workflow_run` to safely provide the secret for pull requests triggered by unsecured flows(forks, dependabot). The new workflow will be run only from the context of the main branch (after merge).

- rel: https://github.com/relative-ci/agent-action/issues/442
- more info: https://relative-ci.com/documentation/setup/agent/github-action/#workflow_run-event


## Test URLs

- Base repository action: 
   - https://github.com/relative-ci/refined-github/actions/runs/13862190986
- Pull request triggered from a forked repo:
   - Pull request: https://github.com/relative-ci/refined-github/pull/3
   - Action logs: https://github.com/relative-ci/refined-github/actions/runs/13862469687/job/38794010415
