### PR TITLE
[User was blocked for this AI PR]

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -1,20 +1,21 @@
 import React from 'dom-chef';
 import {CachedFunction} from 'webext-storage-cache';
-import {$} from 'select-dom/strict.js';
-import {elementExists} from 'select-dom';
+import {$, $optional} from 'select-dom/strict.js';
 import BugIcon from 'octicons-plain-react/Bug';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
+import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {cacheByRepo, triggerRepoNavOverflow} from '../github-helpers/index.js';
+import {cacheByRepo, isNewRepoNav, triggerRepoNavOverflow} from '../github-helpers/index.js';
 import SearchQuery from '../github-helpers/search-query.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {highlightTab, unhighlightTab} from '../helpers/dom-utils.js';
 import isBugLabel from '../github-helpers/bugs-label.js';
 import CountBugs from './bugs-tab.gql';
 import {expectToken} from '../github-helpers/github-token.js';
+import {repoUnderlineNavUl} from '../github-helpers/selectors.js';
 
 type ApiResponse = {
 	issues?: {
@@ -64,7 +65,7 @@ async function isBugsListing(): Promise<boolean> {
 	return SearchQuery.from(location).includes(await getSearchQueryBugLabel());
 }
 
-async function addBugsTab(): Promise<void | false> {
+async function addBugsTab(repoNavigationBar: HTMLElement): Promise<void | false> {
 	// Query API as early as possible, even if it's not necessary on archived repos
 	const bugsPromise = bugs.get();
 
@@ -80,9 +81,15 @@ async function addBugsTab(): Promise<void | false> {
 		}
 	}
 
-	const issuesTab = await elementReady('a.UnderlineNav-item[data-hotkey="g i"]', {waitForChildren: false});
+	// Find Issues tab within the nav container
+	// Old nav: data-hotkey="g i"; New React nav: data-tab-item (href may have query params from other features)
+	const issuesTab = $optional([
+		// Old nav
+		'a[data-hotkey="g i"]',
+		// New React nav (href may have query params from other features)
+		'a[data-tab-item="issues"]',
+	], repoNavigationBar);
 	if (!issuesTab) {
-		// Issues are disabled
 		return false;
 	}
 
@@ -100,19 +107,37 @@ async function addBugsTab(): Promise<void | false> {
 	const bugsTabTitle = $('[data-content]', bugsTab);
 	bugsTabTitle.dataset.content = 'Bugs';
 	bugsTabTitle.textContent = 'Bugs';
-	$('.octicon', bugsTab).replaceWith(<BugIcon className="UnderlineNav-octicon d-none d-sm-inline" />);
 
-	// Set temporary counter
-	const bugsCounter = $('.Counter', bugsTab);
-	bugsCounter.textContent = '0';
-	bugsCounter.title = '';
+	// Icon: old nav uses `.octicon` with wrapper class; new nav wraps in `[data-component="icon"]`
+	const existingIcon = $optional('.octicon', bugsTab);
+	if (existingIcon) {
+		const isOldNav = existingIcon.classList.contains('UnderlineNav-octicon');
+		const iconClasses = isOldNav ? 'UnderlineNav-octicon d-none d-sm-inline' : '';
+		existingIcon.replaceWith(<BugIcon className={iconClasses || undefined} />);
+	}
+
+	const bugsCounter = $optional([
+		// Old nav
+		'.Counter',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], bugsTab);
+	if (bugsCounter) {
+		bugsCounter.textContent = '0';
+		bugsCounter.title = '';
+	}
 
 	// Update Bugs’ link
 	bugsTab.href = SearchQuery.from(bugsTab).append(await getSearchQueryBugLabel()).href;
 
 	// In case GitHub changes its layout again #4166
 	if (issuesTab.parentElement instanceof HTMLLIElement) {
-		issuesTab.parentElement.after(<li className="d-inline-flex">{bugsTab}</li>);
+		// New React nav uses bare <li>; old nav needs d-inline-flex
+		issuesTab.parentElement.after(
+			isNewRepoNav()
+				? <li>{bugsTab}</li>
+				: <li className="d-inline-flex">{bugsTab}</li>,
+		);
 	} else {
 		issuesTab.after(bugsTab);
 	}
@@ -122,18 +147,25 @@ async function addBugsTab(): Promise<void | false> {
 	// Update bugs count
 	try {
 		const {count: bugCount} = await bugsPromise;
-		bugsCounter.textContent = abbreviateNumber(bugCount);
-		bugsCounter.title = bugCount > 999 ? String(bugCount) : '';
+		if (bugsCounter) {
+			bugsCounter.textContent = abbreviateNumber(bugCount);
+			bugsCounter.title = bugCount > 999 ? String(bugCount) : '';
+		}
 	} catch (error) {
-		bugsCounter.remove();
+		bugsCounter?.remove();
 		throw error; // Likely an API call error that will be handled by the init
 	}
 }
 
 // TODO: Use native highlighting https://github.com/refined-github/refined-github/pull/6909#discussion_r1322607091
 function highlightBugsTab(): void {
-	// Remove highlighting from "Issues" tab
-	unhighlightTab($('.UnderlineNav-item[data-hotkey="g i"]'));
+	// Remove highlighting from "Issues" tab (old nav uses hotkey, new React nav uses href)
+	const issuesTab = $optional('a[data-hotkey="g i"]')
+		?? $optional('nav[aria-label="Repository"] ul[role="list"] a[href$="/issues"]');
+	if (issuesTab) {
+		unhighlightTab(issuesTab);
+	}
+
 	highlightTab($('.rgh-bugs-tab'));
 }
 
@@ -165,14 +197,12 @@ async function updateBugsTagHighlighting(): Promise<void | false> {
 	return false;
 }
 
-async function init(): Promise<void | false> {
+async function init(signal: AbortSignal): Promise<void | false> {
 	await expectToken();
-
-	if (!elementExists('.rgh-bugs-tab')) {
-		await addBugsTab();
-	}
-
-	await updateBugsTagHighlighting();
+	observe(repoUnderlineNavUl, async repoNavigationBar => {
+		await addBugsTab(repoNavigationBar as HTMLElement);
+		await updateBugsTagHighlighting();
+	}, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -11,7 +11,15 @@ import api from '../github-helpers/api.js';
 import getTabCount from '../github-helpers/get-tab-count.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
-import {buildRepoURL, cacheByRepo, getRepo} from '../github-helpers/index.js';
+import {
+	buildRepoURL,
+	cacheByRepo,
+	getRepo,
+	isNewRepoNav,
+	triggerRepoNavOverflow,
+} from '../github-helpers/index.js';
+import observe from '../helpers/selector-observer.js';
+import {repoUnderlineNavUl} from '../github-helpers/selectors.js';
 import {unhideOverflowDropdown} from './more-dropdown-links.js';
 
 async function canUserEditOrganization(): Promise<boolean> {
@@ -21,14 +29,20 @@ async function canUserEditOrganization(): Promise<boolean> {
 function mustKeepTab(tab: HTMLElement): boolean {
 	return (
 		// User is on tab 👀
-		tab.matches('.selected')
+		tab.matches('.selected, [aria-current="page"]')
 		// Repo owners should see the tab. If they don't need it, they should disable the feature altogether
 		|| pageDetect.canUserAdminRepo()
 	);
 }
 
 function setTabCounter(tab: HTMLElement, count: number): void {
-	let tabCounter = $optional('.Counter, .num', tab);
+	let tabCounter = $optional([
+		// Old nav
+		'.Counter',
+		'.num',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], tab);
 	if (!tabCounter) {
 		tabCounter = <span className="Counter" /> as HTMLSpanElement;
 		tab.append(<span data-component="counter">{tabCounter}</span>);
@@ -39,7 +53,16 @@ function setTabCounter(tab: HTMLElement, count: number): void {
 }
 
 function onlyShowInDropdown(id: string): void {
-	// TODO: Use selector observer
+	if (isNewRepoNav()) {
+		// New React nav: find tab by href suffix or data-tab-item (Insights uses /pulse, not /insights)
+		const tabPath = id.replace('-tab', '');
+		const tab = $optional(`nav[aria-label="Repository"] ul[role="list"] a[href$="/${tabPath}"]`)
+			?? $optional(`nav[aria-label="Repository"] ul[role="list"] a[data-tab-item="${tabPath}"]`);
+		tab?.closest('li')?.setAttribute('hidden', '');
+		return;
+	}
+
+	// Old nav: move tab to overflow dropdown
 	const tabItem = $optional(`li:not([hidden]) > [data-tab-item$="${id}"]`);
 	if (!tabItem) { // #3962 #7140
 		return;
@@ -52,6 +75,49 @@ function onlyShowInDropdown(id: string): void {
 	menuItem.hidden = false;
 	// The item has to be moved somewhere else because the overflow nav is order-dependent
 	$('.UnderlineNav-actions ul').append(menuItem);
+}
+
+async function handleNewNavTabs(repoNavigationBar: HTMLElement): Promise<void> {
+	// Actions
+	const actionsTab = $optional('a[href$="/actions"]', repoNavigationBar);
+	if (actionsTab && !mustKeepTab(actionsTab) && !(await hasActionRuns.get(getRepo()!.nameWithOwner))) {
+		actionsTab.closest('li')?.setAttribute('hidden', '');
+	}
+
+	// Wiki
+	const wikiTab = $optional('a[href$="/wiki"]', repoNavigationBar);
+	if (wikiTab && !mustKeepTab(wikiTab)) {
+		const count = await wikiPageCount.get();
+		if (count > 0) {
+			setTabCounter(wikiTab, count);
+		} else {
+			wikiTab.closest('li')?.setAttribute('hidden', '');
+		}
+	}
+
+	// Projects
+	const projectsTab = $optional('a[href$="/projects"]', repoNavigationBar);
+	if (projectsTab && !mustKeepTab(projectsTab) && (await getTabCount(projectsTab)) === 0) {
+		projectsTab.closest('li')?.setAttribute('hidden', '');
+	}
+
+	// Security (from moveRareTabs)
+	const securityTab = $optional('a[href$="/security"]', repoNavigationBar);
+	if (securityTab && !mustKeepTab(securityTab) && (await getTabCount(securityTab)) === 0) {
+		securityTab.closest('li')?.setAttribute('hidden', '');
+	}
+
+	// Insights (from moveRareTabs) — href is /pulse, not /insights
+	const insightsTab = $optional([
+		'a[data-tab-item="insights"]',
+		// Insights href is /pulse, not /insights
+		'a[href$="/pulse"]',
+	], repoNavigationBar);
+	if (insightsTab && !mustKeepTab(insightsTab)) {
+		insightsTab.closest('li')?.setAttribute('hidden', '');
+	}
+
+	triggerRepoNavOverflow();
 }
 
 const wikiPageCount = new CachedFunction('wiki-page-count', {
@@ -79,6 +145,10 @@ const hasActionRuns = new CachedFunction('workflows-count', {
 });
 
 async function updateWikiTab(): Promise<void | false> {
+	if (isNewRepoNav()) {
+		return false;
+	}
+
 	const wikiTab = await elementReady('[data-hotkey="g w"]');
 	if (!wikiTab || mustKeepTab(wikiTab)) {
 		return false;
@@ -93,6 +163,10 @@ async function updateWikiTab(): Promise<void | false> {
 }
 
 async function updateActionsTab(): Promise<void | false> {
+	if (isNewRepoNav()) {
+		return false;
+	}
+
 	const actionsTab = await elementReady('[data-hotkey="g a"]');
 	if (!actionsTab || mustKeepTab(actionsTab) || await hasActionRuns.get(getRepo()!.nameWithOwner)) {
 		return false;
@@ -102,6 +176,10 @@ async function updateActionsTab(): Promise<void | false> {
 }
 
 async function updateProjectsTab(): Promise<void | false> {
+	if (isNewRepoNav()) {
+		return false;
+	}
+
 	const projectsTab = await elementReady('[data-hotkey="g b"]');
 	if (!projectsTab || mustKeepTab(projectsTab) || await getTabCount(projectsTab) > 0) {
 		return false;
@@ -121,7 +199,12 @@ async function updateProjectsTab(): Promise<void | false> {
 }
 
 async function moveRareTabs(): Promise<void | false> {
-	// The user may have disabled `more-dropdown-links` so un-hide it
+	// New nav is handled by observe() in initNewNav
+	if (isNewRepoNav()) {
+		return false;
+	}
+
+	// Old nav: use overflow dropdown
 	if (!await unhideOverflowDropdown()) {
 		return false;
 	}
@@ -129,7 +212,6 @@ async function moveRareTabs(): Promise<void | false> {
 	// Wait for the nav dropdown to be loaded #5244
 	await elementReady('.UnderlineNav-actions ul');
 
-	// Only hide security tab if there are no vulnerability alerts #8457
 	const securityTab = $optional('[data-tab-item$="security-tab"]');
 	if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
 		onlyShowInDropdown('security-tab');
@@ -138,11 +220,23 @@ async function moveRareTabs(): Promise<void | false> {
 	onlyShowInDropdown('insights-tab');
 }
 
+async function initNewNav(signal: AbortSignal): Promise<void | false> {
+	if (!isNewRepoNav()) {
+		return false;
+	}
+
+	observe(repoUnderlineNavUl, handleNewNavTabs, {signal});
+}
+
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRepoHeader,
 	],
-	deduplicate: 'has-rgh',
+	init: initNewNav,
+}, {
+	include: [
+		pageDetect.hasRepoHeader,
+	],
 	init: [
 		updateActionsTab,
 		updateWikiTab,
@@ -157,7 +251,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isOrganizationProfile,
 	],
-	deduplicate: 'has-rgh',
 	init: updateProjectsTab,
 });
 

--- a/source/features/more-dropdown-links.tsx
+++ b/source/features/more-dropdown-links.tsx
@@ -12,12 +12,17 @@ import PackageDependenciesIcon from 'octicons-plain-react/PackageDependencies';
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import createDropdownItem from '../github-helpers/create-dropdown-item.js';
-import {buildRepoURL} from '../github-helpers/index.js';
+import {buildRepoURL, isNewRepoNav} from '../github-helpers/index.js';
 import getCurrentGitRef from '../github-helpers/get-current-git-ref.js';
 import observe from '../helpers/selector-observer.js';
 import {expectToken} from '../github-helpers/github-token.js';
 
 export async function unhideOverflowDropdown(): Promise<boolean> {
+	// New React nav manages overflow internally; cannot inject dropdown items
+	if (isNewRepoNav()) {
+		return false;
+	}
+
 	// Wait for the tab bar to be loaded
 	const repoNavigationBar = await elementReady('.UnderlineNav-body');
 
@@ -66,8 +71,13 @@ async function addDropdownItems(repoNavigationDropdown: HTMLElement): Promise<vo
 
 async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
-	await unhideOverflowDropdown();
 
+	// New React nav manages its own overflow; this feature only works on the old nav
+	if (isNewRepoNav()) {
+		return;
+	}
+
+	await unhideOverflowDropdown();
 	observe('.UnderlineNav-actions ul', addDropdownItems, {signal});
 }
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -14,6 +14,7 @@ import {
 	buildRepoURL,
 	cacheByRepo,
 	getRepo,
+	isNewRepoNav,
 	triggerRepoNavOverflow,
 } from '../github-helpers/index.js';
 import {appendBefore} from '../helpers/dom-utils.js';
@@ -61,28 +62,54 @@ async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | v
 		return false;
 	}
 
-	// Wait for the dropdown because `observe` fires as soon as it encounter the container. `releases-tab` must be appended.
-	await elementReady(repoUnderlineNavUl);
+	if (isNewRepoNav()) {
+		// Copy native tab styling from an existing non-selected tab
+		const nativeTab = $optional('nav[aria-label="Repository"] ul[role="list"] a:not([aria-current])');
+		const nativeClassName = nativeTab ? `${nativeTab.className} rgh-releases-tab` : 'rgh-releases-tab';
 
-	repoNavigationBar.append(
-		<li className="d-flex">
-			<a
-				href={buildRepoURL(type.toLowerCase())}
-				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
-				data-hotkey="g r"
-				data-selected-links="repo_releases"
-				data-tab-item="rgh-releases-item"
-				data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
-				title="Hotkey: G R"
-			>
-				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
-				<span data-content={type}>{type}</span>
-				<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
-			</a>
-		</li>,
-	);
+		repoNavigationBar.append(
+			<li>
+				<a
+					href={buildRepoURL(type.toLowerCase())}
+					className={nativeClassName}
+					data-hotkey="g r"
+					data-turbo-frame="repo-content-turbo-frame"
+					title="Hotkey: G R"
+				>
+					<span data-component="icon"><TagIcon /></span>
+					<span data-component="text" data-content={type}>{type}</span>
+					<span data-component="counter">
+						<span className="Counter" aria-hidden="true" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+					</span>
+				</a>
+			</li>,
+		);
+		triggerRepoNavOverflow();
+	} else {
+		// Old ViewComponent nav
+		// Wait for the dropdown because `observe` fires as soon as it encounter the container
+		await elementReady(repoUnderlineNavUl.join?.(',') ?? repoUnderlineNavUl);
 
-	triggerRepoNavOverflow();
+		repoNavigationBar.append(
+			<li className="d-flex">
+				<a
+					href={buildRepoURL(type.toLowerCase())}
+					className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
+					data-hotkey="g r"
+					data-selected-links="repo_releases"
+					data-tab-item="rgh-releases-item"
+					data-turbo-frame="repo-content-turbo-frame"
+					title="Hotkey: G R"
+				>
+					<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
+					<span data-content={type}>{type}</span>
+					<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+				</a>
+			</li>,
+		);
+
+		triggerRepoNavOverflow();
+	}
 }
 
 async function addReleasesDropdownItem(dropdownMenu: HTMLElement): Promise<false | void> {
@@ -110,8 +137,12 @@ async function addReleasesDropdownItem(dropdownMenu: HTMLElement): Promise<false
 async function init(signal: AbortSignal): Promise<void> {
 	await expectToken();
 	observe(repoUnderlineNavUl, addReleasesTab, {signal});
-	observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
-	observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
+
+	// Old nav only: overflow dropdown items and code-tab highlight detachment
+	if (!isNewRepoNav()) {
+		observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
+		observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
+	}
 }
 
 void features.add(import.meta.url, {

--- a/source/github-helpers/get-tab-count.ts
+++ b/source/github-helpers/get-tab-count.ts
@@ -2,7 +2,13 @@ import {$optional} from 'select-dom/strict.js';
 import oneMutation from 'one-mutation';
 
 export default async function getTabCount(tab: Element): Promise<number> {
-	const counter = $optional('.Counter, .num', tab);
+	const counter = $optional([
+		// Old nav
+		'.Counter',
+		'.num',
+		// New Primer React nav
+		'[data-component="counter"] span[aria-hidden]',
+	], tab);
 	if (!counter) {
 		// GitHub might have already dropped the counter, which means it's 0
 		return 0;

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -166,6 +166,11 @@ export function fixFileHeaderOverlap(child: Element): void {
 	child.closest('.container')?.classList.add('rgh-z-index-5');
 }
 
+/** Detect whether the current page uses the new Primer React repo navigation */
+export function isNewRepoNav(): boolean {
+	return Boolean(document.querySelector('nav[aria-label="Repository"] ul[role="list"]'));
+}
+
 /** Trigger a reflow to push the right-most tab into the overflow dropdown */
 export function triggerRepoNavOverflow(): void {
 	globalThis.dispatchEvent(new Event('resize'));

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -5,7 +5,12 @@ const requiresLogin: UrlMatch[] = [];
 export type UrlMatch = [expectations: number, url: string];
 
 /** The repo navigation bar */
-export const repoUnderlineNavUl = '.js-responsive-underlinenav ul.UnderlineNav-body';
+export const repoUnderlineNavUl = [
+	// Old ViewComponent nav
+	'.js-responsive-underlinenav ul.UnderlineNav-body',
+	// New Primer React nav
+	'nav[aria-label="Repository"] ul[role="list"]',
+];
 export const repoUnderlineNavUl_ = [
 	[1, 'https://github.com/refined-github/refined-github'],
 	[1, 'https://github.com/refined-github/refined-github/releases'],


### PR DESCRIPTION
NOT_Closes #8867

## What

Fix all three tab features for GitHub's new Primer React `UnderlineNav` navigation:
- **`releases-tab`**: Correctly styled tab with Counter badge and native Primer CSS classes
- **`bugs-tab`**: Tab re-injected after React reconciliation via `observe()`
- **`clean-repo-tabs`**: Security/Insights/Wiki/Actions/Projects hiding persists across React re-renders

## Why

GitHub migrated the repo navigation from ViewComponent to Primer React `UnderlineNav`. This broke DOM selectors (`data-hotkey` attributes removed, `.Counter` class replaced with `data-component="counter"`) and one-shot DOM manipulation (`elementReady()` changes get wiped when React reconciles).

## How

The core fix replaces one-shot `elementReady()` with `observe(repoUnderlineNavUl)` — the same CSS-animation-based element detection pattern already used by `releases-tab` and 126+ other features. When React creates new DOM nodes during reconciliation, the CSS animation fires again, re-running the handler.

**`bugs-tab`:**
- `init()` now accepts `AbortSignal` and uses `observe()` instead of `elementExists` guard + `elementReady`
- `addBugsTab()` receives the nav container and queries within it using `$optional()`
- Uses `data-tab-item="issues"` selector instead of `href$="/issues"` (other features may append query params to the Issues tab href)

**`clean-repo-tabs`:**
- New `handleNewNavTabs()` function handles all tab hiding/counting for the new nav in one observe callback
- New `initNewNav()` registered as first feature loader
- Existing `updateWikiTab/ActionsTab/ProjectsTab` and `moveRareTabs` gated with `isNewRepoNav()` early return — old nav path unchanged
- Removed `deduplicate: 'has-rgh'` (observe handles deduplication via `seenMark`)

**Other changes (from earlier commits):**
- `isNewRepoNav()` + `triggerRepoNavOverflow()` helpers
- Dual selectors in `selectors.ts` for old/new nav
- `get-tab-count.ts` supports `[data-component="counter"]`
- `more-dropdown-links` gracefully disabled on new nav (React-managed overflow)

## Test URLs & Screenshot
- https://github.com/refined-github/refined-github — Bugs 42, Releases 188, Wiki 9, Security hidden, Insights hidden
<img width="918" height="134" alt="Screenshot 2026-03-26 at 21 08 16" src="https://github.com/user-attachments/assets/d9e4ccb5-f8cb-4cda-8011-af949fac4956" />
- https://github.com/vercel/next.js — Bugs 1k, Releases 1k, Security 36 (visible, has advisories), Insights hidden
<img width="1045" height="109" alt="Screenshot 2026-03-26 at 21 08 25" src="https://github.com/user-attachments/assets/0490c93a-3729-4805-b749-d2871b410441" />
- https://github.com/refined-github/yolo — Issues disabled → no Bugs or other tab (correct)
<img width="421" height="117" alt="Screenshot 2026-03-26 at 21 08 31" src="https://github.com/user-attachments/assets/2b72fc4f-fa54-4633-83e4-593d0434729f" />


## Verified

- [x] TypeScript: 0 errors
- [x] Lint: 0 new errors (pre-existing only)
- [x] Tests: features.test.ts 294/294 passed
- [x] 5x reload stability: no flicker, no duplicate tabs, correct color and ui
- [x] Tab navigation: tabs persist across Code → Issues → Code navigation
- [x] Old nav: not affected (gated by `isNewRepoNav()`)

Assisted-By: Claude Code