### PR TITLE
`sticky-header` - Fix overlap with repository readme header

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -46,6 +46,7 @@ Exclusively use simple sums and use `0px` instead of `0`
 	display: none;
 }
 
+/* Higher than sticky readme header https://github.com/refined-github/refined-github/issues/8462 */
 .rgh-sticky-sidebar:has(.details-reset[open]) {
 	z-index: 90;
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -35,11 +35,6 @@ Exclusively use simple sums and use `0px` instead of `0`
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: var(--rgh-sticky-sidebar-offset, 0) !important;
-	/*
-		Make sure the container's z-index is higher than the readme header
-		to avoid the README header overlapping the sidebar.
-	 */
-	z-index: 9;
 }
 
 #discussion_bucket #partial-discussion-sidebar.rgh-sticky-sidebar-container {
@@ -49,4 +44,8 @@ Exclusively use simple sums and use `0px` instead of `0`
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */
 .rgh-sticky-sidebar + .border-top {
 	display: none;
+}
+
+.rgh-sticky-sidebar:has(.details-reset[open]) {
+	z-index: 90;
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -35,6 +35,11 @@ Exclusively use simple sums and use `0px` instead of `0`
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: var(--rgh-sticky-sidebar-offset, 0) !important;
+	/*
+		Make sure the container's z-index is higher than the readme header
+		to avoid the README header overlapping the sidebar.
+	 */
+	z-index: 9;
 }
 
 #discussion_bucket #partial-discussion-sidebar.rgh-sticky-sidebar-container {


### PR DESCRIPTION
Close: #8462


## Test URLs


Any repo you own.


## Screenshot

https://github.com/user-attachments/assets/43c5ca32-9461-48dd-afd1-4a0d6af635fe




