### PR TITLE
`useful-not-found-page` - Restore link on PR 404 pages

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -193,12 +193,12 @@ async function initOnce(): Promise<void> {
 }
 
 async function initPRCommitOnce(): Promise<void | false> {
-	const commitUrl = location.href.replace(/pull\/\d+\/commits/, 'commit');
+	const commitUrl = location.href.replace(/pull\/\d+\/(commits|changes)/, 'commit');
 	if (!(await isUrlReachable(commitUrl))) {
 		return false;
 	}
 
-	const blankSlateParagraph = await elementReady('.blankslate p', {waitForChildren: false});
+	const blankSlateParagraph = await elementReady('.blankslate:has(> .octicon-telescope) p', {waitForChildren: false});
 	blankSlateParagraph!.after(
 		<p>You can also try to <a href={commitUrl}>view the detached standalone commit</a>.</p>,
 	);


### PR DESCRIPTION
resolves #8880

## Test URLs

`https://github.com/multitheftauto/mtasa-blue/pull/4651/changes/954f7416d83f25683e3db9d18c687e9d7d4f243a`

## Screenshot

<img width="779" height="517" alt="image" src="https://github.com/user-attachments/assets/a428fb24-3e2b-45c7-850e-78e618cac558" />
