### PR TITLE
AI PR

### DIFF
--- a/source/features/esc-to-cancel.tsx
+++ b/source/features/esc-to-cancel.tsx
@@ -1,16 +1,19 @@
 import type {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
-import {$} from 'select-dom/strict.js';
+import {$optional} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';
 import {onConversationTitleFieldKeydown} from '../github-events/on-field-keydown.js';
 
 function handleEscPress(event: DelegateEvent<KeyboardEvent>): void {
 	if (event.key === 'Escape') {
-		$('.js-cancel-issue-edit').click();
-
-		event.stopImmediatePropagation();
-		event.preventDefault();
+		const cancelButton = $optional('.js-cancel-issue-edit');
+		if (cancelButton) {
+			cancelButton.click();
+			event.stopImmediatePropagation();
+			event.preventDefault();
+		}
+		// New React PR view: let the event propagate so React handles cancellation natively
 	}
 }
 

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -30,7 +30,16 @@ export function onCommentFieldKeydown(callback: DelegateFieldEvent, signal: Abor
 }
 
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent, signal: AbortSignal): void {
-	onFieldKeydown('input[placeholder="Title"], #issue_title, #pull_request_title', callback, signal);
+	onFieldKeydown(
+		[
+			'input[placeholder="Title"]',
+			'#issue_title',
+			'#pull_request_title',
+			'[class^="prc-PageLayout-Header"] input', // New React PR view
+		].join(', '),
+		callback,
+		signal,
+	);
 }
 
 export function onCommitTitleFieldKeydown(callback: DelegateFieldEvent, signal: AbortSignal): void {


### PR DESCRIPTION
## Test URLs

- https://github.com/refined-github/sandbox/pull/1 (new React PR view — edit title, press Escape)
- Any open issue: edit title, press Escape (old view — unchanged behaviour)

## Screenshot

_No visual change — restores existing keyboard shortcut behaviour._

---

Closes #9250

## What broke and why

GitHub's new React-based PR page does not have the `.js-cancel-issue-edit` button that the old view used. Two problems:

1. `onConversationTitleFieldKeydown` did not include `[class^="prc-PageLayout-Header"] input`, so the `keydown` listener never fired on the new React title input.
2. `$('.js-cancel-issue-edit')` uses the strict import from `select-dom/strict.js`, which throws when the element is absent — crashing silently on the new view.

## Changes

- `source/github-events/on-field-keydown.tsx`: add `[class^="prc-PageLayout-Header"] input` to `onConversationTitleFieldKeydown` so Escape is intercepted on the new PR title input.
- `source/features/esc-to-cancel.tsx`: switch to `$optional` for `.js-cancel-issue-edit`; when the element is absent (new React view) the event is left to propagate so React handles cancellation natively.