### PR TITLE
`small-user-avatars` - Fix duplicated avatars on merge queue page

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -41,7 +41,10 @@ function initOnce(): void {
 			[data-testid="closed-at"]
 		) a[data-hovercard-url*="/users"]`, // `isIssueList`
 	], addAvatar);
-	observe('.user-mention:not(.commit-author)', addMentionAvatar);
+	observe(`.user-mention:not(${[
+		'.opened-by > *', // Merge queue
+		'.commit-author',
+	].join(',')})`, addMentionAvatar);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
fixes #8883

## Test URLs

not possible to provide

## Screenshot

<img width="693" height="241" alt="image" src="https://github.com/user-attachments/assets/7161c552-c731-4e83-8420-74740a280684" />
