### PR TITLE
Meta: remove `emoji-regex-xs` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 				"dom-loaded": "^3.1.0",
 				"doma": "^4.0.0",
 				"element-ready": "^9.0.2",
-				"emoji-regex-xs": "^2.0.1",
 				"filter-altered-clicks": "^2.1.1",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
@@ -4044,15 +4043,6 @@
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/emoji-regex-xs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
-			"integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/enhance-visitors": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 		"dom-loaded": "^3.1.0",
 		"doma": "^4.0.0",
 		"element-ready": "^9.0.2",
-		"emoji-regex-xs": "^2.0.1",
 		"filter-altered-clicks": "^2.1.1",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -1,7 +1,6 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import batchedFunction from 'batched-function';
-import getEmojiRegex from 'emoji-regex-xs';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -12,8 +11,6 @@ import {usernameLinksSelector} from '../github-helpers/selectors.js';
 import {expectToken} from '../github-helpers/github-token.js';
 import attachElement from '../helpers/attach-element.js';
 import abortableClassName from '../helpers/abortable-classname.js';
-
-const emojiRegex = getEmojiRegex();
 
 async function dropExtraCopy(link: HTMLAnchorElement): Promise<void> {
 	// Drop 'commented' label to shorten the copy
@@ -83,7 +80,7 @@ async function updateLinks(found: HTMLAnchorElement[]): Promise<void> {
 		const userKey = api.escapeKey(username);
 		const {name: fullName} = names[userKey];
 
-		const fullNameWithoutEmoji = fullName?.replace(emojiRegex, '').trim();
+		const fullNameWithoutEmoji = fullName?.replaceAll(/\p{RGI_Emoji}/gv, '').trim();
 
 		// Could be `null` if not set or empty string if consisting only of emojis
 		if (!fullNameWithoutEmoji) {


### PR DESCRIPTION
https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape

https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets

## Test URLs

https://github.com/typescript-eslint/tsgolint/pull/2

## Screenshot

<img width="676" height="220" alt="image" src="https://github.com/user-attachments/assets/23a1f02b-cd02-4a3a-a160-e1a85563564a" />
