### PR TITLE
`clean-repo-tabs` - Fix wiki tab counter

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -30,14 +30,8 @@ function mustKeepTab(tab: HTMLElement): boolean {
 function setTabCounter(tab: HTMLElement, count: number): void {
 	let tabCounter = $optional('.Counter, .num', tab);
 	if (!tabCounter) {
-		const wrapper = (
-			<span data-component="counter">
-				<span className="Counter" />
-			</span>
-		);
-
-		tabCounter = wrapper.firstElementChild as HTMLSpanElement;
-		tab.append(wrapper);
+		tabCounter = <span className="Counter" /> as HTMLSpanElement;
+		tab.append(<span data-component="counter">{tabCounter}</span>);
 	}
 
 	tabCounter.textContent = abbreviateNumber(count);


### PR DESCRIPTION
This fixes:
```
Refined GitHub: clean-repo-tabs
errors.js:78 📕 26.2.19 → ElementNotFoundError: Expected element not found: .Counter
    at expectElement (select-dom.js:21:11)
    at setTabCounter (clean-repo-tabs.js:29:21)
    at updateWikiTab (clean-repo-tabs.js:82:3)
    at async feature-manager.js:197:20
    at async Promise.all (index 1)
    at async asyncForEach (async-for-each.js:6:2)
```

## Test URLs
https://github.com/Netflix/Hystrix/wiki

## Screenshot
| Before | After |
| --- | --- |
| <img width="560" height="64" alt="PixelSnap 2026-02-21 at 20 45 43@2x" src="https://github.com/user-attachments/assets/db19f0bb-3996-4992-b64a-93ba668c6e39" /> | <img width="636" height="64" alt="PixelSnap 2026-02-21 at 20 45 50@2x" src="https://github.com/user-attachments/assets/a5ced26a-61b1-45e7-b517-94a9920b2e3a" /> |
