### PR TITLE
Fix backticked text styling in pinned issues & commit messages

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -1,7 +1,8 @@
 /* Style backticked code in links #4817, matches GitHub’s `.markdown-title code` rule */
-/* `isCommitList` commit message */
-[data-testid='commit-row-item'] code,
-.Box-header .commit-author + span code /* `isRepoTree` commit message */ {
+[data-testid='commit-row-item'] code /* `isCommitList` commit message */,
+.Box-header .commit-author + span code /* `isRepoTree` commit message */,
+a[class*='PinnedIssue-module__Link'] code,
+div[class^='CommitHeader-module__commitMessageContainer'] code {
 	padding: 2px 4px;
 	background-color: var(
 		--bgColor-neutral-muted,

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -1,8 +1,7 @@
 /* Style backticked code in links #4817, matches GitHub’s `.markdown-title code` rule */
-[data-testid='commit-row-item'] code /* `isCommitList` commit message */,
-.Box-header .commit-author + span code /* `isRepoTree` commit message */,
-a[class*='PinnedIssue-module__Link'] code,
-div[class^='CommitHeader-module__commitMessageContainer'] code {
+li[data-testid='commit-row-item'] code /* `isCommitList` commit message */,
+div[class^='CommitHeader-module__commitMessageContainer'] code /* `isCommit` commit message */
+a[class*='PinnedIssue-module__Link'] code {
 	padding: 2px 4px;
 	background-color: var(
 		--bgColor-neutral-muted,

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -1,6 +1,7 @@
 /* Style backticked code in links #4817, matches GitHub’s `.markdown-title code` rule */
 li[data-testid='commit-row-item'] code /* `isCommitList` commit message */,
-div[class^='CommitHeader-module__commitMessageContainer'] code /* `isCommit` commit message */
+div[class^='CommitHeader-module__commitMessageContainer']
+	code /* `isCommit` commit message */,
 a[class*='PinnedIssue-module__Link'] code {
 	padding: 2px 4px;
 	background-color: var(


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/refined-github/issues

https://github.com/refined-github/refined-github/commit/7455659316304023ea3734c71739e2e7b8dd77bf

## Screenshot

| **Before** | <img width="423" height="116" alt="image" src="https://github.com/user-attachments/assets/df4165c5-2bc2-4451-8aa6-55f1e225908c" /> |
|--------|--------|
| **After** | <img width="419" height="112" alt="image" src="https://github.com/user-attachments/assets/728d4b69-9fd3-4ede-b5e6-5fe0e7e2ff86" /> | 

| **Before** | <img width="531" height="214" alt="image" src="https://github.com/user-attachments/assets/f3d423b2-55ae-4f21-a4c5-b5bccee9da57" /> |
|--------|--------|
| **After** | <img width="554" height="205" alt="image" src="https://github.com/user-attachments/assets/4b9c547c-1820-45a1-88a8-f6ffef67036e" /> | 