### PR TITLE
`netiquette` - Fix layout in comment field

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -97,6 +97,7 @@ function addPopularBanner(newCommentField: HTMLElement): void {
 	});
 
 	if (reactWrapper) {
+		reactWrapper.parentElement?.classList.add('flex-column');
 		reactWrapper.before(banner);
 	} else {
 		banner.classList.replace('rounded-0', 'm-2');


### PR DESCRIPTION
fix: #8816 


## Test URLs

https://github.com/actions/runner/issues/662

## Screenshot

<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>
<img width="2942" height="1052" alt="CleanShot 2025-12-09 at 17 11 24@2x" src="https://github.com/user-attachments/assets/adafe33e-75dd-466a-9afe-5a4076c62ccb" />

 <td>
<img width="3122" height="1102" alt="CleanShot 2025-12-09 at 17 10 59@2x" src="https://github.com/user-attachments/assets/c8fc3cc0-ea10-42e9-a253-73a13827e7a4" />

</table>