### PR TITLE
Remove the add-on `id` in `bss.gecko_android`

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -12,7 +12,6 @@
 			"strict_min_version": "128.0"
 		},
 		"gecko_android": {
-			"id": "{a4c4eda4-fb84-4a84-b4a1-f7c1cbf2a1ad}",
 			"strict_min_version": "128.0"
 		}
 	},


### PR DESCRIPTION
The Firefox `id` property isn't accepted in `bss.gecko_android`.