### PR TITLE
`rgh-linkify-features` - Restore on repo tree, commit list, single commit

### DIFF
--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -83,7 +83,7 @@ Test URLs
 - hasComments: https://github.com/refined-github/refined-github/issues/8867
 - isReleasesOrTags: https://github.com/refined-github/refined-github/releases
 - isSingleReleaseOrTag: https://github.com/refined-github/refined-github/releases/tag/23.7.25
-- isCommitList: https://github.com/refined-github/refined-github/commits/main/?after=bb96c11fe1dcc9e3583d54a5129401abe024f488%2034
+- isCommitList: https://github.com/refined-github/refined-github/commits/main
 - isSingleCommit: https://github.com/refined-github/refined-github/commit/d63e2d97fc4d85f986a120fb49cd8e09f6785b93
 - isRepoWiki: https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions
 - isPR: https://github.com/refined-github/refined-github/pull/8904


### PR DESCRIPTION
addresses #8882

## Test URLs

https://github.com/refined-github/refined-github/commit/d63e2d97fc4d85f986a120fb49cd8e09f6785b93

https://github.com/refined-github/refined-github/commits/main/?after=bb96c11fe1dcc9e3583d54a5129401abe024f488%2034

https://github.com/refined-github/refined-github/tree/8b63c998c609c16a3b52daa314444003c84a7fa8 (`shorten-links` shortens this link incorrectly)

## Screenshot

### isSingleCommit

<img width="432" height="194" alt="image" src="https://github.com/user-attachments/assets/e44a3f5d-d62c-4cc9-aac1-5702dd52a33f" />

### isCommitList

<img width="681" height="474" alt="image" src="https://github.com/user-attachments/assets/fa67535b-3fc7-4636-bd1f-3c2b921944b1" />

### isRepoTree

<img width="792" height="381" alt="image" src="https://github.com/user-attachments/assets/d2fd4a2b-9923-40b1-ab69-a73420030b1f" />
