### PR TITLE
`pull-request-hotkeys`: Support physical-key PR tab hotkeys

### DIFF
--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -1,31 +1,106 @@
-import {$$} from 'select-dom/strict.js';
+import {$$, $optional} from 'select-dom/strict.js';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import {addHotkey} from '../github-helpers/hotkey.js';
+import {isEditable} from '../helpers/dom-utils.js';
 
-async function init(): Promise<void> {
-	const tabnav = await elementReady([
-		'[aria-label="Pull request tabs"]',
-		'[aria-label="Pull request navigation tabs"]', // Commits list tab
-	].join(', '));
-	const tabs = $$([
-		'a.tabnav-tab',
-		'a[role="tab"]', // Commits list tab
-	], tabnav);
-	const lastTab = tabs.length - 1;
-	const selectedIndex = tabs.findIndex(tab => tab.classList.contains('selected'));
+const tabnavSelector = [
+	'[aria-label="Pull request tabs"]',
+	'[aria-label="Pull request navigation tabs"]', // Commits list tab
+].join(', ');
+const tabSelector = [
+	'a.tabnav-tab',
+	'a[role="tab"]', // Commits list tab
+].join(', ');
+const chordTimeout = 1500;
 
-	for (const [index, tab] of tabs.entries()) {
-		addHotkey(tab, `g ${index + 1}`);
+function getTabs(): HTMLAnchorElement[] {
+	const tabnav = $optional(tabnavSelector);
+	return tabnav ? $$(tabSelector, tabnav) : [];
+}
 
-		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {
-			addHotkey(tab, 'g ArrowLeft');
-		} else if (index === selectedIndex + 1 || (selectedIndex === lastTab && index === 0)) {
-			addHotkey(tab, 'g ArrowRight');
-		}
+function getSelectedIndex(tabs: HTMLAnchorElement[]): number {
+	return tabs.findIndex(tab =>
+		tab.classList.contains('selected')
+		|| tab.getAttribute('aria-current') === 'page'
+		|| tab.getAttribute('aria-selected') === 'true',
+	);
+}
+
+function getTargetTab(code: string): HTMLAnchorElement | undefined {
+	const tabs = getTabs();
+	if (tabs.length === 0) {
+		return;
 	}
+
+	const selectedIndex = Math.max(getSelectedIndex(tabs), 0);
+	if (code === 'ArrowLeft') {
+		return tabs[(selectedIndex - 1 + tabs.length) % tabs.length];
+	}
+
+	if (code === 'ArrowRight') {
+		return tabs[(selectedIndex + 1) % tabs.length];
+	}
+
+	if (/^Digit[1-9]$/.test(code)) {
+		return tabs[Number(code.slice(-1)) - 1];
+	}
+
+	return undefined;
+}
+
+async function init(signal: AbortSignal): Promise<void> {
+	await elementReady(tabnavSelector);
+
+	let awaitingChord = false;
+	let resetChordTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const clearChord = (): void => {
+		awaitingChord = false;
+		clearTimeout(resetChordTimer);
+		resetChordTimer = undefined;
+	};
+
+	const startChord = (): void => {
+		clearChord();
+		awaitingChord = true;
+		resetChordTimer = setTimeout(clearChord, chordTimeout);
+	};
+
+	const runShortcuts = (event: KeyboardEvent): void => {
+		if (
+			isEditable(event.target)
+			|| event.ctrlKey
+			|| event.metaKey
+			|| event.altKey
+			|| event.repeat
+		) {
+			return;
+		}
+
+		if (event.code === 'KeyG' && !event.shiftKey) {
+			startChord();
+			return;
+		}
+
+		if (!awaitingChord) {
+			return;
+		}
+
+		clearChord();
+		const targetTab = getTargetTab(event.code);
+		if (!targetTab) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		targetTab.click();
+	};
+
+	signal.addEventListener('abort', clearChord);
+	document.body.addEventListener('keydown', runShortcuts, {signal, capture: true});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
## Summary

**NOTE: This fix was generated by Codex. I tested the fix with Slovak and English (US) keyboard layouts.**

Fixes `pull-request-hotkeys` on non-US keyboard layouts by handling the PR tab shortcuts with physical key codes instead of relying on GitHub’s layout-dependent `data-hotkey` parsing.

This keeps `g` + number and `g` + arrow PR tab navigation working on layouts where the number row does not produce `123456789` without `Shift`, such as Slovak.

## Test URLs

- https://github.com/refined-github/sandbox/pull/4

## Screenshot

N/A