### PR TITLE
Fix token expiration date parsing in Safari

### DIFF
--- a/source/github-helpers/github-token.ts
+++ b/source/github-helpers/github-token.ts
@@ -101,9 +101,12 @@ type TokenInfo = {
 
 export async function getTokenInfo(apiBase: string, personalToken: string): Promise<TokenInfo> {
 	const {headers} = await baseApiFetch({apiBase, token: personalToken, path: ''});
+
 	const expiration = headers.get('GitHub-Authentication-Token-Expiration');
-	// Convert `2026-06-03 19:52:44 UTC` to `2026-06-03T19:52:44Z` #9043
+	// Convert `2026-06-03 19:52:44 UTC` to `2026-06-03T19:52:44Z`
+	// So that `Date` constructor in Safari can parse it: #9043
 	const expirationTransformed = expiration?.replace(' ', 'T').replace(' UTC', 'Z');
+
 	return {
 		scopes: parseTokenScopes(headers),
 		expiration: expirationTransformed,


### PR DESCRIPTION
fixes #9043 

`2026-06-03 19:52:44 UTC` -> `2026-06-03T19:52:44Z`

https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format

https://stackoverflow.com/questions/60816691

## Test URLs


## Screenshot
