### PR TITLE
`rgh-improve-new-issue-form` - Restore feature

### DIFF
--- a/source/features/rgh-improve-new-issue-form.tsx
+++ b/source/features/rgh-improve-new-issue-form.tsx
@@ -16,7 +16,7 @@ const isSetTheTokenSelector = 'input[type="checkbox"][required]';
 const liesGif = 'https://github.com/user-attachments/assets/f417264f-f230-4156-b020-16e4390562bd';
 
 function addNotice(adjective: JSX.Element | string): void {
-	$('#issue_body_template_name').before(
+	$('[class^="IssueFormElements-module__formElementsContainer"]').prepend(
 		<div className="flash flash-error h3 my-9" style={{animation: 'pulse-in 0.3s 2'}}>
 			<p>
 				Your token is {adjective}. Many Refined GitHub features don't work without it.


### PR DESCRIPTION
addresses #8882

The `turbo-frame` element is not replaced when navigating from https://github.com/refined-github/refined-github/issues/new/choose to https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml, but it's child `react-app` is re-rendered, so `deduplicate` has to be replaced with observer

## Test URLs

https://github.com/refined-github/refined-github/issues/new/choose -> https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml

## Screenshot

<img width="495" height="675" alt="image" src="https://github.com/user-attachments/assets/5312755d-9ba2-4f0b-9aae-d8698b8f9044" />

<img width="1061" height="518" alt="image" src="https://github.com/user-attachments/assets/40484386-e28f-46ef-9e31-2d02208e9334" />

