### PR TITLE
`sticky-comment-header` - Fix viewer's comment headers color on GHE

### DIFF
--- a/source/features/sticky-comment-header.css
+++ b/source/features/sticky-comment-header.css
@@ -22,6 +22,8 @@ html:not([rgh-OFF-sticky-comment-header]) {
 			var(--base-sticky-header-height, 0px) +
 			var(--rgh-issue-or-pr-sticky-header-height, 0px)
 		);
+		/* Fallback in case `show-names` is disabled - #8726#issuecomment-3606420543 */
+		background: var(--bgColor-muted, var(--color-canvas-subtle, fuchsia));
 	}
 
 	:is([id^='gistcomment'], [id^='commitcomment']) > * {

--- a/source/features/sticky-comment-header.css
+++ b/source/features/sticky-comment-header.css
@@ -1,4 +1,9 @@
 html:not([rgh-OFF-sticky-comment-header]) {
+	--rgh-bg-accent: var(
+		--bgColor-accent-muted,
+		var(--color-accent-subtle, fuchsia)
+	);
+
 	/* biome-ignore format: bug */
 	/* Issue body header */
 	[class^='IssueBodyHeader-module__IssueBodyHeaderContainer'],
@@ -29,10 +34,8 @@ html:not([rgh-OFF-sticky-comment-header]) {
 	[class*='IssueBodyHeader-module__viewerDidAuthor'] {
 		/* Draw a possibly semi-transparent accent color over the opaque background */
 		background:
-			linear-gradient(
-				var(--bgColor-accent-muted, fuchsia),
-				var(--bgColor-accent-muted, fuchsia)
-			), var(--rgh-background);
+			linear-gradient(var(--rgh-bg-accent), var(--rgh-bg-accent)),
+			var(--rgh-background);
 	}
 
 	/* Prevent header of the next comment from overlapping context menu of the sticky header */

--- a/source/features/sticky-comment-header.css
+++ b/source/features/sticky-comment-header.css
@@ -22,8 +22,6 @@ html:not([rgh-OFF-sticky-comment-header]) {
 			var(--base-sticky-header-height, 0px) +
 			var(--rgh-issue-or-pr-sticky-header-height, 0px)
 		);
-		/* Fallback in case `show-names` is disabled - #8726#issuecomment-3606420543 */
-		background: var(--bgColor-muted, var(--color-canvas-subtle, fuchsia));
 	}
 
 	:is([id^='gistcomment'], [id^='commitcomment']) > * {


### PR DESCRIPTION
fixes #8801


## Test URLs


## Screenshot
