### PR TITLE
`reactions-avatars` - Restore feature for issue view

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -26,11 +26,11 @@ function getParticipants(button: HTMLButtonElement): Participant[] {
 	let users;
 
 	if (button.getAttribute('role') === 'switch') { // [aria-label] alone is not a differentiator
-		users = button.getAttribute('aria-label')!
-			.replace(/.*including /, '')
-			.replace(/\)/, '')
+		users = button.nextElementSibling!
+			.textContent
 			.replace(/,? and /, ', ')
 			.replace(/, \d+ more/, '')
+			.replace(/\)/, '')
 			.split(', ');
 	} else if (button.nextElementSibling?.tagName === 'TOOL-TIP') {
 		// The list of people who commented is in an adjacent `<tool-tip>` element #5698


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/refined-github/issues/7856

## Screenshot

| Before | After |
| --- | ---- |
| ![CleanShot 2025-06-30 at 09 35 11](https://github.com/user-attachments/assets/f3186fc2-ad43-4dcf-a21e-709c2f9504c0) | ![CleanShot 2025-06-30 at 09 35 38](https://github.com/user-attachments/assets/d7f662e8-9083-4c18-9d40-c9a1051b7b9a) |

