### PR TITLE
`more-file-links`, `restore-file` - Small fixes

### DIFF
--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -41,16 +41,25 @@ function getMenuItem(viewFile: HTMLElement, name: string, route: string, icon: R
 	return menuItem;
 }
 
-function handleMenuOpening(): void {
-	const viewFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-eye)');
-	viewFile.after(
-		getMenuItem(viewFile, 'raw', 'raw', <FileCodeIcon />),
-		getMenuItem(viewFile, 'blame', 'blame', <VersionsIcon />),
-		getMenuItem(viewFile, 'history', 'commits', <HistoryIcon />),
-		viewFile.nextElementSibling?.getAttribute('data-component') === 'ActionList.Divider'
-			? ''
-			: <li className="dropdown-divider" aria-hidden="true" data-component="ActionList.Divider" />,
-	);
+function handleMenuOpening({delegateTarget: menuButton}: DelegateEvent): void {
+	// Don't run if the menu has been closed
+	if (menuButton.ariaExpanded === 'false') {
+		return;
+	}
+
+	// Wait for the menu DOM to be created, but not rendered
+	requestAnimationFrame(() => {
+		const viewFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-eye)');
+		const {nextElementSibling} = viewFile;
+		viewFile.after(
+			getMenuItem(viewFile, 'raw', 'raw', <FileCodeIcon />),
+			getMenuItem(viewFile, 'blame', 'blame', <VersionsIcon />),
+			getMenuItem(viewFile, 'history', 'commits', <HistoryIcon />),
+			!nextElementSibling || nextElementSibling.getAttribute('data-component') === 'ActionList.Divider'
+				? ''
+				: <li className="dropdown-divider" aria-hidden="true" data-component="ActionList.Divider" />,
+		);
+	});
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -154,12 +154,16 @@ function addLegacyMenuItem(editFile: HTMLAnchorElement): void {
 	);
 }
 
-// New React view handler: track the file container and add menu item
-function handleMenuOpening({delegateTarget}: DelegateEvent<MouseEvent, HTMLElement>): void {
-	// Track the file container for later removal
-	focusedFileContainer = delegateTarget.closest('div[id^="diff-"]')!;
+function handleMenuOpening({delegateTarget: menuButton}: DelegateEvent): void {
+	// Don't run if the menu has been closed
+	if (menuButton.ariaExpanded === 'false') {
+		return;
+	}
 
-	// Wait for the menu to be rendered
+	// Track the file container for later removal
+	focusedFileContainer = menuButton.closest('div[id^="diff-"]')!;
+
+	// Wait for the menu DOM to be created, but not rendered
 	requestAnimationFrame(() => {
 		const editFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-pencil)');
 		const discardItem = editFile.cloneNode(true);


### PR DESCRIPTION
Fixes `restore-file` adding an extra divider to the deleted file menu

<details>
<summary></summary>

https://github.com/refined-github/refined-github/pull/8757#discussion_r2509789081

It is not in the menu if the file was deleted

</details>

Fixes `restore-file` & `more-file-links` trying to append elements to the menu when it has been closed, resulting in console errors

## Test URLs

https://github.com/MicaForEveryone/MicaForEveryone/commit/17a5cd4b9efa9a991c7c7cee7279c5cb49b4734a#diff-390646ccf6d32f5046781bf9358274fb1e2d190cb2e8eeb4999a40511878422e

## Screenshot

| Before | After |
|--------|--------|
| <img width="212" height="214" alt="image" src="https://github.com/user-attachments/assets/1562282b-aaf8-415a-9a7d-46249535e30d" /> | <img width="232" height="226" alt="image" src="https://github.com/user-attachments/assets/b2ad14e9-db40-47c7-92f6-3df712b651d2" /> | 

