### PR TITLE
`quick-review` - Restore feature

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -79,7 +79,7 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 }
 
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
-	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading:not(#collapsible-reviewers-without-write)', addSidebarReviewButton, {signal});
+	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButton, {signal});
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 


### PR DESCRIPTION
fix #8643

## Test URLs

- <https://github.com/refined-github/sandbox/pull/10>
- <https://github.com/envelope-zero/backend/pull/1197>

## Screenshot

<img width="184" height="28" alt="Reviewers with quick review" src="https://github.com/user-attachments/assets/7aa5d190-c89f-4ebf-9129-a43206c640ea" />
