### PR TITLE
`pr-first-commit-title` - Fix feature on long commit lists

### DIFF
--- a/source/features/pr-first-commit-title.tsx
+++ b/source/features/pr-first-commit-title.tsx
@@ -39,7 +39,12 @@ function getFirstCommit(firstCommit: HTMLElement): {title: string; body: string 
 
 function useCommitTitle(firstCommitElement: HTMLElement): void {
 	const requestedContent = new URL(location.href).searchParams;
-	const commitCountIcon = $(['div.Box.mb-3 .octicon-git-commit', 'a[href="#commits_bucket"] .octicon-git-commit']);
+	const commitCountIcon = $([
+		// Few commits
+		'div.Box.mb-3 .octicon-git-commit',
+		// Many commits (rendered in tabs)
+		'a[href="#commits_bucket"] .octicon-git-commit',
+	]);
 	const commitCount = commitCountIcon?.nextElementSibling;
 	if (!commitCount || looseParseInt(commitCount) < 2 || !elementExists('#new_pull_request')) {
 		return;
@@ -81,12 +86,12 @@ void features.add(import.meta.url, {
 		() =>	new URLSearchParams(location.search).has('title'),
 		hasUserAlteredThePR,
 	],
-	deduplicate: 'has-rgh',
 	init,
 });
 
 /*
 Test URLs
 
-https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1
+Few commit: https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1
+Many commits: https://github.com/refined-github/refined-github/compare/refined-github:refined-github:esbuild-2...pgimalac:refined-github:pgimalac/fit-rendered-markdown?expand=1
 */


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/7200

## Test URLs

https://github.com/refined-github/refined-github/compare/refined-github:refined-github:esbuild-2...pgimalac:refined-github:pgimalac/fit-rendered-markdown?expand=1


## Screenshot

<table>
<tr>
 <td>One commit
 <td>Many commits
<tr>
 <td><img width="407" height="774" alt="Screenshot 8" src="https://github.com/user-attachments/assets/d17b3e57-d387-4e92-af67-717e563a1459" />
 <td><img width="407" height="774" alt="Screenshot 9" src="https://github.com/user-attachments/assets/b67334b2-d395-492e-bfac-cbca6770f889" />
</table>



