### PR TITLE
`quick-review` - Speed up "Files changed" page opening

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -64,7 +64,7 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 					data-hotkey="v"
 					aria-label="Hotkey: V"
 					onClick={event => {
-						event.preventDefault();
+						event.preventDefault(); // Fix our buttons being removed
 						void openReviewDialogWhenAvailable();
 						$(prFilesChangedTabSelector).click();
 					}}

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -26,6 +26,10 @@ const reviewMenuButtonSelector = 'button[class*="ReviewMenuButton-module__Review
 const openReviewMenuDeepLink = 'review-changes-modal';
 const openReviewMenuDeepLinkSelector = `#${openReviewMenuDeepLink}`;
 
+const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
+
+const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
+
 async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
 	if (approval === null) {
@@ -47,26 +51,37 @@ async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
 	triggerConversationUpdate();
 }
 
-async function addSidebarReviewButton(reviewersSection: Element): Promise<void> {
-	const reviewFormUrl = new URL(location.href);
-	reviewFormUrl.pathname += '/files';
-	reviewFormUrl.hash = openReviewMenuDeepLink;
-
+async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {
 	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
 	await delay(300);
+
 	const quickReview = (
 		<span className="text-normal color-fg-muted">
 			{'– '}
-			<button
-				className="btn-link Link--muted Link--inTextBlock rgh-quick-review tooltipped tooltipped-nw"
-				data-hotkey="v"
-				aria-label="Hotkey: V"
-			>
-				review now
-			</button>
+			{isNewFilesChangedExperienceEnabled()
+				? <button
+					className="btn-link Link--muted Link--inTextBlock tooltipped tooltipped-nw"
+					data-hotkey="v"
+					aria-label="Hotkey: V"
+					onClick={() => {
+						openReviewDialogWhenAvailable();
+						$(prFilesChangedTabSelector).click();
+					}}
+				>
+					review now
+				</button>
+				// TODO: Drop after legacy PR files view is removed
+				: <a
+					href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
+					className="btn-link Link--muted Link--inTextBlock"
+					data-turbo-frame="repo-content-turbo-frame"
+					data-hotkey="v"
+					title="Hotkey: V"
+				>
+					review now
+				</a>}
 		</span>
 	);
-
 	reviewersSection.append(quickReview);
 
 	// Can't approve own PRs and closed PRs
@@ -91,32 +106,34 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 	);
 }
 
-function openReviewMenu(): void {
-	const tenSecondsMs = 10_000;
-	const signal = AbortSignal.timeout(tenSecondsMs);
+async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
+	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButtons, {signal});
+	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
+}
 
-	const prChangedFilesTab = $('a#prs-files-anchor-tab');
-	if (prChangedFilesTab.href.endsWith('/changes')) {
-		observe(reviewMenuButtonSelector, openReviewDialog, {signal, once: true});
-	} else {
-		// Old view -- TODO: Drop in the fall of 2026
-		// Cannot target the [popover] itself because observe() can't see hidden elements
-		observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal, once: true});
+function openReviewDialogWhenAvailable(): void {
+	const signal = AbortSignal.timeout(10_000);
+	observe(reviewMenuButtonSelector,
+		button => {
+			button.click();
+		},
+		{signal, once: true});
+}
+
+function suggestHowToNameMe(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
+	if (isNewFilesChangedExperienceEnabled()) {
+		openReviewDialogWhenAvailable();
+		return;
 	}
 
-	prChangedFilesTab.click();
+	// TODO: Drop after legacy PR files view is removed
+	event.delegateTarget.hash = openReviewMenuDeepLink;
 }
 
