### PR TITLE
`link-to-compare-diff` - Improve reliability

### DIFF
--- a/source/features/link-to-compare-diff.tsx
+++ b/source/features/link-to-compare-diff.tsx
@@ -16,7 +16,7 @@ function linkify(changedFilesSummary: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.Box li:has(.octicon-file-diff)', linkify, {signal});
+	observe('.Box li:has(> .octicon-file-diff)', linkify, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
fixes #8350

## Test URLs

https://github.com/carlbrown/PDKeychainBindingsController/compare/master...vizlabs:PDKeychainBindingsController:master (no error here anymore)

https://github.com/vizlabs/PDKeychainBindingsController/compare/master...carlbrown:PDKeychainBindingsController:master (works here now)

## Screenshot
