### PR TITLE
`highlight-non-default-base-branch` - Support global PR/issue lists

### DIFF
--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -14,70 +14,119 @@ type BranchInfo = {
 	baseRefName: string;
 };
 
+type PrRef = {
+	link: HTMLAnchorElement;
+	owner: string;
+	repo: string;
+	number: number;
+};
+
 function isClosed(prLink: HTMLElement): boolean {
-	return Boolean(prLink.closest('.js-issue-row')!.querySelector(['.octicon.merged', '.octicon.closed']));
+	return Boolean(prLink.closest('.js-issue-row')?.querySelector(['.octicon.merged', '.octicon.closed']));
 }
 
-function buildQuery(issueIds: string[]): string {
-	return `
-		repository() {
-			nameWithOwner
-			defaultBranchRef {name}
-			${issueIds.map(id => `
-				${id}: pullRequest(number: ${id.replaceAll(/\D/g, '')}) {
-					baseRef {id}
-					baseRefName
-				}
-			`).join('\n')}
-		}
-	`;
+function repoAlias(owner: string, repo: string): string {
+	return `repo_${owner}_${repo}`.replaceAll(/\W/g, '_');
 }
 
-async function add(prLinks: HTMLElement[]): Promise<void> {
-	const query = buildQuery(prLinks.map(pr => pr.id));
-	const data = await api.v4(query);
-	const defaultBranch = data.repository.defaultBranchRef?.name;
+function buildQuery(groups: Map<string, PrRef[]>): string {
+	return [...groups.values()].map(prs => {
+		const {owner, repo} = prs[0];
+		return `
+			${repoAlias(owner, repo)}: repository(owner: "${owner}", name: "${repo}") {
+				nameWithOwner
+				defaultBranchRef {name}
+				${prs.map(pr => `
+					pr_${pr.number}: pullRequest(number: ${pr.number}) {
+						baseRef {id}
+						baseRefName
+					}
+				`).join('\n')}
+			}
+		`;
+	}).join('\n');
+}
 
-	for (const prLink of prLinks) {
-		const pr: BranchInfo = data.repository[prLink.id];
-		if (pr.baseRefName === defaultBranch) {
+function renderBadge(pr: PrRef, info: BranchInfo, nameWithOwner: string): void {
+	const branch = info.baseRef && `/${nameWithOwner}/tree/${info.baseRefName}`;
+	const displayName = abbreviateString(info.baseRefName, 25);
+
+	const badge = (
+		<span className="issue-meta-section ml-2">
+			<GitPullRequestIcon />
+			{' To '}
+			<span
+				className="commit-ref user-select-contain mb-n1"
+				style={branch ? {} : {textDecoration: 'line-through'}}
+			>
+				<a title={branch ? info.baseRefName : 'Deleted'} href={branch}>
+					{displayName}
+				</a>
+			</span>
+		</span>
+	);
+
+	// Legacy DOM exposes a dedicated metadata container; React rows (global list) don't, so place next to the title link
+	const legacyMeta = pr.link.parentElement?.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex');
+	if (legacyMeta) {
+		legacyMeta.append(badge);
+	} else {
+		pr.link.after(badge);
+	}
+}
+
+async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
+	const groups = new Map<string, PrRef[]>();
+	for (const link of prLinks) {
+		const [, owner, repo, , number] = link.pathname.split('/');
+		const ref: PrRef = {
+			link, owner, repo, number: Number(number),
+		};
+		const key = `${owner}/${repo}`;
+		const list = groups.get(key) ?? [];
+		list.push(ref);
+		groups.set(key, list);
+	}
+
+	const data = await api.v4(buildQuery(groups));
+
+	for (const prs of groups.values()) {
+		const {owner, repo} = prs[0];
+		const repository = data[repoAlias(owner, repo)];
+		if (!repository) {
 			continue;
 		}
 
-		// Avoid noise on old PRs pointing to `master` #3910
-		// If the PR is open, it means that `master` still exists
-		if (pr.baseRefName === 'master' && isClosed(prLink)) {
-			continue;
+		const defaultBranch = repository.defaultBranchRef?.name;
+		for (const pr of prs) {
+			const info: BranchInfo = repository[`pr_${pr.number}`];
+			if (info.baseRefName === defaultBranch) {
+				continue;
+			}
+
+			// Avoid noise on old PRs pointing to `master` #3910
+			// If the PR is open, it means that `master` still exists
+			if (info.baseRefName === 'master' && isClosed(pr.link)) {
+				continue;
+			}
+
+			renderBadge(pr, info, repository.nameWithOwner);
 		}
-
-		const branch = pr.baseRef && `/${data.repository.nameWithOwner}/tree/${pr.baseRefName}`;
-		const displayName = abbreviateString(pr.baseRefName, 25);
-
-		prLink.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!.append(
-			<span className="issue-meta-section ml-2">
-				<GitPullRequestIcon />
-				{' To '}
-				<span
-					className="commit-ref user-select-contain mb-n1"
-					style={branch ? {} : {textDecoration: 'line-through'}}
-				>
-					<a title={branch ? pr.baseRefName : 'Deleted'} href={branch}>
-						{displayName}
-					</a>
-				</span>
-			</span>,
-		);
 	}
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
 	await expectToken();
-	observe('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', batchedFunction(add, {delay: 100}), {signal});
+	observe([
+		'.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', // Per-repo issue/PR list
+		'a[data-testid="issue-pr-title-link"][href*="/pull/"]', // Global PR list (React row)
+	], batchedFunction(add, {delay: 100}), {signal});
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoIssueOrPRList,
+		pageDetect.isGlobalIssueOrPRList,
 	],
 	init,
 });
@@ -86,6 +135,7 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
+- Repo PR list:   https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
+- Global PR list: https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3A%40me
 
 */

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -21,8 +21,21 @@ type PrRef = {
 	number: number;
 };
 
+const closedSelectors = [
+	'.octicon.merged', // Legacy DOM
+	'.octicon.closed', // Legacy DOM
+	'.octicon-git-merge', // React DOM
+	'.octicon-git-pull-request-closed', // React DOM
+];
+
 function isClosed(prLink: HTMLElement): boolean {
-	return Boolean(prLink.closest('.js-issue-row')?.querySelector(['.octicon.merged', '.octicon.closed']));
+	const row = prLink.closest('.js-issue-row') // Legacy DOM
+		?? prLink.closest('[class^="IssueRow"]'); // React DOM
+	if (!row) {
+		return false;
+	}
+
+	return Boolean(row.querySelector(closedSelectors));
 }
 
 function repoAlias(owner: string, repo: string): string {
@@ -125,8 +138,7 @@ async function init(signal: AbortSignal): Promise<false | void> {
 
 void features.add(import.meta.url, {
 	include: [
-		pageDetect.isRepoIssueOrPRList,
-		pageDetect.isGlobalIssueOrPRList,
+		pageDetect.isIssueOrPRList,
 	],
 	init,
 });

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -142,7 +142,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Repo PR list:   https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
-- Global PR list: https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3A%40me
+- Repo PR list: https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
+- Repo issue list: https://github.com/refined-github/sandbox/issues?q=is%3Apr%20state%3Aopen+pr+branch
+- Global PR list: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Arefined-github%2Fsandbox+pr+branch
 
 */

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -136,9 +136,9 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Repo PR list: https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
-- Repo issue list: https://github.com/refined-github/sandbox/issues?q=is%3Apr%20state%3Aopen+pr+branch
-- Global PR list: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Arefined-github%2Fsandbox+pr+branch
-- Global issue list: https://github.com/issues?q=is%3Aopen+is%3Apr+repo%3Arefined-github%2Fsandbox+pr+branch
+- Repo PR list: https://github.com/refined-github/sandbox/pulls?q=is%3Apr+non+default
+- Repo issue list: https://github.com/refined-github/sandbox/issues?q=is%3Apr+non+default
+- Global PR list: https://github.com/pulls?q=is%3Apr+repo%3Arefined-github%2Fsandbox+non+default
+- Global issue list: https://github.com/issues?q=is%3Apr+repo%3Arefined-github%2Fsandbox+non+default
 
 */

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -11,7 +11,7 @@ import {expectToken} from '../github-helpers/github-token.js';
 import abbreviateString from '../helpers/abbreviate-string.js';
 
 type BaseBranch = {
-	ref: string;
+	ref: string | undefined;
 	refName: string;
 };
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -60,7 +60,7 @@ function renderBadge(pr: PrRef, baseBranch: BaseBranch, nameWithOwner: string): 
 	const displayName = abbreviateString(baseBranch.refName, 25);
 
 	const badge = (
-		<span className="issue-meta-section ml-2">
+		<span className="ml-2">
 			<GitPullRequestIcon />
 			{' To '}
 			<span

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -29,28 +29,22 @@ const closedSelectors = [
 ];
 
 function isClosed(prLink: HTMLElement): boolean {
-	const row = prLink.closest('.js-issue-row') // Legacy DOM
-		?? prLink.closest('[class^="IssueRow"]'); // React DOM
-	if (!row) {
-		return false;
-	}
-
-	return Boolean(row.querySelector(closedSelectors));
-}
-
-function repoAlias(owner: string, repo: string): string {
-	return `repo_${owner}_${repo}`.replaceAll(/\W/g, '_');
+	const row = prLink.closest([
+		'.js-issue-row', // Legacy DOM
+		'[class^="IssueRow"]', // React DOM
+	]);
+	return Boolean(row!.querySelector(closedSelectors));
 }
 
 function buildQuery(groups: Map<string, PrRef[]>): string {
 	return [...groups.values()].map(prs => {
 		const {owner, repo} = prs[0];
 		return `
-			${repoAlias(owner, repo)}: repository(owner: "${owner}", name: "${repo}") {
+			${api.escapeKey('repo', owner, repo)}: repository(owner: "${owner}", name: "${repo}") {
 				nameWithOwner
 				defaultBranchRef {name}
 				${prs.map(pr => `
-					pr_${pr.number}: pullRequest(number: ${pr.number}) {
+					${api.escapeKey('pr', pr.number)}: pullRequest(number: ${pr.number}) {
 						baseRef {id}
 						baseRefName
 					}
@@ -105,14 +99,14 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 
 	for (const prs of groups.values()) {
 		const {owner, repo} = prs[0];
-		const repository = data[repoAlias(owner, repo)];
+		const repository = data[api.escapeKey('repo', owner, repo)];
 		if (!repository) {
 			continue;
 		}
 
 		const defaultBranch = repository.defaultBranchRef?.name;
 		for (const pr of prs) {
-			const info: BranchInfo = repository[`pr_${pr.number}`];
+			const info: BranchInfo = repository[api.escapeKey('pr', pr.number)];
 			if (info.baseRefName === defaultBranch) {
 				continue;
 			}

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -22,19 +22,19 @@ type PrRef = {
 	number: number;
 };
 
-const closedSelectors = [
-	'.octicon.merged', // Legacy DOM
-	'.octicon.closed', // Legacy DOM
-	'.octicon-git-merge', // React DOM
-	'.octicon-git-pull-request-closed', // React DOM
-];
-
 function isClosed(prLink: HTMLElement): boolean {
 	const row = prLink.closest([
 		'.js-issue-row', // Legacy DOM
-		'[class^="IssueRow"]', // React DOM
-	]);
-	return elementExists(closedSelectors, row!);
+		'[class^="IssueRow"]',
+	])!;
+	return elementExists([
+		// Legacy DOM
+		'.octicon.merged',
+		'.octicon.closed',
+		// React DOM
+		'.octicon-git-merge',
+		'.octicon-git-pull-request-closed',
+	], row);
 }
 
 function buildQuery(groups: Map<string, PrRef[]>): string {

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -25,7 +25,7 @@ type Pr = {
 function isClosed(prLink: HTMLElement): boolean {
 	const row = prLink.closest([
 		'.js-issue-row', // Legacy DOM
-		'[class^="IssueRow"]',
+		'li',
 	])!;
 	return elementExists([
 		// Legacy DOM
@@ -76,7 +76,10 @@ function renderBranches(pr: Pr, baseBranch: BaseBranch, nameWithOwner: string): 
 
 	const metadataRow = pr.link.matches('.js-navigation-open')
 		? pr.link.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!
-		: pr.link.closest('li')!.querySelector('[data-testid="list-row-repo-name-and-number"]')!;
+		: pr.link.closest('li')!.querySelector([
+			'div[data-testid="list-row-repo-name-and-number"]',
+			'div[class^="Description"]'
+		])!;
 	metadataRow.append(badge);
 }
 
@@ -121,7 +124,8 @@ async function init(signal: AbortSignal): Promise<false | void> {
 	await expectToken();
 	observe([
 		'.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', // Repo and global PR lists
-		'a[data-testid="issue-pr-title-link"][data-hovercard-type="pull_request"]', // Repo issue list
+		'a[data-testid="listitem-title-link"][data-hovercard-type="pull_request"]', // Preview global PR list
+		'a[data-testid="issue-pr-title-link"][data-hovercard-type="pull_request"]', // Issue list
 	], batchedFunction(add, {delay: 100}), {signal});
 }
 

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -75,10 +75,12 @@ function renderBranches(pr: Pr, baseBranch: BaseBranch, nameWithOwner: string): 
 	);
 
 	const metadataRow = pr.link.matches('.js-issue-row *')
+		// Legacy DOM
 		? pr.link.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!
+		// React DOM
 		: pr.link.closest('li')!.querySelector([
-			'div[data-testid="list-row-repo-name-and-number"]',
-			'div[class^="Description"]',
+			'div[data-testid="list-row-repo-name-and-number"]', // Issue list
+			'div[class^="Description"]', // Preview global PR list
 		])!;
 	metadataRow.append(badge);
 }

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -10,9 +10,9 @@ import observe from '../helpers/selector-observer.js';
 import {expectToken} from '../github-helpers/github-token.js';
 import abbreviateString from '../helpers/abbreviate-string.js';
 
-type BranchInfo = {
-	baseRef: string;
-	baseRefName: string;
+type BaseBranch = {
+	ref: string;
+	refName: string;
 };
 
 type PrRef = {
@@ -55,9 +55,9 @@ function buildQuery(groups: Map<string, PrRef[]>): string {
 	}).join('\n');
 }
 
-function renderBadge(pr: PrRef, info: BranchInfo, nameWithOwner: string): void {
-	const branch = info.baseRef && `/${nameWithOwner}/tree/${info.baseRefName}`;
-	const displayName = abbreviateString(info.baseRefName, 25);
+function renderBadge(pr: PrRef, baseBranch: BaseBranch, nameWithOwner: string): void {
+	const branch = baseBranch.ref && `/${nameWithOwner}/tree/${baseBranch.refName}`;
+	const displayName = abbreviateString(baseBranch.refName, 25);
 
 	const badge = (
 		<span className="issue-meta-section ml-2">
@@ -67,7 +67,7 @@ function renderBadge(pr: PrRef, info: BranchInfo, nameWithOwner: string): void {
 				className="commit-ref user-select-contain mb-n1"
 				style={branch ? {} : {textDecoration: 'line-through'}}
 			>
-				<a title={branch ? info.baseRefName : 'Deleted'} href={branch}>
+				<a title={branch ? baseBranch.refName : 'Deleted'} href={branch}>
 					{displayName}
 				</a>
 			</span>
@@ -107,18 +107,18 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 
 		const defaultBranch = repository.defaultBranchRef?.name;
 		for (const pr of prs) {
-			const info: BranchInfo = repository[api.escapeKey('pr', pr.number)];
-			if (info.baseRefName === defaultBranch) {
+			const baseBranch: BaseBranch = repository[api.escapeKey('pr', pr.number)];
+			if (baseBranch.refName === defaultBranch) {
 				continue;
 			}
 
 			// Avoid noise on old PRs pointing to `master` #3910
 			// If the PR is open, it means that `master` still exists
-			if (info.baseRefName === 'master' && isClosed(pr.link)) {
+			if (baseBranch.refName === 'master' && isClosed(pr.link)) {
 				continue;
 			}
 
-			renderBadge(pr, info, repository.nameWithOwner);
+			renderBadge(pr, baseBranch, repository.nameWithOwner);
 		}
 	}
 }

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -2,6 +2,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import GitPullRequestIcon from 'octicons-plain-react/GitPullRequest';
 import batchedFunction from 'batched-function';
+import {elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -33,7 +34,7 @@ function isClosed(prLink: HTMLElement): boolean {
 		'.js-issue-row', // Legacy DOM
 		'[class^="IssueRow"]', // React DOM
 	]);
-	return Boolean(row!.querySelector(closedSelectors));
+	return elementExists(closedSelectors, row!);
 }
 
 function buildQuery(groups: Map<string, PrRef[]>): string {

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -74,7 +74,7 @@ function renderBranches(pr: Pr, baseBranch: BaseBranch, nameWithOwner: string): 
 		</span>
 	);
 
-	const metadataRow = pr.link.matches('.js-navigation-open')
+	const metadataRow = pr.link.matches('.js-issue-row *')
 		? pr.link.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!
 		: pr.link.closest('li')!.querySelector([
 			'div[data-testid="list-row-repo-name-and-number"]',
@@ -122,11 +122,11 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<false | void> {
 	await expectToken();
-	observe([
-		'.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', // Repo and global PR lists
-		'a[data-testid="listitem-title-link"][data-hovercard-type="pull_request"]', // Preview global PR list
-		'a[data-testid="issue-pr-title-link"][data-hovercard-type="pull_request"]', // Issue list
-	], batchedFunction(add, {delay: 100}), {signal});
+	observe(`a[data-hovercard-type="pull_request"]:is(${[
+		'.js-issue-row *', // Repo and global PR lists
+		'[data-testid="listitem-title-link"]', // Preview global PR list
+		'[data-testid="issue-pr-title-link"]', // Issue list
+	].join(',')})`, batchedFunction(add, {delay: 100}), {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -15,7 +15,7 @@ type BaseBranch = {
 	refName: string;
 };
 
-type PrRef = {
+type Pr = {
 	link: HTMLAnchorElement;
 	owner: string;
 	repo: string;
@@ -37,8 +37,8 @@ function isClosed(prLink: HTMLElement): boolean {
 	], row);
 }
 
-function buildQuery(groups: Map<string, PrRef[]>): string {
-	return [...groups.values()].map(prs => {
+function buildQuery(prsByRepo: Map<string, Pr[]>): string {
+	return [...prsByRepo.values()].map(prs => {
 		const {owner, repo} = prs[0];
 		return `
 			${api.escapeKey('repo', owner, repo)}: repository(owner: "${owner}", name: "${repo}") {
@@ -46,8 +46,8 @@ function buildQuery(groups: Map<string, PrRef[]>): string {
 				defaultBranchRef {name}
 				${prs.map(pr => `
 					${api.escapeKey('pr', pr.number)}: pullRequest(number: ${pr.number}) {
-						baseRef {id}
-						baseRefName
+						ref: baseRef {id}
+						refName: baseRefName
 					}
 				`).join('\n')}
 			}
@@ -55,7 +55,7 @@ function buildQuery(groups: Map<string, PrRef[]>): string {
 	}).join('\n');
 }
 
-function renderBadge(pr: PrRef, baseBranch: BaseBranch, nameWithOwner: string): void {
+function renderBranches(pr: Pr, baseBranch: BaseBranch, nameWithOwner: string): void {
 	const branch = baseBranch.ref && `/${nameWithOwner}/tree/${baseBranch.refName}`;
 	const displayName = abbreviateString(baseBranch.refName, 25);
 
@@ -74,39 +74,33 @@ function renderBadge(pr: PrRef, baseBranch: BaseBranch, nameWithOwner: string): 
 		</span>
 	);
 
-	// Legacy DOM exposes a dedicated metadata container; React rows (global list) don't, so place next to the title link
-	const legacyMeta = pr.link.parentElement?.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex');
-	if (legacyMeta) {
-		legacyMeta.append(badge);
-	} else {
-		pr.link.after(badge);
-	}
+	const metadataRow = pr.link.matches('.js-navigation-open')
+		? pr.link.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!
+		: pr.link.closest('li')!.querySelector('[data-testid="list-row-repo-name-and-number"]')!;
+	metadataRow.append(badge);
 }
 
 async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
-	const groups = new Map<string, PrRef[]>();
+	const prs = new Set<Pr>();
 	for (const link of prLinks) {
 		const [, owner, repo, , number] = link.pathname.split('/');
-		const ref: PrRef = {
+		prs.add({
 			link, owner, repo, number: Number(number),
-		};
-		const key = `${owner}/${repo}`;
-		const list = groups.get(key) ?? [];
-		list.push(ref);
-		groups.set(key, list);
+		});
 	}
 
-	const data = await api.v4(buildQuery(groups));
+	const prsByRepo = Map.groupBy(prs, pr => `${pr.owner}/${pr.repo}`);
+	const data = await api.v4(buildQuery(prsByRepo));
 
-	for (const prs of groups.values()) {
-		const {owner, repo} = prs[0];
+	for (const repoPrs of prsByRepo.values()) {
+		const {owner, repo} = repoPrs[0];
 		const repository = data[api.escapeKey('repo', owner, repo)];
 		if (!repository) {
 			continue;
 		}
 
 		const defaultBranch = repository.defaultBranchRef?.name;
-		for (const pr of prs) {
+		for (const pr of repoPrs) {
 			const baseBranch: BaseBranch = repository[api.escapeKey('pr', pr.number)];
 			if (baseBranch.refName === defaultBranch) {
 				continue;
@@ -118,7 +112,7 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 				continue;
 			}
 
-			renderBadge(pr, baseBranch, repository.nameWithOwner);
+			renderBranches(pr, baseBranch, repository.nameWithOwner);
 		}
 	}
 }
@@ -145,5 +139,6 @@ Test URLs:
 - Repo PR list: https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
 - Repo issue list: https://github.com/refined-github/sandbox/issues?q=is%3Apr%20state%3Aopen+pr+branch
 - Global PR list: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Arefined-github%2Fsandbox+pr+branch
+- Global issue list: https://github.com/issues?q=is%3Aopen+is%3Apr+repo%3Arefined-github%2Fsandbox+pr+branch
 
 */

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -98,11 +98,7 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 	for (const repoPrs of prsByRepo.values()) {
 		const {owner, repo} = repoPrs[0];
 		const repository = data[api.escapeKey('repo', owner, repo)];
-		if (!repository) {
-			continue;
-		}
-
-		const defaultBranch = repository.defaultBranchRef?.name;
+		const defaultBranch = repository.defaultBranchRef.name;
 		for (const pr of repoPrs) {
 			const baseBranch: BaseBranch = repository[api.escapeKey('pr', pr.number)];
 			if (baseBranch.refName === defaultBranch) {

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -78,7 +78,7 @@ function renderBranches(pr: Pr, baseBranch: BaseBranch, nameWithOwner: string): 
 		? pr.link.parentElement!.querySelector('.text-small.color-fg-muted .d-none.d-md-inline-flex')!
 		: pr.link.closest('li')!.querySelector([
 			'div[data-testid="list-row-repo-name-and-number"]',
-			'div[class^="Description"]'
+			'div[class^="Description"]',
 		])!;
 	metadataRow.append(badge);
 }

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -120,11 +120,11 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<false | void> {
 	await expectToken();
-	observe(`a[data-hovercard-type="pull_request"]:is(${[
-		'.js-issue-row *', // Repo and global PR lists
-		'[data-testid="listitem-title-link"]', // Preview global PR list
-		'[data-testid="issue-pr-title-link"]', // Issue list
-	].join(',')})`, batchedFunction(add, {delay: 100}), {signal});
+	observe([
+		'.js-issue-row a[data-hovercard-type="pull_request"]', // Repo and global PR lists
+		'a[data-hovercard-type="pull_request"][data-testid="listitem-title-link"]', // Preview global PR list
+		'a[data-hovercard-type="pull_request"][data-testid="issue-pr-title-link"]', // Issue list
+	], batchedFunction(add, {delay: 100}), {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -126,8 +126,8 @@ async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
 async function init(signal: AbortSignal): Promise<false | void> {
 	await expectToken();
 	observe([
-		'.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', // Per-repo issue/PR list
-		'a[data-testid="issue-pr-title-link"][href*="/pull/"]', // Global PR list (React row)
+		'.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]', // Repo and global PR lists
+		'a[data-testid="issue-pr-title-link"][data-hovercard-type="pull_request"]', // Repo issue list
 	], batchedFunction(add, {delay: 100}), {signal});
 }
 


### PR DESCRIPTION
Closes #9167. Follow-up to #9168.

Extends the feature to the global PR/issue dashboards (`/pulls`, `/issues`, `/pulls?author=@me`, etc.) where the badge is arguably most useful — that's where you scan PRs across many repos and have no other quick way to spot one targeting a non-default branch.

## What changed

- Added `pageDetect.isGlobalIssueOrPRList` to `include`.
- Added the React row selector (`a[data-testid="issue-pr-title-link"][href*="/pull/"]`) used by the global lists, alongside the existing legacy selector.
- Each PR's owner/repo/number is parsed from its `href`, so the feature no longer assumes a single-repo page context.
- `buildQuery` now emits one aliased `repository(owner, name) { ... }` block per repo, all in a single GraphQL query.
- Badge insertion: legacy rows still use the existing metadata container; React rows (no stable container yet) get the badge placed right after the title link.

Why grouping by repo into a single query:

Sending one query per PR (or per repo, in parallel) would be simpler, but I went with single-query alias grouping to be safe against GitHub's secondary rate limits — the global PR list can easily contain PRs from 10+ distinct repos, and the per-request limit (and burst limit) is much tighter than the points budget. One batched query also saves a round trip and keeps response handling sequential. The added complexity is contained to `buildQuery` + alias lookup in `add`.

If you'd rather have the simpler version (one `api.v4` call per repo, in parallel), happy to switch.

## Test URLs

- Per-repo (existing): https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+pr+branch
- Global PR list: https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3A%40me

## Screenshot
### Per-repo
<img width="3172" height="1712" alt="image" src="https://github.com/user-attachments/assets/7e4f25b7-fb9b-422e-b028-234bc36fc07b" />

### Global PR list
<img width="3024" height="694" alt="image" src="https://github.com/user-attachments/assets/3c590bda-29e2-47cb-8919-dd9f42fe1c62" />