### PR TITLE
GitHub bug fix: container's width is overing browser viewport

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -118,7 +118,9 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	}
 }
 
-/* Container's width is overing browser viewport #8454 */
+/* Issue picker does not clip unbreakable issue titles in PRs */
+/* Info: https://github.com/refined-github/refined-github/pull/8454 */
+/* Test: type "#113" in https://github.com/refined-github/sandbox/pull/4 */
 .suggester-container li {
 	max-width: 500px;
 	overflow: hidden;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -118,6 +118,14 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	}
 }
 
+/* Container's width is overing browser viewport */
+.suggester-container li {
+	max-width: 500px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 /*
 
 Test URLs:

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -118,7 +118,7 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	}
 }
 
-/* Container's width is overing browser viewport */
+/* Container's width is overing browser viewport #8454 */
 .suggester-container li {
 	max-width: 500px;
 	overflow: hidden;


### PR DESCRIPTION
## Test URLs

PR description's input in [Folo](https://github.com/RSSNext/Folo)


## Screenshot


| Before | After |
| ----- | ----- |
| ![CleanShot 2025-05-19 at 15 13 07](https://github.com/user-attachments/assets/946f5b93-a50e-423f-a8eb-74b160baeb1e) | ![CleanShot 2025-05-19 at 15 27 46](https://github.com/user-attachments/assets/abbd8272-5f10-4646-9638-40931c212497) |
