### PR TITLE
`restore-file` - Add support for new PR view

### DIFF
--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -157,8 +157,7 @@ function addLegacyMenuItem(editFile: HTMLAnchorElement): void {
 // New React view handler: track the file container and add menu item
 function handleMenuOpening({delegateTarget}: DelegateEvent<MouseEvent, HTMLElement>): void {
 	// Track the file container for later removal
-	focusedFileContainer = delegateTarget.closest('[class*="DiffFileHeader-module__diff-file-header"]')!
-		.parentElement!;
+	focusedFileContainer = delegateTarget.closest('div[id^="diff-"]')!;
 
 	// Wait for the menu to be rendered
 	requestAnimationFrame(() => {


### PR DESCRIPTION
Fixes

- https://github.com/refined-github/refined-github/issues/8714

Reimplementation of 
- #8749

addressing the maintainer's feedback, trying to sidestep drama. In honesty I don't totally know how to test this.

## Changes

- Added support for the new React-based PR files view while keeping the legacy view handling completely unchanged
- Use `GitHubFileURL` helper for URL parsing instead of manual regex
- Track focused file container via a global variable (`focusedFileContainer`) for removal after discard operation
- Use the octicon library (`GitCompareIcon`) for the menu item icon
- Handle renamed files by checking React props for `RENAMED` status with the suggested conditional expression
- Use `handleMenuOpening` pattern from `more-file-links.tsx` for adding menu items

## Key differences from previous PR

1. **Legacy code unchanged**: The legacy view handling (`addLegacyMenuItem`, `observe`) remains exactly as it was
2. **Global file tracking**: Following the suggestion to save the file container on menu open for later removal
3. **Cleaner URL parsing**: Using `GitHubFileURL` instead of manual string manipulation
4. **Proper getFilenames function**: Lives in `restore-file.tsx` where it belongs, returns `{original, new}` as suggested

## Test URLs

- https://github.com/refined-github/sandbox/pull/16/files
- https://github.com/refined-github/sandbox/pull/29/files