### PR TITLE
`ci-link` - Fix popup is cut off

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -3,3 +3,8 @@
 	pointer-events: none;
 	margin-left: 0.3em;
 }
+
+/* The popup is cut off by the global bar #8495 */
+.AppHeader-globalBar-start {
+	overflow: visible !important;
+}


### PR DESCRIPTION
close: #8495 


## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<img width="993" alt="image" src="https://github.com/user-attachments/assets/45c4186a-6c7a-4876-a8e7-12e436d96926" />
