### PR TITLE
`clean-conversation-headers` - Fix issues cased by history navigation

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -21,10 +21,10 @@ async function highlightNonDefaultBranchPRs(base: HTMLElement, baseBranch: strin
 	}
 }
 
-async function cleanPrHeader(byline: HTMLElement): Promise<void> {
-	byline.classList.add('rgh-clean-conversation-headers');
+async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
+	summaryRow.classList.add('rgh-clean-conversation-headers');
 	// TODO: Remove after July 2026
-	byline.parentElement!.closest('.d-flex')?.classList.add('flex-items-center');
+	summaryRow.parentElement!.closest('.d-flex')?.classList.add('flex-items-center');
 
 	const prCreatorSelector = [
 		'.TimelineItem .author',
@@ -36,17 +36,17 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 	const shouldHideAuthor
 		= pageDetect.isPRConversation()
 			// #7802
-			&& !byline.closest([
+			&& !summaryRow.closest([
 				'div[class*="stickyHeader"]',
 				// TODO: Remove after July 2026
 				'.sticky-content',
 				'.gh-header-sticky',
 			])
 			// First link in the summary row is always the author
-			&& $('a', byline).textContent === (await elementReady(prCreatorSelector))!.textContent;
+			&& $('a', summaryRow).textContent === (await elementReady(prCreatorSelector))!.textContent;
 
 	if (shouldHideAuthor) {
-		byline.classList.add('rgh-hide-author');
+		summaryRow.classList.add('rgh-hide-author');
 	}
 
 	const base = $([
@@ -54,7 +54,7 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 		// Old views - TODO: Remove after July 2026
 		'.commit-ref',
 		'[class^="BranchName"]',
-	], byline);
+	], summaryRow);
 
 	let baseBranch;
 	if (base.title) {
@@ -68,7 +68,7 @@ async function cleanPrHeader(byline: HTMLElement): Promise<void> {
 
 	// Shows on PRs: main [←] feature
 	const anchor
-		= $optional('.commit-ref-dropdown', byline)?.nextSibling // TODO: remove after July 2026
+		= $optional('.commit-ref-dropdown', summaryRow)?.nextSibling // TODO: remove after July 2026
 			?? base.nextSibling!.nextSibling!;
 	assertNodeContent(anchor, 'from');
 


### PR DESCRIPTION
Fixes #9001

All of these selectors target the summary row, which always contains three links: one to the author/person who merged the PR (always first in the DOM), and two to branches:

https://github.com/refined-github/refined-github/blob/88883bcfc7fbb8e99c53b57fa087acc5718c132b/source/features/clean-conversation-headers.tsx#L85-L91

Alternative solution would be to use `elementReady`

## Test URLs

https://github.com/refined-github/refined-github/pulls

## Screenshot

![msedge_iNnYFMvNhv](https://github.com/user-attachments/assets/e32df59c-bfa8-462a-ae14-b4cd27dbfd57)
