### PR TITLE
`unread-anywhere` - Several improvements

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -541,7 +541,7 @@
 	},
 	{
 		"id": "open-all-notifications",
-		"description": "Adds a button to open all your unread notifications at once.",
+		"description": "Adds a button to the notification page to open all your unread notifications at once.",
 		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png"
 	},
@@ -929,7 +929,7 @@
 	},
 	{
 		"id": "unread-anywhere",
-		"description": "Adds a global shortcut to open all your unread notifications at once: <kbd>g</kbd> <kbd>u</kbd>",
+		"description": "Adds a button to the global header to open your unread notifications from any page.",
 		"screenshot": "https://github.com/user-attachments/assets/3afb7e86-66e8-4b26-a5c0-9c93fb5d8141"
 	},
 	{

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -930,7 +930,7 @@
 	{
 		"id": "unread-anywhere",
 		"description": "Adds a button to the global header to open your unread notifications from any page.",
-		"screenshot": "https://github.com/user-attachments/assets/3afb7e86-66e8-4b26-a5c0-9c93fb5d8141"
+		"screenshot": "https://github.com/user-attachments/assets/978ac1fe-db98-40f9-9b56-7d289849aa2f"
 	},
 	{
 		"id": "unreleased-commits",

--- a/readme.md
+++ b/readme.md
@@ -318,8 +318,8 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 ### Notifications
 
-- [](# "open-all-notifications") [Adds a button to open all your unread notifications at once.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png)
-- [](# "unread-anywhere") 🔥 [Adds a global shortcut to open all your unread notifications at once: <kbd>g</kbd> <kbd>u</kbd>](https://github.com/user-attachments/assets/3afb7e86-66e8-4b26-a5c0-9c93fb5d8141)
+- [](# "open-all-notifications") [Adds a button to the notification page to open all your unread notifications at once.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png)
+- [](# "unread-anywhere") 🔥 [Adds a button to the global header to open your unread notifications from any page.](https://github.com/user-attachments/assets/3afb7e86-66e8-4b26-a5c0-9c93fb5d8141)
 - [](# "select-all-notifications-shortcut") Adds a shortcut to select all visible notifications: <kbd>a</kbd>.
 - [](# "stop-redirecting-in-notification-bar") [Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.](https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png)
 - [](# "last-notification-page-button") [Adds a link to the last page of notifications.](https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png)

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 ### Notifications
 
 - [](# "open-all-notifications") [Adds a button to the notification page to open all your unread notifications at once.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png)
-- [](# "unread-anywhere") 🔥 [Adds a button to the global header to open your unread notifications from any page.](https://github.com/user-attachments/assets/3afb7e86-66e8-4b26-a5c0-9c93fb5d8141)
+- [](# "unread-anywhere") 🔥 [Adds a button to the global header to open your unread notifications from any page.](https://github.com/user-attachments/assets/978ac1fe-db98-40f9-9b56-7d289849aa2f)
 - [](# "select-all-notifications-shortcut") Adds a shortcut to select all visible notifications: <kbd>a</kbd>.
 - [](# "stop-redirecting-in-notification-bar") [Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.](https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png)
 - [](# "last-notification-page-button") [Adds a link to the last page of notifications.](https://user-images.githubusercontent.com/16872793/199828181-3ff2cef3-8740-4efa-8122-8f2f222bd657.png)

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -65,7 +65,7 @@ function addButton(nativeLink: HTMLAnchorElement): void {
 			type="button"
 			onClick={openUnreadNotifications}
 			style={{width: 10}}
-			aria-label="Open unread notifications"
+			aria-label="Open unread notifications\nHotkey: g u"
 		>
 			<ArrowUpRightIcon className="mb-2"/>
 		</button>

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -65,9 +65,10 @@ function addButton(nativeLink: HTMLAnchorElement): void {
 			type="button"
 			onClick={openUnreadNotifications}
 			style={{width: 10}}
-			aria-label="Open unread notifications\nHotkey: g u"
+			// JSX swallows \n if you skip {''}
+			aria-label={'Open unread notifications\nHotkey: g u'}
 		>
-			<ArrowUpRightIcon className="mb-2"/>
+			<ArrowUpRightIcon className="mb-2" />
 		</button>
 	);
 	nativeLink.before(button);

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -11,6 +11,7 @@ import pluralize from '../helpers/pluralize.js';
 import {removeLinkToPRFilesTab} from './pr-notification-link.js';
 import observe from '../helpers/selector-observer';
 import {getClasses, isSmallDevice} from '../helpers/dom-utils';
+import * as pageDetect from 'github-url-detection';
 
 const limit = 10;
 
@@ -71,9 +72,12 @@ function addButton(nativeLink: HTMLAnchorElement): void {
 }
 
 // No signal, created once per load
-function initOnce(): void {
+function registerHotkeyOnce(): void {
 	registerHotkey('g u', openUnreadNotifications);
 	document.documentElement.classList.add('rgh-unread-anywhere');
+}
+
+function addButtonOnce(): void {
 	observe('a#AppHeader-notifications-button', addButton);
 }
 
@@ -85,7 +89,16 @@ void features.add(import.meta.url, {
 		// Disable the feature entirely on small screens
 		isSmallDevice,
 	],
-	init: onetime(initOnce),
+	init: onetime(registerHotkeyOnce),
+}, {
+	exclude: [
+		// Disable the feature entirely on small screens
+		isSmallDevice,
+
+		// Not worth integrating on gist: https://github.com/refined-github/refined-github/issues/8641
+		pageDetect.isGist,
+	],
+	init: onetime(addButtonOnce),
 });
 
 /*

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -1,6 +1,7 @@
 import {$, $$optional} from 'select-dom/strict.js';
 import {messageRuntime} from 'webext-msg';
 import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import {registerHotkey} from '../github-helpers/hotkey.js';
@@ -11,7 +12,6 @@ import pluralize from '../helpers/pluralize.js';
 import {removeLinkToPRFilesTab} from './pr-notification-link.js';
 import observe from '../helpers/selector-observer';
 import {getClasses, isSmallDevice} from '../helpers/dom-utils';
-import * as pageDetect from 'github-url-detection';
 
 const limit = 10;
 
@@ -72,12 +72,9 @@ function addButton(nativeLink: HTMLAnchorElement): void {
 }
 
 // No signal, created once per load
-function registerHotkeyOnce(): void {
+function initOnce(): void {
 	registerHotkey('g u', openUnreadNotifications);
 	document.documentElement.classList.add('rgh-unread-anywhere');
-}
-
-function addButtonOnce(): void {
 	observe('a#AppHeader-notifications-button', addButton);
 }
 
@@ -88,17 +85,11 @@ void features.add(import.meta.url, {
 	exclude: [
 		// Disable the feature entirely on small screens
 		isSmallDevice,
-	],
-	init: onetime(registerHotkeyOnce),
-}, {
-	exclude: [
-		// Disable the feature entirely on small screens
-		isSmallDevice,
 
-		// Not worth integrating on gist: https://github.com/refined-github/refined-github/issues/8641
+		// Can't work on gists due to CORS: https://github.com/refined-github/refined-github/issues/8641
 		pageDetect.isGist,
 	],
-	init: onetime(addButtonOnce),
+	init: onetime(initOnce),
 });
 
 /*

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -16,8 +16,8 @@ import {getClasses, isSmallDevice} from '../helpers/dom-utils';
 
 const limit = 5;
 
-async function openUnreadNotifications(event: Event): Promise<void> {
-	if (event.target instanceof HTMLButtonElement) {
+async function openUnreadNotifications(event?: React.MouseEvent): Promise<void> {
+	if (event?.target instanceof HTMLButtonElement) {
 		// Hide the tooltip
 		event.target.blur();
 	}

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -104,6 +104,9 @@ void features.add(import.meta.url, {
 
 		// Can't work on gists due to CORS: https://github.com/refined-github/refined-github/issues/8641
 		pageDetect.isGist,
+
+		// Disable on notification page, `open-all-notifications` already handles the entire UI better there
+		pageDetect.isNotifications,
 	],
 	init: onetime(initOnce),
 });

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -20,6 +20,7 @@ async function openUnreadNotifications(event?: React.MouseEvent): Promise<void> 
 	if (event?.target instanceof HTMLButtonElement) {
 		// Hide the tooltip
 		event.target.blur();
+		event.target.disabled = true; // Prevent multiple clicks
 	}
 
 	await showToast(async updateToast => {
@@ -51,6 +52,10 @@ async function openUnreadNotifications(event?: React.MouseEvent): Promise<void> 
 	}, {
 		message: 'Loading notifications…',
 		doneMessage: false,
+	}).finally(() => {
+		if (event?.target instanceof HTMLButtonElement) {
+			event.target.disabled = false;
+		}
 	});
 }
 
@@ -64,7 +69,9 @@ function addButton(nativeLink: HTMLAnchorElement): void {
 		<button
 			type="button"
 			onClick={openUnreadNotifications}
-			style={{width: 10}}
+			// Show pointer cursor even when disabled
+			style={{width: 10, cursor: 'pointer'}}
+
 			// JSX swallows \n if you skip {''}
 			aria-label={'Open unread notifications\nHotkey: g u'}
 		>


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/8641
- Fixes https://github.com/refined-github/refined-github/issues/8646
- Closes https://github.com/refined-github/refined-github/issues/8645

## Changes

- Disable on Gists
- Disable on notifications page 
- Fix on Enterprise
- Add arrow icon
- Hide if there are no notifications (but stays visible after a click)
- Mention shortcut in tooltip
- Close tooltip after click
- GIF and description updated
- Limited to 5 notifications (just click multiple times if needed)
- Avoid double-clicks


## Test URLs

https://gist.github.com


## Demo

![new demo](https://github.com/user-attachments/assets/978ac1fe-db98-40f9-9b56-7d289849aa2f)

