### PR TITLE
`suggest-commit-title-limit` - Fix "bypass rules" checkbox width

### DIFF
--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -5,7 +5,7 @@
 /* Limit width of commit title to 72 characters */
 .rgh-suggest-commit-title-limit
 :is(
-	[data-testid='mergebox-partial'] input:not([type='checkbox']),
+	[data-testid='mergebox-partial'] input[type='text'],
 	#commit-message-input,
 	/* TODO: Remove after July 2026 */
 		#commit-summary-input

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -13,7 +13,7 @@ import setReactInputValue from '../helpers/set-react-input-value.js';
 import {confirmMergeButton} from '../github-helpers/selectors.js';
 import parseRenderedText from '../github-helpers/parse-rendered-text.js';
 
-const commitTitleFieldSelector = '[data-testid="mergebox-partial"] input';
+const commitTitleFieldSelector = '[data-testid="mergebox-partial"] input[type="text"]';
 
 function getCurrentCommitTitleField(): HTMLInputElement | undefined {
 	return $optional(commitTitleFieldSelector);

--- a/source/github-events/on-commit-title-update.ts
+++ b/source/github-events/on-commit-title-update.ts
@@ -2,7 +2,7 @@ import delegate, {type DelegateEventHandler} from 'delegate-it';
 
 const fieldSelector = [
 	// PR merge message field
-	'[data-testid="mergebox-partial"] input',
+	'[data-testid="mergebox-partial"] input[type="text"]',
 	// Commit title on edit file page
 	'#commit-message-input',
 	// Commit title on edit file page before some update - TODO: Remove after July 2026


### PR DESCRIPTION
Fixes #9038

Avoid changing width of the checkbox input

Looks like the change to the CSS rule in #8933 caused this.

## Test URLs



## Screenshot

<img width="871" height="289" alt="image" src="https://github.com/user-attachments/assets/b8bc781a-d4da-47d4-bfe0-314797ce65f9" />
