### PR TITLE
`release-download-count` - Fix regex

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -53,7 +53,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		const assetSize = assetLink
 			.closest('.Box-row')!
 			.querySelector(':scope > .flex-justify-end > span')!;
-		assertNodeContent(assetSize.firstChild, /^\d+ \w{2,5}$/);
+		assertNodeContent(assetSize.firstChild, /^\d+(\.\d+)? \w{2,5}$/);
 
 		assetSize.classList.replace('text-sm-left', 'text-md-right');
 		assetSize.parentElement!.classList.add('rgh-release-download-count');


### PR DESCRIPTION
fixes #8608 

## Test URLs

https://github.com/SubtitleEdit/subtitleedit/releases/tag/4.0.13

## Screenshot

<img width="1251" height="431" alt="image" src="https://github.com/user-attachments/assets/40b4409c-962a-4b3b-a6ec-2f97c4968e46" />
