### PR TITLE
`show-names` - Fix extra margin on PR comments

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -39,7 +39,7 @@ function createElement(element: HTMLAnchorElement, fullName: string): JSX.Elemen
 		// `readable-title-change-events` adds gap to rename events
 		'.TimelineItem-body:not(:has(> del.markdown-title)) > *',
 		// Reference event: https://github.com/refined-github/refined-github/pull/9041#ref-issue-4028015976
-		'.TimelineItem-body:not(:has(> del.markdown-title)) > div > *',
+		'.TimelineItem-body > div > *',
 	])) {
 		nameElement.classList.add('ml-1');
 	} else if (


### PR DESCRIPTION
introduced in #9044

## Test URLs

https://github.com/refined-github/refined-github/pull/9078#issue-4056761502

https://github.com/refined-github/refined-github/pull/9041#ref-issue-4028015976

## Screenshot

<img width="478" height="104" alt="image" src="https://github.com/user-attachments/assets/3d0e6fd1-20cf-4ee1-ad0d-3f0811d1f06d" />

| Before | After |
|--------|--------|
| <img width="448" height="379" alt="image" src="https://github.com/user-attachments/assets/c2f53842-390b-4e3f-be0b-1a20f71992df" /> | <img width="462" height="381" alt="image" src="https://github.com/user-attachments/assets/1ca96001-9cc3-4859-b932-d9c0bcd1d86a" /> | 
