### PR TITLE
`more-file-links`, `restore-file` - Fix accessibility

### DIFF
--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -36,6 +36,7 @@ function getMenuItem(viewFile: HTMLElement, name: string, route: string, icon: R
 	const link = $('a', menuItem);
 	link.href = new GitHubFileURL(fileLink).assign({route}).href;
 	link.dataset.turbo = String(route !== 'raw');
+	link.removeAttribute('aria-labelledby');
 	$('[class^="prc-ActionList-ItemLabel"]', menuItem).textContent = `View ${name}`;
 	$('[class^="prc-ActionList-LeadingVisual"]', menuItem).replaceChildren(icon);
 	return menuItem;

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -168,7 +168,10 @@ function handleMenuOpening({delegateTarget: menuButton}: DelegateEvent): void {
 		const editFile = $('[class^="prc-ActionList-ActionListItem"]:has(.octicon-pencil)');
 		const discardItem = editFile.cloneNode(true);
 		discardItem.classList.add('rgh-restore-file');
-		$('a', discardItem).removeAttribute('href');
+		const link = $('a', discardItem);
+		link.ariaKeyShortcuts = 'd';
+		link.removeAttribute('href');
+		link.removeAttribute('aria-labelledby');
 		$('[class^="prc-ActionList-ItemLabel"]', discardItem).textContent = 'Discard changes';
 		$('[class^="prc-ActionList-LeadingVisual"]', discardItem).replaceChildren(<UndoIcon />);
 


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/sandbox/pull/16/changes

## Screenshot

| Before | <img width="438" height="208" alt="image" src="https://github.com/user-attachments/assets/1091c812-e474-4287-abfe-f6742a7966a9" /> |
|--------|--------|
| **After** | <img width="404" height="215" alt="image" src="https://github.com/user-attachments/assets/5f2f8183-f813-49dc-b309-76a6e3b0059d" /> |