### PR TITLE
`parse-backticks` - Enable for linked PR titles

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -18,6 +18,10 @@ const selectors = [
 	// https://github.com/refined-github/sandbox/pull/55#commits-pushed-d4852bb
 	'.TimelineItem-body pre',
 
+	// `isIssue` linked PRs
+	// https://github.com/refined-github/refined-github/issues/7856
+	'span[id$="--label"]',
+
 	// `isPRFiles` sticky header PR title
 	// https://github.com/refined-github/refined-github/pull/9053/changes
 	'bdi[class*="pr-sticky-title"]',


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

If you haven't done so yet, check out the Contributing page in the wiki: https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines

-->



## Test URLs

https://github.com/refined-github/refined-github/issues/7856

## Screenshot

| Before | After |
|--------|--------|
| <img width="303" height="217" alt="image" src="https://github.com/user-attachments/assets/250284a0-9f14-4018-aad0-477131f10122" /> | <img width="304" height="232" alt="image" src="https://github.com/user-attachments/assets/8fce54a4-bdfe-4f8a-a8d3-c536a47e37b5" /> | 