### PR TITLE
`new-or-deleted-files`: Support new PR files view

### DIFF
--- a/source/features/new-or-deleted-file.tsx
+++ b/source/features/new-or-deleted-file.tsx
@@ -12,23 +12,36 @@ function add(filename: HTMLAnchorElement): void {
 		return;
 	}
 
-	const fileInList = $optional(`[href="${filename.hash}"]`, list);
+	const fileInList = $optional([
+		`[href="${filename.hash}"]`, // TODO: Old PR Files view, drop in 2026
+		`[class^="PRIVATE_TreeView-item-content"]:has([href="${filename.hash}"])`,
+	], list);
 	if (!fileInList) {
 		features.unload(import.meta.url);
 		throw new Error('Could not find file in sidebar, is the sidebar loaded?');
 	}
 
-	const icon = $optional(['.octicon-diff-removed', '.octicon-diff-added'], fileInList)
+	const icon = $optional([
+		'.octicon-diff-removed', // TODO: Old PR Files view, drop in 2026
+		'.octicon-diff-added', // TODO: Old PR Files view, drop in 2026
+		'.octicon-file-removed',
+		'.octicon-file-added',
+		'.octicon-file-moved',
+	], fileInList)
 		?.cloneNode(true);
 	if (icon) {
+		const filenameParent = filename.closest('div');
 		// `span` needed for native vertical alignment
-		filename.parentElement!.append(<span className="ml-1">{icon}</span>);
+		filenameParent!.append(<span className="ml-1">{icon}</span>);
 	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	// Link--primary excludes CODEOWNERS icon #5565
-	observe('.file-info a.Link--primary', add, {signal});
+	observe([
+		'.file-info a.Link--primary', // TODO: Old PR Files view, drop in 2026
+		'[class^="DiffFileHeader-module"] a.Link--primary',
+	], add, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -46,7 +59,6 @@ void features.add(import.meta.url, {
 Commit: https://github.com/refined-github/sandbox/commit/a00694ff7370d46b5f6d723a0b39141903dae45a
 PR: https://github.com/refined-github/sandbox/pull/71/files
 PR with CODEOWNERS: https://github.com/dotnet/winforms/pull/6028/files
-
-Note: Not possible with 1-file commits: https://github.com/refined-github/sandbox/commit/1ed862e3abd13004009927b26355a51a109d6855
+1-file commits: https://github.com/refined-github/sandbox/commit/1ed862e3abd13004009927b26355a51a109d6855
 
 */


### PR DESCRIPTION
Relates to #8504 

The new PR page also now enables this feature on 1 file commits.

I also snuck in the renamed file icon from the new PR page too, let me know if we wanna keep that or not.


## Test URLs

Commit: https://github.com/refined-github/sandbox/commit/a00694ff7370d46b5f6d723a0b39141903dae45a
PR: https://github.com/refined-github/sandbox/pull/71/files
1-file commits: https://github.com/refined-github/sandbox/commit/1ed862e3abd13004009927b26355a51a109d6855

## Screenshot

New PR page:
<img width="1491" height="918" alt="image" src="https://github.com/user-attachments/assets/03c59609-68ef-4cdf-9991-8734e5ea22d1" />
Commit page:
<img width="1472" height="941" alt="image" src="https://github.com/user-attachments/assets/165b26cc-c524-4313-97b1-6788f00fa547" />
Single commit:
<img width="612" height="391" alt="image" src="https://github.com/user-attachments/assets/c3c98567-3c70-432e-ada2-af6c8c673f74" />

Old PR page:
<img width="1103" height="845" alt="image" src="https://github.com/user-attachments/assets/a0746c49-a787-4cf8-900e-9b570a768415" />
