### PR TITLE
`file-age-color` - Dim older files

### DIFF
--- a/source/features/file-age-color.tsx
+++ b/source/features/file-age-color.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
-import {createHeatIndexFunction} from '../helpers/math.js';
+import { createHeatIndexFunction } from '../helpers/math.js';
 
 const calculateHeatIndex = createHeatIndexFunction([0, -2_000_000_000]);
 const threeMonths = 365.25 / 4 * 24 * 60 * 60 * 1000;
@@ -25,7 +25,7 @@ function addHeatIndex(lastUpdateElement: HTMLElement): void {
 	}
 
 	if (diff > threeMonths) {
-		lastUpdateElement.style.opacity = '0.65';
+		lastUpdateElement.style.opacity = '0.75';
 		return;
 	}
 
@@ -33,7 +33,7 @@ function addHeatIndex(lastUpdateElement: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.react-directory-commit-age > [title]', addHeatIndex, {signal});
+	observe('.react-directory-commit-age > [title]', addHeatIndex, { signal });
 }
 
 void features.add(import.meta.url, {

--- a/source/features/file-age-color.tsx
+++ b/source/features/file-age-color.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 
 import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
-import { createHeatIndexFunction } from '../helpers/math.js';
+import {createHeatIndexFunction} from '../helpers/math.js';
 
 const calculateHeatIndex = createHeatIndexFunction([0, -2_000_000_000]);
 const threeMonths = 365.25 / 4 * 24 * 60 * 60 * 1000;
@@ -33,7 +33,7 @@ function addHeatIndex(lastUpdateElement: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.react-directory-commit-age > [title]', addHeatIndex, { signal });
+	observe('.react-directory-commit-age > [title]', addHeatIndex, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/file-age-color.tsx
+++ b/source/features/file-age-color.tsx
@@ -11,21 +11,16 @@ import features from '../feature-manager.js';
 import {createHeatIndexFunction} from '../helpers/math.js';
 
 const calculateHeatIndex = createHeatIndexFunction([0, -2_000_000_000]);
-const threeMonths = 365.25 / 4 * 24 * 60 * 60 * 1000;
-const oneYear = 365.25 * 24 * 60 * 60 * 1000;
+const month = 30 * 24 * 60 * 60 * 1000;
 
 function addHeatIndex(lastUpdateElement: HTMLElement): void {
 	// `datetime` attribute used by pre-React version
 	const lastUpdate = new Date(lastUpdateElement.getAttribute('datetime') ?? lastUpdateElement.title);
 	const diff = Date.now() - lastUpdate.getTime();
 
-	if (diff > oneYear) {
-		lastUpdateElement.style.opacity = '0.45';
-		return;
-	}
-
-	if (diff > threeMonths) {
-		lastUpdateElement.style.opacity = '0.75';
+	// Dim files older than 4 months; dimmer after 12
+	if (diff > 4 * month) {
+		lastUpdateElement.style.opacity = diff > 12 * month ? '0.6' : '0.8';
 		return;
 	}
 

--- a/source/features/file-age-color.tsx
+++ b/source/features/file-age-color.tsx
@@ -11,11 +11,23 @@ import features from '../feature-manager.js';
 import {createHeatIndexFunction} from '../helpers/math.js';
 
 const calculateHeatIndex = createHeatIndexFunction([0, -2_000_000_000]);
+const threeMonths = 365.25 / 4 * 24 * 60 * 60 * 1000;
+const oneYear = 365.25 * 24 * 60 * 60 * 1000;
 
 function addHeatIndex(lastUpdateElement: HTMLElement): void {
 	// `datetime` attribute used by pre-React version
 	const lastUpdate = new Date(lastUpdateElement.getAttribute('datetime') ?? lastUpdateElement.title);
 	const diff = Date.now() - lastUpdate.getTime();
+
+	if (diff > oneYear) {
+		lastUpdateElement.style.opacity = '0.45';
+		return;
+	}
+
+	if (diff > threeMonths) {
+		lastUpdateElement.style.opacity = '0.65';
+		return;
+	}
 
 	lastUpdateElement.setAttribute('data-rgh-heat', String(calculateHeatIndex(-diff)));
 }


### PR DESCRIPTION
Keep recent file activity dates highlighted in orange, then fade older dates by reducing the opacity of GitHub's muted text color. 

Adds extra context with minimal styling and without overwhelming the page with hot file color. This makes the old-age side of the gradient theme-aware, adds customization hooks for the orange threshold, fade threshold, hot color, and minimum opacity, and avoids changing the shared heat-map logic used by other features.

Defaults to 365 as the threshold for oldest file color. Fades from default gray color to our default cold file color over the 365 period.

## Test URLs
https://github.com/refined-github/refined-github/

## Screenshot
<img width="1414" height="1318" alt="image" src="https://github.com/user-attachments/assets/12cdf16c-0a78-4b12-952f-79f580a31a4f" />
