### PR TITLE
`github-actions-indicators` - Integrate better

### DIFF
--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -89,22 +89,32 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 	}
 
 	if (workflow.manuallyDispatchable && workflowLink.pathname !== location.pathname) {
-		// This class keeps the action on a single line. It natively exists if the item can be pinned (if current user has write access)
-		workflowLink.parentElement!.classList.add('ActionListItem--withActions');
-
-		const url = new URL(workflowLink.href);
-		url.hash = 'rgh-run-workflow';
-		workflowLink.after(
-			<a
-				href={url.href}
-				data-turbo-frame={workflowLink.dataset.turboFrame}
-				// `actions-unpin-button` provides the hover style
-				className="tooltipped tooltipped-sw Button Button--iconOnly Button--invisible Button--medium color-bg-transparent actions-unpin-button"
-				aria-label="Trigger manually"
-			>
-				<PlayIcon className="m-auto" />
-			</a>,
-		);
+		if (workflowLink.nextElementSibling) {
+			const url = new URL(workflowLink.href);
+			url.hash = 'rgh-run-workflow';
+			workflowLink.after(
+				<a
+					href={url.href}
+					data-turbo-frame={workflowLink.dataset.turboFrame}
+					// `actions-unpin-button` provides the hover style
+					className="tooltipped tooltipped-sw Button Button--iconOnly Button--invisible Button--medium color-bg-transparent actions-unpin-button"
+					aria-label="Trigger manually"
+				>
+					<PlayIcon />
+				</a>,
+			);
+		} else {
+			// This class keeps the action on a single line. It natively exists if the item can be pinned (if current user has write access)
+			workflowLink.parentElement!.classList.add('ActionListItem--withActions');
+			workflowLink.after(
+				<div
+					className="tooltipped tooltipped-sw Button Button--iconOnly Button--invisible Button--medium color-bg-transparent"
+					aria-label="This workflow can be triggered manually"
+				>
+					<PlayIcon />
+				</div>,
+			);
+		}
 	}
 
 	let nextTime: Date | undefined;


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/8629
## Changes

Schedule:
- the tooltip is no longer shown since the line is no longer clipped, the contents were redundant

Trigger:
- the icon looks native now
- the icon is only clickable when the user has repo access (and presumably "trigger" access)
- the tooltip varies by user access: "Trigger manually" or "This workflow can be triggered manually
- the tooltip has been moved back to the icon itself for better clarity



## Collaborator

![insider](https://github.com/user-attachments/assets/1e52d1c1-93c1-4a88-8f2d-1c951bbd4a62)

## Public

![outsider](https://github.com/user-attachments/assets/599d85c5-447b-47f6-a7c0-0819f3fed473)

