### PR TITLE
`list-prs-for-file` - Restore feature

### DIFF
--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -137,7 +137,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
 
 	observe([
-		'[aria-label="More file actions"]', // `isSingleFile`
+		'[data-testid="more-file-actions-button-nav-menu-wide"]', // `isSingleFile`
 		'[data-hotkey="Mod+s"]', // `isEditingFile`
 	], add, {signal});
 }

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -138,6 +138,7 @@ async function init(signal: AbortSignal): Promise<void> {
 
 	observe([
 		'[data-testid="more-file-actions-button-nav-menu-wide"]', // `isSingleFile`
+		'[data-testid="more-file-actions-button-nav-menu-narrow"]', // `isSingleFile`
 		'[data-hotkey="Mod+s"]', // `isEditingFile`
 	], add, {signal});
 }


### PR DESCRIPTION
This pull request fixes a bug where `list-prs-for-file` does not add the dropdown button to view the PR list as expected. From my understanding, when it was last written, the "More file actions" dropdown button had an `aria-label` attribute, but it has now been changed to use `aria-labelledby`, which causes it not to function properly. So when I checked using the browser’s built-in Inspect tool, the `data-testid` attribute among the "More file actions" dropdown button’s properties appeared to be usable for identification purposes. I applied this to the code, and since it appears to work correctly in my case, I’m submitting this PR.

## Test URLs

- https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/components/VPDocFooterLastUpdated.vue
- https://github.com/vuejs/vitepress/blob/main/src/node/plugins/localSearchPlugin.ts
- https://github.com/refined-github/sandbox/blob/6619/6619

## Screenshot

Screenshot for https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/components/VPDocFooterLastUpdated.vue
<img width="1662" alt="image" src="https://github.com/user-attachments/assets/f6327da3-d1aa-4c6c-b803-612bd576104d" />

Screenshot for https://github.com/vuejs/vitepress/blob/main/src/node/plugins/localSearchPlugin.ts
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/b33b6471-c3c3-482f-84ea-0738549d967e" />

Screenshot for https://github.com/refined-github/sandbox/blob/6619/6619
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/fe060768-451f-48a6-b97e-c138e99e5400" />

Screenshot for https://github.com/refined-github/refined-github/blob/main/source/features/list-prs-for-file.tsx with narrow screen
<img width="345" alt="image" src="https://github.com/user-attachments/assets/47c0cbfc-646f-4d9d-9d7f-8b352921d8ea" />