### PR TITLE
`new-repo-disable-projects-and-wikis` - Avoid duplicates

### DIFF
--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -70,7 +70,7 @@ function add(blueprintRow: HTMLElement): void {
 }
 
 function addOld(submitButton: HTMLElement): void {
-	// Special name banner has octicon-info icon as well
+	// .github repos have a banner that matches this #8716
 	if (elementExists('[data-testid="special-repo-name-banner"]')) {
 		return;
 	}


### PR DESCRIPTION



## Test URLs

https://github.com/new

New a special repo like `.github` in org.

## Screenshot

<img width="1448" height="226" alt="CleanShot 2025-10-22 at 11 59 47@2x" src="https://github.com/user-attachments/assets/a33af7b3-c463-4c91-bef7-7caf4ce47cd1" />


<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="1834" height="1208" alt="CleanShot 2025-10-22 at 11 59 31@2x" src="https://github.com/user-attachments/assets/4cc4c9bb-5c06-4987-8a28-91bc20f7b7a4" />

 <td>
<img width="1790" height="1048" alt="CleanShot 2025-10-22 at 11 59 42@2x" src="https://github.com/user-attachments/assets/f86a8419-d2d6-4f83-bf17-858d887c12b7" />

</table>

