### PR TITLE
`update-pr-from-base-branch` - Improve reliability

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -15,7 +15,7 @@ import showToast from '../github-helpers/toast.js';
 import {getConversationNumber, getRepo} from '../github-helpers/index.js';
 import createMergeabilityRow from '../github-widgets/mergeability-row.js';
 import {expectToken} from '../github-helpers/github-token.js';
-import {deletedHeadRepository, prMergeabilityBoxCaption} from '../github-helpers/selectors.js';
+import {deletedHeadRepository, prMergeabilityBoxHeader} from '../github-helpers/selectors.js';
 
 // TODO: Use CachedMap after https://github.com/fregante/webext-storage-cache/issues/51
 const nativeRepos = new CachedFunction('native-update-button', {
@@ -152,7 +152,7 @@ async function init(signal: AbortSignal): Promise<false | void> {
 	delegate('.rgh-update-pr-from-base-branch', 'click', handler, {signal});
 	observe([
 		'.mergeability-details > *:last-child', // Old view - TODO: Drop after June 2025
-		prMergeabilityBoxCaption,
+		prMergeabilityBoxHeader,
 	], addButton, {signal});
 	observe([
 		'.js-update-branch-form', // Old view - TODO: Remove in July 2025

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -242,6 +242,9 @@ export const actionBarSelectors_ = requiresLogin;
 export const prMergeabilityBoxCaption = '[aria-label="Conflicts"] [class^="MergeBoxSectionHeader-module__wrapper"] h3 + .fgColor-muted';
 export const prMergeabilityBoxCaption_ = requiresLogin;
 
+export const prMergeabilityBoxHeader = '[aria-label="Conflicts"] [class^="MergeBoxSectionHeader-module__wrapper"]';
+export const prMergeabilityBoxHeader_ = requiresLogin;
+
 export const deletedHeadRepository = [
 	'span[title="This repository has been deleted"]',
 	'.head-ref[title="This repository has been deleted"]', // TODO: Remove in June 2026


### PR DESCRIPTION
Fixes #8828.
The existing selector relied on specific text content (caption) within the merge box. This updates it to target the stable container class (`MergeBoxSectionHeader-module__wrapper`), ensuring the button appears even if the text varies or is missing.