### PR TITLE
`clean-conversation-sidebar` - Restore feature for development hint

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -111,7 +111,7 @@ async function cleanSidebar(): Promise<void> {
 	}
 
 	// Development (linked issues/PRs)
-	const developmentHint = $optional('[aria-label="Link issues"] p');
+	const developmentHint = $optional('[aria-label="Link issues"] > p');
 	if (developmentHint) { // This may not exist if issues are disabled
 		removeTextNodeContaining(developmentHint, /No branches or pull requests|Successfully merging/);
 	}


### PR DESCRIPTION


## Test URLs

https://github.com/refined-github/sandbox/pull/60

## Screenshot

Before:

<img width="1475" alt="image" src="https://github.com/user-attachments/assets/15add3a4-834f-4bb8-8664-da1c5179587f" />

After:

![CleanShot 2025-06-24 at 15 01 11](https://github.com/user-attachments/assets/7b4c6658-3e00-48d1-82e0-e950118c35b9)



