### PR TITLE
`bugs-tab` - Stop counting bugs twice when using issue types

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -38,13 +38,15 @@ type Bugs = {
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs) as {repository: ApiResponse};
 	const bugTypeCount = repository?.issues?.totalCount ?? 0;
-
+	
 	let label = repository?.labels?.nodes?.find(label => label.name === 'bug');
 	if (!label) {
 		label = repository?.labels?.nodes?.find(label => isBugLabel(label.name));
 	}
-
-	const bugCount = bugTypeCount + (label?.issues?.totalCount ?? 0);
+	
+	const bugLabelCount = label?.issues?.totalCount ?? 0;
+	const bugCount = Math.max(bugTypeCount, bugLabelCount);
+	
 	return {label: label?.name ?? 'bug', count: bugCount};
 }
 

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -38,15 +38,15 @@ type Bugs = {
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs) as {repository: ApiResponse};
 	const bugTypeCount = repository?.issues?.totalCount ?? 0;
-	
+
 	let label = repository?.labels?.nodes?.find(label => label.name === 'bug');
 	if (!label) {
 		label = repository?.labels?.nodes?.find(label => isBugLabel(label.name));
 	}
-	
+
 	const bugLabelCount = label?.issues?.totalCount ?? 0;
 	const bugCount = Math.max(bugTypeCount, bugLabelCount);
-	
+
 	return {label: label?.name ?? 'bug', count: bugCount};
 }
 


### PR DESCRIPTION
Linked Issue: [#8484](https://github.com/refined-github/refined-github/issues/8484)

this PR solves the issue where in the `Bugs` tabs it showed the wrong number of bugs.

fix: assumes that most bug-type issues also have bug labels, so we take the larger of the two counts as our approximation

## Test URLs


## Screenshot
screenshot of issues filtered by `(label:"type: bug" OR type:Bug) ` and it also matches `Bugs` tab both are `554`
<img width="672" height="571" alt="bug-tab" src="https://github.com/user-attachments/assets/65794c93-6148-40b5-9ca0-a550c9bf3c0a" />


