### PR TITLE
`show-names` - Exclude username in nested item

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -39,6 +39,7 @@ function appendName(element: HTMLAnchorElement, fullName: string): void {
 
 async function updateLinks(found: HTMLAnchorElement[]): Promise<void> {
 	const users = Map.groupBy(
+		// Exclude nested items https://github.com/refined-github/refined-github/pull/8661
 		found.filter(element => element.textContent.trim() === element.href.split('/').pop()),
 		element => element.textContent.trim(),
 	);


### PR DESCRIPTION



## Test URLs

https://github.com/dashboard


## Screenshot

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="1958" height="334" alt="CleanShot 2025-09-05 at 11 01 34@2x" src="https://github.com/user-attachments/assets/035d3a06-7ed8-43eb-ab02-5d8d3c697b14" />
 <td>
<img width="2104" height="1292" alt="CleanShot 2025-09-05 at 10 58 19@2x" src="https://github.com/user-attachments/assets/c0ad3906-6de3-41a7-96ec-2087df3a283d" />

</table>


