### PR TITLE
`parse-backticks` - Enable for sticky PR files header

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -18,6 +18,10 @@ const selectors = [
 	// https://github.com/refined-github/sandbox/pull/55#commits-pushed-d4852bb
 	'.TimelineItem-body pre',
 
+	// `isPRFiles` sticky header PR title
+	// https://github.com/refined-github/refined-github/pull/9053/changes
+	'bdi[class*="pr-sticky-title"]',
+
 	// `isReleasesOrTags` Headers
 	// https://github.com/refined-github/sandbox/releases/tag/cool
 	'.Box-body h1',


### PR DESCRIPTION


## Test URLs

https://github.com/refined-github/refined-github/pull/9053/changes

## Screenshot

<img width="548" height="66" alt="image" src="https://github.com/user-attachments/assets/05fc78b6-51aa-42a1-8229-abc269dd998a" />
