### PR TITLE
`easy-toggle-commit-messages` - Restore feature on compare pages

### DIFF
--- a/source/features/easy-toggle-commit-messages.tsx
+++ b/source/features/easy-toggle-commit-messages.tsx
@@ -21,6 +21,7 @@ function toggleCommitMessage(event: DelegateEvent<MouseEvent>): void {
 	$optional([
 		'[data-testid="commit-row-show-description-button"]', // Commit list
 		'[data-testid="latest-commit-details-toggle"]', // File/folder
+		'.ellipsis-expander', // Compare
 	], event.delegateTarget)?.dispatchEvent(
 		new MouseEvent('click', {bubbles: true, altKey: event.altKey}),
 	);
@@ -29,6 +30,7 @@ function toggleCommitMessage(event: DelegateEvent<MouseEvent>): void {
 const commitMessagesSelector = [
 	'[data-testid="commit-row-item"]',
 	'[data-testid="latest-commit"]', // Commit message in file tree header
+	'.js-commits-list-item', // Compare
 ];
 
 function init(signal: AbortSignal): void {
@@ -55,6 +57,7 @@ Test URLs:
 - Repo root: https://github.com/refined-github/sandbox/tree/254a81ef488dcb3866cf8a4cacde501d9faaa588
 - Commit list: https://github.com/refined-github/refined-github/commits/main/?after=384131b0be3d4097f7cc633f76aecd43f1292471+69
 - File/folder: https://github.com/refined-github/sandbox/tree/254a81ef488dcb3866cf8a4cacde501d9faaa588/.github/workflows
+- Compare: https://github.com/refined-github/sandbox/compare/default-a...Dont-mess
 
 How to test:
 


### PR DESCRIPTION
Those selectors were mistakenly removed in #7775


## Test URLs

https://github.com/refined-github/sandbox/compare/default-a...Dont-mess

## Screenshot

![msedge_RnCbBvxHMM](https://github.com/user-attachments/assets/4b39466c-5724-4ad2-a2db-13223ae2bf13)
