### PR TITLE
`rgh-linkify-features` - Restore on PR files page

### DIFF
--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -48,7 +48,7 @@ function linkifyFeature(possibleFeature: HTMLElement): void {
 
 function init(signal: AbortSignal): void {
 	observe([
-		'.js-issue-title code', // Old `isPR` and `isIssue` views
+		'.js-issue-title code', // `isPRConversation`, Old view `isIssue`
 		'h1[class^="prc-PageHeader-Title"] code', // `isPRFiles`,
 		'[data-testid="issue-title"] code', // `isIssue`
 		'.js-comment-body code', // Old view `hasComments`


### PR DESCRIPTION
follow-up to #8911

## Test URLs

https://github.com/refined-github/refined-github/pull/8931/changes

`https://github.com/refined-github/refined-github/pull/8931/changes/39bdcd90f9c03e68e14c430b60e2ec7df8e17244`

## Screenshot

<img width="976" height="153" alt="image" src="https://github.com/user-attachments/assets/9d47dad1-b237-4c69-aa83-2c1625bd0c2b" />
