### PR TITLE
`sync-pr-commit-title` - Support more merge methods

### DIFF
--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -49,7 +49,8 @@ function needsSubmission(): boolean {
 		return false;
 	}
 
-	return createCommitTitle() !== getCurrentCommitTitle()!;
+	const currentCommitTitle = getCurrentCommitTitle()!;
+	return Boolean(currentCommitTitle) && (createCommitTitle() !== currentCommitTitle);
 }
 
 function getUI(): HTMLElement {


### PR DESCRIPTION
I don't think we should do `textContent.includes('Confirm') && textContent.includes('squash')`

## Test URLs


## Screenshot

GH source code:

<img width="847" height="514" alt="image" src="https://github.com/user-attachments/assets/9673f3d3-8b18-4edb-b067-6240ef17425c" />
