### PR TITLE
`no-modals` - Restore feature

### DIFF
--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -12,7 +12,7 @@ function init(signal: AbortSignal): void {
 	delegate([
 		'a[href$="/issues/new/choose"]', // New issue button
 		'a[class*="SubIssueTitle"]', // Sub-issue links
-		'a[data-testid="issue-pr-title-link"]', // Global Issue title
+		'a[data-testid="issue-pr-title-link"]', // Global issue list links
 		'.board-view-column-card a', // Project issue links
 	], 'click', fix, {signal, capture: true});
 }

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -12,8 +12,8 @@ function init(signal: AbortSignal): void {
 	delegate([
 		'a[href$="/issues/new/choose"]', // New issue button
 		'a[class*="SubIssueTitle"]', // Sub-issue links
-		'a[class^="TitleHeader-module__inline"]', // Global Issue title
-		'[class*="base-cell-module"] a', // Project issue links
+		'a[data-testid="issue-pr-title-link"]', // Global Issue title
+		'.board-view-column-card a', // Project issue links
 	], 'click', fix, {signal, capture: true});
 }
 


### PR DESCRIPTION
Close: #8556


## Test URLs

- http://github.com/issues
- https://github.com/orgs/CherryHQ/projects/3?query=sort%3Aupdated-desc+is%3Aopen


## Screenshot

![CleanShot 2025-07-18 at 10 19 00](https://github.com/user-attachments/assets/e7c854e7-676e-434e-93a8-fe3a46dfae48)
