### PR TITLE
`easy-toggle-files` -  Support new PR files view

### DIFF
--- a/source/features/easy-toggle-files.tsx
+++ b/source/features/easy-toggle-files.tsx
@@ -23,8 +23,8 @@ function toggleFile(event: DelegateEvent<MouseEvent>): void {
 		$([
 			'[aria-label="Toggle diff contents"]',
 			// React
-			'[aria-label^="collapse file"]',
-			'[aria-label^="expand file"]',
+			'[aria-label^="collapse file" i]',
+			'[aria-label^="expand file" i]',
 		], headerBar)
 			.dispatchEvent(new MouseEvent('click', {bubbles: true, altKey: event.altKey}));
 	}


### PR DESCRIPTION
Super simple fix to get the basic functionality working again. Microsoft had capitalised the aria label 🙈 

This uses the css case-insensitive attribute marker `i`.

Relates to #8504

## Test URLs
- Pull Request: https://github.com/refined-github/refined-github/pull/7036/files
- Code Search: https://github.com/search?q=repo%3Arefined-github%2Frefined-github%20easy&type=code

## Screenshot

https://github.com/user-attachments/assets/0f7a12d3-6422-4f42-af87-713d1b552153

