### PR TITLE
`linkify-user-labels` - Avoid duplicates when unhiding comments

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -10,7 +10,6 @@ import observe from '../helpers/selector-observer.js';
 import {removeTextNodeContaining} from '../helpers/dom-utils.js';
 import {usernameLinksSelector} from '../github-helpers/selectors.js';
 import {expectToken} from '../github-helpers/github-token.js';
-import attachElement from '../helpers/attach-element.js';
 
 const emojiRegex = getEmojiRegex();
 
@@ -23,9 +22,12 @@ async function dropExtraCopy(link: HTMLAnchorElement): Promise<void> {
 	}
 }
 
-function createElement(element: HTMLAnchorElement, fullName: string): JSX.Element {
+function appendName(element: HTMLAnchorElement, fullName: string): void {
+	// If it's a regular comment author, add it outside <strong> otherwise it's something like "User added some commits"
+	const {parentElement} = element;
+	const insertionPoint = parentElement!.tagName === 'STRONG' ? parentElement! : element;
 	const nameElement = (
-		<span className="color-fg-muted css-truncate d-inline-block rgh-show-names">
+		<span className="color-fg-muted css-truncate d-inline-block">
 			{/* .css-truncate-target sets display: inline-block and confines bidi overrides #8191 */}
 			(<span className="css-truncate-target" style={{maxWidth: '200px'}}>{fullName}</span>)
 		</span>
@@ -34,17 +36,8 @@ function createElement(element: HTMLAnchorElement, fullName: string): JSX.Elemen
 	const testId = element.getAttribute('data-testid');
 	if (testId && ['issue-body-header-author', 'avatar-link'].includes(testId))
 		nameElement.classList.add('ml-1');
-	return nameElement;
-}
 
-function appendName(element: HTMLAnchorElement, fullName: string): void {
-	// If it's a regular comment author, add it outside <strong> otherwise it's something like "User added some commits"
-	const {parentElement} = element;
-	const insertionPoint = parentElement!.tagName === 'STRONG' ? parentElement! : element;
-
-	// React might create a new label without removing the old one
-	// https://github.com/refined-github/refined-github/issues/8478
-	attachElement(insertionPoint, {after: () => createElement(element, fullName)});
+	insertionPoint.after(' ', nameElement, ' ');
 }
 
 async function updateLinks(found: HTMLAnchorElement[]): Promise<void> {


### PR DESCRIPTION
- part of https://github.com/refined-github/refined-github/issues/8478
- sibling of https://github.com/refined-github/refined-github/pull/8756


## Test URLs

https://github.com/refined-github/refined-github/issues/8478#issuecomment-3218528346

## Screenshot

This gif shows a log placed just before the `.remove()` call added by this PR


![gif](https://github.com/user-attachments/assets/0544d339-6218-4a1a-b231-d50d8494603b)
