### PR TITLE
Fix field label wrapping in options

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -139,6 +139,11 @@ summary:hover {
 	-webkit-text-security: circle;
 }
 
+/* Improve wrapping https://github.com/refined-github/refined-github/issues/9153 */
+#validation {
+	display: inline-block;
+}
+
 .feature:not([hidden]) {
 	display: flex;
 	align-items: baseline;


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9153


## Test URLs

<a name="options-page-link">Options page</a>


## Before


<img width="500" height="215" alt="Screenshot 38" src="https://github.com/user-attachments/assets/78051118-67fc-4e97-9fd9-00ba429b39c1" />

## After 
<img width="500" height="215" alt="Screenshot 37" src="https://github.com/user-attachments/assets/ba9dd998-9c65-4ae1-89b9-3ec75e009820" />