-async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
-	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButton, {signal});
-	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
-	delegate('.rgh-quick-review', 'click', openReviewMenu, {signal});
-}
-
-function enhanceNativeReviewButton(signal: AbortSignal): void {
+function initReviewRequestedButton(signal: AbortSignal): void {
 	delegate('section[aria-label="Review Request Banner"] a[type="button"]',
 		'click',
-		openReviewMenu,
+		suggestHowToNameMe,
 		{capture: true, signal},
 	);
 }
@@ -144,8 +161,10 @@ async function openReviewPopup(button: HTMLButtonElement): Promise<void> {
 	(button.popoverTargetElement as HTMLElement).showPopover();
 }
 
-function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
-	reviewMenuButton.click();
+function initNativeDeepLinking(signal: AbortSignal): void {
+	// Legacy PR files view -- TODO: Drop it is removed
+	// Cannot target the [popover] itself because observe() can't see hidden elements
+	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -157,7 +176,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	init: enhanceNativeReviewButton,
+	init: initReviewRequestedButton,
 }, {
 	shortcuts: {
 		v: 'Open PR review popup',
@@ -166,6 +185,12 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 	],
 	init: initReviewButtonEnhancements,
+}, {
+	asLongAs: [
+		() => location.hash === openReviewMenuDeepLinkSelector,
+		pageDetect.isPRFiles,
+	],
+	init: initNativeDeepLinking,
 });
 
 /*

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -68,6 +68,10 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 						void openReviewDialogWhenAvailable();
 						$(prFilesChangedTabSelector).click();
 					}}
+					onMouseEnter={() =>
+						// Trigger data preloading
+						$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}))
+					}
 				>
 					review now
 				</button>

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -117,7 +117,7 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 	reviewMenuButton!.click();
 }
 
-function suggestHowToNameMe(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
+function onReviewRequestedButtonClick(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
 	if (isNewFilesChangedExperienceEnabled()) {
 		void openReviewDialogWhenAvailable();
 		return;
@@ -130,7 +130,7 @@ function suggestHowToNameMe(event: DelegateEvent<PointerEvent, HTMLAnchorElement
 function initReviewRequestedButton(signal: AbortSignal): void {
 	delegate('section[aria-label="Review Request Banner"] a[type="button"]',
 		'click',
-		suggestHowToNameMe,
+		onReviewRequestedButtonClick,
 		{capture: true, signal},
 	);
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -145,11 +145,12 @@ function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
 }
 
 async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> {
+	// Legacy PR files view -- TODO: Drop after it is removed
 	delegate(openReviewMenuDeepLinkSelector, 'toggle', focusReviewTextarea, {capture: true, signal});
 
 	const reviewDropdownButton = await elementReady([
 		reviewMenuButtonSelector,
-		'.js-reviews-toggle', // Old view -- TODO: Drop in the fall of 2026
+		'.js-reviews-toggle', // Legacy PR files view -- TODO: Drop after it is removed
 	]);
 	if (reviewDropdownButton) {
 		reviewDropdownButton.dataset.hotkey = 'v';
@@ -162,7 +163,7 @@ async function openReviewPopup(button: HTMLButtonElement): Promise<void> {
 }
 
 function initNativeDeepLinking(signal: AbortSignal): void {
-	// Legacy PR files view -- TODO: Drop it is removed
+	// Legacy PR files view -- TODO: Drop after it is removed
 	// Cannot target the [popover] itself because observe() can't see hidden elements
 	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -91,9 +91,11 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 	);
 }
 
-function openReviewMenu(signal: AbortSignal): void {
-	const prChangedFilesTab = $('a#prs-files-anchor-tab');
+function openReviewMenu(): void {
+	const tenSecondsMs = 10_000;
+	const signal = AbortSignal.timeout(tenSecondsMs);
 
+	const prChangedFilesTab = $('a#prs-files-anchor-tab');
 	if (prChangedFilesTab.href.endsWith('/changes')) {
 		observe(reviewMenuButtonSelector, openReviewDialog, {signal, once: true});
 	} else {
@@ -108,13 +110,13 @@ function openReviewMenu(signal: AbortSignal): void {
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButton, {signal});
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
-	delegate('.rgh-quick-review', 'click', openReviewMenu.bind(undefined, signal), {signal});
+	delegate('.rgh-quick-review', 'click', openReviewMenu, {signal});
 }
 
 function enhanceNativeReviewButton(signal: AbortSignal): void {
 	delegate('section[aria-label="Review Request Banner"] a[type="button"]',
 		'click',
-		openReviewMenu.bind(undefined, signal),
+		openReviewMenu,
 		{capture: true, signal},
 	);
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -15,7 +15,7 @@ import {
 import showToast from '../github-helpers/toast.js';
 import delay from '../helpers/delay.js';
 import {randomArrayItem} from '../helpers/math.js';
-import observe from '../helpers/selector-observer.js';
+import observe, {waitForElement} from '../helpers/selector-observer.js';
 import {getToken} from '../options-storage.js';
 
 const emojis = ['🚀', '🐿️', '⚡️', '🤌', '🥳', '🥰', '🤩', '🥸', '😎', '🤯', '🚢', '🛫', '🏳️', '🏁'];
@@ -64,7 +64,7 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 					data-hotkey="v"
 					aria-label="Hotkey: V"
 					onClick={() => {
-						openReviewDialogWhenAvailable();
+						void openReviewDialogWhenAvailable();
 						$(prFilesChangedTabSelector).click();
 					}}
 				>
@@ -111,18 +111,15 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 
-function openReviewDialogWhenAvailable(): void {
+async function openReviewDialogWhenAvailable(): Promise<void> {
 	const signal = AbortSignal.timeout(10_000);
-	observe(reviewMenuButtonSelector,
-		button => {
-			button.click();
-		},
-		{signal, once: true});
+	const reviewMenuButton = await waitForElement(reviewMenuButtonSelector, {signal});
+	reviewMenuButton.click();
 }
 
 function suggestHowToNameMe(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
 	if (isNewFilesChangedExperienceEnabled()) {
-		openReviewDialogWhenAvailable();
+		void openReviewDialogWhenAvailable();
 		return;
 	}
 
@@ -157,15 +154,12 @@ async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> 
 	}
 }
 
-async function openReviewPopup(button: HTMLButtonElement): Promise<void> {
-	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
-	(button.popoverTargetElement as HTMLElement).showPopover();
-}
-
-function initNativeDeepLinking(signal: AbortSignal): void {
+async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
 	// Legacy PR files view -- TODO: Drop after it is removed
 	// Cannot target the [popover] itself because observe() can't see hidden elements
-	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
+	const reviewButton = await waitForElement(`[popovertarget="${openReviewMenuDeepLink}"]`, {signal});
+	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
+	(reviewButton.popoverTargetElement as HTMLElement).showPopover();
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -63,7 +63,8 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 					className="btn-link Link--muted Link--inTextBlock tooltipped tooltipped-nw"
 					data-hotkey="v"
 					aria-label="Hotkey: V"
-					onClick={() => {
+					onClick={event => {
+						event.preventDefault();
 						void openReviewDialogWhenAvailable();
 						$(prFilesChangedTabSelector).click();
 					}}

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -114,7 +114,7 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 async function openReviewDialogWhenAvailable(): Promise<void> {
 	const signal = AbortSignal.timeout(10_000);
 	const reviewMenuButton = await waitForElement(reviewMenuButtonSelector, {signal});
-	reviewMenuButton.click();
+	reviewMenuButton!.click();
 }
 
 function suggestHowToNameMe(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
@@ -159,7 +159,7 @@ async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
 	// Cannot target the [popover] itself because observe() can't see hidden elements
 	const reviewButton = await waitForElement(`[popovertarget="${openReviewMenuDeepLink}"]`, {signal});
 	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
-	(reviewButton.popoverTargetElement as HTMLElement).showPopover();
+	(reviewButton!.popoverTargetElement as HTMLElement).showPopover();
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -157,7 +157,7 @@ async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> 
 async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
 	// Legacy PR files view -- TODO: Drop after it is removed
 	// Cannot target the [popover] itself because observe() can't see hidden elements
-	const reviewButton = await waitForElement(`[popovertarget="${openReviewMenuDeepLink}"]`, {signal});
+	const reviewButton = await waitForElement(`button[popovertarget="${openReviewMenuDeepLink}"]`, {signal});
 	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
 	(reviewButton!.popoverTargetElement as HTMLElement).showPopover();
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -57,15 +57,13 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 	const quickReview = (
 		<span className="text-normal color-fg-muted">
 			{'– '}
-			<a
-				href={reviewFormUrl.href}
-				className="btn-link Link--muted Link--inTextBlock"
+			<button
+				className="btn-link Link--muted Link--inTextBlock rgh-quick-review tooltipped tooltipped-nw"
 				data-hotkey="v"
-				data-turbo-frame="repo-content-turbo-frame"
-				title="Hotkey: V"
+				aria-label="Hotkey: V"
 			>
 				review now
-			</a>
+			</button>
 		</span>
 	);
 
@@ -93,20 +91,32 @@ async function addSidebarReviewButton(reviewersSection: Element): Promise<void> 
 	);
 }
 
+function openReviewMenu(signal: AbortSignal): void {
+	const prChangedFilesTab = $('a#prs-files-anchor-tab');
+
+	if (prChangedFilesTab.href.endsWith('/changes')) {
+		observe(reviewMenuButtonSelector, openReviewDialog, {signal, once: true});
+	} else {
+		// Old view -- TODO: Drop in the fall of 2026
+		// Cannot target the [popover] itself because observe() can't see hidden elements
+		observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal, once: true});
+	}
+
+	prChangedFilesTab.click();
+}
+
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButton, {signal});
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
+	delegate('.rgh-quick-review', 'click', openReviewMenu.bind(undefined, signal), {signal});
 }
 
-function initNativeReviewButton(signal: AbortSignal): void {
-	observe('section[aria-label="Review Request Banner"] a[type="button"]', enhanceNativeReviewButton, {signal});
-}
-
-function enhanceNativeReviewButton(button: HTMLAnchorElement): void {
-	// Clone button to remove GitHub's event listeners, which interfere with ours
-	const clonedButton = button.cloneNode(true);
-	clonedButton.hash = openReviewMenuDeepLink;
-	button.replaceWith(clonedButton);
+function enhanceNativeReviewButton(signal: AbortSignal): void {
+	delegate('section[aria-label="Review Request Banner"] a[type="button"]',
+		'click',
+		openReviewMenu.bind(undefined, signal),
+		{capture: true, signal},
+	);
 }
 
 function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
@@ -136,13 +146,6 @@ function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
 	reviewMenuButton.click();
 }
 
-function initNativeDeepLinking(signal: AbortSignal): void {
-	observe(reviewMenuButtonSelector, openReviewDialog, {signal});
-	// Old view -- TODO: Drop in the fall of 2026
-	// Cannot target the [popover] itself because observe() can't see hidden elements
-	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
-}
-
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
@@ -152,7 +155,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isPRConversation,
 	],
-	init: initNativeReviewButton,
+	init: enhanceNativeReviewButton,
 }, {
 	shortcuts: {
 		v: 'Open PR review popup',
@@ -161,12 +164,6 @@ void features.add(import.meta.url, {
 		pageDetect.isPRFiles,
 	],
 	init: initReviewButtonEnhancements,
-}, {
-	asLongAs: [
-		() => location.hash === openReviewMenuDeepLinkSelector,
-		pageDetect.isPRFiles,
-	],
-	init: initNativeDeepLinking,
 });
 
 /*

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -47,6 +47,12 @@ export default function observe<
 		signal = signal ? AbortSignal.any([signal, delayedDomReady]) : delayedDomReady;
 	}
 
+	let onceController: AbortController | undefined;
+	if (once) {
+		onceController = new AbortController();
+		signal = signal ? AbortSignal.any([signal, onceController.signal]) : onceController.signal;
+	}
+
 	const selector = typeof selectors === 'string' ? selectors : selectors.join(',\n');
 	const seenMark = 'rgh-seen-' + getCallerId(ancestor);
 
@@ -86,6 +92,10 @@ export default function observe<
 	})();
 
 	globalThis.addEventListener('animationstart', (event: AnimationEvent) => {
+		if (event.animationName !== animation) {
+			return;
+		}
+
 		const target = event.target as ExpectedElement;
 		// The target can match a selector even if the animation actually happened on a ::before pseudo-element, so it needs an explicit exclusion here
 		if (target.classList.contains(seenMark) || !target.matches(selector)) {
@@ -98,7 +108,8 @@ export default function observe<
 		target.classList.add(seenMark);
 
 		listener(target, {signal});
-	}, {once, signal});
+		onceController?.abort();
+	}, {signal});
 }
 
 // Untested, likely breaks due to wrong `ancestor` level

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -1,4 +1,4 @@
-import {signalFromPromise} from 'abort-utils';
+import {mergeSignals, signalFromPromise} from 'abort-utils';
 import {css} from 'code-tag';
 import React from 'dom-chef';
 import domLoaded from 'dom-loaded';
@@ -44,13 +44,13 @@ export default function observe<
 			await delay(100); // Allow the animation and events to complete; Also adds support for ajaxed pages
 		})());
 
-		signal = signal ? AbortSignal.any([signal, delayedDomReady]) : delayedDomReady;
+		signal = mergeSignals(signal, delayedDomReady);
 	}
 
 	let onceController: AbortController | undefined;
 	if (once) {
 		onceController = new AbortController();
-		signal = signal ? AbortSignal.any([signal, onceController.signal]) : onceController.signal;
+		signal = mergeSignals(signal, onceController.signal);
 	}
 
 	const selector = typeof selectors === 'string' ? selectors : selectors.join(',\n');

--- a/source/helpers/selector-observer.tsx
+++ b/source/helpers/selector-observer.tsx
@@ -112,7 +112,6 @@ export default function observe<
 	}, {signal});
 }
 
-// Untested, likely breaks due to wrong `ancestor` level
 export async function waitForElement<
 	Selector extends string,
 	ExpectedElement extends ParseSelector<Selector, HTMLElement | SVGElement>,
@@ -120,16 +119,17 @@ export async function waitForElement<
 	selectors: Selector | readonly Selector[],
 	{signal, stopOnDomReady}: Options = {},
 ): Promise<ExpectedElement | void> {
-	const local = new AbortController();
-	signal = signal ? AbortSignal.any([signal, local.signal]) : local.signal;
-
 	return new Promise<ExpectedElement | void>(resolve => {
 		observe<Selector, ExpectedElement>(selectors, element => {
 			resolve(element);
-			local.abort();
-		}, {signal, stopOnDomReady, once: true});
+		}, {
+			signal,
+			stopOnDomReady,
+			once: true,
+			ancestor: 4,
+		});
 
-		signal.addEventListener('abort', () => {
+		signal?.addEventListener('abort', () => {
 			resolve();
 		});
 	});


### PR DESCRIPTION
Depends on #9258

The problem with the current implementation is that it forces a hard navigation instead of client-side soft navigation (https://github.com/refined-github/refined-github/pull/9192#discussion_r3083397310), significantly slowing down page loading.

## Test URLs

this PR

## Screenshot

Before:

<img width="954" height="695" alt="chrome_UqGcVX9cQw" src="https://github.com/user-attachments/assets/09fd5a98-3a06-4352-bdf1-75bd9852f785" />

After:

<img width="954" height="695" alt="chrome_2AWVbKhBoY" src="https://github.com/user-attachments/assets/794f538f-8481-4c01-a4d1-3b3cbf1a49dd" />
