### PR TITLE
`batch-mark-files-as-viewed` - Restore on new Files changed experience

### DIFF
--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -64,14 +64,12 @@ function batchToggle(event: DelegateEvent<MouseEvent, HTMLFormElement>): void {
 }
 
 function markAsViewedSelector(file: HTMLElement): string {
+	const fileElement = fileSelector.join(',');
+	const viewedToggle = viewedToggleSelector.join(',');
+	const checkedState = isChecked(file) ? `:not(${checkedSelector})` : checkedSelector;
 	// The `hidden` attribute excludes filtered-out files
 	// https://github.com/refined-github/refined-github/issues/7819
-	return [
-		`:is(${fileSelector.join(',')}):not([hidden])`,
-		' ',
-		`:is(${viewedToggleSelector.join(',')})`,
-		isChecked(file) ? `:not(${checkedSelector})` : checkedSelector,
-	].join('');
+	return `:is(${fileElement}):not([hidden]) :is(${viewedToggle})${checkedState}`;
 }
 
 const markAsViewed = clickAll(markAsViewedSelector);


### PR DESCRIPTION
#8504

## Test URLs

`https://github.com/refined-github/sandbox/pull/55/changes?new_files_changed=false`

`https://github.com/refined-github/sandbox/pull/55/changes?new_files_changed=true`

## Screenshot
