### PR TITLE
`more-file-links` - Restore on new PR & commit pages

### DIFF
--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -9,45 +9,44 @@ import HistoryIcon from 'octicons-plain-react/History';
 import features from '../feature-manager.js';
 import GitHubFileURL from '../github-helpers/github-file-url.js';
 
-function handleMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
+function getLegacyMenuItem(viewFile: HTMLAnchorElement, name: string, route: string): JSX.Element {
+	const {href} = new GitHubFileURL(viewFile.href).assign({route});
+	return (
+		<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 dropdown-item btn-link" role="menuitem">
+			View {name}
+		</a>
+	);
+}
+
+function handleLegacyMenuOpening({delegateTarget: dropdown}: DelegateEvent): void {
 	dropdown.classList.add('rgh-more-file-links'); // Mark this as processed
 
 	const viewFile = $('a[data-ga-click^="View file"]', dropdown);
-	const getDropdownLink = (name: string, route: string): JSX.Element => {
-		const {href} = new GitHubFileURL(viewFile.href).assign({route});
-		return (
-			<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 dropdown-item btn-link" role="menuitem">
-				View {name}
-			</a>
-		);
-	};
-
 	viewFile.after(
-		getDropdownLink('raw', 'raw'),
-		getDropdownLink('blame', 'blame'),
-		getDropdownLink('history', 'commits'),
+		getLegacyMenuItem(viewFile, 'raw', 'raw'),
+		getLegacyMenuItem(viewFile, 'blame', 'blame'),
+		getLegacyMenuItem(viewFile, 'history', 'commits'),
 		<div className="dropdown-divider" role="none" />,
 	);
 }
 
-function handleMenuOpeningReact(): void {
-	const viewFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-eye)');
+function getMenuItem(viewFile: HTMLElement, name: string, route: string, icon: React.JSX.Element): HTMLElement {
+	const menuItem = viewFile.cloneNode(true);
 	const fileLink = $('a', viewFile).href;
+	const link = $('a', menuItem);
+	link.href = new GitHubFileURL(fileLink).assign({route}).href;
+	link.dataset.turbo = String(route !== 'raw');
+	$('[class^="prc-ActionList-ItemLabel"]', menuItem).textContent = `View ${name}`;
+	$('[class^="prc-ActionList-LeadingVisual"]', menuItem).replaceChildren(icon);
+	return menuItem;
+}
 
-	function getMenuItem(name: string, route: string, icon: React.JSX.Element): HTMLElement {
-		const menuItem = viewFile.cloneNode(true);
-		const link = $('a', menuItem);
-		link.href = new GitHubFileURL(fileLink).assign({route}).href;
-		link.dataset.turbo = String(route !== 'raw');
-		$('[class^="prc-ActionList-ItemLabel"]', menuItem).textContent = `View ${name}`;
-		$('[class^="prc-ActionList-LeadingVisual"]', menuItem).replaceChildren(icon);
-		return menuItem;
-	}
-
+function handleMenuOpening(): void {
+	const viewFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-eye)');
 	viewFile.after(
-		getMenuItem('raw', 'raw', <FileCodeIcon />),
-		getMenuItem('blame', 'blame', <VersionsIcon />),
-		getMenuItem('history', 'commits', <HistoryIcon />),
+		getMenuItem(viewFile, 'raw', 'raw', <FileCodeIcon />),
+		getMenuItem(viewFile, 'blame', 'blame', <VersionsIcon />),
+		getMenuItem(viewFile, 'history', 'commits', <HistoryIcon />),
 		viewFile.nextElementSibling?.getAttribute('data-component') === 'ActionList.Divider'
 			? ''
 			: <li className="dropdown-divider" aria-hidden="true" data-component="ActionList.Divider" />,
@@ -56,8 +55,8 @@ function handleMenuOpeningReact(): void {
 
 function init(signal: AbortSignal): void {
 	// `capture: true` required to be fired before GitHub's handlers
-	delegate('.file-header .js-file-header-dropdown:not(.rgh-more-file-links)', 'toggle', handleMenuOpening, {capture: true, signal});
-	delegate('[class^="DiffFileHeader-module__diff-file-header"] button:has(>.octicon-kebab-horizontal)', 'click', handleMenuOpeningReact);
+	delegate('.file-header .js-file-header-dropdown:not(.rgh-more-file-links)', 'toggle', handleLegacyMenuOpening, {capture: true, signal});
+	delegate('[class^="DiffFileHeader-module__diff-file-header"] button:has(>.octicon-kebab-horizontal)', 'click', handleMenuOpening);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
#8504, #7808

## Test URLs

https://github.com/refined-github/sandbox/pull/55/files

https://github.com/refined-github/sandbox/commit/0504e7dccb40374c24c1217f37d3579993d6071e

## Screenshot

<img width="237" height="296" alt="image" src="https://github.com/user-attachments/assets/b6457326-e1be-43ab-b084-d41654712ed8" />

