### PR TITLE
`sticky-sidebar` - Enable on more pages

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -5,17 +5,21 @@
 	z-index: initial !important; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
 }
 
-/*
-Have the calculations available even when the sidebar isn't sticky so that `--rgh-sticky-sidebar-offset` can be used via JS.
-
-Exclusively use simple sums and use `0px` instead of `0`
-*/
-.rgh-sticky-sidebar-container {
+.rgh-sidebar {
+	height: min-content;
+	/*
+	Have the calculations available even when the sidebar isn't sticky so that `--rgh-sticky-sidebar-offset` can be used via JS.
+	Exclusively use simple sums and use `0px` instead of `0`
+	*/
 	--rgh-sticky-sidebar-minimal-margin: 16px;
 	--rgh-sticky-sidebar-offset: calc(
 		var(--rgh-sticky-header-height, var(--rgh-sticky-sidebar-minimal-margin)) +
 		var(--rgh-sticky-notification-header-height, 0px)
 	);
+	&.rgh-sticky-sidebar {
+		position: sticky;
+		top: var(--rgh-sticky-sidebar-offset) !important;
+	}
 }
 
 #discussion_bucket /* `isDiscussion`, old `isConversation` */,
@@ -30,18 +34,9 @@ react-app[app-name='issues-react'] {
 	--rgh-sticky-notification-header-height: 69px;
 }
 
-/* required to make `sticky` work for the issue Sidebar */
-.rgh-sticky-sidebar-container {
-	display: unset !important;
-}
-
-.rgh-sticky-sidebar {
-	position: sticky;
-	top: var(--rgh-sticky-sidebar-offset, 0) !important;
-}
-
-#discussion_bucket #partial-discussion-sidebar.rgh-sticky-sidebar-container {
-	height: min-content;
+/* `isRepoRoot` */
+.repository-content .rgh-sticky-sidebar {
+	--rgh-sticky-sidebar-offset: 0px;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -12,7 +12,7 @@ import calculateCssCalcString from '../helpers/calculate-css-calc-string.js';
 const minimumViewportWidthForSidebar = 768; // Less than this, the layout is single-column
 
 const sidebarSelector = [
-	'.Layout-sidebar .BorderGrid', // `isRepoRoot`
+	'.repository-content .Layout-sidebar .BorderGrid', // `isRepoRoot`
 	'.Layout-sidebar #partial-discussion-sidebar', // Old `isConversation`
 	'div[data-testid="issue-viewer-metadata-pane"]', // `isConversation`
 	'#discussion_bucket #partial-discussion-sidebar', // `isDiscussion`
@@ -46,13 +46,12 @@ function trackSidebar(signal: AbortSignal, foundSidebar: HTMLElement): void {
 	}
 
 	sidebar = foundSidebar;
+	sidebar.classList.add('rgh-sidebar');
+
 	sidebarObserver.observe(sidebar);
 	onAbort(signal, sidebarObserver, () => {
 		sidebar = undefined;
 	});
-
-	const container = sidebar.parentElement!.id === 'discussion_bucket' ? sidebar : sidebar.parentElement!;
-	container.classList.add('rgh-sticky-sidebar-container');
 
 	sidebar.addEventListener('mouseenter', toggleHoverState, {signal});
 	sidebar.addEventListener('mouseleave', toggleHoverState, {signal});


### PR DESCRIPTION
Because why not. That's better than leaving the space empty. Feel free to close without comments if you disagree.

I'll extract cleanup and improvements from #8979 to a separate PR once this PR is closed or merged.

## Test URLs

https://github.com/fregante

https://github.com/refined-github

https://github.com/settings/profile

https://github.com/refined-github/refined-github/settings

https://github.com/refined-github/refined-github/wiki/Contributing

https://github.com/eslint/eslint/discussions

## Screenshot

<img width="1328" height="918" alt="image" src="https://github.com/user-attachments/assets/8b280fff-069b-474a-b345-1f954a51cf21" />

---

<img width="996" height="628" alt="image" src="https://github.com/user-attachments/assets/0a46225f-d27b-4ac5-85fa-d9d37bc2032b" />
