### PR TITLE
Fix `restore-file` for new GitHub PR file view

### DIFF
--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -87,15 +87,29 @@ async function discardChanges(progress: (message: string) => void, originalFileN
 async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): Promise<void> {
 	const menuItem = event.delegateTarget;
 
-	const [originalFileName, newFileName = originalFileName] = menuItem
-		.closest('[data-path]')!
-		.querySelector('.Link--primary')!
-		.textContent
-		.split(' → ');
+	let originalFileName = '';
+	let newFileName = '';
+	// eslint-disable-next-line ts/no-restricted-types -- prompt also returns null
+	let commitTitle: undefined | null | string;
 
-	const commitTitle = prompt(`Are you sure you want to discard the changes to ${newFileName}? Enter the commit title`, `Discard changes to ${newFileName}`);
-	if (!commitTitle) {
-		return;
+	if (menuItem.tagName === 'A') {
+		originalFileName = '';
+		newFileName = '';
+		commitTitle = prompt('Are you sure you want to discard these changes? Enter the commit title', '');
+		if (!commitTitle) {
+			return;
+		}
+	} else {
+		const [originalFileName, newFileName = originalFileName] = menuItem
+			.closest('[data-path]')!
+			.querySelector('.Link--primary')!
+			.textContent
+			.split(' → ');
+
+		commitTitle = prompt(`Are you sure you want to discard the changes to ${newFileName}? Enter the commit title`, `Discard changes to ${newFileName}`);
+		if (!commitTitle) {
+			return;
+		}
 	}
 
 	await showToast(async progress => discardChanges(progress!, originalFileName, newFileName, commitTitle), {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

If you haven't done so yet, check out the Contributing page in the wiki: https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines

-->

Fixes: https://github.com/refined-github/refined-github/issues/8714

- Unfortunately the dropdowns are now portaled so we can't get the filename of the file that this btn was clicked on as easily. We previously looked for a `closest` header wrapper and then went down from there. Now there's nothing in the DOM tieing the dropdown to the specific header (file) to which its attached.
	- This was necessary to pre-fill a good commit message like, "deleting changes in file: [filepath]".
	- For now I just left the pre-fill blank and allow the user to fill it in if they want

## Test URLs

- https://github.com/refined-github/sandbox/pull/16/files

## Screenshot

Still rendering in old view and renders nicely in new view now as well:

<table>
<tr>
<td align="center"> 

<strong>Old View</strong>

</td>
<td align="center">

<strong>New View</strong>

</td>
</tr>
<tr>
<td>

<img width="380" height="451" alt="CleanShot 2025-10-21 at 18 33 35" src="https://github.com/user-attachments/assets/dfb8d376-9279-42d1-aa75-5142db5ed3c0" />

</td>
<td>

<img width="424" height="345" alt="CleanShot 2025-10-21 at 18 32 46" src="https://github.com/user-attachments/assets/b9264819-c83d-43fc-b84c-6ada61a453a5" />


</td>
</tr>
</table>


