### PR TITLE
feat(`copy-on-y`): enhance clipboard functionality for URLs

### DIFF
--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -4,6 +4,38 @@ import {isEditable} from '../helpers/dom-utils.js';
 async function handler({key, target}: KeyboardEvent): Promise<void> {
 	if (key === 'y' && !isEditable(target)) {
 		const url = location.href;
+		// make the URL a permalink with title.text being the text of the link
+		const title = document.querySelector('title')?.textContent;
+		if (title) {
+			// Copy the URL to the clipboard
+			// Check if the clipboard API is available
+			if (!navigator.clipboard) {
+				console.error('Clipboard API not available');
+				return;
+			}
+			// Check if the user has granted permission to write to the clipboard
+			const permission = await navigator.permissions.query({name: 'clipboard-write' as PermissionName});
+			if (permission.state !== 'granted') {
+				console.error('Clipboard permission not granted');
+				return;
+			}
+			// Copy the URL to the clipboard
+			try {
+				const text = `${title} (${url})`;
+				const permalink = `<a href="${url}">${title}</a>`;
+				await navigator.clipboard.write([
+					new ClipboardItem({
+						'text/plain': new Blob([text], {type: 'text/plain'}),
+						'text/html': new Blob([permalink], {type: 'text/html'}),
+					}),
+				]);
+				console.log('Copied title and URL to the clipboard as link and text\ntext:', text, '\nlink:', permalink);
+				return;
+			} catch (error) {
+				console.error('Failed to copy URL to clipboard', error);
+				return;
+			}
+		}
 		await navigator.clipboard.writeText(url);
 		// Log to ensure we're coping the new URL
 		console.log('Copied URL to the clipboard', url);


### PR DESCRIPTION
Details:
-
Add functionality to copy the current page URL along with its title to the clipboard when the 'y' key is pressed, provided the target element is not editable. This improves user experience by allowing easy sharing of links with context.

Implementation Details:
-
- Checks for clipboard API availability and permission before attempting to copy.
- Supports both plain text and HTML formats for the copied content.

Testing Notes:
-
- Verified functionality by pressing 'y' on various pages to ensure the correct URL and title are copied to the clipboard.