### PR TITLE
`bugs-tab` - Support `category:bug`

### DIFF
--- a/source/github-helpers/bugs-label.ts
+++ b/source/github-helpers/bugs-label.ts
@@ -1,4 +1,4 @@
-const supportedLabels = /^(?:bug|bug-?fix|confirmed-bug|(?:type|kind|triage|issue)[:/-]bug|(?::[\w-]+:|\p{Emoji})bug)$/iu;
+const supportedLabels = /^(?:bug|bug-?fix|confirmed-bug|(?:category|type|kind|triage|issue)[:/-]bug|(?::[\w-]+:|\p{Emoji})bug)$/iu;
 export default function isBugLabel(label: string): boolean {
 	return supportedLabels.test(label.replaceAll(/\s/g, ''));
 }


### PR DESCRIPTION
Hello, the company im in has a repo where bug issues have the label `category:bug`. Unfortunately I cant provide screenshots or other prove of it working, because that is a private repo.  
I love this project and wanted it to work on my company repos too, so i updated the file in question.

I would be happy to provide more information if you need anything further and im allowed to give.