### PR TITLE
`pr-first-commit-title` - Restore on compare pages with few commits

### DIFF
--- a/source/features/pr-first-commit-title.tsx
+++ b/source/features/pr-first-commit-title.tsx
@@ -39,14 +39,13 @@ function getFirstCommit(firstCommit: HTMLElement): {title: string; body: string 
 
 function useCommitTitle(firstCommitElement: HTMLElement): void {
 	const requestedContent = new URL(location.href).searchParams;
-	const commitCountIcon = $optional([
+	const commitCount = $([
 		// Few commits
-		'div.Box:is(.tmp-mb-3, .mb-3) .octicon-git-commit',
+		'div.Box:is(.tmp-mb-3, .mb-3) .octicon-git-commit + span',
 		// Many commits (rendered in tabs)
-		'a[href="#commits_bucket"] .octicon-git-commit',
+		'a[href="#commits_bucket"] .Counter',
 	]);
-	const commitCount = commitCountIcon?.nextElementSibling;
-	if (!commitCount || looseParseInt(commitCount) < 2 || !elementExists('#new_pull_request')) {
+	if (looseParseInt(commitCount) < 2 || !elementExists('#new_pull_request')) {
 		return;
 	}
 


### PR DESCRIPTION
This fixes:

```
errors.js:77 ❌ Refined GitHub: pr-first-commit-title
errors.js:78 📕 26.2.19 → ElementNotFoundError: Expected element not found: div.Box.mb-3 .octicon-git-commit,a[href="#commits_bucket"] .octicon-git-commit
    at expectElement (select-dom.js:21:11)
    at useCommitTitle (pr-first-commit-title.js:38:26)
    at globalThis.addEventListener.once.once (selector-observer.js:88:3)
```

## Test URLs

https://github.com/refined-github/sandbox/compare/rendered-commit-title?expand=1
