### PR TITLE
`no-unnecessary-split-diff-view` - Restore on new PR & commit pages

### DIFF
--- a/source/features/no-unnecessary-split-diff-view.css
+++ b/source/features/no-unnecessary-split-diff-view.css
@@ -68,6 +68,11 @@ html:not([rgh-OFF-no-unnecessary-split-diff-view]) {
 		--rgh-left-side-w: 100%;
 	}
 
+	/* Align line number cells with the header first cell */
+	.diff-line-number {
+		min-width: 40px;
+	}
+
 	.diff-line-row {
 		/* The left side (deletions) */
 		/* > to avoid selecting suggested changes */
@@ -86,10 +91,5 @@ html:not([rgh-OFF-no-unnecessary-split-diff-view]) {
 			/* Only additions: expand the right side */
 			width: var(--rgh-right-side-w, auto) !important;
 		}
-	}
-
-	/* Align line number cells with the header first cell */
-	.diff-line-number {
-		min-width: 40px;
 	}
 }

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -1,9 +1,9 @@
+import './no-unnecessary-split-diff-view.css';
 import * as pageDetect from 'github-url-detection';
 import {$, $optional} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import './no-unnecessary-split-diff-view.css';
 
 /* TODO: remove in late 2026 */
 void features.addCssFeature(import.meta.url);
@@ -16,7 +16,8 @@ function manageSplitDiffState(tableBody: HTMLTableSectionElement): void {
 		table.classList.remove('rgh-no-split-diff');
 		return;
 	}
-	// avoid selecting suggested deletions/additions
+
+	// Avoid selecting suggested deletions/additions
 	if (!$optional(':scope > tr > td:nth-child(2) > .deletion', tableBody)) {
 		table.classList.add('rgh-no-split-diff', 'rgh-only-additions');
 	} else if (!$optional(':scope > tr > td:nth-child(4) > .addition', tableBody)) {

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -62,8 +62,10 @@ async function updateLinks(found: HTMLAnchorElement[]): Promise<void> {
 			// For `sticky-comment-header`. Use attribute because classes are altered by GitHub
 			currentUserElement.closest('[data-testid="comment-header"]')?.setAttribute('data-rgh-viewer-did-author', '');
 		}
+
 		users.delete(currentUser);
 	}
+
 	users.delete('ghost'); // Consider using `github-reserved-names` if more exclusions are needed
 
 	if (users.size === 0) {

--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -52,7 +52,6 @@ async function openUnreadNotifications(event?: React.MouseEvent): Promise<void> 
 	}, {
 		message: 'Loading notifications…',
 		doneMessage: false,
-	// eslint-disable-next-line promise/prefer-await-to-then -- Nah
 	}).finally(() => {
 		if (event?.target instanceof HTMLButtonElement) {
 			event.target.disabled = false;


### PR DESCRIPTION
fixes #8559

## Test URLs

https://github.com/refined-github/sandbox/pull/50/files?diff=split

https://github.com/fregante/sandbox/pull/30/files

https://github.com/refined-github/sandbox/commit/c28cc8e5271452b5b4c347d46a63f717c29417d6?diff=split

## Screenshot

<img width="1056" height="1059" alt="image" src="https://github.com/user-attachments/assets/d7b02f58-1453-4b66-8e20-fdd486733ae1" />
