### PR TITLE
`emphasize-draft-pr-label` - Support in notifications

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -14,13 +14,10 @@
 		[aria-label*='Status: Draft (not ready)']
 		[data-testid='list-row-state-icon']
 		svg,
-		:is(
-			/* Notification select by */
-			.rgh-select-notifications,
-			/* Notification list */
-			.notification-list-item-link
-		)
-		 svg.octicon-git-pull-request-draft, {
+		/* Notification select by */
+		.rgh-select-notifications .octicon-git-pull-request-draft,
+		/* Notification list */
+		.notification-list-item-link .octicon-git-pull-request-draft {
 			stroke: var(--fgColor-muted, var(--color-fg-muted, fuchsia));
 			stroke-width: 1.2px;
 			color: var(--rgh-background, fuchsia) !important;

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -13,7 +13,9 @@
 		/* React issue list */
 		[aria-label*='Status: Draft (not ready)']
 		[data-testid='list-row-state-icon']
-		svg {
+		svg,
+		/* Notification select by */
+		#rgh-select-notifications-form .color-fg-subtle {
 			stroke: var(--fgColor-muted, var(--color-fg-muted, fuchsia));
 			stroke-width: 1.2px;
 			color: var(--rgh-background, fuchsia) !important;

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -14,8 +14,14 @@
 		[aria-label*='Status: Draft (not ready)']
 		[data-testid='list-row-state-icon']
 		svg,
-		/* Notification select by */
-		#rgh-select-notifications-form .color-fg-subtle {
+		:is(
+			/* Notification select by */
+			.rgh-select-notifications,
+			/* Notification list */
+			.notification-list-item-link
+		)
+		 svg.octicon-git-pull-request-draft,
+		{
 			stroke: var(--fgColor-muted, var(--color-fg-muted, fuchsia));
 			stroke-width: 1.2px;
 			color: var(--rgh-background, fuchsia) !important;

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -20,8 +20,7 @@
 			/* Notification list */
 			.notification-list-item-link
 		)
-		 svg.octicon-git-pull-request-draft,
-		{
+		 svg.octicon-git-pull-request-draft, {
 			stroke: var(--fgColor-muted, var(--color-fg-muted, fuchsia));
 			stroke-width: 1.2px;
 			color: var(--rgh-background, fuchsia) !important;


### PR DESCRIPTION
Close: #8252 


## Test URLs

https://github.com/notifications

## Screenshot

<img src="https://github.com/user-attachments/assets/2b1a85fc-8df3-4636-be80-f72e995b2408" width="300" />

<img src="https://github.com/user-attachments/assets/45a60c97-7d2c-4dc3-9a45-08d51a616786" width="300" />


