### PR TITLE
`conflict-marker` - Remove feature for repo issue list

### DIFF
--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -60,7 +60,7 @@ async function init(signal: AbortSignal): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isIssueOrPRList,
+		pageDetect.isRepoPRList,
 	],
 	init,
 });


### PR DESCRIPTION
> Shows which PRs have conflicts in PR lists

As the description of `conflict-marker` says, we don't need the feature in issue list page.

## Test URLs

https://github.com/CherryHQ/cherry-studio/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen


## Screen shot

Before

<img width="2502" height="232" alt="CleanShot 2025-09-05 at 16 59 19@2x" src="https://github.com/user-attachments/assets/99034678-dbcb-4a50-b2e5-97dd022aaa68" />

After

<img width="2548" height="240" alt="CleanShot 2025-09-05 at 16 58 57@2x" src="https://github.com/user-attachments/assets/0a2c63d4-b045-4455-9100-74f1cc9f8dc5" />
