### PR TITLE
Drop "more extensions" link from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -399,5 +399,4 @@ We're happy to receive suggestions and contributions, but be aware this is a hig
 
 ## Links
 
-- [More extensions](https://github.com/refined-github/refined-github/wiki/Other-extensions)
 - [Contribution guide](https://github.com/refined-github/refined-github/wiki/Contributing)


### PR DESCRIPTION
Broken since linked wiki page has been removed.

Or replace with https://github.com/stefanbuck/awesome-browser-extensions-for-github? I remember bringing up the idea before, but that list is lacking maintenance as well (better than nothing I suppose).

## Test URLs


## Screenshot
