### PR TITLE
Add sort-activity-map-monday-first feature

### DIFF
--- a/source/features/sort-activity-map-monday-first.css
+++ b/source/features/sort-activity-map-monday-first.css
@@ -1,0 +1,32 @@
+/* Sort GitHub activity map from Monday to Sunday instead of Sunday to Saturday */
+
+/* Dynamic --dist variable based on border-spacing */
+/* when the activity overview is enabled the grid rects are 10px * 10px (3px spacing) */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid[style*="border-spacing: 3px"] {
+	--dist: 13px;
+}
+
+/* but when it's disabled, they're 11px * 11px (4px spacing) */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid[style*="border-spacing: 4px"] {
+	--dist: 15px;
+}
+
+/* all days move up a little */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid tbody tr {
+	transform: translateY(calc(var(--dist) * -1));
+}
+
+/* all sundays move all the way down */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid tbody tr:first-child {
+	transform: translateY(calc(var(--dist) * 6));
+}
+
+/* hide first sunday (otherwise it'll be outside the box) */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid tbody tr:first-child .ContributionCalendar-label + * {
+	display: none;
+}
+
+/* show sunday text */
+html:not([rgh-OFF-sort-activity-map-monday-first]) .ContributionCalendar-grid tbody tr:first-child .ContributionCalendar-label span:last-child {
+	clip-path: unset !important;
+}

--- a/source/features/sort-activity-map-monday-first.tsx
+++ b/source/features/sort-activity-map-monday-first.tsx
@@ -1,0 +1,14 @@
+import './sort-activity-map-monday-first.css';
+
+import features from '../feature-manager.js';
+
+void features.addCssFeature(import.meta.url);
+
+/*
+
+Test URLs:
+
+- Any user profile with activity map: https://github.com/fregante
+- Repository contributor page: https://github.com/refined-github/refined-github/graphs/contributors
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -56,6 +56,7 @@ import './features/pagination-hotkey.js';
 import './features/conversation-links-on-repo-lists.js';
 import './features/more-conversation-filters.js';
 import './features/sort-conversations-by-update-time.js'; // Must be after more-conversation-filters and conversation-links-on-repo-lists
+import './features/sort-activity-map-monday-first.js';
 import './features/pinned-issues-update-time.js';
 import './features/default-branch-button.js';
 import './features/one-click-diff-options.js';


### PR DESCRIPTION
Sorts GitHub activity map to start from Monday instead of Sunday.

This feature addresses issue #8563 by rearranging the contribution calendar
to follow a Monday-to-Sunday week layout instead of GitHub's default
Sunday-to-Saturday arrangement.

The feature uses CSS transforms to:
- Move all day rows up by one position
- Move Sunday (first row) to the bottom
- Hide the first Sunday cell that would be outside the calendar bounds
- Ensure the Sunday label remains visible

Fixes #8563