### PR TITLE
Fix getting compare branch in some scenarios

### DIFF
--- a/source/github-helpers/pr-branches.ts
+++ b/source/github-helpers/pr-branches.ts
@@ -71,7 +71,7 @@ export function getBranches(): {base: PrReference; head: PrReference} {
 		},
 		get head() {
 			return parseReference($([
-				'span[class*="PullRequestHeaderSummary"] > div > a[class^="PullRequestBranchName"]',
+				'span[class*="PullRequestHeaderSummary"] > div a[class^="PullRequestBranchName"]',
 				'[class*="PullRequestHeaderSummary"] * [class*="PullRequestHeaderSummary"]', // TODO: Remove after July 2026
 				'.head-ref', // TODO: Remove in June 2026
 			]));


### PR DESCRIPTION
happens because `conversation-activity-filter` wraps the element with an additional div

sometimes affects `pr-branch-auto-delete`

## Test URLs

Can't consistently reproduce the issue

## Screenshot
