### PR TITLE
Fix button color contrast when deleting tags

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -115,10 +115,10 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 
 /* Fix button color contrast when deleting an unused tag */
 /* Info: https://github.com/refined-github/refined-github/issues/8803 */
-/* Test: https://github.com/refined-github/refined-github/tags */
+/* Test: https://github.com/refined-github/sandbox/tags */
 .dropdown-item.btn-link.color-fg-danger:hover {
-	color: var(--fgColor-onEmphasis) !important;
-	background-color: var(--bgColor-danger-emphasis);
+	color: var(--fgColor-onEmphasis, fuchsia) !important;
+	background-color: var(--bgColor-danger-emphasis, fuchsia);
 }
 
 /*


### PR DESCRIPTION
Improve button color contrast for unused tag deletion (https://github.com/refined-github/refined-github/issues/8803)

> [!NOTE]  
>
> - `!important` was required as `.color-fg-danger` in GitHub's CSS was already using `!important`.
> - This may break when GitHub switches to BEM as seen on other pages, but I couldn't find an example of BEM being used on a dropdown component.

## Test URLs

https://github.com/refined-github/refined-github/tags

## Screenshot

Before:

<img width="213" height="145" src="https://github.com/user-attachments/assets/f07f085c-f7de-4719-aab4-5286fdba690d" />

After:

<img width="213" height="141" src="https://github.com/user-attachments/assets/913ce962-4d39-4a29-8d2b-a2574cd54b89" />