### PR TITLE
`quick-file-edit` - Fix icon alignment

### DIFF
--- a/source/features/quick-file-edit.css
+++ b/source/features/quick-file-edit.css
@@ -7,5 +7,7 @@
 /* Widen column to avoid bumps in directory-less listings */
 .rgh-quick-file-edit {
 	width: 16px;
+	font-size: 0;
+	line-height: 0;
 	display: inline-block;
 }


### PR DESCRIPTION
now the `height` value matches the content 

fixes #8532 

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

![image](https://github.com/user-attachments/assets/00c41f32-af96-42c2-a492-3e506df9533f)
