### PR TITLE
`comments-time-machine-links` - Don't show on profile URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"filter-altered-clicks": "^2.1.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^10.0.1",
+				"github-url-detection": "^10.1.0",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkify-issues": "^4.1.0",
@@ -5673,9 +5673,10 @@
 			"license": "MIT"
 		},
 		"node_modules/github-url-detection": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-10.0.1.tgz",
-			"integrity": "sha512-0mCQew9imKutjcEEw4mo9WKOaVFm9h8gH8lWY8kYh2UCKcjWu2gvC4nuGbZOGPN/myIPusbIOaz6sY9cXuwxKQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-10.1.0.tgz",
+			"integrity": "sha512-vzjI8se6gwSos+flHOGh756oE4NPNJp1B61puiJYJGxk2M4/+ELcPfrshXn27zVv8KcTIBQfoK+dxCtG0LDQfw==",
+			"license": "MIT",
 			"dependencies": {
 				"github-reserved-names": "^2.0.7"
 			},

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"filter-altered-clicks": "^2.1.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^10.0.1",
+		"github-url-detection": "^10.1.0",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkify-issues": "^4.1.0",

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -74,13 +74,12 @@ async function showTimeMachineBar(): Promise<void | false> {
 
 function addInlineLinks(comment: HTMLElement, timestamp: string): void {
 	for (const link of $$optional(`a[href^="${location.origin}"]:not(.${linkifiedURLClass})`, comment)) {
-		const linkParts = link.pathname.split('/');
-		// Skip non-git-object links. `undefined` covers links to the repo home #4979
-		if (![undefined, 'blob', 'tree', 'blame'].includes(linkParts[3])) {
+		if (!pageDetect.isRepoGitObject(link)) {
 			continue;
 		}
 
 		// Skip permalinks
+		const linkParts = link.pathname.split('/');
 		if (/^[\da-f]{40}$/.test(linkParts[4])) {
 			continue;
 		}


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/8304



## Test URLs


Here


## Before

<img width="469" alt="Screenshot 14" src="https://github.com/user-attachments/assets/9e35b339-c6e2-43db-bf6d-005814bc566c" />


## After
<img width="469" alt="Screenshot 15" src="https://github.com/user-attachments/assets/28b48e78-8860-4e4c-84bf-ad9785626ee8" />


