### PR TITLE
`previous-next-commit-buttons` - Fix on initial PR commits

### DIFF
--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -6,7 +6,7 @@ import features from '../feature-manager.js';
 
 function init(): false | void {
 	const originalPreviousNext = $optional('.commit .float-right.ButtonGroup') // Legacy
-		?? $optional('[class^="prc-ButtonGroup-ButtonGroup"]:has(a[aria-label="Previous commit"])');
+		?? $optional('[class^="prc-ButtonGroup-ButtonGroup"]:has(a[aria-label$="previous commit" i])');
 	if (!originalPreviousNext) {
 		return false;
 	}


### PR DESCRIPTION
fixes #8856

## Test URLs

`https://github.com/refined-github/refined-github/pull/5113/changes/5b7282afc40b013f5928271fb6740cf70b4e4295`

## Screenshot

<img width="884" height="660" alt="image" src="https://github.com/user-attachments/assets/f411720a-0eba-4cdb-9dea-05defd20a420" />
