### PR TITLE
`quick-mention` - Exclude apps

### DIFF
--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -122,7 +122,10 @@ async function init(signal: AbortSignal): Promise<void> {
 		:is(
 			div.TimelineItem-avatar > [data-hovercard-type="user"]:first-child,
 			a.TimelineItem-avatar
-		):not([href="/${getUsername()!}"])
+		):not(
+			[href="/${getUsername()!}"],
+			[href^="/apps/"]
+		)
 	`,
 		`[data-testid="issue-viewer-container"]:has(${fieldSelector[1]}) [class^="LayoutHelpers-module__timelineElement"] a:not([href="/${getUsername()!}"])`,
 	], add, {signal});


### PR DESCRIPTION
Motivation is to exclude Copilot but could catch more cases.

I asked Copilot for a review here so we have a live example 😉 

## Test URLs

https://togithub.com/dotnet/maui/pull/28831#pullrequestreview-2747076622

## Screenshot

Before:

<img width="346" alt="Screenshot 2025-04-08 at 5 45 53 PM" src="https://github.com/user-attachments/assets/0f49fb0a-18e9-470b-a8f2-450643f579e6" />

After: Copilot is excluded