### PR TITLE
Vertically center PR summary row

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -141,7 +141,7 @@ svg.octicon-package + a.Truncate[href*='/releases/download/'] > .Truncate-text {
 	}
 }
 
-/* Horizontally PR summary row */
+/* Vertically center PR summary row */
 /* Info: https://github.com/refined-github/refined-github/pull/9116/ */
 /* Test: https://github.com/refined-github/sandbox/pull/61 */
 div[class^='prc-PageHeader-Description']


### PR DESCRIPTION
Fixes the issue with GitHub's vanilla styles.

While our styles didn't have the alignment issue, they had another one: https://github.com/refined-github/refined-github/pull/9113#discussion_r2979338617. They were removed in #9079.

When the window width is less than 544px, `flex-direction` changes from `row` to `column`. Combined with `align-items: center`, this was triggering the misplacement bug.

## Test URLs

https://github.com/refined-github/sandbox/pull/61

## Screenshot

| **Before** | <img width="749" height="101" alt="image" src="https://github.com/user-attachments/assets/a7fd727d-b700-43a6-930a-9cba77a99dba" /> |
|--------|--------|
| After | <img width="744" height="103" alt="image" src="https://github.com/user-attachments/assets/bcc45c41-1333-491a-b26f-08d1fbc7f805" /> |

![msedge_fOMrgioCtH](https://github.com/user-attachments/assets/8a44a513-a730-4317-a3a9-631870632ab2)