### PR TITLE
Preserve new-lines in user bio

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -117,8 +117,7 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 /* Test (profile): https://github.com/caugner */
 /* Test (hovercard): https://github.com/mdn/fred */
 .user-profile-bio,
-/* Hovercard */
-[aria-label="User bio"] div {
+[aria-label='User bio'] div /* Hovercard */ {
 	white-space: pre-wrap;
 }
 

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -113,6 +113,15 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	white-space: nowrap;
 }
 
+/* Preserves new-lines in user bio #8631 */
+/* Test (profile): https://github.com/caugner */
+/* Test (hovercard): https://github.com/mdn/fred */
+.user-profile-bio,
+/* Hovercard */
+[aria-label="User bio"] div {
+	white-space: pre-wrap;
+}
+
 /*
 
 Test URLs:


### PR DESCRIPTION
Resolve #8631

## Test URLs

- Profile: https://github.com/caugner
- Hovercard: https://github.com/mdn/fred

## Screenshot

| | Profile | Hovercard |
|--------|--------|--------|
| Before | <img width="307" height="126" alt="Screenshot 2025-10-10 at 9 48 18 PM" src="https://github.com/user-attachments/assets/3ecff1f6-6c62-436b-ac5e-79c72b68a8c6" /> | <img width="338" height="72" alt="Screenshot 2025-10-10 at 9 48 30 PM" src="https://github.com/user-attachments/assets/e78d4028-ec95-44e1-95c2-863e3be302ba" /> |
| After | <img width="296" height="171" alt="Screenshot 2025-10-10 at 9 48 40 PM" src="https://github.com/user-attachments/assets/8ca95733-56c0-41b0-9b14-aae3641ed2b0" /> | <img width="289" height="116" alt="Screenshot 2025-10-10 at 9 48 53 PM" src="https://github.com/user-attachments/assets/b7d39f3f-cad8-4a09-b503-4849e3ef67ae" /> | 