### PR TITLE
`bugs-tab` - Support Bug type

### DIFF
--- a/source/features/bugs-tab.gql
+++ b/source/features/bugs-tab.gql
@@ -8,5 +8,8 @@ query CountBugs($owner: String!, $name: String!) {
 				}
 			}
 		}
+		issues(filterBy: {type: "Bug", states: OPEN}) {
+			totalCount
+		}
 	}
 }

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -24,22 +24,22 @@ type Bugs = {
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs);
 
-	const issuesBugCount = repository.issues.totalCount ?? 0;
+	const bugTypeCount = repository.issues.totalCount ?? 0;
 
 	// Prefer native "bug" label
 	for (const label of repository.labels.nodes) {
 		if (label.name === 'bug') {
-			return {label: 'bug', count: (label.issues.totalCount ?? 0) + issuesBugCount};
+			return {label: 'bug', count: (label.issues.totalCount ?? 0) + bugTypeCount};
 		}
 	}
 
 	for (const label of repository.labels.nodes) {
 		if (isBugLabel(label.name)) {
-			return {label: label.name, count: (label.issues.totalCount ?? 0) + issuesBugCount};
+			return {label: label.name, count: (label.issues.totalCount ?? 0) + bugTypeCount};
 		}
 	}
 
-	return {label: '', count: issuesBugCount};
+	return {label: '', count: bugTypeCount};
 }
 
 const bugs = new CachedFunction('bugs', {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -24,24 +24,22 @@ type Bugs = {
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs);
 
-	if (repository.issues.totalCount > 0) {
-		return {label: 'bug', count: repository.issues.totalCount};
-	}
+	const issuesBugCount = repository.issues.totalCount ?? 0;
 
 	// Prefer native "bug" label
 	for (const label of repository.labels.nodes) {
 		if (label.name === 'bug') {
-			return {label: 'bug', count: label.issues.totalCount ?? 0};
+			return {label: 'bug', count: (label.issues.totalCount ?? 0) + issuesBugCount};
 		}
 	}
 
 	for (const label of repository.labels.nodes) {
 		if (isBugLabel(label.name)) {
-			return {label: label.name, count: label.issues.totalCount ?? 0};
+			return {label: label.name, count: (label.issues.totalCount ?? 0) + issuesBugCount};
 		}
 	}
 
-	return {label: '', count: 0};
+	return {label: '', count: issuesBugCount};
 }
 
 const bugs = new CachedFunction('bugs', {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -65,7 +65,7 @@ const bugs = new CachedFunction('bugs', {
 
 async function getSearchQueryBugLabel(): Promise<string> {
 	const {label} = await bugs.getCached() ?? {};
-	return `(label:${SearchQuery.escapeValue(label ?? 'bug') ?? 'bug'} OR type:Bug)`;
+	return `(label:${SearchQuery.escapeValue(label ?? 'bug')} OR type:Bug)`;
 }
 
 async function isBugsListing(): Promise<boolean> {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -16,6 +16,20 @@ import isBugLabel from '../github-helpers/bugs-label.js';
 import CountBugs from './bugs-tab.gql';
 import {expectToken} from '../github-helpers/github-token.js';
 
+type ApiResponse = {
+	issues?: {
+		totalCount?: number;
+	};
+	labels?: {
+		nodes?: Array<{
+			name: string;
+			issues: {
+				totalCount?: number;
+			};
+		}>;
+	};
+};
+
 type Bugs = {
 	label: string;
 	count: number;

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -24,6 +24,10 @@ type Bugs = {
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs);
 
+	if (repository.issues.totalCount > 0) {
+		return {label: 'bug', count: repository.issues.totalCount};
+	}
+
 	// Prefer native "bug" label
 	for (const label of repository.labels.nodes) {
 		if (label.name === 'bug') {
@@ -49,7 +53,7 @@ const bugs = new CachedFunction('bugs', {
 
 async function getSearchQueryBugLabel(): Promise<string> {
 	const {label} = await bugs.getCached() ?? {};
-	return 'label:' + SearchQuery.escapeValue(label ?? 'bug');
+	return `(label:${label ?? 'bug'} OR type:Bug)`;
 }
 
 async function isBugsListing(): Promise<boolean> {

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -51,7 +51,7 @@ const bugs = new CachedFunction('bugs', {
 
 async function getSearchQueryBugLabel(): Promise<string> {
 	const {label} = await bugs.getCached() ?? {};
-	return `(label:${label ?? 'bug'} OR type:Bug)`;
+	return `(label:${SearchQuery.escapeValue(label ?? 'bug') ?? 'bug'} OR type:Bug)`;
 }
 
 async function isBugsListing(): Promise<boolean> {

--- a/source/github-helpers/search-query.test.ts
+++ b/source/github-helpers/search-query.test.ts
@@ -17,6 +17,11 @@ test('getQueryParts with spaces support', () => {
 	assert.deepEqual(query.getQueryParts(), ['please', 'label:"under discussion"']);
 });
 
+test('getQueryParts with parentheses support', () => {
+	const query = SearchQuery.from({q: 'please (label:"bug" or type:bug)'});
+	assert.deepEqual(query.getQueryParts(), ['please', '(label:"bug" or type:bug)']);
+});
+
 test('.set', () => {
 	const query = SearchQuery.from({q: 'wow'});
 	query.set('lol');

--- a/source/github-helpers/search-query.test.ts
+++ b/source/github-helpers/search-query.test.ts
@@ -98,3 +98,124 @@ test('parse label link', () => {
 	assert.equal(query.get(), 'is:open label:bug');
 	assert.isTrue(query.href.startsWith('https://github.com/owner/repo/issues?'));
 });
+
+test('complex queries with multiple conditions', () => {
+	const query = SearchQuery.from({q: 'is:issue is:open label:bug author:user milestone:"Q1 2023"'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'is:open', 'label:bug', 'author:user', 'milestone:"Q1 2023"']);
+});
+
+test('queries with special characters in quoted values', () => {
+	const query = SearchQuery.from({q: 'label:"bug: critical!" milestone:"version 1.0-beta"'});
+	assert.deepEqual(query.getQueryParts(), ['label:"bug: critical!"', 'milestone:"version 1.0-beta"']);
+});
+
+test('queries with colons in quoted values', () => {
+	const query = SearchQuery.from({q: 'label:"feature: enhancement" comment:"fixes: #1234"'});
+	assert.deepEqual(query.getQueryParts(), ['label:"feature: enhancement"', 'comment:"fixes: #1234"']);
+});
+
+test('queries with multiple spaces between parts', () => {
+	const query = SearchQuery.from({q: 'is:issue   label:bug    author:user'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'label:bug', 'author:user']);
+});
+
+test('queries with empty quoted values', () => {
+	const query = SearchQuery.from({q: 'is:issue label:""'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'label:""']);
+});
+
+test('complex parenthesized expressions', () => {
+	const query = SearchQuery.from({q: 'repo:user/repo (is:issue OR is:pr) label:bug'});
+	assert.deepEqual(query.getQueryParts(), ['repo:user/repo', '(is:issue OR is:pr)', 'label:bug']);
+});
+
+test('quoted strings without keys', () => {
+	const query = SearchQuery.from({q: '"exact phrase search" label:bug'});
+	assert.deepEqual(query.getQueryParts(), ['"exact phrase search"', 'label:bug']);
+});
+
+test('keys with special characters', () => {
+	const query = SearchQuery.from({q: 'is:issue assignee-review-requested:@me'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'assignee-review-requested:@me']);
+});
+
+test('mixed key-value types in one query', () => {
+	const query = SearchQuery.from({q: 'is:issue "exact match" label:"needs help" (author:user1 OR author:user2)'});
+	assert.deepEqual(
+		query.getQueryParts(),
+		['is:issue', '"exact match"', 'label:"needs help"', '(author:user1 OR author:user2)'],
+	);
+});
+
+test('queries with date ranges', () => {
+	const query = SearchQuery.from({q: 'is:issue created:2023-01-01..2023-12-31'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'created:2023-01-01..2023-12-31']);
+});
+
+test('queries with negation operators', () => {
+	const query = SearchQuery.from({q: 'is:issue -label:bug -author:user'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', '-label:bug', '-author:user']);
+});
+
+test('queries with comparison operators', () => {
+	const query = SearchQuery.from({q: 'is:issue comments:>10 created:>=2023-01-01'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'comments:>10', 'created:>=2023-01-01']);
+});
+
+test('queries with wildcard characters', () => {
+	const query = SearchQuery.from({q: 'is:issue label:bug-* author:*-bot'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'label:bug-*', 'author:*-bot']);
+});
+
+test('queries with special URL characters', () => {
+	const query = SearchQuery.from({q: 'repo:user/repo-name+feature is:issue'});
+	assert.deepEqual(query.getQueryParts(), ['repo:user/repo-name+feature', 'is:issue']);
+});
+
+test('queries with multiple negation patterns', () => {
+	const query = SearchQuery.from({q: 'is:pr -is:draft -is:merged -label:WIP'});
+	assert.deepEqual(query.getQueryParts(), ['is:pr', '-is:draft', '-is:merged', '-label:WIP']);
+});
+
+test('queries with multiple key-value pairs having the same key', () => {
+	const query = SearchQuery.from({q: 'is:issue label:bug label:enhancement label:"good first issue"'});
+	assert.deepEqual(query.getQueryParts(), ['is:issue', 'label:bug', 'label:enhancement', 'label:"good first issue"']);
+});
+
+test('queries with complex boolean combinations', () => {
+	const query = SearchQuery.from({q: 'is:issue (label:bug AND author:user) OR (label:feature AND milestone:v1.0)'});
+	assert.deepEqual(
+		query.getQueryParts(),
+		['is:issue', '(label:bug AND author:user)', 'OR', '(label:feature AND milestone:v1.0)'],
+	);
+});
+
+test('queries with numbers and other special characters in search terms', () => {
+	const query = SearchQuery.from({q: 'issue#123 PR#456 @user branch:fix/bug-123'});
+	assert.deepEqual(query.getQueryParts(), ['issue#123', 'PR#456', '@user', 'branch:fix/bug-123']);
+});
+
+test('queries with dots in key values', () => {
+	const query = SearchQuery.from({q: 'filename:test.js extension:.tsx repo:user/repo.js'});
+	assert.deepEqual(query.getQueryParts(), ['filename:test.js', 'extension:.tsx', 'repo:user/repo.js']);
+});
+
+test('queries with unicode characters', () => {
+	const query = SearchQuery.from({q: 'label:"优先级高" author:用户'});
+	assert.deepEqual(query.getQueryParts(), ['label:"优先级高"', 'author:用户']);
+});
+
+test('queries with multiple parenthesized groups', () => {
+	const query = SearchQuery.from({q: '(is:issue) (is:open) (label:bug) (author:user)'});
+	assert.deepEqual(query.getQueryParts(), ['(is:issue)', '(is:open)', '(label:bug)', '(author:user)']);
+});
+
+test('queries with multiple quoted strings', () => {
+	const query = SearchQuery.from({q: '"first string" "second string" "third string"'});
+	assert.deepEqual(query.getQueryParts(), ['"first string"', '"second string"', '"third string"']);
+});
+
+test('queries with URL-encoded characters', () => {
+	const query = SearchQuery.from({q: 'label:bug%20fix author:user%2Dname'});
+	assert.deepEqual(query.getQueryParts(), ['label:bug%20fix', 'author:user%2Dname']);
+});

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,4 +1,4 @@
-const queryPartsRegExp = /(?:[^\s"]|"[^"]*")+/g;
+const queryPartsRegExp = /[^\s"()]+:[^"\s()]*(?:"[^"]*")?|\([^)]*\)|"[^"]*"|[^\s"():]+/g;
 const labelLinkRegex = /^(?:\/[^/]+){2}\/labels\/([^/]+)\/?$/;
 
 function splitQueryString(query: string): string[] {

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,4 +1,4 @@
-const queryPartsRegExp = /\([^()]*(?:\([^()]*\)[^()]*)*\)|"[^"]*"|[^\s"()]+/g;
+const queryPartsRegExp = /(?:[^\s"]|"[^"]*")+/g;
 const labelLinkRegex = /^(?:\/[^/]+){2}\/labels\/([^/]+)\/?$/;
 
 function splitQueryString(query: string): string[] {

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,4 +1,4 @@
-const queryPartsRegExp = /(?:[^\s"]|"[^"]*")+/g;
+const queryPartsRegExp = /\([^()]*(?:\([^()]*\)[^()]*)*\)|"[^"]*"|[^\s"()]+/g;
 const labelLinkRegex = /^(?:\/[^/]+){2}\/labels\/([^/]+)\/?$/;
 
 function splitQueryString(query: string): string[] {


### PR DESCRIPTION
Closes #8227

Not the best at crafting regexp, so would appreciate suggestions on how to improve it if possible, but all existing tests on queryPartsRegExp are still passing.

## Test URLs
https://github.com/refined-github/refined-github/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+%28label%3Abug+OR+type%3ABug%29

Unfortunately don't have any public repository available to test the issue type bug on. 

## Screenshot

<img width="479" alt="image" src="https://github.com/user-attachments/assets/5c6b3a41-bab1-4c2c-83a9-44744560d425" />

<img width="637" alt="image" src="https://github.com/user-attachments/assets/a3503ae9-665e-43b3-b043-dd94e2f26eba" />

