### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ GitHub Enterprise is also supported: [How to enable it](https://fregante.github.
 
 ## Install
 
-[link-chrome]: https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf 'Version published on Chrome Web Store'
+[link-chrome]: https://chromewebstore.google.com/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf 'Version published on Chrome Web Store'
 [link-firefox]: https://addons.mozilla.org/firefox/addon/refined-github-/ 'Version published on Mozilla Add-ons'
 [link-safari]: https://apps.apple.com/app/id1519867270 'Version published on the Mac App Store'
 

--- a/source/options.html
+++ b/source/options.html
@@ -12,7 +12,7 @@
 <rgh-header title="Refined GitHub">
 	<p>
 		Visit the <a href="https://github.com/refined-github/refined-github/wiki">wiki</a> to learn about updates, debugging, and GitHub Enterprise.
-		You can <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
+		You can <a href="https://chromewebstore.google.com/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf/reviews" id="rate-link">rate Refined GitHub</a> to help others find it.
 		Follow or sponsor <a href="https://github.com/sponsors/fregante">@fregante</a> if Refined GitHub helps you work more efficiently. 🍻
 	</p>
 </rgh-header>


### PR DESCRIPTION
## Summary
- Update Chrome Web Store URLs from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/`
- Google migrated CWS to the new domain; old URLs redirect but this avoids unnecessary redirects

## Changes
- `readme.md`: 1 URL updated
- `source/options.html`: 1 URL updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)