### PR TITLE
`table-input` - Show tooltip for entire button

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -41,17 +41,13 @@ function append(container: HTMLElement): void {
 	container.append(
 		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm">
 			<summary
+				id="rgh-table-input-button"
 				className="Button Button--iconOnly Button--invisible Button--medium"
 				role="button"
-				aria-label="Add a table"
+				aria-labelledby="rgh-table-input-tooltip"
 				aria-haspopup="menu"
 			>
-				<div
-					className="tooltipped tooltipped-sw"
-					aria-label="Add a table"
-				>
-					<TableIcon />
-				</div>
+				<TableIcon />
 			</summary>
 			<details-menu
 				className="select-menu-modal position-absolute right-0 hx_rsm-modal rgh-table-input"
@@ -68,6 +64,16 @@ function append(container: HTMLElement): void {
 				))}
 			</details-menu>
 		</details>,
+		<tool-tip
+			id="rgh-table-input-tooltip"
+			for="rgh-table-input-button"
+			className="sr-only position-absolute"
+			popover="manual"
+			data-direction="s"
+			data-type="label"
+		>
+			Add a table
+		</tool-tip>,
 	);
 }
 

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -69,6 +69,7 @@ declare namespace JSX {
 		'action-menu': IntrinsicElements.HTMLELement;
 		'focus-group': IntrinsicElements.HTMLELement;
 		'action-list': IntrinsicElements.HTMLELement;
+		'tool-tip': IntrinsicElements.HTMLElement;
 	}
 
 	type BaseElement = IntrinsicElements['div'];


### PR DESCRIPTION
Super nit-picking cosmetic change incoming. The tooltip currently only applies to the icon, which is a bit off.

Can't just move `.tooltipped` to `<summary>` as that would show the tooltip together with the table popup.

## Test URLs

Here

## Screenshot

<table>
<tr>
 <td>Before
 <td>

https://github.com/user-attachments/assets/d869ced7-4c0c-4a6e-acb5-8b62c850c644


<tr>
 <td>After
 <td>

https://github.com/user-attachments/assets/79432f7b-21d8-44a0-851d-2aa4506ee33d


</table>