### PR TITLE
`conventional-commits` - Support uppercase type

### DIFF
--- a/source/helpers/conventional-commits.test.ts
+++ b/source/helpers/conventional-commits.test.ts
@@ -81,3 +81,83 @@ test('parseConventionalCommit', () => {
 	expect(parseConventionalCommit('feat(): Commit message')).toBeUndefined();
 	expect(parseConventionalCommit('fe at(scope): Commit message) ')).toBeUndefined();
 });
+
+test('parseConventionalCommit support upper case types', () => {
+	expect(parseConventionalCommit('Fix: Commit message')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Fix: ",
+		  "rawType": "Fix",
+		  "scope": undefined,
+		  "type": "Fix",
+		}
+	`);
+	expect(parseConventionalCommit('Feat: Commit message')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Feat: ",
+		  "rawType": "Feat",
+		  "scope": undefined,
+		  "type": "Feature",
+		}
+	`);
+	expect(parseConventionalCommit('Fix!: Breaking change')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Fix!: ",
+		  "rawType": "Fix",
+		  "scope": undefined,
+		  "type": "Fix!",
+		}
+	`);
+	expect(parseConventionalCommit('Feat(scope): Commit message')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Feat(scope): ",
+		  "rawType": "Feat",
+		  "scope": "scope: ",
+		  "type": "Feature",
+		}
+	`);
+	expect(parseConventionalCommit('Feat(scope)!: Breaking change')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Feat(scope)!: ",
+		  "rawType": "Feat",
+		  "scope": "scope: ",
+		  "type": "Feature!",
+		}
+	`);
+	expect(parseConventionalCommit('Revert(scope): Revert "Feat(scope): Commit message"')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Revert(scope): ",
+		  "rawType": "Revert",
+		  "scope": "scope: ",
+		  "type": "Revert",
+		}
+	`);
+	expect(parseConventionalCommit('Feat(sco pe): Commit message')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Feat(sco pe): ",
+		  "rawType": "Feat",
+		  "scope": "sco pe: ",
+		  "type": "Feature",
+		}
+	`);
+	expect(parseConventionalCommit(('Feat: Commit (message)'))).toMatchInlineSnapshot(`
+		{
+		  "raw": "Feat: ",
+		  "rawType": "Feat",
+		  "scope": undefined,
+		  "type": "Feature",
+		}
+	`);
+	expect(parseConventionalCommit('Fix:')).toMatchInlineSnapshot(`
+		{
+		  "raw": "Fix:",
+		  "rawType": "Fix",
+		  "scope": undefined,
+		  "type": "Fix",
+		}
+	`);
+
+	expect(parseConventionalCommit('Idk(label): not recognized')).toBeUndefined();
+	expect(parseConventionalCommit('Commit message')).toBeUndefined();
+	expect(parseConventionalCommit('Feat(): Commit message')).toBeUndefined();
+	expect(parseConventionalCommit('Fe at(scope): Commit message) ')).toBeUndefined();
+});

--- a/source/helpers/conventional-commits.ts
+++ b/source/helpers/conventional-commits.ts
@@ -29,7 +29,7 @@ export function parseConventionalCommit(commitTitle: string): {
 	}
 
 	const {type: rawType, scope, major} = match.groups;
-	const type = types.get(rawType);
+	const type = types.get(rawType.toLowerCase());
 	if (!type) {
 		return;
 	}


### PR DESCRIPTION

Some commits may have a type with the first letter capitalized; perhaps we can make the type parsing process more compatible.
