### PR TITLE
`clear-pr-merge-commit-message` - Restore feature

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -1,8 +1,6 @@
 import React from 'dom-chef';
 import {countElements} from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import delegate, {type DelegateEvent} from 'delegate-it';
-import {$} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
@@ -14,24 +12,6 @@ import attachElement from '../helpers/attach-element.js';
 import observe from '../helpers/selector-observer.js';
 
 const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().base.branch === await getDefaultBranch();
-
-// TODO: Drop in May 2025
-function handleLegacyToggle(event: DelegateEvent<CustomEvent, HTMLTextAreaElement>): void {
-	if (event.detail?.open !== true) {
-		return;
-	}
-
-	const messageField = $('textarea#merge_message_field', event.delegateTarget);
-	if (messageField.value.trim()) {
-		clear(messageField);
-	}
-}
-
-function clearReactTextarea(textarea: HTMLTextAreaElement): void {
-	if (textarea.labels[0]?.textContent === 'Extended description') {
-		clear(textarea);
-	}
-}
 
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
@@ -47,17 +27,14 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	// Trigger `fit-textareas` if enabled
 	messageField.dispatchEvent(new Event('input', {bubbles: true}));
 
-	// TODO: Drop `?? messageField` in May 2025
-	const anchor = messageField.closest('div[data-has-label]') ?? messageField;
+	const anchor = messageField.closest('div[data-has-label]')!;
 
-	// TODO: Drop `<hr>` in May 2025
 	attachElement(anchor, {
 		after: () => (
 			<div className="flex-self-stretch">
 				<p className="note">
 					The description field was cleared by <a target="_blank" href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message" rel="noreferrer">Refined GitHub</a>.
 				</p>
-				{anchor.nodeName === 'TEXTAREA' && <hr />}
 			</div>
 		),
 	});
@@ -65,8 +42,7 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
-	delegate('.js-merge-pr', 'details:toggled', handleLegacyToggle, {signal}); // TODO: Drop in August 2025
-	observe('[data-testid="mergebox-partial"] div[data-has-label] textarea', clearReactTextarea, {signal});
+	observe('textarea[placeholder="Add an optional extended description…"]', clear, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
-  Part of #8123 

It was already fixed twice, I suppose this is the last time since the box is out of the beta. I'm also dropping support for GHE right away.

## Test URLs

Any open mergeable PRs like this one

## Screenshot


![ko](https://github.com/user-attachments/assets/168f3fb2-77d4-4cb1-bef9-6a83a227813d)
