### PR TITLE
`one-click-diff-options` - Restore `d w` shortcut in PRs

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -513,8 +513,8 @@
 	},
 	{
 		"id": "one-click-diff-options",
-		"description": "Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: <kbd>d</kbd> <kbd>w</kbd>.",
-		"screenshot": "https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png"
+		"description": "Adds \"Hide whitespace\" button to Compare pages and a keyboard shortcut to PRs and Compare pages: <kbd>d</kbd> <kbd>w</kbd>.",
+		"screenshot": "https://github.com/user-attachments/assets/0b92992a-69a4-4de1-ab2a-cb6508870b4a"
 	},
 	{
 		"id": "one-click-pr-or-gist",

--- a/readme.md
+++ b/readme.md
@@ -267,7 +267,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 - [](# "patch-diff-links") [Adds links to `.patch` and `.diff` files in commits.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png)
 - [](# "more-file-links") [Adds links to view the raw version, the blame, and the history of files in PRs and commits.](https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png)
-- [](# "one-click-diff-options") [Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: <kbd>d</kbd> <kbd>w</kbd>.](https://user-images.githubusercontent.com/46634000/156766044-18c9ff50-aead-4c40-ba16-7428b3742b6c.png)
+- [](# "one-click-diff-options") [Adds "Hide whitespace" button to Compare pages and a keyboard shortcut to PRs and Compare pages: <kbd>d</kbd> <kbd>w</kbd>.](https://github.com/user-attachments/assets/0b92992a-69a4-4de1-ab2a-cb6508870b4a)
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif)
 - [](# "hide-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
 - [](# "suggest-commit-title-limit") [Suggests limiting commit and PR titles to 72 characters.](https://github.com/user-attachments/assets/e0392989-9c60-4f5c-9052-27a3bb51d4e4)

--- a/source/features/one-click-diff-options.tsx
+++ b/source/features/one-click-diff-options.tsx
@@ -1,23 +1,16 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import BookIcon from 'octicons-plain-react/Book';
 import CheckIcon from 'octicons-plain-react/Check';
-import DiffIcon from 'octicons-plain-react/Diff';
-import DiffModifiedIcon from 'octicons-plain-react/DiffModified';
-import {elementExists} from 'select-dom';
-import {$, $optional} from 'select-dom/strict.js';
 
 import features from '../feature-manager.js';
-import {removeTextNodeContaining} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
+import {registerHotkey} from '../github-helpers/hotkey.js';
 
 function isHidingWhitespace(): boolean {
-	// The selector is the native button
-	return new URL(location.href).searchParams.get('w') === '1'
-		|| elementExists('button[name="w"][value="0"]:not([hidden])');
+	return new URL(location.href).searchParams.get('w') === '1';
 }
 
-function createWhitespaceButton(): HTMLElement {
+function getAlternateUrl(): string {
 	const url = new URL(location.href);
 
 	if (isHidingWhitespace()) {
@@ -26,95 +19,24 @@ function createWhitespaceButton(): HTMLElement {
 		url.searchParams.set('w', '1');
 	}
 
-	return (
-		<a
-			href={url.href}
-			data-hotkey="d w"
-			className={'tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-fg-subtle' : '')}
-			aria-label={`${isHidingWhitespace() ? 'Show' : 'Hide'} whitespace changes`}
-		>
-			{isHidingWhitespace() && <CheckIcon />} No Whitespace
-		</a>
-	);
+	return url.href;
 }
 
-function attachPrButtons(dropdown: HTMLDetailsElement): void {
-	const diffSettingsForm = $('form[action$="/diffview"]', dropdown);
-
-	// Preserve data before emption the form
-	const isUnified = new FormData(diffSettingsForm).get('diff') === 'unified';
-	const token = $('[name="authenticity_token"]', diffSettingsForm);
-
-	// Empty form except the token field
-	diffSettingsForm.replaceChildren(token);
-
-	const type = isUnified ? 'split' : 'unified';
-	const Icon = isUnified ? BookIcon : DiffIcon;
-	diffSettingsForm.append(
-		<button
-			className="tooltipped tooltipped-s ml-2 btn-link Link--muted px-2"
-			aria-label={`Switch to the ${type} diff view`}
-			name="diff"
-			value={type}
-			type="submit"
-		>
-			<Icon className="v-align-middle" />
-		</button>,
-	);
-
-	if (!isHidingWhitespace()) {
-		diffSettingsForm.append(
-			<button
-				data-hotkey="d w"
-				className="tooltipped tooltipped-s btn-link Link--muted px-2"
-				aria-label="Hide whitespace changes"
-				name="w"
-				value="1"
-				type="submit"
-			>
-				<DiffModifiedIcon className="v-align-middle" />
-			</button>,
-		);
-	}
-
-	dropdown.replaceWith(diffSettingsForm);
-
-	// Trim title
-	const prTitle = $optional('.pr-toolbar .js-issue-title');
-	if (prTitle && elementExists('.pr-toolbar progress-bar')) { // Only review view has progress-bar
-		prTitle.style.maxWidth = '24em';
-		prTitle.title = prTitle.textContent;
-	}
-
-	// Make space for the new button #655
-	removeTextNodeContaining(
-		$('[data-hotkey="c"] strong').previousSibling!,
-		'Changes from',
-	);
-
-	// Remove extraneous padding around "Clear filters" button
-	$optional('.subset-files-tab')?.classList.replace('px-sm-3', 'ml-sm-2');
-}
-
-function initPr(signal: AbortSignal): void {
-	// There are two "diff settings" element, one for mobile and one for the desktop. We only replace the one for the desktop
-	observe('.hide-sm.hide-md details.diffbar-item:has(svg.octicon-gear)', attachPrButtons, {signal});
+function addShortcut(signal: AbortSignal): void {
+	registerHotkey('d w', getAlternateUrl(), {signal});
 }
 
 function attachButtons(nativeDiffButtons: HTMLElement): void {
-	const anchor = nativeDiffButtons.parentElement!;
-
-	// `usesFloats` is necessary to ensure the order and spacing as seen in #5958
-	const usesFloats = anchor?.classList.contains('float-right');
-	if (usesFloats) {
-		anchor.after(
-			<div className="float-right mr-3">
-				{createWhitespaceButton()}
-			</div>,
-		);
-	} else {
-		anchor.before(createWhitespaceButton());
-	}
+	nativeDiffButtons.parentElement!.after(
+		<a
+			href={getAlternateUrl()}
+			data-hotkey="d w"
+			className={'float-right mr-3 tooltipped tooltipped-s btn btn-sm tooltipped ' + (isHidingWhitespace() ? 'color-fg-subtle' : '')}
+			aria-label={`${isHidingWhitespace() ? 'Show' : 'Hide'} whitespace changes`}
+		>
+			{isHidingWhitespace() && <CheckIcon />} No Whitespace
+		</a>,
+	);
 }
 
 function init(signal: AbortSignal): void {
@@ -129,12 +51,12 @@ void features.add(import.meta.url, {
 	shortcuts,
 	include: [
 		pageDetect.isPRFiles,
+		pageDetect.isSingleCommit,
 	],
 	exclude: [
 		pageDetect.isPRFile404,
-		pageDetect.isEnterprise, // #5820
 	],
-	init: initPr,
+	init: addShortcut,
 }, {
 	shortcuts,
 	include: [
@@ -146,9 +68,12 @@ void features.add(import.meta.url, {
 /*
 # Test URLs
 
+Shortcut only:
 - PR files: https://github.com/refined-github/refined-github/pull/6261/files
+- Single commit: https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e
+
+Button:
 - Compare, in "Files changed" tab: https://github.com/rancher/rancher/compare/v2.6.3...v2.6.6
 - Compare, without tab: https://github.com/rancher/rancher/compare/v2.6.5...v2.6.6
-- Single commit: https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e
 
 */


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9232


## Test URLs

Shortcut only:
- PR files: https://github.com/refined-github/refined-github/pull/6261/files
- Single commit: https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e

Button:
- Compare, in "Files changed" tab: https://github.com/rancher/rancher/compare/v2.6.3...v2.6.6
- Compare, without tab: https://github.com/rancher/rancher/compare/v2.6.5...v2.6.6


## Tab

<img width="717" height="178" alt="Screenshot 15" src="https://github.com/user-attachments/assets/e60b88e3-87f7-4e9d-a6ff-3835b34c37ac" />

## No tab

<img width="717" height="603" alt="Screenshot 14" src="https://github.com/user-attachments/assets/b05a5005-a028-4dda-aef9-7838631820df" />

## Disable style (unchanged)

<img width="275" height="58" alt="Screenshot 16" src="https://github.com/user-attachments/assets/3f2c3602-c1a1-4c9d-b881-a36902d7946c" />
