### PR TITLE
Add cookies permissions missed in #8740

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -20,7 +20,8 @@
 		"scripting",
 		"contextMenus",
 		"activeTab",
-		"alarms"
+		"alarms",
+		"cookies"
 	],
 	"host_permissions": [
 		"https://github.com/*",


### PR DESCRIPTION
Really fixes #8657 this time. #8740 missed adding the required "cookies" permissions.

From https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities#permissions:

> If an API enables cookies to be modified, you need the "cookies" permission. For example, using cookieStoreId in [tabs.query](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query) does not require the "cookies" API, as reading the property doesn't affect the cookies in the containers. **However, using [tabs.create](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create) requires the permission because the opened tab can read and modify cookies in a container.**

Fixes #8785 

## Test URLs

* https://github.com/notifications

## Screenshot
