### PR TITLE
`default-branch-button` - Avoid duplicate buttons

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -72,7 +72,7 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 		<a
 			className="btn tooltipped tooltipped-se px-2 rgh-default-branch-button flex-self-start"
 			href={await getUrl(location.href)}
-			aria-label="See this view on the default branch"
+			aria-label="View on default branch"
 			// Update on hover because the URL may change without a DOM refresh
 			// https://github.com/refined-github/refined-github/issues/6554
 			// Inlined listener because `mouseenter` is too heavy for `delegate`

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -48,6 +48,12 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 		: branchSelector;
 	selectorWrapper.classList.add('rgh-highlight-non-default-branch');
 
+	const buttonGroup = branchSelector.closest('[class*="ButtonGroup"]') ?? undefined;
+	const nativeButton = $optional('[type="button"]:has(> .octicon-chevron-left)', buttonGroup);
+	if (nativeButton?.ariaDisabled !== 'true') {
+		return;
+	}
+
 	const existingLink = $optional('.rgh-default-branch-button', branchSelector.parentElement!);
 
 	// React issues. Duplicates appear after a color scheme update
@@ -81,6 +87,8 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 
 	selectorWrapper.before(defaultLink);
 	wrapButtons([defaultLink, selectorWrapper]);
+
+	nativeButton?.classList.add('d-none');
 }
 
 async function init(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
Closes #8662

## Test URLs

https://github.com/refined-github/refined-github/tree/unread-in-backgr0und/source

https://github.com/refined-github/refined-github/blob/5c41c2983e0dc7b420b1598f5525949e371f7e99/.ncurc.json

## Screenshot

<img width="310" height="99" alt="image" src="https://github.com/user-attachments/assets/88c1be52-86c5-4dd5-83d7-80ed33ab4524" />

<img width="303" height="87" alt="image" src="https://github.com/user-attachments/assets/ac21c91a-9596-456c-b6fe-faaed03ce083" />