### PR TITLE
`new-or-deleted-file` - Fix icons aligment

### DIFF
--- a/source/features/new-or-deleted-file.tsx
+++ b/source/features/new-or-deleted-file.tsx
@@ -38,7 +38,7 @@ function maybeAddIcon(fileHeader: HTMLDivElement): void {
 	], fileInList)
 		?.cloneNode(true);
 	if (icon) {
-		fileHeader.append(<div className="ml-1 d-flex">{icon}</div>);
+		fileHeader.append(<div className="d-flex ml-1">{icon}</div>);
 	}
 }
 


### PR DESCRIPTION
Initially, I just wanted to add a check if we're on the React-based view to add the `d-flex` class accordingly. But after looking at the logic and the DOM, I saw there wasn't much overlap. Given that and the fact that old view will most likely be dropped in a month or two I decided to split the code into two functions

Code for the old view was restored from: https://github.com/refined-github/refined-github/blob/1342aee09ebd9cec17e0adc708c1ce8bd949d9d2/source/features/new-or-deleted-file.tsx

## Test URLs

https://github.com/refined-github/sandbox/commit/a00694ff7370d46b5f6d723a0b39141903dae45a

## Screenshot

| Before | After |
|--------|--------|
| <img width="356" height="360" alt="image" src="https://github.com/user-attachments/assets/82cf4959-0a09-4412-9373-78be8dc45325" /> | <img width="385" height="346" alt="image" src="https://github.com/user-attachments/assets/502c53d9-3884-44ff-bbd1-f62d05992642" /> | 