### PR TITLE
Rename "Find feature" to "Identify feature" in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         # Thanks for reporting a bug! ⛰
 
-        Help us replicate the issue by filling in this form. You can use the "Find feature" button in the options page to find which feature is causing the issue.
+        Help us replicate the issue by filling in this form. You can use the "Identify feature" button in the options page to find which feature is causing the issue.
 
         Please ensure:
 


### PR DESCRIPTION
Updates the bug report GitHub issue template from "Find feature" to "Identify feature" to match the text in the options page.

<img width="729" alt="Brave Browser 2025-06-24 13 53 01" src="https://github.com/user-attachments/assets/6f558688-4ca4-4ba2-914f-ba6757fd2dd1" />
