### PR TITLE
`improve-shortcut-help` - Restore dialog height change

### DIFF
--- a/source/features/improve-shortcut-help.css
+++ b/source/features/improve-shortcut-help.css
@@ -1,5 +1,5 @@
 html:not([rgh-OFF-improve-shortcut-help]) {
-	div[class^='ShortcutsDialog-module__ShortcutsDialogRoot'] {
+	div[aria-modal='true'][class*='ShortcutsDialogRoot'] {
 		height: auto;
 	}
 }


### PR DESCRIPTION
the component was renamed from "ShortcutsDialog" to "KeyboardShortcutsDialog"

## Test URLs


## Screenshot
