### PR TITLE
`center-reactions-popup` - Don't cut off on mobile

### DIFF
--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -35,8 +35,9 @@
 	/* Reset the width */
 	min-width: 0px !important;
 
-	/* Move the popups */
-	translate: -56px -52px;
+	/* Center, but keep in view on mobile too */
+	/* https://github.com/refined-github/refined-github/issues/8605 */
+	translate: -28px -56px;
 }
 
 /*

--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -13,7 +13,9 @@
 	}
 
 	&.dropdown-menu-se {
-		translate: -61px -44px;
+		/* Keep in view on mobile too */
+		/* https://github.com/refined-github/refined-github/issues/8605 */
+		translate: -28px -62px;
 	}
 
 	/* Button on the bottom left of comments */


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/8605


## Test URLs

https://togithub.com/facebook/react/pull/34091

## Mobile

Translucent to see how it aligns


<img width="553" height="201" alt="Screenshot 24" src="https://github.com/user-attachments/assets/00d8ef22-0c13-4b44-b52b-0cb91c1cee75" />

## Desktop

<img width="791" height="223" alt="Screenshot 23" src="https://github.com/user-attachments/assets/eb052ff1-0502-4df8-beb9-4ada7328ecb4" />
