### PR TITLE
`quick-mention` - Fix comment header overlap

### DIFF
--- a/source/features/quick-mention.css
+++ b/source/features/quick-mention.css
@@ -29,6 +29,7 @@
 	color: inherit;
 }
 
+/* Show tooltip on top of `sticky-comment-header` */
 .TimelineItem-avatar:has(.rgh-quick-mention) {
 	z-index: 4;
 }


### PR DESCRIPTION



## Test URLs
You can view the comments corresponding to the PR to reproduce the issue. https://github.com/refined-github/refined-github/pull/8771

## Screenshot
<img width="596" height="252" alt="image" src="https://github.com/user-attachments/assets/7abe0947-91a5-40aa-b155-f5e9c1f4779b" />

As shown in the image, when the approved comment card appears, the tooltip content is obscured when the mouse hovers over the quick mention icon.