### PR TITLE
`parse-backticks` - Enable on dashboard items

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -53,7 +53,8 @@ const selectors = [
 	// https://github.com/notifications/subscriptions
 	'.notification-thread-subscription [id^="subscription_link_"]',
 
-	// Dashboard https://github.com/
+	// Dashboard
+	// https://github.com
 	'[class^="DashboardListView-module__ItemTitle"]',
 ] as const;
 


### PR DESCRIPTION

## Test URLs

https://github.com/

## Screenshot



| | |
|--------|--------|
|  Before  | <img width="959" height="138" alt="image" src="https://github.com/user-attachments/assets/3a71c8a4-54b0-4028-9bfb-e0402f7bb75e" /> |
| After  |<img width="929" height="131" alt="image" src="https://github.com/user-attachments/assets/614cf8a5-8fef-4012-a107-58dc6bd89557" /> | 


