### PR TITLE
`sticky-sidebar` - Fix "Code" dropdown overlap

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -48,6 +48,6 @@ Exclusively use simple sums and use `0px` instead of `0`
 }
 
 /* Higher than sticky readme header https://github.com/refined-github/refined-github/issues/8462 */
-.rgh-sticky-sidebar:has(.details-reset[open]) {
+.rgh-sticky-sidebar:has(.details-overlay[open]) {
 	z-index: 90;
 }


### PR DESCRIPTION
fixes #8730

## Test URLs

https://github.com/refined-github/refined-github/pull/8544

## Screenshot

<img width="1024" height="404" alt="image" src="https://github.com/user-attachments/assets/5b4b84de-b61a-4b49-8425-33158e635362" />
