### PR TITLE
Hide `repo-avatars` for custom pages, like codespaces

### DIFF
--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -7,11 +7,21 @@ import getUserAvatar from '../github-helpers/get-user-avatar.js';
 import observe from '../helpers/selector-observer.js';
 import {isSmallDevice} from '../helpers/dom-utils.js';
 
+// Some subpages act just like repository headers but don't belong to any user or organization,
+// therefore there is no avatar to show.
+const disallowedOwners = new Set([
+	'codespaces',
+]);
+
 async function add(ownerLabel: HTMLElement): Promise<void> {
 	// TODO: Drop after June 2026
 	const isOldNavbar = ownerLabel.classList.contains('AppHeader-context-item-label');
 
 	const username = getRepo()!.owner;
+	if (disallowedOwners.has(username.toLowerCase())) {
+		return;
+	}
+
 	const size = 16;
 	const source = getUserAvatar(username, size)!;
 


### PR DESCRIPTION
The custom page "Create new Codespaces" seems to have the same DOM tree than a normal repository. 
Therefore, the `repo-avatars` feature tried to fetch an avatar for it. 

I added a denyList/set of "owners" that don't have avatars as they are GitHub special pages. Currently, I only found it on the Codespaces site, but I assume that there are more. The list is currently hardcoded. 

Maybe, a more permanent solution would be to integrate a feature into `github-url-detection` in order to detect these special pages and not identify these as repositories. 


## Test URLs
https://github.com/codespaces/new
https://github.com/refined-github/refined-github (nothing changed)

## Screenshot

Before:
<img width="221" height="49" alt="Bildschirmfoto 2026-03-08 um 18 49 43" src="https://github.com/user-attachments/assets/6809a238-0152-4737-8e71-5b91938fc879" />

After:
<img width="223" height="57" alt="Bildschirmfoto 2026-03-08 um 19 32 10" src="https://github.com/user-attachments/assets/a2cf0308-6347-44f3-95b1-b7104112b923" />
