### PR TITLE
`clean-repo-tabs` - Restore feature

### DIFF
--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import {CachedFunction} from 'webext-storage-cache';
 import {countElements} from 'select-dom';
-import {$, $optional} from 'select-dom/strict.js';
+import {$optional} from 'select-dom/strict.js';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
@@ -12,7 +12,13 @@ import getTabCount from '../github-helpers/get-tab-count.js';
 import looseParseInt from '../helpers/loose-parse-int.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {buildRepoUrl, cacheByRepo, getRepo} from '../github-helpers/index.js';
-import {unhideOverflowDropdown} from './more-dropdown-links.js';
+import {
+	wikiTab,
+	actionsTab,
+	projectsTab,
+	securityTab,
+	insightsTab,
+} from '../github-helpers/selectors.js';
 
 async function canUserEditOrganization(): Promise<boolean> {
 	return Boolean(await elementReady('.btn-primary[href$="repositories/new"]'));
@@ -20,16 +26,23 @@ async function canUserEditOrganization(): Promise<boolean> {
 
 function mustKeepTab(tab: HTMLElement): boolean {
 	return (
-		// User is on tab 👀
-		tab.matches('.selected')
+		// User is on tab
+		tab.matches('.selected, [aria-current="page"]')
 		// Repo owners should see the tab. If they don't need it, they should disable the feature altogether
 		|| pageDetect.canUserAdminRepo()
 	);
 }
 
 function setTabCounter(tab: HTMLElement, count: number): void {
-	let tabCounter = $optional('.Counter, .num', tab);
+	// Old DOM: .Counter or .num inside the tab link
+	// New React DOM: [data-component="counter"] wrapping the counter label
+	let tabCounter = $optional([
+		'.Counter', // Old DOM
+		'.num', // Old DOM alternate
+		'[data-component="counter"]', // React DOM
+	], tab);
 	if (!tabCounter) {
+		// Old DOM: create a .Counter span
 		tabCounter = <span className="Counter" /> as HTMLSpanElement;
 		tab.append(<span data-component="counter">{tabCounter}</span>);
 	}
@@ -38,20 +51,11 @@ function setTabCounter(tab: HTMLElement, count: number): void {
 	tabCounter.title = count > 999 ? String(count) : '';
 }
 
-function onlyShowInDropdown(id: string): void {
-	// TODO: Use selector observer
-	const tabItem = $optional(`li:not([hidden]) > [data-tab-item$="${id}"]`);
-	if (!tabItem) { // #3962 #7140
-		return;
+function hideTab(tab: HTMLElement): void {
+	const li = tab.closest('li');
+	if (li) {
+		li.hidden = true;
 	}
-
-	tabItem.closest('li')!.hidden = true;
-
-	const menuItem = $(`[data-menu-item$="${id}"]`);
-	menuItem.removeAttribute('data-menu-item');
-	menuItem.hidden = false;
-	// The item has to be moved somewhere else because the overflow nav is order-dependent
-	$('.UnderlineNav-actions ul').append(menuItem);
 }
 
 const wikiPageCount = new CachedFunction('wiki-page-count', {
@@ -79,36 +83,36 @@ const hasActionRuns = new CachedFunction('workflows-count', {
 });
 
 async function updateWikiTab(): Promise<void | false> {
-	const wikiTab = await elementReady('[data-hotkey="g w"]');
-	if (!wikiTab || mustKeepTab(wikiTab)) {
+	const tab = await elementReady(wikiTab);
+	if (!tab || mustKeepTab(tab)) {
 		return false;
 	}
 
 	const count = await wikiPageCount.get();
 	if (count > 0) {
-		setTabCounter(wikiTab, count);
+		setTabCounter(tab, count);
 	} else {
-		onlyShowInDropdown('wiki-tab');
+		hideTab(tab);
 	}
 }
 
 async function updateActionsTab(): Promise<void | false> {
-	const actionsTab = await elementReady('[data-hotkey="g a"]');
-	if (!actionsTab || mustKeepTab(actionsTab) || await hasActionRuns.get(getRepo()!.nameWithOwner)) {
+	const tab = await elementReady(actionsTab);
+	if (!tab || mustKeepTab(tab) || await hasActionRuns.get(getRepo()!.nameWithOwner)) {
 		return false;
 	}
 
-	onlyShowInDropdown('actions-tab');
+	hideTab(tab);
 }
 
 async function updateProjectsTab(): Promise<void | false> {
-	const projectsTab = await elementReady('[data-hotkey="g b"]');
-	if (!projectsTab || mustKeepTab(projectsTab) || await getTabCount(projectsTab) > 0) {
+	const tab = await elementReady(projectsTab);
+	if (!tab || mustKeepTab(tab) || await getTabCount(tab) > 0) {
 		return false;
 	}
 
 	if (pageDetect.isRepo()) {
-		onlyShowInDropdown('projects-tab');
+		hideTab(tab);
 		return;
 	}
 
@@ -117,25 +121,19 @@ async function updateProjectsTab(): Promise<void | false> {
 		return;
 	}
 
-	projectsTab.remove();
+	tab.remove();
 }
 
-async function moveRareTabs(): Promise<void | false> {
-	// The user may have disabled `more-dropdown-links` so un-hide it
-	if (!await unhideOverflowDropdown()) {
-		return false;
+async function hideRareTabs(): Promise<void | false> {
+	const security = await elementReady(securityTab);
+	if (security && !mustKeepTab(security) && await getTabCount(security) === 0) {
+		hideTab(security);
 	}
 
-	// Wait for the nav dropdown to be loaded #5244
-	await elementReady('.UnderlineNav-actions ul');
-
-	// Only hide security tab if there are no vulnerability alerts #8457
-	const securityTab = $optional('[data-tab-item$="security-tab"]');
-	if (securityTab && !mustKeepTab(securityTab) && await getTabCount(securityTab) === 0) {
-		onlyShowInDropdown('security-tab');
+	const insights = await elementReady(insightsTab);
+	if (insights && !mustKeepTab(insights)) {
+		hideTab(insights);
 	}
-
-	onlyShowInDropdown('insights-tab');
 }
 
 void features.add(import.meta.url, {
@@ -147,12 +145,8 @@ void features.add(import.meta.url, {
 		updateActionsTab,
 		updateWikiTab,
 		updateProjectsTab,
+		hideRareTabs,
 	],
-}, {
-	include: [
-		pageDetect.hasRepoHeader,
-	],
-	init: moveRareTabs,
 }, {
 	include: [
 		pageDetect.isOrganizationProfile,

--- a/source/features/clean-repo-tabs.tsx
+++ b/source/features/clean-repo-tabs.tsx
@@ -27,22 +27,15 @@ async function canUserEditOrganization(): Promise<boolean> {
 function mustKeepTab(tab: HTMLElement): boolean {
 	return (
 		// User is on tab
-		tab.matches('.selected, [aria-current="page"]')
+		tab.matches('[aria-current="page"]')
 		// Repo owners should see the tab. If they don't need it, they should disable the feature altogether
 		|| pageDetect.canUserAdminRepo()
 	);
 }
 
 function setTabCounter(tab: HTMLElement, count: number): void {
-	// Old DOM: .Counter or .num inside the tab link
-	// New React DOM: [data-component="counter"] wrapping the counter label
-	let tabCounter = $optional([
-		'.Counter', // Old DOM
-		'.num', // Old DOM alternate
-		'[data-component="counter"]', // React DOM
-	], tab);
+	let tabCounter = $optional('[data-component="counter"]', tab);
 	if (!tabCounter) {
-		// Old DOM: create a .Counter span
 		tabCounter = <span className="Counter" /> as HTMLSpanElement;
 		tab.append(<span data-component="counter">{tabCounter}</span>);
 	}
@@ -140,7 +133,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRepoHeader,
 	],
-	deduplicate: 'has-rgh',
 	init: [
 		updateActionsTab,
 		updateWikiTab,
@@ -151,7 +143,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isOrganizationProfile,
 	],
-	deduplicate: 'has-rgh',
 	init: updateProjectsTab,
 });
 

--- a/source/github-helpers/get-tab-count.ts
+++ b/source/github-helpers/get-tab-count.ts
@@ -2,7 +2,11 @@ import {$optional} from 'select-dom/strict.js';
 import oneMutation from 'one-mutation';
 
 export default async function getTabCount(tab: Element): Promise<number> {
-	const counter = $optional('.Counter, .num', tab);
+	const counter = $optional([
+		'.Counter', // Old DOM
+		'.num', // Old DOM alternate
+		'[data-component="counter"]', // React DOM
+	], tab);
 	if (!counter) {
 		// GitHub might have already dropped the counter, which means it's 0
 		return 0;

--- a/source/github-helpers/get-tab-count.ts
+++ b/source/github-helpers/get-tab-count.ts
@@ -2,11 +2,7 @@ import {$optional} from 'select-dom/strict.js';
 import oneMutation from 'one-mutation';
 
 export default async function getTabCount(tab: Element): Promise<number> {
-	const counter = $optional([
-		'.Counter', // Old DOM
-		'.num', // Old DOM alternate
-		'[data-component="counter"]', // React DOM
-	], tab);
+	const counter = $optional('[data-component="counter"]', tab);
 	if (!counter) {
 		// GitHub might have already dropped the counter, which means it's 0
 		return 0;

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -97,9 +97,49 @@ export const openIssueToLastComment_ = [
 	[2, 'https://github.com/refined-github/sandbox/labels/bug'],
 ] satisfies UrlMatch[];
 
-export const actionsTab = '#actions-tab';
+export const actionsTab = [
+	'#actions-tab', // Old DOM
+	'[data-tab-item$="actions-tab"]', // Old anonymous DOM
+	'[data-tab-item="actions"]', // React DOM
+];
 export const actionsTab_ = [
 	[1, 'https://github.com/refined-github/sandbox'],
+] satisfies UrlMatch[];
+
+/** Repo nav tab selectors — arrays support old DOM, old anonymous DOM, and React DOM */
+export const wikiTab = [
+	'[data-hotkey="g w"]', // Old DOM (logged in)
+	'[data-tab-item$="wiki-tab"]', // Old anonymous DOM
+	'[data-tab-item="wiki"]', // React DOM
+];
+export const wikiTab_ = [
+	[1, 'https://github.com/refined-github/refined-github'],
+] satisfies UrlMatch[];
+
+export const projectsTab = [
+	'[data-hotkey="g b"]', // Old DOM (logged in)
+	'[data-tab-item$="projects-tab"]', // Old anonymous DOM
+	'[data-tab-item="projects"]', // React DOM
+];
+export const projectsTab_ = [
+	// Not all repos have projects enabled
+	[0, 'https://github.com/refined-github/refined-github'],
+] satisfies UrlMatch[];
+
+export const securityTab = [
+	'[data-tab-item$="security-and-quality-tab"]', // Old anonymous DOM
+	'[data-tab-item="security-and-quality"]', // React DOM
+];
+export const securityTab_ = [
+	[1, 'https://github.com/refined-github/refined-github'],
+] satisfies UrlMatch[];
+
+export const insightsTab = [
+	'[data-tab-item$="insights-tab"]', // Old anonymous DOM
+	'[data-tab-item="insights"]', // React DOM
+];
+export const insightsTab_ = [
+	[1, 'https://github.com/refined-github/refined-github'],
 ] satisfies UrlMatch[];
 
 export const paginationButtonSelector = '.ajax-pagination-form button.ajax-pagination-btn';

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -97,49 +97,34 @@ export const openIssueToLastComment_ = [
 	[2, 'https://github.com/refined-github/sandbox/labels/bug'],
 ] satisfies UrlMatch[];
 
-export const actionsTab = [
-	'#actions-tab', // Old DOM
-	'[data-tab-item$="actions-tab"]', // Old anonymous DOM
-	'[data-tab-item="actions"]', // React DOM
-];
+export const actionsTab = '[data-tab-item="actions"]';
 export const actionsTab_ = [
-	[1, 'https://github.com/refined-github/sandbox'],
+	// React-rendered, not present in static HTML
+	[0, 'https://github.com/refined-github/sandbox'],
 ] satisfies UrlMatch[];
 
-/** Repo nav tab selectors — arrays support old DOM, old anonymous DOM, and React DOM */
-export const wikiTab = [
-	'[data-hotkey="g w"]', // Old DOM (logged in)
-	'[data-tab-item$="wiki-tab"]', // Old anonymous DOM
-	'[data-tab-item="wiki"]', // React DOM
-];
+export const wikiTab = '[data-tab-item="wiki"]';
 export const wikiTab_ = [
-	[1, 'https://github.com/refined-github/refined-github'],
-] satisfies UrlMatch[];
-
-export const projectsTab = [
-	'[data-hotkey="g b"]', // Old DOM (logged in)
-	'[data-tab-item$="projects-tab"]', // Old anonymous DOM
-	'[data-tab-item="projects"]', // React DOM
-];
-export const projectsTab_ = [
-	// Not all repos have projects enabled
+	// React-rendered, not present in static HTML
 	[0, 'https://github.com/refined-github/refined-github'],
 ] satisfies UrlMatch[];
 
-export const securityTab = [
-	'[data-tab-item$="security-and-quality-tab"]', // Old anonymous DOM
-	'[data-tab-item="security-and-quality"]', // React DOM
-];
-export const securityTab_ = [
-	[1, 'https://github.com/refined-github/refined-github'],
+export const projectsTab = '[data-tab-item="projects"]';
+export const projectsTab_ = [
+	// React-rendered, not present in static HTML
+	[0, 'https://github.com/refined-github/refined-github'],
 ] satisfies UrlMatch[];
 
-export const insightsTab = [
-	'[data-tab-item$="insights-tab"]', // Old anonymous DOM
-	'[data-tab-item="insights"]', // React DOM
-];
+export const securityTab = '[data-tab-item="security-and-quality"]';
+export const securityTab_ = [
+	// React-rendered, not present in static HTML
+	[0, 'https://github.com/refined-github/refined-github'],
+] satisfies UrlMatch[];
+
+export const insightsTab = '[data-tab-item="insights"]';
 export const insightsTab_ = [
-	[1, 'https://github.com/refined-github/refined-github'],
+	// React-rendered, not present in static HTML
+	[0, 'https://github.com/refined-github/refined-github'],
 ] satisfies UrlMatch[];
 
 export const paginationButtonSelector = '.ajax-pagination-form button.ajax-pagination-btn';


### PR DESCRIPTION
Part of #8867 (partially -- `clean-repo-tabs` only, other affected features are separate)

GitHub replaced the repo nav with a React `UnderlineNav` component. Every selector in `clean-repo-tabs` was targeting DOM that no longer exists -- hotkey attributes, `.selected`, `.Counter`, `.UnderlineNav-body`, the overflow dropdown mechanism. The feature was silently doing nothing.

## What changed

- Tab discovery switched to `[data-tab-item="..."]` selectors in `selectors.ts`. Plain strings, not arrays -- old DOM support dropped per @fregante's feedback.
- `mustKeepTab` checks `aria-current="page"` instead of `.selected`
- `setTabCounter` / `getTabCount` target `[data-component="counter"]` instead of `.Counter` / `.num`
- `hideTab` uses `li.hidden = true` instead of the old `onlyShowInDropdown` mechanism. React handles the remaining layout correctly, no visual glitches.
- Removed `moveRareTabs` and its dependency on `unhideOverflowDropdown` from `more-dropdown-links`. Security and insights tabs just get hidden directly.
- Dropped `deduplicate: 'has-rgh'` per the migration tracked in #7000. The init functions already bail early when tabs don't exist or `mustKeepTab` returns true, so re-running on SPA navigation is safe. Cached API calls (`wikiPageCount`, `hasActionRuns`) prevent redundant fetches.

## Test URLs

- Repo with 0 projects: https://github.com/babel/flavortown
- Repo with 0 wiki: https://github.com/babel/babel-sublime-snippets
- Repo with 0 actions: https://github.com/babel/jade-babel
- Repo with security + insights to hide: https://github.com/refined-github/refined-github
- Org with 0 projects: https://github.com/babel

## Screenshot

Tested across all URLs above. Tabs hide correctly on both hard refresh and SPA navigation.
<img width="2152" height="1316" alt="CleanShot 2026-04-11 at 21 55 07@2x" src="https://github.com/user-attachments/assets/8a0fad9c-dd13-4f90-a854-dbd48e0678bf" />
<img width="2238" height="1342" alt="CleanShot 2026-04-11 at 21 55 55@2x" src="https://github.com/user-attachments/assets/72fa7c53-05f1-4488-9b2d-79ce1292ac0c" />
<img width="2242" height="1254" alt="CleanShot 2026-04-11 at 21 56 38@2x" src="https://github.com/user-attachments/assets/458ab7cb-06a9-4dd9-b84f-edd06c264bc2" />
<img width="2270" height="1276" alt="CleanShot 2026-04-11 at 21 57 24@2x" src="https://github.com/user-attachments/assets/128f3efc-090e-4aed-bb84-694c868c0c9e" />
<img width="2402" height="1490" alt="CleanShot 2026-04-11 at 21 57 58@2x" src="https://github.com/user-attachments/assets/73068461-f9fa-4fcc-b8ba-860a10cbce28" />

