### PR TITLE
`clean-conversation-sidebar` - Restore feature on issues

### DIFF
--- a/source/features/clean-conversation-sidebar.css
+++ b/source/features/clean-conversation-sidebar.css
@@ -1,3 +1,21 @@
+html:not([rgh-OFF-clean-conversation-sidebar]) {
+	div[class^='IssueSidebar-module__sidebarContent'] {
+		div[class*='SectionContainer'] {
+			&:has(span[class*='emptyText']):not(:has(.octicon-gear)) {
+				display: none;
+			}
+
+			span:is([class*='emptyText'], [class*='developmentHelpText']):not(
+					:has(> button)
+				) {
+				display: none;
+			}
+		}
+	}
+}
+
+/* Legacy styles */
+
 /* Adjust spacing of empty sections */
 .discussion-sidebar-item.rgh-clean-sidebar {
 	margin-bottom: -5px;

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -80,8 +80,8 @@ function cleanSection(selector: string): boolean {
 	return true;
 }
 
-async function cleanSidebar(): Promise<void> {
-	$('#partial-discussion-sidebar').classList.add('rgh-clean-sidebar');
+async function cleanSidebarLegacy(sidebar: HTMLElement): Promise<void> {
+	sidebar.classList.add('rgh-clean-sidebar');
 
 	// Assignees
 	const assignees = $('.js-issue-assignees');
@@ -135,7 +135,7 @@ async function cleanSidebar(): Promise<void> {
 }
 
 function init(signal: AbortSignal): void {
-	observe('#partial-discussion-sidebar', cleanSidebar, {signal});
+	observe('#partial-discussion-sidebar', cleanSidebarLegacy, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -145,6 +145,8 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // The sidebar is at the end of the page + it needs to be fully loaded
 	init,
 });
+
+void features.addCssFeature(import.meta.url);
 
 /*
 


### PR DESCRIPTION
fixes #8024 

## Test URLs

https://github.com/refined-github/sandbox/issues/15

## Screenshot

### With write access 

<img width="376" height="821" alt="image" src="https://github.com/user-attachments/assets/810fae91-1782-4ed5-8703-ea4c7bd1f8e7" />

### Without write access

<img width="332" height="230" alt="image" src="https://github.com/user-attachments/assets/388f8aa0-8e92-4430-b956-0378045e10f2" />