### PR TITLE
`html-preview-link` - Fix button style

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -44,6 +44,7 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
+https://github.com/refined-github/sandbox/blob/html/preview-link/public/test.html
 https://github.com/CodingTrain/website/blob/4f90eedb9618257d9166241e92e51a7f3f00a08e/code_challenges/PerlinNoiseTerrain_p5.js/index.html
 
 */

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -12,10 +12,12 @@ function add(rawButton: HTMLAnchorElement): void {
 	}
 
 	rawButton
+		.parentElement! // `div`
 		.parentElement! // `BtnGroup`
 		.prepend(
 			<a
-				className="btn btn-sm BtnGroup-item"
+				className="btn btn-sm BtnGroup-item border-right-0"
+				style={{zIndex: 0}}
 				// #3305
 				href={`https://refined-github-html-preview.kidonng.workers.dev${rawButton.pathname}`}
 			>

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -15,14 +15,17 @@ function add(rawButton: HTMLAnchorElement): void {
 		.parentElement! // `div`
 		.parentElement! // `BtnGroup`
 		.prepend(
-			<a
-				className="btn btn-sm BtnGroup-item border-right-0"
-				style={{zIndex: 0}}
-				// #3305
-				href={`https://refined-github-html-preview.kidonng.workers.dev${rawButton.pathname}`}
-			>
-				Preview
-			</a>,
+			<div>
+				<a
+					className={rawButton.className}
+					data-variant="default"
+					data-size="small"
+					// #3305
+					href={`https://refined-github-html-preview.kidonng.workers.dev${rawButton.pathname}`}
+				>
+					Preview
+				</a>
+			</div>,
 		);
 }
 


### PR DESCRIPTION
Also:

- Rewrote the worker
- Added description and worker source code to [wiki](https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#html-preview-link)
- Write a test suite in sandbox ([rendered](https://refined-github-html-preview.kidonng.workers.dev/refined-github/sandbox/raw/refs/heads/html/preview-link/public/test.html))

## Test URLs

https://github.com/refined-github/sandbox/blob/html/preview-link/public/test.html

## Screenshot

Before:

https://github.com/user-attachments/assets/2c5a3f87-12e7-45d9-bf0f-60b136c196b6

After:

https://github.com/user-attachments/assets/12a8fd12-975f-4539-b2fa-9564d2ab8763


