### PR TITLE
[User was blocked for this AI PR]

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {cacheByRepo, triggerRepoNavOverflow} from '../github-helpers/index.js';
+import {cacheByRepo, isNewRepoNav, triggerRepoNavOverflow} from '../github-helpers/index.js';
 import SearchQuery from '../github-helpers/search-query.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils.js';
@@ -82,7 +82,7 @@ async function addBugsTab(): Promise<void | false> {
 
 	// Find Issues tab by hotkey (old nav) or href (new React nav has no data-hotkey)
 	const issuesTab = await elementReady(
-		'a[data-hotkey="g i"], nav[aria-label="Repository"] ul[role="list"] a[href*="/issues"]',
+		'a[data-hotkey="g i"], nav[aria-label="Repository"] ul[role="list"] a[href$="/issues"]',
 		{waitForChildren: false},
 	);
 	if (!issuesTab) {
@@ -129,7 +129,12 @@ async function addBugsTab(): Promise<void | false> {
 
 	// In case GitHub changes its layout again #4166
 	if (issuesTab.parentElement instanceof HTMLLIElement) {
-		issuesTab.parentElement.after(<li className="d-inline-flex">{bugsTab}</li>);
+		// New React nav uses bare <li>; old nav needs d-inline-flex
+		issuesTab.parentElement.after(
+			isNewRepoNav()
+				? <li>{bugsTab}</li>
+				: <li className="d-inline-flex">{bugsTab}</li>,
+		);
 	} else {
 		issuesTab.after(bugsTab);
 	}
@@ -153,7 +158,7 @@ async function addBugsTab(): Promise<void | false> {
 function highlightBugsTab(): void {
 	// Remove highlighting from "Issues" tab (old nav uses hotkey, new React nav uses href)
 	const issuesTab = $optional('a[data-hotkey="g i"]')
-		?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href*="/issues"]');
+		?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href$="/issues"]');
 	if (issuesTab) {
 		unhighlightTab(issuesTab);
 	}

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -80,8 +80,11 @@ async function addBugsTab(): Promise<void | false> {
 		}
 	}
 
-	// Find Issues tab by hotkey (works in both old and new nav)
-	const issuesTab = await elementReady('a[data-hotkey="g i"]', {waitForChildren: false});
+	// Find Issues tab by hotkey (old nav) or href (new React nav has no data-hotkey)
+	const issuesTab = await elementReady(
+		'a[data-hotkey="g i"], nav[aria-label="Repository"] ul[role="list"] a[href*="/issues"]',
+		{waitForChildren: false},
+	);
 	if (!issuesTab) {
 		// Issues are disabled
 		return false;
@@ -148,8 +151,13 @@ async function addBugsTab(): Promise<void | false> {
 
 // TODO: Use native highlighting https://github.com/refined-github/refined-github/pull/6909#discussion_r1322607091
 function highlightBugsTab(): void {
-	// Remove highlighting from "Issues" tab (works in both old and new nav)
-	unhighlightTab($('a[data-hotkey="g i"]'));
+	// Remove highlighting from "Issues" tab (old nav uses hotkey, new React nav uses href)
+	const issuesTab = $optional('a[data-hotkey="g i"]')
+		?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href*="/issues"]');
+	if (issuesTab) {
+		unhighlightTab(issuesTab);
+	}
+
 	highlightTab($('.rgh-bugs-tab'));
 }
 

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 import {CachedFunction} from 'webext-storage-cache';
-import {$} from 'select-dom/strict.js';
+import {$, $optional} from 'select-dom/strict.js';
 import {elementExists} from 'select-dom';
 import BugIcon from 'octicons-plain-react/Bug';
 import elementReady from 'element-ready';
@@ -80,7 +80,8 @@ async function addBugsTab(): Promise<void | false> {
 		}
 	}
 
-	const issuesTab = await elementReady('a.UnderlineNav-item[data-hotkey="g i"]', {waitForChildren: false});
+	// Find Issues tab by hotkey (works in both old and new nav)
+	const issuesTab = await elementReady('a[data-hotkey="g i"]', {waitForChildren: false});
 	if (!issuesTab) {
 		// Issues are disabled
 		return false;
@@ -100,12 +101,25 @@ async function addBugsTab(): Promise<void | false> {
 	const bugsTabTitle = $('[data-content]', bugsTab);
 	bugsTabTitle.dataset.content = 'Bugs';
 	bugsTabTitle.textContent = 'Bugs';
-	$('.octicon', bugsTab).replaceWith(<BugIcon className="UnderlineNav-octicon d-none d-sm-inline" />);
 
-	// Set temporary counter
-	const bugsCounter = $('.Counter', bugsTab);
-	bugsCounter.textContent = '0';
-	bugsCounter.title = '';
+	// Icon: old nav uses `.octicon` with wrapper class; new nav wraps in `[data-component="icon"]`
+	const existingIcon = $optional('.octicon', bugsTab);
+	if (existingIcon) {
+		const isOldNav = existingIcon.classList.contains('UnderlineNav-octicon');
+		const iconClasses = isOldNav ? 'UnderlineNav-octicon d-none d-sm-inline' : '';
+		existingIcon.replaceWith(<BugIcon className={iconClasses || undefined} />);
+	}
+
+	const bugsCounter = $optional([
+		// Old nav
+		'.Counter',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], bugsTab);
+	if (bugsCounter) {
+		bugsCounter.textContent = '0';
+		bugsCounter.title = '';
+	}
 
 	// Update Bugs’ link
 	bugsTab.href = SearchQuery.from(bugsTab).append(await getSearchQueryBugLabel()).href;
@@ -122,18 +136,20 @@ async function addBugsTab(): Promise<void | false> {
 	// Update bugs count
 	try {
 		const {count: bugCount} = await bugsPromise;
-		bugsCounter.textContent = abbreviateNumber(bugCount);
-		bugsCounter.title = bugCount > 999 ? String(bugCount) : '';
+		if (bugsCounter) {
+			bugsCounter.textContent = abbreviateNumber(bugCount);
+			bugsCounter.title = bugCount > 999 ? String(bugCount) : '';
+		}
 	} catch (error) {
-		bugsCounter.remove();
+		bugsCounter?.remove();
 		throw error; // Likely an API call error that will be handled by the init
 	}
 }
 
 // TODO: Use native highlighting https://github.com/refined-github/refined-github/pull/6909#discussion_r1322607091
 function highlightBugsTab(): void {
-	// Remove highlighting from "Issues" tab
-	unhighlightTab($('.UnderlineNav-item[data-hotkey="g i"]'));
+	// Remove highlighting from "Issues" tab (works in both old and new nav)
+	unhighlightTab($('a[data-hotkey="g i"]'));
 	highlightTab($('.rgh-bugs-tab'));
 }
 

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -11,7 +11,12 @@ import api from '../github-helpers/api.js';
 import getTabCount from '../github-helpers/get-tab-count.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
-import {buildRepoURL, cacheByRepo, getRepo} from '../github-helpers/index.js';
+import {
+	buildRepoURL,
+	cacheByRepo,
+	getRepo,
+	isNewRepoNav,
+} from '../github-helpers/index.js';
 import {unhideOverflowDropdown} from './more-dropdown-links.js';
 
 async function canUserEditOrganization(): Promise<boolean> {
@@ -21,14 +26,20 @@ async function canUserEditOrganization(): Promise<boolean> {
 function mustKeepTab(tab: HTMLElement): boolean {
 	return (
 		// User is on tab 👀
-		tab.matches('.selected')
+		tab.matches('.selected, [aria-current="page"]')
 		// Repo owners should see the tab. If they don't need it, they should disable the feature altogether
 		|| pageDetect.canUserAdminRepo()
 	);
 }
 
 function setTabCounter(tab: HTMLElement, count: number): void {
-	let tabCounter = $optional('.Counter, .num', tab);
+	let tabCounter = $optional([
+		// Old nav
+		'.Counter',
+		'.num',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], tab);
 	if (!tabCounter) {
 		tabCounter = <span className="Counter" /> as HTMLSpanElement;
 		tab.append(<span data-component="counter">{tabCounter}</span>);
@@ -39,7 +50,15 @@ function setTabCounter(tab: HTMLElement, count: number): void {
 }
 
 function onlyShowInDropdown(id: string): void {
-	// TODO: Use selector observer
+	if (isNewRepoNav()) {
+		// New React nav manages overflow internally; hide tab via CSS instead
+		const tab = $optional(`a[data-hotkey][href*="${id.replace('-tab', '')}"]`)
+			?? $optional(`[data-tab-item$="${id}"]`);
+		tab?.closest('li')?.setAttribute('hidden', '');
+		return;
+	}
+
+	// Old nav: move tab to overflow dropdown
 	const tabItem = $optional(`li:not([hidden]) > [data-tab-item$="${id}"]`);
 	if (!tabItem) { // #3962 #7140
 		return;
@@ -121,7 +140,19 @@ async function updateProjectsTab(): Promise<void | false> {
 }
 
 async function moveRareTabs(): Promise<void | false> {
-	// The user may have disabled `more-dropdown-links` so un-hide it
+	if (isNewRepoNav()) {
+		// New React nav: hide tabs directly via CSS; overflow is managed by React
+		const securityTab = $optional('[data-hotkey="g s"]')
+			?? $optional('[data-tab-item$="security-tab"]');
+		if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
+			onlyShowInDropdown('security-tab');
+		}
+
+		onlyShowInDropdown('insights-tab');
+		return;
+	}
+
+	// Old nav: use overflow dropdown
 	if (!await unhideOverflowDropdown()) {
 		return false;
 	}
@@ -129,7 +160,6 @@ async function moveRareTabs(): Promise<void | false> {
 	// Wait for the nav dropdown to be loaded #5244
 	await elementReady('.UnderlineNav-actions ul');
 
-	// Only hide security tab if there are no vulnerability alerts #8457
 	const securityTab = $optional('[data-tab-item$="security-tab"]');
 	if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
 		onlyShowInDropdown('security-tab');

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -100,7 +100,7 @@ const hasActionRuns = new CachedFunction('workflows-count', {
 async function updateWikiTab(): Promise<void | false> {
 	// Old nav uses hotkey; new React nav has no data-hotkey on tabs
 	const wikiTab = await elementReady(
-		'[data-hotkey="g w"], nav[aria-label="Repository"] ul[role="list"] a[href*="/wiki"]',
+		'[data-hotkey="g w"], nav[aria-label="Repository"] ul[role="list"] a[href$="/wiki"]',
 	);
 	if (!wikiTab || mustKeepTab(wikiTab)) {
 		return false;
@@ -116,7 +116,7 @@ async function updateWikiTab(): Promise<void | false> {
 
 async function updateActionsTab(): Promise<void | false> {
 	const actionsTab = await elementReady(
-		'[data-hotkey="g a"], nav[aria-label="Repository"] ul[role="list"] a[href*="/actions"]',
+		'[data-hotkey="g a"], nav[aria-label="Repository"] ul[role="list"] a[href$="/actions"]',
 	);
 	if (!actionsTab || mustKeepTab(actionsTab) || await hasActionRuns.get(getRepo()!.nameWithOwner)) {
 		return false;
@@ -127,7 +127,7 @@ async function updateActionsTab(): Promise<void | false> {
 
 async function updateProjectsTab(): Promise<void | false> {
 	const projectsTab = await elementReady(
-		'[data-hotkey="g b"], nav[aria-label="Repository"] ul[role="list"] a[href*="/projects"]',
+		'[data-hotkey="g b"], nav[aria-label="Repository"] ul[role="list"] a[href$="/projects"]',
 	);
 	if (!projectsTab || mustKeepTab(projectsTab) || await getTabCount(projectsTab) > 0) {
 		return false;
@@ -150,7 +150,7 @@ async function moveRareTabs(): Promise<void | false> {
 	if (isNewRepoNav()) {
 		// New React nav: hide tabs directly via CSS; overflow is managed by React
 		const securityTab = $optional('[data-hotkey="g s"]')
-			?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href*="/security"]');
+			?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href$="/security"]');
 		if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
 			onlyShowInDropdown('security-tab');
 		}

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -98,7 +98,10 @@ const hasActionRuns = new CachedFunction('workflows-count', {
 });
 
 async function updateWikiTab(): Promise<void | false> {
-	const wikiTab = await elementReady('[data-hotkey="g w"]');
+	// Old nav uses hotkey; new React nav has no data-hotkey on tabs
+	const wikiTab = await elementReady(
+		'[data-hotkey="g w"], nav[aria-label="Repository"] ul[role="list"] a[href*="/wiki"]',
+	);
 	if (!wikiTab || mustKeepTab(wikiTab)) {
 		return false;
 	}
@@ -112,7 +115,9 @@ async function updateWikiTab(): Promise<void | false> {
 }
 
 async function updateActionsTab(): Promise<void | false> {
-	const actionsTab = await elementReady('[data-hotkey="g a"]');
+	const actionsTab = await elementReady(
+		'[data-hotkey="g a"], nav[aria-label="Repository"] ul[role="list"] a[href*="/actions"]',
+	);
 	if (!actionsTab || mustKeepTab(actionsTab) || await hasActionRuns.get(getRepo()!.nameWithOwner)) {
 		return false;
 	}
@@ -121,7 +126,9 @@ async function updateActionsTab(): Promise<void | false> {
 }
 
 async function updateProjectsTab(): Promise<void | false> {
-	const projectsTab = await elementReady('[data-hotkey="g b"]');
+	const projectsTab = await elementReady(
+		'[data-hotkey="g b"], nav[aria-label="Repository"] ul[role="list"] a[href*="/projects"]',
+	);
 	if (!projectsTab || mustKeepTab(projectsTab) || await getTabCount(projectsTab) > 0) {
 		return false;
 	}
@@ -143,7 +150,7 @@ async function moveRareTabs(): Promise<void | false> {
 	if (isNewRepoNav()) {
 		// New React nav: hide tabs directly via CSS; overflow is managed by React
 		const securityTab = $optional('[data-hotkey="g s"]')
-			?? $optional('[data-tab-item$="security-tab"]');
+			?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href*="/security"]');
 		if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
 			onlyShowInDropdown('security-tab');
 		}

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -12,12 +12,17 @@ import PackageDependenciesIcon from 'octicons-plain-react/PackageDependencies';
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';
-import {buildRepoURL} from '../github-helpers/index.js';
+import {buildRepoURL, isNewRepoNav} from '../github-helpers/index.js';
 import getCurrentGitRef from '../github-helpers/get-current-git-ref.js';
 import observe from '../helpers/selector-observer.js';
 import {expectToken} from '../github-helpers/github-token.js';
 
 export async function unhideOverflowDropdown(): Promise<boolean> {
+	// New React nav manages overflow internally; cannot inject dropdown items
+	if (isNewRepoNav()) {
+		return false;
+	}
+
 	// Wait for the tab bar to be loaded
 	const repoNavigationBar = await elementReady('.UnderlineNav-body');
 
@@ -66,8 +71,13 @@ async function addDropdownItems(repoNavigationDropdown: HTMLElement): Promise<vo
 
 async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
-	await unhideOverflowDropdown();
 
+	// New React nav manages its own overflow; this feature only works on the old nav
+	if (isNewRepoNav()) {
+		return;
+	}
+
+	await unhideOverflowDropdown();
 	observe('.UnderlineNav-actions ul', addDropdownItems, {signal});
 }
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -14,6 +14,7 @@ import {
 	buildRepoURL,
 	cacheByRepo,
 	getRepo,
+	isNewRepoNav,
 	triggerRepoNavOverflow,
 } from '../github-helpers/index.js';
 import {appendBefore} from '../helpers/dom-utils.js';
@@ -61,28 +62,50 @@ async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | v
 		return false;
 	}
 
-	// Wait for the dropdown because `observe` fires as soon as it encounter the container. `releases-tab` must be appended.
-	await elementReady(repoUnderlineNavUl);
+	if (isNewRepoNav()) {
+		// New Primer React nav: use matching structure
+		repoNavigationBar.append(
+			<li>
+				<a
+					href={buildRepoURL(type.toLowerCase())}
+					className="rgh-releases-tab"
+					data-hotkey="g r"
+					data-turbo-frame="repo-content-turbo-frame"
+					title="Hotkey: G R"
+				>
+					<span data-component="icon"><TagIcon /></span>
+					<span data-component="text" data-content={type}>{type}</span>
+					<span data-component="counter">
+						<span aria-hidden="true" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+					</span>
+				</a>
+			</li>,
+		);
+	} else {
+		// Old ViewComponent nav
+		// Wait for the dropdown because `observe` fires as soon as it encounter the container
+		await elementReady(repoUnderlineNavUl.join?.(',') ?? repoUnderlineNavUl);
 
-	repoNavigationBar.append(
-		<li className="d-flex">
-			<a
-				href={buildRepoURL(type.toLowerCase())}
-				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
-				data-hotkey="g r"
-				data-selected-links="repo_releases"
-				data-tab-item="rgh-releases-item"
-				data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
-				title="Hotkey: G R"
-			>
-				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
-				<span data-content={type}>{type}</span>
-				<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
-			</a>
-		</li>,
-	);
+		repoNavigationBar.append(
+			<li className="d-flex">
+				<a
+					href={buildRepoURL(type.toLowerCase())}
+					className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
+					data-hotkey="g r"
+					data-selected-links="repo_releases"
+					data-tab-item="rgh-releases-item"
+					data-turbo-frame="repo-content-turbo-frame"
+					title="Hotkey: G R"
+				>
+					<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
+					<span data-content={type}>{type}</span>
+					<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+				</a>
+			</li>,
+		);
 
-	triggerRepoNavOverflow();
+		triggerRepoNavOverflow();
+	}
 }
 
 async function addReleasesDropdownItem(dropdownMenu: HTMLElement): Promise<false | void> {
@@ -110,8 +133,12 @@ async function addReleasesDropdownItem(dropdownMenu: HTMLElement): Promise<false
 async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
 	observe(repoUnderlineNavUl, addReleasesTab, {signal});
-	observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
-	observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
+
+	// Old nav only: overflow dropdown items and code-tab highlight detachment
+	if (!isNewRepoNav()) {
+		observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
+		observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
+	}
 }
 
 void features.add(import.meta.url, {

--- a/source/github-helpers/get-tab-count.ts
+++ b/source/github-helpers/get-tab-count.ts
@@ -2,7 +2,13 @@ import {$optional} from 'select-dom/strict.js';
 import oneMutation from 'one-mutation';
 
 export default async function getTabCount(tab: Element): Promise<number> {
-	const counter = $optional('.Counter, .num', tab);
+	const counter = $optional([
+		// Old nav
+		'.Counter',
+		'.num',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], tab);
 	if (!counter) {
 		// GitHub might have already dropped the counter, which means it's 0
 		return 0;

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -166,6 +166,11 @@ export function fixFileHeaderOverlap(child: Element): void {
 	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 
+/** Detect whether the current page uses the new Primer React repo navigation */
+export function isNewRepoNav(): boolean {
+	return Boolean(document.querySelector('nav[aria-label="Repository"] ul[role="list"]'));
+}
+
 /** Trigger a reflow to push the right-most tab into the overflow dropdown */
 export function triggerRepoNavOverflow(): void {
 	globalThis.dispatchEvent(new Event('resize'));

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -5,7 +5,12 @@ const requiresLogin: UrlMatch[] = [];
 export type UrlMatch = [expectations: number, url: string];
 
 /** The repo navigation bar */
-export const repoUnderlineNavUl = '.js-responsive-underlinenav ul.UnderlineNav-body';
+export const repoUnderlineNavUl = [
+	// Old ViewComponent nav
+	'.js-responsive-underlinenav ul.UnderlineNav-body',
+	// New Primer React nav
+	'nav[aria-label="Repository"] ul[role="list"]',
+];
 export const repoUnderlineNavUl_ = [
 	[1, 'https://github.com/refined-github/refined-github'],
 	[1, 'https://github.com/refined-github/refined-github/releases'],


### PR DESCRIPTION
NOT_Closes #8867

## What

Fixes three features that broke when GitHub rolled out the new Primer React repo navigation (`UnderlineNav` from `@primer/react`):

- **`releases-tab`** — inject tab with matching markup per nav type
- **`bugs-tab`** — find Issues tab by `href$="/issues"` fallback (new nav has no `data-hotkey`)
- **`clean-repo-tabs`** — use CSS hiding instead of DOM removal on new nav (React manages overflow)
- **`more-dropdown-links`** — gracefully disabled on new nav (cannot inject into React-managed overflow)

## Why

GitHub is progressively replacing the server-rendered ViewComponent repo nav with a React-based `UnderlineNav`. The new nav:
- Has no `data-hotkey` attributes on tabs
- Uses `<span data-component="counter">` instead of `.Counter`
- Manages overflow internally (no accessible dropdown DOM)

Features relying on the old selectors fail silently on the new nav.

## How

- Add `isNewRepoNav()` detection helper (checks for `nav[aria-label="Repository"] ul[role="list"]`)
- Dual selectors: old `data-hotkey` + new `href$="/..."` fallback scoped to the React nav
- `releases-tab`: branch on `isNewRepoNav()` to emit matching markup per nav type
- `clean-repo-tabs`: use `onlyShowInDropdown()` CSS hiding on new nav instead of DOM manipulation
- `get-tab-count` / `setTabCounter`: handle both `.Counter` and `data-component="counter"` markup
- `more-dropdown-links`: early return on new nav with `features.unload` (no dropdown to inject into)

## Test URLs

- https://github.com/refined-github/refined-github (new React nav — bugs-tab, releases-tab, clean-repo-tabs all verified)
- https://github.com/vercel/next.js (new React nav — bugs-tab, releases-tab verified)

## Screenshot
<img width="1133" height="179" alt="Screenshot 2026-03-26 at 18 05 19" src="https://github.com/user-attachments/assets/b90ad65b-3a52-463f-b2a4-98c14d1944fc" />
<img width="1125" height="95" alt="Screenshot 2026-03-26 at 18 07 29" src="https://github.com/user-attachments/assets/0dd5afe0-87cf-46b8-bb50-bf35da98ddd6" />



---

Assisted-By: Claude Code (Claude Opus 4.6, 1M context)