### PR TITLE
Open and highlight targeted feature in options page

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -55,7 +55,13 @@ handleMessages({
 		const response = await fetch(url);
 		return response.json();
 	},
-	async openOptionsPage() {
+	async openOptionsPage(targetFeature: true | string) {
+		if (typeof targetFeature === 'string') {
+			return chrome.tabs.create({
+				url: chrome.runtime.getURL(`assets/options.html#${encodeURIComponent(targetFeature)}`),
+			});
+		}
+
 		return chrome.runtime.openOptionsPage();
 	},
 	async getStyleHotfixes() {

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -126,7 +126,9 @@ async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {
 			text: 'You disabled this feature on GitHub.com.',
 			classes: [...classes, 'flash-warn'],
 			icon: <AlertIcon className="mr-0" />,
-			action: openOptions,
+			action(event) {
+				openOptions(event, id);
+			},
 			buttonLabel: 'Refined GitHub Options',
 		});
 	}

--- a/source/helpers/open-options.tsx
+++ b/source/helpers/open-options.tsx
@@ -1,9 +1,9 @@
 import React from 'dom-chef';
 import {messageRuntime} from 'webext-msg';
 
-export default function openOptions(event: Event | React.UIEvent): void {
+export default function openOptions(event: Event | React.UIEvent, featureId?: string): void {
 	event.preventDefault();
-	void messageRuntime({openOptionsPage: true});
+	void messageRuntime({openOptionsPage: featureId ?? true});
 }
 
 export function OptionsLink(): JSX.Element {

--- a/source/options.css
+++ b/source/options.css
@@ -166,6 +166,17 @@ summary:hover {
 	opacity: 80%;
 }
 
+#features :target {
+	scroll-margin-top: 80px;
+}
+
+#features .feature:has(:target) {
+	background: light-dark(#ddf4ff, #033a6b);
+	outline: 2px solid light-dark(#0969da, #1f6feb);
+	border-radius: 6px;
+	padding-inline: 0.3em;
+}
+
 .feature-link {
 	margin: 0 0.6em;
 }

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -66,6 +66,27 @@ function updateRateLink(): void {
 	$('a#rate-link').href = isFirefox() ? 'https://addons.mozilla.org/en-US/firefox/addon/refined-github-' : 'https://apps.apple.com/app/id1519867270?action=write-review';
 }
 
+function focusFeatureFromHash(): void {
+	const hash = decodeURIComponent(location.hash.slice(1));
+	if (!hash) {
+		return;
+	}
+
+	const target = $optional('#' + CSS.escape(hash));
+	if (!target) {
+		return;
+	}
+
+	$('details#features').open = true;
+	const featureFilter = $('input#filter-features');
+	if (featureFilter.value) {
+		featureFilter.value = '';
+		featureFilter.dispatchEvent(new Event('input'));
+	}
+
+	target.closest('.feature')?.scrollIntoView({behavior: 'smooth', block: 'center'});
+}
+
 function isEnterprise(): boolean {
 	return syncedForm!.getSelectedDomain() !== 'default';
 }
@@ -131,6 +152,8 @@ async function generateDom(): Promise<void> {
 	if (doesBrowserActionOpenOptions) {
 		$('#action').hidden = true;
 	}
+
+	focusFeatureFromHash();
 
 	// Show stored CSS hotfixes
 	void showStoredCssHotfixes();


### PR DESCRIPTION
## Summary
- allow openOptions to pass a target feature id to the background script
- open assets/options.html#<feature-id> when a feature-specific options button is clicked
- auto-open the Features section and scroll to the targeted feature on options load
- add :target styling and scroll margin so the selected feature is clearly highlighted

## Testing
- npm run build:typescript

Closes #8833