### PR TITLE
`pr-jump-to-first-non-viewed-file` - Support new PR Files view

### DIFF
--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -6,7 +6,10 @@ import * as pageDetect from 'github-url-detection';
 import features from '../feature-manager.js';
 
 function jumpToFirstNonViewed(): void {
-	const firstNonViewedFile = $optional('[id][data-details-container-group="file"]:not([data-file-user-viewed])');
+	const firstNonViewedFile = $optional([
+		'[id][data-details-container-group="file"]:not([data-file-user-viewed])', // TODO: Old PR Files view, drop in 2026
+		'[id][class^="Diff-module"]:has(button[aria-pressed="false"])',
+	]);
 	if (firstNonViewedFile) {
 		// Scroll to file without pushing to history
 		location.replace('#' + firstNonViewedFile.id);
@@ -16,11 +19,14 @@ function jumpToFirstNonViewed(): void {
 	}
 }
 
-const selector = '.diffbar-item progress-bar';
+const selectors = [
+	'.diffbar-item progress-bar', // TODO: Old PR Files view, drop in 2026
+	'section[class*="PullRequestFilesToolbar-module"] > div:last-child',
+].join(',');
 async function init(signal: AbortSignal): Promise<void> {
-	const bar = await elementReady(selector);
+	const bar = await elementReady(selectors);
 	bar!.style.cursor = 'pointer';
-	delegate(selector, 'click', jumpToFirstNonViewed, {signal});
+	delegate(selectors, 'click', jumpToFirstNonViewed, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Quick fix attempt at the PR jump to first non-viewed file.

Not super happy with the selector for the viewed file count but it _does_ work. Unfortunately the cute `progress-bar` element has been replaced with an SVG.

Relates to #8504 

## Test URLs

- PR: https://github.com/refined-github/sandbox/pull/55/files
- Large PR https://github.com/pixiebrix/pixiebrix-extension/pull/6808/files

## Screenshot

https://github.com/user-attachments/assets/e8bc4c88-4cc8-412d-bf8b-5c55f319cb0a