### PR TITLE
`linkify-user-location` - Use Open Street Map instead of Google Maps

### DIFF
--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -10,10 +10,10 @@ function addLocation({nextElementSibling, nextSibling}: SVGElement): Element {
 	const userLocation = nextElementSibling ?? nextSibling as Element;
 
 	const locationName = userLocation.textContent.trim();
-	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
+	const mapLink = `https://www.openstreetmap.org/search?query=${encodeURIComponent(locationName)}`;
 
 	userLocation.before(' '); // Keeps the link’s underline from extending out to the icon
-	const link = <a className="Link--primary" href={googleMapsLink} />;
+	const link = <a className="Link--primary" href={mapLink} />;
 
 	if (userLocation.parentElement!.closest('.Popover')) {
 	// Match the style of other links in the hovercard


### PR DESCRIPTION
Closes #8482 

## Test URLs
https://github.com/f15u

## Screenshot
![image](https://github.com/user-attachments/assets/2f5f1f72-2473-4963-86ad-5380702b2bd3)