### PR TITLE
`conventional-commits` - Support message starting with backtick

### DIFF
--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -27,7 +27,7 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 		// Skip commits that are _only_ "ci:" without anything else. Rare but it would be confusing to show just the label
 		commit.raw === textNode.textContent
 		&& !commitTitleElement.nextElementSibling
-		
+
 		// Ensure that the element contains only plain text, not stuff like <code>
 		&& commitTitleElement.childElementCount < 1
 	) {

--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -23,9 +23,14 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 		return;
 	}
 
-	// Skip commits that are _only_ "ci:" without anything else. Rare but would be confusing to show just the label
-	// The childElementCount is checked to ensure that the element contains only plain text, not stuff like <code>
-	if (commit.raw === textNode.textContent && !commitTitleElement.nextElementSibling && commitTitleElement.childElementCount < 1) {
+	if (
+		// Skip commits that are _only_ "ci:" without anything else. Rare but it would be confusing to show just the label
+		commit.raw === textNode.textContent
+		&& !commitTitleElement.nextElementSibling
+		
+		// Ensure that the element contains only plain text, not stuff like <code>
+		&& commitTitleElement.childElementCount < 1
+	) {
 		return;
 	}
 

--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -24,7 +24,8 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 	}
 
 	// Skip commits that are _only_ "ci:" without anything else. Rare but would be confusing to show just the label
-	if (commit.raw === textNode.textContent && !commitTitleElement.nextElementSibling) {
+	// The childElementCount is checked to ensure that the element contains only plain text, not stuff like <code>
+	if (commit.raw === textNode.textContent && !commitTitleElement.nextElementSibling && commitTitleElement.childElementCount < 1) {
 		return;
 	}
 


### PR DESCRIPTION
Apparently, the problem with the label not showing up when the message starts with a backtick, was fault of:
https://github.com/refined-github/refined-github/blob/1f6ec8a24faa3a489001c843e50d31314a6244da/source/features/conventional-commits.tsx#L27
The `commit.raw` and `textNode.textContent` were identical and no sibling was found because the `<code>` element is inside `commitTitleElement`, not as a sibling.
By counting the children, the `<code>` element or any element should avoid the early return, as text nodes don't count as childElements.

## Test URLs
https://github.com/loky-lp/rgh-dummy-conventional-commits/commits/main
https://github.com/refined-github/sandbox/pull/91/commits

## Screenshot

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="370" alt="Screenshot 2025-05-02 alle 22 56 03" src="https://github.com/user-attachments/assets/220d7750-03f4-4345-8306-1d17389a4b8d" />
	<td><img width="371" alt="Screenshot 2025-05-02 alle 22 55 17" src="https://github.com/user-attachments/assets/2f657840-3a8a-4170-bedc-42043d53caa0" />
</table>

### Control

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="595" alt="Screenshot 2025-05-02 alle 22 56 35" src="https://github.com/user-attachments/assets/4c0bfae5-aa6a-42ea-9c66-998ef4e598b7" />
	<td><img width="590" alt="Screenshot 2025-05-02 alle 22 57 10" src="https://github.com/user-attachments/assets/71fa5ccf-0484-4a03-99c7-bf48a3128fb2" />
</table>


Closes: #8223 