### PR TITLE
`pr-jump-to-first-non-viewed-file` - Fix click conflicts

### DIFF
--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -21,7 +21,7 @@ function jumpToFirstNonViewed(): void {
 
 const selectors = [
 	'.diffbar-item progress-bar', // TODO: Old PR Files view, drop in 2026
-	'section[class*="PullRequestFilesToolbar-module"] > div:last-child',
+	'.d-flex:has([class*="ViewedFileProgress"])',
 ].join(',');
 async function init(signal: AbortSignal): Promise<void> {
 	const bar = await elementReady(selectors);


### PR DESCRIPTION
- Fixes #8610


## Test URLs

This PR's Files tab


## Screenshot


![insider](https://github.com/user-attachments/assets/211b6042-e34f-4dae-91fa-84eae7dba840)

