### PR TITLE
`open-all-notifications` - Don't remove button after cancel

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -51,7 +51,8 @@ async function openNotifications(notifications: Element[], markAsDone = false): 
 
 async function openUnreadNotifications({delegateTarget, altKey}: DelegateEvent<MouseEvent>): Promise<void> {
 	const container = delegateTarget.closest('.js-notifications-group') ?? document;
-	const didOpenNotifications = await openNotifications(getUnreadNotifications(container), altKey);
+	const unreadNotifications = getUnreadNotifications(container);
+	const didOpenNotifications = await openNotifications(unreadNotifications, altKey);
 	if (didOpenNotifications) {
 		// Remove all now-unnecessary buttons
 		removeOpenUnreadButtons(container);


### PR DESCRIPTION
Fixes #9026

## Test URLs

https://github.com/notifications

## Screenshot

![msedge_xdWqv5rAXy](https://github.com/user-attachments/assets/1c00ca9f-9fd3-48e1-ba44-265dd9b5cd8f)
