### PR TITLE
`release-download-count` - Don't hide file size

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -70,7 +70,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		assetSize.parentElement!.classList.add('rgh-release-download-count');
 
 		// Hide sha on mobile. They have the classes but they're not correct (they hide in mid sizes, but show on smallest and largest...)
-		$optional(':scope > div', assetSize.parentElement!)?.classList.add('d-none');
+		$optional(':scope > div:has(clipboard-copy)', assetSize.parentElement!)?.classList.add('d-none');
 
 		// Add at the beginning of the line to avoid (clickable) content shift
 		assetSize.parentElement!.prepend(


### PR DESCRIPTION
fixes #8734


## Test URLs

https://github.com/NateShoffner/Disable-Nvidia-Telemetry/releases/tag/1.1

## Screenshot

<details>
<summary>Screenshots</summary>

<img width="939" height="243" alt="image" src="https://github.com/user-attachments/assets/c616c00e-7450-469a-a4db-5af1dbfda169" />

<img width="934" height="585" alt="image" src="https://github.com/user-attachments/assets/8a485a2e-904b-4af3-84f8-bda20373fd85" />

<img width="434" height="682" alt="image" src="https://github.com/user-attachments/assets/2f4d3d6b-0094-4c5d-89fe-6005dae4848a" />

</details>
