### PR TITLE
Hide 'Markdown is supported' label from comment box footer

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -129,6 +129,18 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	visibility: hidden;
 }
 
+/* Hide the 'Markdown is supported' label from the comment box footer, as it can overflow the viewport and isn't very useful */
+/* Info: https://github.com/refined-github/refined-github/issues/9075 */
+/* Test: https://github.com/refined-github/refined-github/pull/9115 */
+.js-previewable-comment-form a[href$='basic-writing-and-formatting-syntax'] {
+	.Button-label {
+		display: none;
+	}
+	.Button-visual {
+		margin-right: 0;
+	}
+}
+
 /*
 
 Test URLs:


### PR DESCRIPTION
Closes https://github.com/refined-github/refined-github/issues/9075

## Test URLs

This PR

## Screenshot

<img width="830" height="235" alt="image" src="https://github.com/user-attachments/assets/24760de1-044e-4db8-8ad8-8f43d29b412a" />

<img width="505" height="319" alt="image" src="https://github.com/user-attachments/assets/861b2679-afab-4dc8-b63e-e12330d87330" />