### PR TITLE
`no-self-reference` - Enable only on markdown blocks

### DIFF
--- a/source/features/no-self-reference.tsx
+++ b/source/features/no-self-reference.tsx
@@ -18,7 +18,7 @@ function underlineSelfReference(link: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	const [currentPage] = location.href.split('#');
-	observe(`.issue-link[href="${currentPage}"]`, underlineSelfReference, {signal});
+	observe(`.markdown-body:is(:not(section[aria-label="Events"] *)) .issue-link[href="${currentPage}"]`, underlineSelfReference, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
resolves #8915

## Test URLs

https://github.com/refined-github/sandbox/issues/122

https://github.com/refined-github/sandbox/pull/120

## Screenshot

<img width="780" height="479" alt="image" src="https://github.com/user-attachments/assets/a46e9910-73e0-4a25-b4f6-c2bd62c59753" />

<img width="740" height="490" alt="image" src="https://github.com/user-attachments/assets/9507d58c-9db9-4a4c-9ed7-e75d94fc6bb5" />

<img width="767" height="458" alt="image" src="https://github.com/user-attachments/assets/10680b38-e178-43ba-930e-a0e81978fd45" />
