### PR TITLE
`small-user-avatars` - Disable on own username

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -5,10 +5,14 @@ import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 import getUserAvatarURL from '../github-helpers/get-user-avatar.js';
 import './small-user-avatars.css';
+import {getUsername} from '../github-helpers/index.js';
 
 function addAvatar(link: HTMLElement): void {
-	const username = link.textContent;
 	const size = 14;
+	const username = link.textContent;
+	if (username === getUsername()) {
+		return;
+	}
 
 	link.classList.add('d-inline-block', 'lh-condensed-ultra');
 	link.prepend(
@@ -24,6 +28,10 @@ function addAvatar(link: HTMLElement): void {
 
 function addMentionAvatar(link: HTMLAnchorElement): void {
 	const username = link.href.split('/').pop()!;
+	if (username === getUsername()) {
+		return;
+	}
+
 	const avatarUrl = getUserAvatarURL(username, 16);
 
 	link.classList.add('rgh-small-user-avatars', 'rgh-mention-avatar');


### PR DESCRIPTION
@kovsu @yakov116 @busches thoughts on this change?


## Test URLs

- Any page where your username is mentioned
- https://github.com/refined-github/refined-github/issues?q=(involves%3Akovsu%20OR%20involves%3Ayakov116%20OR%20involves%3Abusches)%20is%3Apr%20sort%3Areactions-smile-desc
- https://github.com/refined-github/refined-github/releases/tag/25.7.1

## Screenshot


<img width="421" height="338" alt="Screenshot" src="https://github.com/user-attachments/assets/f6336cf9-efe3-4759-9fa6-97e664514a32" />

<img width="562" height="316" alt="Screenshot 13" src="https://github.com/user-attachments/assets/119c327b-02f5-4336-a907-da6c1003cbe1" />

