### PR TITLE
`jump-to-conversation-close-event` - Restore on PRs

### DIFF
--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -11,6 +11,8 @@ import observe from '../helpers/selector-observer.js';
 import './jump-to-conversation-close-event.css';
 
 export const statusBadgeSelector = [
+	'span[class*="StateLabel"]',
+	// TOdO: Drop both in September 2026
 	'#partial-discussion-header .State:not(.rgh-locked-issue)',
 	'[data-testid="header-state"]',
 ] as const;


### PR DESCRIPTION
- Closes https://github.com/refined-github/refined-github/issues/9248


## Test URLs

https://github.com/refined-github/refined-github/pull/9231

## Screenshot

GitHub has a couple of bugs around scrolling to the event but that's not this feature's responsibility to fix

<img width="560" height="403" alt="gif233" src="https://github.com/user-attachments/assets/6613bb6d-f7fb-41df-a8b9-e0a83c0f0bd6" />
