### PR TITLE
`linkify-code` - Restore on inline review comments

### DIFF
--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -18,7 +18,7 @@ export const codeElementsSelector = [
 	// Sometimes formatted diffs are loaded later and discard our formatting #5870
 	'.blob-code-inner:not(deferred-diff-lines.awaiting-highlight *)', // Code lines
 	':is(.snippet-clipboard-content, .highlight) > pre.notranslate', // Code blocks in comments. May be wrapped twice
-	'.comment-body code:not(a code, pre code)', // Inline code in comments
+	'.markdown-body code:not(a code, pre code)', // Inline code in comments
 	'.diff-text-inner',
 	'.react-file-line',
 ];


### PR DESCRIPTION

## Test URLs

https://github.com/refined-github/refined-github/pull/9036/changes#r2899180532

## Screenshot

<img width="654" height="243" alt="image" src="https://github.com/user-attachments/assets/258277c8-2d70-4c80-a9f4-b74c21283f02" />
