### PR TITLE
`linkify-user-labels` - Expand to PR list

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -428,7 +428,7 @@
 	},
 	{
 		"id": "linkify-user-labels",
-		"description": "Links the \"Contributor\", \"Member\" and \"Collaborator\" labels on comments to the author’s commits on the repo.",
+		"description": "Links the \"Contributor\", \"Member\" and \"Collaborator\" labels on comments and PRs to the author’s commits on the repo.",
 		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png"
 	},

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif)
 - [](# "esc-to-cancel") [Adds a shortcut to cancel editing a issue/PR title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
 - [](# "no-duplicate-list-update-time") [Hides the update time of issues/PRs in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
-- [](# "linkify-user-labels") [Links the "Contributor", "Member" and "Collaborator" labels on comments to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
+- [](# "linkify-user-labels") [Links the "Contributor", "Member" and "Collaborator" labels on comments and PRs to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
 - [](# "jump-to-conversation-close-event") [Adds a link to jump to the latest close event of a issue/PR.](https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif)
 - [](# "close-as-unplanned") [Lets you "close issue as unplanned" in one click instead of three.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/279745773-709cde60-c26a-4a0e-89e1-56444d25ebdf.png)
 - [](# "locked-issue") [Show a label on locked issues and PRs.](https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png)

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -8,8 +8,22 @@ import features from '../feature-manager.js';
 import {buildRepoUrl} from '../github-helpers/index.js';
 import getCommentAuthor from '../github-helpers/get-comment-author.js';
 import observe from '../helpers/selector-observer.js';
+import onetime from '../helpers/onetime.js';
 
-function linkify(label: Element): void {
+const isPrList = onetime((): boolean => pageDetect.isPRList());
+
+function getAuthor(label: HTMLElement): string {
+	if (isPrList()) {
+		const authorPrsLink = label.closest('.opened-by')!.querySelector('a')!;
+		// The link always ends with author
+		const username = authorPrsLink.href.split('author%3A')[1];
+		return username;
+	}
+
+	return getCommentAuthor(label);
+}
+
+function linkify(label: HTMLElement): void {
 	if (label.closest('a')) {
 		throw new Error('Already linkified, feature needs to be updated');
 	}
@@ -19,7 +33,7 @@ function linkify(label: Element): void {
 	label.parentElement!.querySelector('.rgh-linkify-user-labels')?.remove();
 
 	const url = new URL(buildRepoUrl('commits'));
-	url.searchParams.set('author', getCommentAuthor(label));
+	url.searchParams.set('author', getAuthor(label));
 	wrap(label, <a className="Link--onHover color-fg-inherit rgh-linkify-user-labels" href={url.href} />);
 }
 
@@ -42,6 +56,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	include: [
+		isPrList,
 		pageDetect.hasComments,
 	],
 	init,
@@ -77,5 +92,8 @@ https://github.com/refined-github/sandbox/issues/74#issuecomment-2143792189
 
 Collaborator review comment
 https://github.com/editorconfig/editorconfig-emacs/pull/389/changes#r2809824690
+
+Pull request list
+https://github.com/refined-github/sandbox/pulls
 
 */

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -8,15 +8,13 @@ import features from '../feature-manager.js';
 import {buildRepoUrl} from '../github-helpers/index.js';
 import getCommentAuthor from '../github-helpers/get-comment-author.js';
 import observe from '../helpers/selector-observer.js';
-import onetime from '../helpers/onetime.js';
-
-const isPrList = onetime((): boolean => pageDetect.isPRList());
 
 function getAuthor(label: HTMLElement): string {
-	if (isPrList()) {
-		const authorPrsLink = label.closest('.opened-by')!.querySelector('a')!;
+	// `isPRList`
+	if (label.parentElement!.classList.contains('opened-by')) {
+		const userPrsLink = label.previousElementSibling as HTMLAnchorElement;
 		// The link always ends with author
-		const username = authorPrsLink.href.split('author%3A')[1];
+		const username = userPrsLink.href.split('author%3A')[1];
 		return username;
 	}
 
@@ -56,7 +54,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	include: [
-		isPrList,
+		pageDetect.isPRList,
 		pageDetect.hasComments,
 	],
 	init,

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -12,14 +12,14 @@ import observe from '../helpers/selector-observer.js';
 
 function getAuthor(label: HTMLElement): string {
 	const prMetadataRow = label.closest('.opened-by');
-	if (prMetadataRow) {
-		const userPrsLink = $('a[data-hovercard-type="user"]', prMetadataRow);
-		// The link always ends with author
-		const username = userPrsLink.href.split('author%3A')[1];
-		return username;
+	if (!prMetadataRow) {
+		return getCommentAuthor(label);
 	}
 
-	return getCommentAuthor(label);
+	const userPrsLink = $('a[data-hovercard-type="user"]', prMetadataRow);
+	// The link always ends with author
+	const username = userPrsLink.href.split('author%3A')[1];
+	return username;
 }
 
 function linkify(label: HTMLElement): void {

--- a/source/features/linkify-user-labels.tsx
+++ b/source/features/linkify-user-labels.tsx
@@ -1,6 +1,7 @@
 import './linkify-user-labels.css';
 
 import React from 'dom-chef';
+import {$} from 'select-dom/strict.js';
 import * as pageDetect from 'github-url-detection';
 
 import {wrap} from '../helpers/dom-utils.js';
@@ -10,9 +11,9 @@ import getCommentAuthor from '../github-helpers/get-comment-author.js';
 import observe from '../helpers/selector-observer.js';
 
 function getAuthor(label: HTMLElement): string {
-	// `isPRList`
-	if (label.parentElement!.classList.contains('opened-by')) {
-		const userPrsLink = label.previousElementSibling as HTMLAnchorElement;
+	const prMetadataRow = label.closest('.opened-by');
+	if (prMetadataRow) {
+		const userPrsLink = $('a[data-hovercard-type="user"]', prMetadataRow);
 		// The link always ends with author
 		const username = userPrsLink.href.split('author%3A')[1];
 		return username;
@@ -91,7 +92,7 @@ https://github.com/refined-github/sandbox/issues/74#issuecomment-2143792189
 Collaborator review comment
 https://github.com/editorconfig/editorconfig-emacs/pull/389/changes#r2809824690
 
-Pull request list
-https://github.com/refined-github/sandbox/pulls
+Pull requests from a contributor
+https://github.com/refined-github/refined-github/pulls?q=is%3Apr+author%3Anotlmn
 
 */


### PR DESCRIPTION
https://github.blog/changelog/2026-04-09-repository-member-role-labels-now-in-pull-request-list-view/

## Test URLs

https://github.com/refined-github/sandbox/pulls

## Screenshot

<img width="564" height="100" alt="image" src="https://github.com/user-attachments/assets/d42201cc-7174-4917-872e-1a69fc6e1367" />
