### PR TITLE
`pr-first-commit-title` - Restore feature

### DIFF
--- a/source/features/pr-first-commit-title.tsx
+++ b/source/features/pr-first-commit-title.tsx
@@ -8,12 +8,12 @@ import looseParseInt from '../helpers/loose-parse-int.js';
 import observe from '../helpers/selector-observer.js';
 import parseRenderedText from '../github-helpers/parse-rendered-text.js';
 
-function getFirstCommit(firstCommit: HTMLElement): {title: string; body: string | undefined} {
-	const body = $optional('.Details-content--hidden pre', firstCommit.parentElement!)
+function getFirstCommit(firstCommitTitle: HTMLElement): {title: string; body: string | undefined} {
+	const body = $optional('.Details-content--hidden pre', firstCommitTitle.parentElement!)
 		?.textContent
 		.trim() ?? undefined;
 
-	const title = parseRenderedText(firstCommit, ({nodeName}) =>
+	const title = parseRenderedText(firstCommitTitle, ({nodeName}) =>
 		// Exclude expand body button
 		nodeName === 'BUTTON' ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT,
 	);
@@ -21,7 +21,7 @@ function getFirstCommit(firstCommit: HTMLElement): {title: string; body: string 
 	return {title, body};
 }
 
-function useCommitTitle(firstCommitElement: HTMLElement): void {
+function useCommitTitle(firstCommitTitle: HTMLElement): void {
 	const requestedContent = new URL(location.href).searchParams;
 	const commitCount = $([
 		// Few commits
@@ -33,7 +33,7 @@ function useCommitTitle(firstCommitElement: HTMLElement): void {
 		return;
 	}
 
-	const firstCommit = getFirstCommit(firstCommitElement);
+	const firstCommit = getFirstCommit(firstCommitTitle);
 
 	if (!requestedContent.has('pull_request[title]')) {
 		setFieldText(


### PR DESCRIPTION
https://github.blog/changelog/2026-02-25-generate-pull-request-titles-with-copilot-on-the-web/

and fixes + cleanup

## Test URLs

https://github.com/refined-github/sandbox/compare/9012-2?expand=1

## Screenshot

<img width="253" height="238" alt="image" src="https://github.com/user-attachments/assets/26b7f1bc-2867-40c7-b46d-f317bbc288b1" />