### PR TITLE
`improve-shortcut-help` - Restore feature

### DIFF
--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -110,7 +110,7 @@ function improveShortcutHelp(columnsContainer: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('[class^="ShortcutsDialog-module__ColumnsContainer"]', improveShortcutHelp, {signal});
+	observe('div[class^="ShortcutsDialog"][class*="ColumnsContainer"]', improveShortcutHelp, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
the component was renamed to `ShortcutsDialogContent`

## Test URLs

this PR

## Screenshot

<img width="324" height="410" alt="image" src="https://github.com/user-attachments/assets/ac391a60-376d-4329-8bd0-fe19082c1db3" />