### PR TITLE
Bump `github-url-detection` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
 				"github-reserved-names": "^2.1.1",
-				"github-url-detection": "^11.1.2",
+				"github-url-detection": "^11.1.3",
 				"indent-textarea": "^4.0.0",
 				"js-abbreviation-number": "^1.4.0",
 				"linkify-issues": "^4.2.0",
@@ -5822,9 +5822,9 @@
 			"license": "MIT"
 		},
 		"node_modules/github-url-detection": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-11.1.2.tgz",
-			"integrity": "sha512-JK5prSxl03m1Dz41YgaMAChPjJzi/quOR4lp3VeOv+0b/EGHhlJ0lwWKGQSRNmm3n7GlG+YpgLI7TMbkSd/lDw==",
+			"version": "11.1.3",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-11.1.3.tgz",
+			"integrity": "sha512-yIi7NJ34EYfwX7o3GhxlJKqflQsVq/CiOI8Q1DtQgQ22kaaodua4+efJ51GSLynhVx/fCweW8BIKVHvtBQV/WQ==",
 			"license": "MIT",
 			"dependencies": {
 				"github-reserved-names": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
 		"github-reserved-names": "^2.1.1",
-		"github-url-detection": "^11.1.2",
+		"github-url-detection": "^11.1.3",
 		"indent-textarea": "^4.0.0",
 		"js-abbreviation-number": "^1.4.0",
 		"linkify-issues": "^4.2.0",

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -21,7 +21,8 @@ void features.add(import.meta.url, {
 	],
 	exclude: [
 		() => elementExists(['[data-hotkey="t"]', '[data-hotkey="t,Shift+T"]']),
-		pageDetect.isEmptyRepo,
+		// TODO: Detect empty repos differently or fail gracefully
+		pageDetect.isEmptyRepoRoot,
 		pageDetect.isPRFiles,
 		pageDetect.isFileFinder,
 	],


### PR DESCRIPTION
Affects features that use:

- `isPrivateUserProfile`:
	- `user-profile-follower-badge` (fixes #8952)
- `isOrganizationRepo`:
	- `repo-avatars` (https://github.com/refined-github/refined-github/pull/8971#issuecomment-3896679736)
	- `quick-repo-deletion`
- `isEmptyRepoRoot`:
	- `repo-age` (fixes #9014)
- `isEmptyRepo`:
	- `repo-wide-file-finder`
- `canUserAdminRepo`:
	- `clean-repo-sidebar`
	
https://github.com/refined-github/github-url-detection/releases/tag/v11.1.3