### PR TITLE
`releases-tab` - Restore `g r` hotkey

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -20,6 +20,7 @@ import {appendBefore} from '../helpers/dom-utils.js';
 import {repoUnderlineNavUl, repoUnderlineNavDropdownUl} from '../github-helpers/selectors.js';
 import GetReleasesCount from './releases-tab.gql';
 import {expectToken} from '../github-helpers/github-token.js';
+import {registerHotkey} from '../github-helpers/hotkey.js';
 
 function detachHighlightFromCodeTab(codeTab: HTMLAnchorElement): void {
 	codeTab.dataset.selectedLinks = codeTab.dataset.selectedLinks!.replace('repo_releases ', '');
@@ -112,6 +113,9 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe(repoUnderlineNavUl, addReleasesTab, {signal});
 	observe(repoUnderlineNavDropdownUl, addReleasesDropdownItem, {signal});
 	observe(['[data-menu-item="i0code-tab"] a', 'a#code-tab'], detachHighlightFromCodeTab, {signal});
+	// Workaround for #8867
+	// TODO: remove once the issue is resolved
+	registerHotkey('g r', buildRepoUrl('releases'), {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Registers `g r` hotkey during init as a temporary workaround for #8867


## Test URLs
https://github.com/refined-github/refined-github

## Screenshot
