### PR TITLE
`workflow scope detection` display and Improved error message

### DIFF
--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -264,6 +264,15 @@ async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError>
 		);
 	}
 
+	if ((apiResponse.message as string)?.includes('Personal Access Token')
+		&& (apiResponse.message as string)?.includes('without `workflow` scope')) {
+		return new RefinedGitHubAPIError(
+			'Your personal access token lacks the `workflow` scope.',
+			'To update workflow files, you need to grant the `workflow` scope to your token.',
+			'Update your token at https://github.com/settings/tokens',
+		);
+	}
+
 	const error = new RefinedGitHubAPIError(
 		'Unable to fetch.',
 		personalToken

--- a/source/options.html
+++ b/source/options.html
@@ -27,7 +27,7 @@
 		<summary><strong>🔑 Personal token</strong></summary>
 		<div>
 			<!-- Keep this URL in sync with welcome.html -->
-			<p>You should <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,read:project&default_expires_at=none">generate a token</a> to ensure that every feature works correctly. You can read more about the token on <a href="https://github.com/refined-github/refined-github/wiki/Security">the wiki.</a></p>
+			<p>You should <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,read:project,workflow&default_expires_at=none">generate a token</a> to ensure that every feature works correctly. You can read more about the token on <a href="https://github.com/refined-github/refined-github/wiki/Security">the wiki.</a></p>
 			<p><strong>Token-less usage is not officially supported.</strong></p>
 			<p>
 				<input
@@ -46,6 +46,7 @@
 				<li data-validation data-scope="public_repo">The <code>public_repo</code> scope lets them <strong>edit</strong> your public repositories
 				<li data-validation data-scope="repo">The <code>repo</code> scope lets them <strong>edit private</strong> repositories as well
 				<li data-validation data-scope="read:project">The <code>read:project</code> scope lets them determine if a repo/org uses projects
+				<li data-validation data-scope="workflow">The <code>workflow</code> scope lets them <strong>edit workflow files</strong> like <code>.github/workflows/*.yml</code>
 			</ul>
 		</div>
 	</details>

--- a/source/welcome.svelte
+++ b/source/welcome.svelte
@@ -100,7 +100,7 @@
 			>
 				<!-- Keep this URL in sync with options.html -->
 				<a
-					href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,read:project&default_expires_at=none"
+					href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,read:project,workflow&default_expires_at=none"
 					onclick={markSecondStep}
 				>
 					Generate a token


### PR DESCRIPTION


Closes: [#8341](https://github.com/refined-github/refined-github/issues/8341)
Related Sub Issue: [#7641](https://github.com/refined-github/refined-github/issues/7641)

In this PR I have added workflow scope to the token validation display and provided a clear error message with direct link to token settings. 
## Test URLs


## Screenshot
`without workflow permission`
<img width="1036" height="712" alt="workscope_perm" src="https://github.com/user-attachments/assets/636c81a9-7f33-4434-b6c6-0c92f789ce3f" />
`with workflow permission`
<img width="1023" height="718" alt="workflow_perm_enab" src="https://github.com/user-attachments/assets/b6ebf584-ade4-4c4c-b61e-275f65355b41" />

