### PR TITLE
Fix Watch/Unwatch button height on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -153,6 +153,14 @@ div[class^='prc-PageHeader-Description']
 	}
 }
 
+/* Fix Watch/Unwatch button height on mobile */
+/* Info: https://github.com/refined-github/refined-github/issues/9183 */
+/* Test: https://github.com/refined-github/refined-github */
+#responsive-meta-container
+	button[data-testid='notifications-subscriptions-menu-button'] {
+	height: 32px;
+}
+
 /*
 
 Test URLs:


### PR DESCRIPTION
Fixes #9183 

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<img width="363" height="116" alt="Image" src="https://github.com/user-attachments/assets/899a3d08-883a-43cd-9763-272a873eec91" />

<img width="702" height="66" alt="Image" src="https://github.com/user-attachments/assets/1df0ed89-9098-4e19-83f4-7b8174885e1b" />