### PR TITLE
`improve-shortcut-help` - Optimize feature

### DIFF
--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -95,7 +95,6 @@ const getRghShortcutsContainer = memoize(
 	{
 		cacheKey: () => location.origin + location.pathname,
 	},
-
 );
 
 function improveShortcutHelp(columnsContainer: HTMLElement): void {


### PR DESCRIPTION
Optimizes the feature by:

- unloading it if no shortcuts are available on the current page
- memoizing the resulting shortcuts element, which doesn't change until the feature is re-run

A follow-up to #8775

## Test URLs


## Screenshot
