### PR TITLE
`clean-conversation-headers` - Fix PR summary row position on small screens

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -23,8 +23,6 @@ async function highlightNonDefaultBranchPRs(base: HTMLElement, baseBranch: strin
 
 async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 	summaryRow.classList.add('rgh-clean-conversation-headers');
-	// TODO: Remove after July 2026
-	summaryRow.parentElement!.closest('.d-flex')?.classList.add('flex-items-center');
 
 	const prCreatorSelector = [
 		'.TimelineItem .author',


### PR DESCRIPTION
This creates a misalignment:

<img width="793" height="88" alt="image" src="https://github.com/user-attachments/assets/6f5a60b0-d63f-4a9d-bec2-8a49b6676fcb" />

However, I think it's a minor issue compared to the current one. Plus, GitHub is to blame for it, not us

## Test URLs

https://github.com/refined-github/refined-github/pull/9067

## Screenshot

| Before | After |
|--------|--------|
| <img width="500" height="591" alt="image" src="https://github.com/user-attachments/assets/87567458-49b1-42ec-bd35-0053a6a92207" /> | <img width="494" height="588" alt="image" src="https://github.com/user-attachments/assets/2ef08a89-5918-41a1-a0a9-6d94d789d4bb" /> | 