### PR TITLE
`comments-time-machine-links` - Fix date parameter disappearing 

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -81,7 +81,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 	);
 }
 
-async function addDateParameterToLink(link: HTMLAnchorElement): Promise<void> {
+function addDateParameterToLink(link: HTMLAnchorElement): void {
 	if (!pageDetect.isRepoGitObject(link)) {
 		return;
 	}


### PR DESCRIPTION
addresses https://github.com/refined-github/refined-github/pull/8712#issuecomment-3484194515

fixes the issue of the date parameter not reappearing after a comment was edited

addresses some review comments

## Test URLs

https://github.com/refined-github/refined-github/issues/8698

## Screenshot
