### PR TITLE
`suggest-commit-title-limit` - Validate PR title when entering editing mode

### DIFF
--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -28,10 +28,6 @@ async function validatePrTitle(field: HTMLInputElement): Promise<void> {
 	field.classList.toggle('rgh-title-over-limit', prTitle.length > limit);
 }
 
-function unload(): void {
-	features.unload(import.meta.url);
-}
-
 const currentPrTitleSelectors = [
 	'[class^="prc-PageLayout-Header"] input', // `isPR`
 	'input[name="pull_request[title]"]', // `isCompare`
@@ -52,7 +48,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe(currentPrTitleSelectors, validatePrTitle, {signal});
 
 	await waitForPrMerge(signal);
-	unload();
+	features.unload(import.meta.url);
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION


## Test URLs

https://github.com/refined-github/refined-github/pull/9079

## Screenshot

Before:

![msedge_o0QyRODv7a](https://github.com/user-attachments/assets/fb215d7e-1ab0-4735-8363-a980335805d6)

After:

![msedge_1Jdy1pPFm2](https://github.com/user-attachments/assets/566f878b-16c6-43bf-8d92-6729def61f64)