### PR TITLE
`pr-jump-to-first-non-viewed-file` - Disable feature on PR commit pages

### DIFF
--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -35,7 +35,6 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		pageDetect.isPRFile404,
-		// TODO: remove once #8778#issuecomment-3550122271 is fixed
 		pageDetect.isPRCommit,
 	],
 	init,


### PR DESCRIPTION
fixes:

<img width="1408" height="193" alt="image" src="https://github.com/user-attachments/assets/ff4821db-aa41-45ac-8f1f-5a3e630fb2f9" />

## Test URLs

`https://github.com/refined-github/refined-github/pull/8763/commits/139a39cf8dd9d6acad3c895a83134247d4ccae5a`

## Screenshot
