### PR TITLE
`convert-release-to-draft` - Fix button size

### DIFF
--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -52,7 +52,7 @@ function attachButton(editButton: HTMLAnchorElement): void {
 	editButton.before(
 		<button
 			type="button"
-			className="btn btn-sm ml-3 mr-1 rgh-convert-draft"
+			className="Button Button--secondary Button--small ml-3 mr-1 rgh-convert-draft"
 		>
 			Convert to draft
 		</button>,


### PR DESCRIPTION
## Test URLs

- When viewing a repo with write permission: https://github.com/:org/:repo/releases/tag/v1.0.0

## Screenshot

Before:

<img width="316" height="72" alt="before" src="https://github.com/user-attachments/assets/db846981-0162-4273-96e9-e732231ef2b7" />

After:

<img width="316" height="60" alt="after" src="https://github.com/user-attachments/assets/a26fa01b-0e40-43d3-8792-3baa32618eca" />