### PR TITLE
fix: unread-anywhere #8649

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -136,10 +136,11 @@ void features.add(import.meta.url, {
 	],
 	shortcuts: {
 		p: 'Open selected notifications',
+		gn: 'Open all notifications',
+		gu: 'Open all unread notifications',
 	},
 	init,
 });
-
 /*
 
 Test URLs:


### PR DESCRIPTION
Fixes #8649 

I have contributed to ```open_all_notifications``` which fixes the issue of  ```gu```  and  ```gn```. 

When user presses ```g-u``` to open all unread notifications. 
When user presses ```g-n``` it open the notifications page.  


Please refer the video attached.

## Test URLs
https://github.com/notifications
https://github.com/refined-github/refined-github

## Video
https://github.com/user-attachments/assets/1a3a45af-18d9-4584-bc0f-86ed8a8593e0

