### PR TITLE
`emphasize-draft-pr-label` - Implement in dashboard lists

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -2,6 +2,8 @@
 
 @media (min-resolution: 2x) {
 	html:not([rgh-OFF-emphasize-draft-pr-label]) {
+		/* Dashboard PR lists */
+		div[class*='DashboardListView-module__ItemLeadingVisual'] svg[aria-label='Status: Draft (not ready).'],
 		.js-issue-row
 			/* biome-ignore format: bug */
 			:is(


### PR DESCRIPTION

## Test URLs

https://github.com/

## Screenshot

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="2392" height="1138" alt="CleanShot 2025-11-26 at 10 43 08@2x" src="https://github.com/user-attachments/assets/c6281ce7-4a53-4382-8e73-3868c73880d5" />

 <td>

<img width="2630" height="1120" alt="CleanShot 2025-11-26 at 10 42 21@2x" src="https://github.com/user-attachments/assets/b630a680-0e0f-481b-8f57-9ea0b1141edb" />

</table>

