### PR TITLE
 `dim-bots` - Add Mend to botnames

### DIFF
--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -174,6 +174,7 @@ const botNames = [
 	'rust-highfive',
 	'scala-steward',
 	'weblate',
+	'mend',
 	'apps', // Matches any `/apps/*` URLs
 	'github-apps', // GHE apps
 ] as const;


### PR DESCRIPTION
This is due to an upcoming change with renovate being renamed to mend (https://github.com/renovatebot/renovate/discussions/37842)

For the `dim-bots` feature
