### PR TITLE
`clean-readme-url` - Improve on Safari and Firefox

### DIFF
--- a/source/features/clean-readme-url.tsx
+++ b/source/features/clean-readme-url.tsx
@@ -12,7 +12,17 @@ function maybeCleanUrl(event?: NavigateEvent): void {
 
 function init(signal: AbortSignal): void {
 	maybeCleanUrl();
-	globalThis.navigation?.addEventListener('navigate', maybeCleanUrl, {signal});
+	let interval: NodeJS.Timeout;
+	if (globalThis.navigation) {
+		navigation.addEventListener('navigate', maybeCleanUrl, {signal});
+	} else {
+		interval = setInterval(() => {
+			maybeCleanUrl();
+		}, 1000);
+		signal.addEventListener('abort', () => {
+			clearInterval(interval);
+		});
+	}
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
The navigation API is still nowhere to be found, so let's just use interval on non-Chrome browsers

https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API#api.navigation