### PR TITLE
`patch-diff-links` - Update link when navigating commits

### DIFF
--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -23,6 +23,8 @@ function createLink(type: 'patch' | 'diff'): JSX.Element {
 		<a
 			href={getCommitUrl(type)}
 			className="sha color-fg-default"
+			// Update URL because it might be out of date due to SPA navigation
+			// https://github.com/refined-github/refined-github/issues/8737
 			onMouseEnter={updateCommitUrl}
 			onFocus={updateCommitUrl}
 		>


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/8737


## Test URLs

https://github.com/refined-github/sandbox/commit/75f309b0b63c36075a617a3e3179774e2a6860e7

## Screenshot

![gif](https://github.com/user-attachments/assets/d3ec693a-c8ac-4914-b6d7-c8403774dba1)
