### PR TITLE
`global-conversation-list-filters` - Correctly limit to PRs

### DIFF
--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -10,7 +10,7 @@ import observe from '../helpers/selector-observer.js';
 
 function createLink(label: string, title: string, query: string): HTMLElement {
 	const url = new URL('/pulls', location.origin);
-	url.searchParams.set('q', `is:open archived:false ${query}`);
+	url.searchParams.set('q', `is:pr is:open archived:false ${query}`);
 	const link = <a href={url.href} title={title} className="subnav-item">{label}</a>;
 
 	const isCurrentPage = SearchQuery.from(location).includes(query);


### PR DESCRIPTION


In gitHub, the Create/Assigned/Mentioned/Review Request tabs now have the "is:pr" filter. (I think github changed over a year ago):

<img width="1457" height="181" alt="image" src="https://github.com/user-attachments/assets/159c1536-215f-4880-9ea1-0f3f08217854" />

However the Involved/Yours tabs added by this plugin does not have that filter. As a result the Involved/Yours tabs show issues from github that are not PRs

<img width="1491" height="193" alt="image" src="https://github.com/user-attachments/assets/344705af-731f-40da-ac57-66f85db2192a" />

Fix is to add "is:pr" to the query string on the code that generates those tabs.