### PR TITLE
Fix PR branch selectors for new GitHub React UI

### DIFF
--- a/source/github-helpers/pr-branches.ts
+++ b/source/github-helpers/pr-branches.ts
@@ -64,13 +64,13 @@ export function getBranches(): {base: PrReference; head: PrReference} {
 	return {
 		get base() {
 			return parseReference($([
-				'[class*="PullRequestHeaderSummary"] > [class*="PullRequestHeaderSummary"]',
+				'[class*="PullRequestHeaderSummary"] [class*="PullRequestBranchName"]:last-of-type',
 				'.base-ref', // TODO: Remove in June 2026
 			]));
 		},
 		get head() {
 			return parseReference($([
-				'[class*="PullRequestHeaderSummary"] * [class*="PullRequestHeaderSummary"]',
+				'[class*="PullRequestHeaderSummary"] [class*="PullRequestBranchName"]:first-of-type',
 				'.head-ref', // TODO: Remove in June 2026
 			]));
 		},


### PR DESCRIPTION
Fixes:

- https://github.com/refined-github/refined-github/issues/8949

## Summary

- Fix `restore-file` and other features that use `getBranches()` by updating selectors for the new GitHub React UI
- GitHub changed the PR header structure - branch references are now in `PullRequestBranchName` elements within the summary container
- The old selector looked for nested `PullRequestHeaderSummary` elements which no longer exist

## Test plan

- [ ] Test on https://github.com/refined-github/sandbox/pull/16/files
- [ ] Verify "Discard changes" option appears in file dropdown menu
- [ ] Verify the commit is created on the correct branch