### PR TITLE
`show-names` - treat `github-apps` as a bot

### DIFF
--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -173,6 +173,7 @@ const botNames = [
 	'scala-steward',
 	'weblate',
 	'apps', // Matches any `/apps/*` URLs
+	'github-apps', // GHE apps
 ] as const;
 
 const botAttributes = botNames.map(bot => `[href^="/${bot}"]`).join(', ');


### PR DESCRIPTION
Closes #8433 

Documentation references to `/github-apps`:
- https://docs.github.com/en/enterprise-server@3.16/apps/using-github-apps/installing-a-github-app-from-a-third-party
- https://docs.github.com/en/enterprise-server@3.16/apps/sharing-github-apps/sharing-your-github-app
- https://docs.github.com/en/enterprise-server@3.16/apps/creating-github-apps/about-creating-github-apps/migrating-oauth-apps-to-github-apps

No test url as it applies to private GHE only.