### PR TITLE
`netiquette` - Fix banner margins

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -71,7 +71,7 @@ function addResolvedBanner(newCommentField: HTMLElement): void {
 	const reactWrapper = newCommentField.closest('[class^="InlineAutocomplete"]');
 	const banner = createBanner({
 		icon: <InfoIcon className="m-0" />,
-		classes: 'p-2 text-small color-fg-muted border-0 rounded-0 rgh-resolved-banner'.split(' '),
+		classes: 'm-0 p-2 text-small color-fg-muted border-0 rounded-0 rgh-resolved-banner'.split(' '),
 		text: getResolvedText(),
 	});
 


### PR DESCRIPTION
Fix: #8558 

- There is a `margin: 0 auto` being applied by the `flash` CSS class upstream somewhere in Primer. So I added a `m-0` to override this unwanted styling.
- I verified all the banner example URLs I could find in the issue and in the netiquette files.

## Test URLs
Fix visible here: https://github.com/sindresorhus/create-html-element/issues/2
Make sure I didn't break other banners: https://github.com/refined-github/refined-github/issues/3076, https://github.com/refined-github/refined-github/pull/159, https://github.com/refined-github/refined-github/pull/159

## Screenshot
Before | After
:---: | :---:
<img width="1412" height="488" alt="image" src="https://github.com/user-attachments/assets/441438b3-44a1-4e87-8e5b-4ff7de536a23" /> | <img width="1404" height="478" alt="image" src="https://github.com/user-attachments/assets/7d3681d2-b429-4db0-96e6-e5bd2db31fed" />