### PR TITLE
`netiquette` - Don't suggest opening new issues if not possible

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -54,18 +54,17 @@ function isPopular(): boolean {
 
 export function getResolvedText(closingDate: Date): JSX.Element {
 	const ago = <strong>{twas(closingDate.getTime())}</strong>;
-	const canOpenNewIssue = elementExists('li:has([data-content="Issues"])');
 	const newIssue = <a href={buildRepoURL('issues/new/choose')}>new issue</a>;
 	return (
 		<>
-			This {pageDetect.isPR() ? 'PR' : 'issue'} was closed {ago}.
-			{canOpenNewIssue && <> Please consider opening a {newIssue} instead of leaving a comment here.</>}
+			This {pageDetect.isPR() ? 'PR' : 'issue'} was closed {ago}. Please consider opening a {newIssue} instead of leaving a comment here.
 		</>
 	);
 }
 
 function addResolvedBanner(newCommentField: HTMLElement, closingDate: Date): void {
-	if (elementExists('.rgh-resolved-banner')) {
+	const canOpenNewIssue = elementExists('li:has([data-content="Issues"])');
+	if (!canOpenNewIssue || elementExists('.rgh-resolved-banner')) {
 		return;
 	}
 


### PR DESCRIPTION
This prevents the new issue link from being displayed if issues are disabled. `rgh-netiquette` is similarly affected, but the copy isn't as easily updated.

## Test URLs
https://github.com/palera1n/loader/pull/66

## Screenshot
| Before | After |
| --- | --- |
| <img width="1616" height="530" alt="PixelSnap 2026-03-02 at 20 32 38@2x" src="https://github.com/user-attachments/assets/0b665d34-2789-4c73-9796-62ccdbe7880a" /> | <img width="1616" height="530" alt="PixelSnap 2026-03-02 at 20 32 21@2x" src="https://github.com/user-attachments/assets/9f500fc6-6520-4653-96d7-6c193826bab7" /> |

