### PR TITLE
`repo-age` - Fix positioning in document

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -89,7 +89,7 @@ async function init(): Promise<void> {
 		: <><strong>{value}</strong> {unit} old</>;
 
 	const sidebarForksLinkIcon = await elementReady('.BorderGrid .octicon-repo-forked');
-	sidebarForksLinkIcon!.closest('.mt-2')!.parentElement!.append(
+	sidebarForksLinkIcon!.closest('.mt-2')!.after(
 		<h3 className="sr-only">Repository age</h3>,
 		<div className="mt-2">
 			<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -89,7 +89,7 @@ async function init(): Promise<void> {
 		: <><strong>{value}</strong> {unit} old</>;
 
 	const sidebarForksLinkIcon = await elementReady('.BorderGrid .octicon-repo-forked');
-	sidebarForksLinkIcon!.closest('.mt-2')!.append(
+	sidebarForksLinkIcon!.closest('.mt-2')!.parentElement!.append(
 		<h3 className="sr-only">Repository age</h3>,
 		<div className="mt-2">
 			<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>


### PR DESCRIPTION
A small fix to properly anchor the `repo-age` feature, as it's currently being injected into the `Forks` row.

## Test URLs

Any repo

## Screenshot

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c5932422-edad-4348-84b2-4bfe250f0789) | ![image](https://github.com/user-attachments/assets/69ad7bbd-0a90-4fcc-a2a7-b5529113a257) |