### PR TITLE
`conversation-activity-filter` - Fix filter icon margin on PRs

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -152,7 +152,7 @@ async function addWidget(state: State, anchor: HTMLElement): Promise<void> {
 
 	// Place the icon first to calculate available space for the dropdown after
 	const details = <details
-		className={`details-reset details-overlay ${position.clientWidth > 0 ? 'ml-2' : ''} d-inline-block position-relative ${dropdownClass}`}
+		className={`details-reset details-overlay ${position.offsetWidth > 0 ? 'ml-2' : ''} d-inline-block position-relative ${dropdownClass}`}
 		id="rgh-conversation-activity-filter-select-menu"
 	>
 		<summary className="height-full color-fg-muted">


### PR DESCRIPTION
No clue how this slipped. Maybe it worked?

## Test URLs

https://github.com/refined-github/refined-github/pull/8806

## Screenshot

| |
|--------|
|  Before  | 
<img width="1016" height="221" alt="image" src="https://github.com/user-attachments/assets/92dd874f-459c-45da-877d-5bff62373806" /> |
| After  | 
<img width="1050" height="206" alt="image" src="https://github.com/user-attachments/assets/bbde5971-93c2-4f48-8435-e4e4d6a9ed8f" /> | 


