### PR TITLE
Remove outdated sidebar style fix from dashboard

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -34,11 +34,6 @@
 	margin-right: 4px !important;
 }
 
-/* Make sticky left-side sidebar scrollable on the dashboard: Also enables padding-bottom */
-.dashboard-sidebar .loading-context {
-	min-height: initial !important;
-}
-
 /* Align icons in the release search field #6506 */
 /* Test: https://github.com/refined-github/refined-github/releases */
 [action$='/releases'] .subnav-search-icon {


### PR DESCRIPTION
fixes #8539

was added in #6102 and should probably have been removed in #6796 (https://github.com/refined-github/refined-github/pull/6796#discussion_r1276615971)

## Test URLs

https://github.com

## Screenshot

![image](https://github.com/user-attachments/assets/037c623d-d147-40e3-b853-8627349a7704)
