### PR TITLE
`clean-repo-sidebar` - Various improvements

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -32,7 +32,8 @@
 	* Hide "+ 123 contributors" link
 	* Don't hide "Create new release" link #8442
 	*/
-	.Layout-sidebar .BorderGrid-cell > .mt-3:not(:has(> a[href$="releases/new"])) {
+	.Layout-sidebar .BorderGrid-cell
+		> .mt-3:not(:has(> a[href$='releases/new'])) {
 		display: none;
 	}
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -6,7 +6,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import {buildRepoURL} from '../github-helpers';
+import {buildRepoURL} from '../github-helpers/index.js';
 
 // The h2 is to avoid hiding website links that include '/releases' #4424
 // TODO: It's broken


### PR DESCRIPTION

- closes https://github.com/refined-github/refined-github/issues/8442


### Show "create new release" on no-release repos

https://github.com/fregante/bin-dir

<img width="206" height="109" alt="Screenshot" src="https://github.com/user-attachments/assets/b4f8d9cd-38db-4c30-b3bc-bf43cfe520d9" />

### No changes to no-tag repos

https://github.com/refined-github/yolo

<img width="232" height="135" alt="Screenshot" src="https://github.com/user-attachments/assets/cabe982a-9bf9-43b9-b722-c80014b5acfd" />

### The latest release link now points to the releases page (no visual change)
https://github.com/refined-github/refined-github 

<img width="221" height="123" alt="Screenshot 6" src="https://github.com/user-attachments/assets/27d16bb6-e211-429f-84cf-0b54b221013a" />
