### PR TITLE
Add version number to Safari extension app

### DIFF
--- a/safari/Refined GitHub/MainScreen.swift
+++ b/safari/Refined GitHub/MainScreen.swift
@@ -61,12 +61,16 @@ struct MainScreen: View {
 		.padding()
 		.offset(y: -20) // Looks better than fully center.
 		.safeAreaInset(edge: .bottom) {
-			Text("The app is just a container for the Safari extension and does not do anything.")
-				.font(.subheadline)
-				.foregroundStyle(.secondary)
-				.multilineTextAlignment(.center)
-				.padding()
-				.padding(.horizontal)
+			VStack(spacing: 16) {
+				Text("The app is just a container for the Safari extension and does not do anything.")
+				Text("v\(SSApp.version)")
+					.foregroundStyle(.tertiary)
+			}
+			.font(.subheadline)
+			.foregroundStyle(.secondary)
+			.multilineTextAlignment(.center)
+			.padding()
+			.padding(.horizontal)
 		}
 		.task {
 			requestReviewIfNeeded()

--- a/safari/Refined GitHub/Utilities.swift
+++ b/safari/Refined GitHub/Utilities.swift
@@ -26,6 +26,8 @@ enum SafariExtension {
 
 
 enum SSApp {
+	static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "<Unknown version>"
+
 	static let isFirstLaunch: Bool = {
 		let key = "SS_hasLaunched"
 


### PR DESCRIPTION
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-23 at 23 42 13" src="https://github.com/user-attachments/assets/e635e3d7-c676-40c3-8d9e-830d8714114c" />

<img width="643" height="706" alt="Screen Shot 2026-01-23 at 23 44 58" src="https://github.com/user-attachments/assets/70b50382-03aa-4c56-859c-66a76adbd1b6" />
