### PR TITLE
`more-file-links`, `restore-file` - Fix padding in old views

### DIFF
--- a/source/features/more-file-links.tsx
+++ b/source/features/more-file-links.tsx
@@ -12,7 +12,7 @@ import GitHubFileUrl from '../github-helpers/github-file-url.js';
 function getLegacyMenuItem(viewFile: HTMLAnchorElement, name: string, route: string): JSX.Element {
 	const {href} = new GitHubFileUrl(viewFile.href).assign({route});
 	return (
-		<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 dropdown-item btn-link" role="menuitem">
+		<a href={href} data-turbo={String(route !== 'raw')} className="pl-5 tmp-pl-5 dropdown-item btn-link" role="menuitem">
 			View {name}
 		</a>
 	);

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -153,7 +153,7 @@ async function handleClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>):
 function addLegacyMenuItem(editFile: HTMLAnchorElement): void {
 	editFile.after(
 		<button
-			className="pl-5 dropdown-item btn-link rgh-restore-file"
+			className="pl-5 tmp-pl-5 dropdown-item btn-link rgh-restore-file"
 			role="menuitem"
 			type="button"
 		>


### PR DESCRIPTION
<img width="355" height="157" alt="image" src="https://github.com/user-attachments/assets/0234bb2b-6ce6-4887-8427-79e989cec82d" />

<img width="346" height="148" alt="image" src="https://github.com/user-attachments/assets/6cb1ee6a-cf5e-4c09-8ea8-abbdc37a424c" />

## Test URLs

https://github.com/refined-github/sandbox/pull/55/changes?new_files_changed=false

## Screenshot

| Before | After |
|--------|--------|
| <img width="234" height="394" alt="image" src="https://github.com/user-attachments/assets/ed17920c-3b7f-45f4-a8fb-cf25599d0df3" /> | <img width="265" height="393" alt="image" src="https://github.com/user-attachments/assets/fc1bb2d4-c1d3-44c6-801d-b354b143c703" /> |





