### PR TITLE
`table-input` - Restore feature

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -13,9 +13,13 @@ import observe from '../helpers/selector-observer.js';
 import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const container = square.closest('[data-testid="comment-composer"]')!;
+	console.log('addTable', square);
+
+	const container = square.closest('#new_comment_form')!;
+	console.log(container);
+
 	const field = $(
-		'textarea[aria-labelledby="comment-composer-heading"]',
+		'textarea#new_comment_field',
 		container,
 	);
 	const cursorPosition = field.selectionStart;

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -13,7 +13,8 @@ import observe from '../helpers/selector-observer.js';
 import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const container = square.closest('fieldset[class^="MarkdownEditor-module"]') ?? square.form!.querySelector('.CommentBox-container')!;
+	const container = square.closest('fieldset[class^="MarkdownEditor-module"]') // Issue
+		?? square.form!.querySelector('.CommentBox-container')!; // PR
 	const field = $('textarea', container);
 	const cursorPosition = field.selectionStart;
 

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -13,7 +13,7 @@ import observe from '../helpers/selector-observer.js';
 import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const container = square.closest('fieldset[class^="MarkdownEditor-module"]') // Issue
+	const container = square.closest('fieldset') // Issue
 		?? square.form!.querySelector('.CommentBox-container')!; // PR
 	const field = $('textarea', container);
 	const cursorPosition = field.selectionStart;

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -14,13 +14,16 @@ import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	const container = square.closest([
-		'#new_comment_form', // New Comment
-		'.js-comment-container', // First Comment
+		'[data-testid="comment-composer"]', // Issue Comment
+		'#new_comment_form', // PR New Comment
+		'.js-comment-container', // PR First Comment
 	])!;
-	console.log(container);
 
 	const field = $(
-		'textarea.js-comment-field',
+		[
+			'textarea.js-comment-field', // PR Textarea
+			'textarea[aria-labelledby="comment-composer-heading"]', // Issue Textarea
+		],
 		container,
 	);
 	const cursorPosition = field.selectionStart;

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -13,13 +13,14 @@ import observe from '../helpers/selector-observer.js';
 import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	console.log('addTable', square);
-
-	const container = square.closest('#new_comment_form')!;
+	const container = square.closest([
+		'#new_comment_form', // New Comment
+		'.js-comment-container', // First Comment
+	])!;
 	console.log(container);
 
 	const field = $(
-		'textarea#new_comment_field',
+		'textarea.js-comment-field',
 		container,
 	);
 	const cursorPosition = field.selectionStart;

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -13,19 +13,8 @@ import observe from '../helpers/selector-observer.js';
 import {actionBarSelectors} from '../github-helpers/selectors';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
-	const container = square.closest([
-		'[data-testid="comment-composer"]', // Issue Comment
-		'#new_comment_form', // PR New Comment
-		'.js-comment-container', // PR First Comment
-	])!;
-
-	const field = $(
-		[
-			'textarea.js-comment-field', // PR Textarea
-			'textarea[aria-labelledby="comment-composer-heading"]', // Issue Textarea
-		],
-		container,
-	);
+	const container = square.closest('fieldset[class^="MarkdownEditor-module"]') ?? square.form!.querySelector('.CommentBox-container')!;
+	const field = $('textarea', container);
 	const cursorPosition = field.selectionStart;
 
 	const columns = Number(square.dataset.x);


### PR DESCRIPTION


## Test URLs

Any issue or PR

## Screenshot

<table>

<tr>
 <td>

![CleanShot 2025-07-21 at 11 10 56](https://github.com/user-attachments/assets/3647def4-250c-4dfa-81c8-a934aecef5cd)

 <td>

![CleanShot 2025-07-21 at 10 40 13](https://github.com/user-attachments/assets/27d4b6af-ec9e-40ce-9b23-1837e5186d4a)
</table>
