### PR TITLE
`parse-backticks` - Restore feature on some pages

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -19,7 +19,6 @@ const selectors = [
 	'.TimelineItem-body pre',
 
 	// `isReleasesOrTags` Headers
-	// TODO: Fix. Not working
 	// https://github.com/refined-github/sandbox/releases/tag/cool
 	'.Box-body h1',
 


### PR DESCRIPTION
## Test URLs

https://github.com/refined-github/sandbox

https://github.com/refined-github/sandbox/commits/buncha-files/

https://github.com/refined-github/sandbox/pull/55#commits-pushed-d4852bb

https://github.com/refined-github/sandbox/releases/tag/cool

https://github.com/refined-github/refined-github/pulse

https://github.com/refined-github/refined-github/actions

https://github.com/orgs/refined-github

https://github.com/orgs/refined-github/repositories

https://github.com/refined-github/sandbox/issues/72

https://github.com/orgs/refined-github/dashboard

## Screenshot

#### isRepoHome

<img width="173" height="150" alt="image" src="https://github.com/user-attachments/assets/64ddcd4d-b779-462b-b707-512597fc5e91" />

#### isCommitList

<img width="275" height="120" alt="image" src="https://github.com/user-attachments/assets/c255b0cd-a24e-4270-837f-8ac9d242f13a" />

#### isPRConversation

<img width="241" height="72" alt="image" src="https://github.com/user-attachments/assets/c109dac8-8254-4fa1-9565-ae9a843c92ac" />

#### isReleasesOrTags

<img width="462" height="152" alt="image" src="https://github.com/user-attachments/assets/b1049567-b617-4f70-abf3-78ab6bc24102" />

#### Pulse

<img width="663" height="426" alt="image" src="https://github.com/user-attachments/assets/b26ec9a0-3ea9-49e3-b784-f4bd97fb5f7d" />

#### Actions (No RGH)

<img width="425" height="159" alt="image" src="https://github.com/user-attachments/assets/f2bb03ad-e6ac-4ec6-8878-17817559a1d1" />

#### Repo list

<img width="245" height="126" alt="image" src="https://github.com/user-attachments/assets/d60be90f-9c0b-4add-b71c-557e39c1bc57" />

#### Hovercard (No RGH)

<img width="599" height="423" alt="image" src="https://github.com/user-attachments/assets/6ea63bcd-ef83-4b1e-ae60-7028f3b6f93d" />

### Dashboard

<img width="575" height="203" alt="image" src="https://github.com/user-attachments/assets/30b3ca46-89d5-411b-a47e-a61711834422" />