### PR TITLE
`readable-title-change-events` - Restore line through

### DIFF
--- a/source/features/readable-title-change-events.css
+++ b/source/features/readable-title-change-events.css
@@ -16,6 +16,11 @@ span[class^='RenamedTitleEvent'],
 	word-break: break-word !important;
 }
 
+/* GitHub bug */
+.TimelineItem-body del.markdown-title {
+	text-decoration: line-through !important;
+}
+
 /*
 Test URLs
 


### PR DESCRIPTION
GitHub bug, their other style is overriding the `<del>` base style.

<img width="512" height="211" alt="Screenshot 2025-09-09 at 12 20 05 PM" src="https://github.com/user-attachments/assets/2ec21826-3ead-4885-befe-b4538a05121c" />

## Test URLs

https://togithub.com/refined-github/refined-github/pull/8668#event-19553429615

## Screenshot

| Before | <img width="441" height="81" alt="Screenshot 2025-09-09 at 11 46 21 AM" src="https://github.com/user-attachments/assets/6b572cae-d904-463c-9879-0ba14729816e" /> |
|--------|--------|
| After | <img width="428" height="83" alt="Screenshot 2025-09-09 at 12 17 48 PM" src="https://github.com/user-attachments/assets/c64d7aa7-3a30-4da0-b948-fc404564a3e8" /> |