### PR TITLE
`open-all-conversations` - use "view" verbiage instead of "open"

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -525,7 +525,7 @@
 	},
 	{
 		"id": "open-all-conversations",
-		"description": "Lets you open all visible issues/PRs at once.",
+		"description": "Adds \"View all\" button to open all or selected issues/PRs in new tabs.",
 		"screenshot": "https://github.com/user-attachments/assets/0d890b01-d5ca-4247-8270-055dd6355606"
 	},
 	{

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 ### Conversations
 
-- [](# "open-all-conversations") [Lets you open all visible issues/PRs at once.](https://github.com/user-attachments/assets/0d890b01-d5ca-4247-8270-055dd6355606)
+- [](# "open-all-conversations") [Adds "View all" button to open all or selected issues/PRs in new tabs.](https://github.com/user-attachments/assets/0d890b01-d5ca-4247-8270-055dd6355606)
 - [](# "sticky-conversation-list-toolbar") [Makes the issue/PR list’s filters toolbar sticky.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif)
 - [](# "conversation-authors") [Highlights issues/PRs opened by you or the current repo’s collaborators.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png)
 - [](# "align-issue-labels") [In issue/PR lists, aligns the labels to the left, below each title.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160640-28ae4f12-0e95-4db5-a79c-e89ae523a4d0.png)

--- a/source/features/open-all-conversations.tsx
+++ b/source/features/open-all-conversations.tsx
@@ -59,8 +59,8 @@ function add(anchor: HTMLElement): void {
 			className={`rgh-open-all-conversations ${classes}`}
 		>
 			{isSelected
-				? 'Open selected'
-				: 'Open all'}
+				? 'View selected'
+				: 'View all'}
 		</button>,
 	);
 }


### PR DESCRIPTION
 - Closes #8543 


## Test URLs
- Global: https://github.com/issues
- Issues: https://github.com/refined-github/refined-github/issues
- PRs: https://github.com/refined-github/refined-github/pulls
- Nothing to open: https://github.com/fregante/empty/pulls

## Screenshot

Global
![image](https://github.com/user-attachments/assets/66281534-41be-46f7-a871-e7042f2c9ef7)

Issues
![image](https://github.com/user-attachments/assets/903f85c9-9d40-43ac-bfdf-ec7042e0d9f8)

PR
![image](https://github.com/user-attachments/assets/097b7993-2922-4d60-ad03-f842ad54f98b)

PR Selected
![image](https://github.com/user-attachments/assets/bd7d30a0-8f66-4def-b964-133b646ff655)


I don't have easy access to a repo on my personal GH account where I have write/admin permission with lots of issues to show the selected state there, but it's a super trivial text fix.

Do we need to update the linked screenshot/gif in the metadata?