### PR TITLE
`small-user-avatar` - Restore feature

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -8,8 +8,6 @@ import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
 import './small-user-avatars.css';
 
 function addAvatar(link: HTMLElement): void {
-	console.log('addAvatar', link);
-
 	const username = link.textContent;
 	const size = 14;
 

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -8,6 +8,8 @@ import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
 import './small-user-avatars.css';
 
 function addAvatar(link: HTMLElement): void {
+	console.log('addAvatar', link);
+
 	const username = link.textContent;
 	const size = 14;
 
@@ -37,7 +39,10 @@ function initOnce(): void {
 	observe([
 		'.js-issue-row [data-hovercard-type="user"]', // `isPRList` + old `isIssueList`
 		'.notification-thread-subscription [data-hovercard-type="user"]', // https://github.com/notifications/subscriptions
-		'[data-testid="created-at"] a[data-hovercard-url*="/users"]:first-child', // `isIssueList`. `:first-child` skips links that already include the avatar #7975
+		`:is(
+			[data-testid="created-at"],
+			[data-testid="closed-at"]
+		) a[data-hovercard-url*="/users"]`, // `isIssueList`
 	], addAvatar);
 	observe('.user-mention:not(.commit-author)[data-hovercard-type="user"]', addMentionAvatar);
 }


### PR DESCRIPTION
Close: #8354 


## Test URLs

It seems like native avatar has been removed.

- Native avatars: [download-directory/download-directory.github.io/issues (sort:updated-desc is:pr)](https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc+is%3Apr)
- Our avatars: [download-directory/download-directory.github.io/issues (sort:updated-desc)](https://github.com/download-directory/download-directory.github.io/issues?q=sort%3Aupdated-desc)

## Screenshot


https://github.com/user-attachments/assets/2510d19e-1825-4bfa-9f24-2381f73e058a

