### PR TITLE
`prevent-comment-loss` - Ignore self-reference links

### DIFF
--- a/source/features/prevent-comment-loss.tsx
+++ b/source/features/prevent-comment-loss.tsx
@@ -12,7 +12,8 @@ function openInNewTab(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void
 function init(signal: AbortSignal): void {
 	delegate(
 		[
-			'.js-preview-body a', // `hasRichTextEditor`
+			// Ignore self-reference links: https://github.com/refined-github/refined-github/pull/8854#issuecomment-3794351054
+			'.js-preview-body a[href]', // `hasRichTextEditor`
 			'.html-blob a', // `isEditingFile`
 		],
 		'click',


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/pull/8854#issuecomment-3794351054

## Test URLs

https://github.com/refined-github/refined-github/pull/8854#issuecomment-3794351054

## Screenshot
