### PR TITLE
`tags-on-commits-list` - Don't show `nightly` tag

### DIFF
--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -68,6 +68,10 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 
 	let tags: CommitTags = {};
 	for (const node of nodes) {
+		if (node.name === 'nightly') {
+			continue;
+		}
+
 		const commit = node.target.commitResourcePath.split('/')[4];
 		tags[commit] ||= [];
 


### PR DESCRIPTION
- closes #8592 


## Test URLs

https://github.com/micro5k/microg-unofficial-installer/commits/main/


## Before

<img width="500" height="409" alt="Screenshot" src="https://github.com/user-attachments/assets/102ba9ff-68ea-463b-8ea7-9d179ca2ddb5" />



## After

<img width="433" height="409" alt="Screenshot 20" src="https://github.com/user-attachments/assets/b068172a-cbd0-4d34-821c-aa46f237cb26" />

