### PR TITLE
`conversation-authors` - Match own-user highlight to GitHub's

### DIFF
--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -13,3 +13,14 @@
 [data-testid='list-row-repo-name-and-number'] {
 	margin-top: 1.5px;
 }
+
+a.rgh-own-conversation,
+a.rgh-own-conversation:hover {
+	/* Colors taken from native .user-mention class */
+	color: var(--color-user-mention-fg, fuchsia) !important; /* Their :hover	uses !important... */
+	background-color: var(--bgColor-attention-muted, fuchsia);
+}
+
+a.rgh-own-conversation:hover {
+	text-decoration: underline !important;
+}

--- a/source/features/conversation-authors.tsx
+++ b/source/features/conversation-authors.tsx
@@ -28,7 +28,8 @@ async function highlightCollaborators(signal: AbortSignal): Promise<void> {
 		'.js-issue-row [data-hovercard-type="user"]',
 		'a[class^="IssueItem-module__authorCreatedLink"]',
 	], author => {
-		if (list.includes(author.textContent.trim())) {
+		const name = author.textContent.trim();
+		if (list.includes(name) && name !== getUsername()) {
 			author.classList.add('rgh-collaborator');
 		}
 	}, {signal});
@@ -41,8 +42,7 @@ function highlightSelf(signal: AbortSignal): void {
 		`.opened-by a[title$="ed by ${CSS.escape(getUsername()!)}"]`,
 		`a[class^="IssueItem-module__authorCreatedLink"][data-hovercard-url="/users/${CSS.escape(getUsername()!)}/hovercard"]`,
 	], author => {
-		author.classList.add('rgh-collaborator');
-		author.style.fontStyle = 'italic';
+		author.classList.add('rgh-own-conversation');
 	}, {signal});
 }
 


### PR DESCRIPTION
- follows https://github.com/refined-github/refined-github/pull/8602


## Test URLs

https://github.com/issues



## Screenshot

<img width="643" height="350" alt="Screenshot 16" src="https://github.com/user-attachments/assets/7ddaf08f-c148-432c-9d92-0f11a8ade7d4" />

<img width="643" height="350" alt="Screenshot 17" src="https://github.com/user-attachments/assets/7b390294-eb20-4be6-a093-f8bd9ffb3956" />

## Before


<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="643" height="350" alt="Screenshot 18" src="https://github.com/user-attachments/assets/26aecc90-2f9f-4659-9b12-945725aecf63" />
	<td><img width="643" height="350" alt="Screenshot 17" src="https://github.com/user-attachments/assets/7b390294-eb20-4be6-a093-f8bd9ffb3956" />
</table>


