### PR TITLE
`jump-to-conversation-close-event` - Update selector

### DIFF
--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -28,7 +28,7 @@ export function getLastCloseEvent(): HTMLElement | undefined {
 		)`,
 	])?.closest([
 		'.TimelineItem', // Old view
-		'.Timeline-Item',
+		'[data-timeline-event-id]',
 	])?.querySelector('relative-time') ?? undefined;
 }
 


### PR DESCRIPTION
https://github.com/refined-github/refined-github/issues/8296#issuecomment-2759478677

`.Timeline-Item` is missing. We need to update the selector.


## Test URLs

https://github.com/ktheory/dalli-elasticache/issues/54

## Screenshot

<img width="885" alt="image" src="https://github.com/user-attachments/assets/05f5a57a-f04a-4800-aaf9-f8fb19315b7d" />


![CleanShot 2025-03-28 at 09 11 10](https://github.com/user-attachments/assets/b3740ddc-645e-4da0-9c2e-8e85f5f132ee)
