### PR TITLE
AI PR

### DIFF
--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -13,6 +13,9 @@ function init(signal: AbortSignal): void {
 		[
 			'a[href$="/issues/new/choose"]', // New issue button
 			'a[class*="SubIssueTitle"]', // Sub-issue links
+			'a[class*="IssueLink-module__issueLinkAnchor"]', // Timeline issue dependency/sub-issue links
+			'a[data-hovercard-type="issue"]', // Markdown issue links
+			'a[data-hovercard-type="pull_request"]', // Markdown PR links
 			'a[data-testid="issue-pr-title-link"]', // Global issue list links
 		],
 		'click',


### PR DESCRIPTION
Fixes #9234

## Summary
- Prevent GitHub's issue overlay handler from taking over issue/PR links rendered in issue timelines and markdown.
- Covers timeline relation cards such as sub-issues/dependencies and plain markdown issue/PR links.

## Test URLs
- https://github.com/refined-github/refined-github/issues/9234
- https://github.com/refined-github/refined-github/issues/8504#event-24694028909
- https://github.com/refined-github/refined-github/issues/9237#event-24741479409
- https://github.com/refined-github/refined-github/issues/9136#event-24741479378

## Screenshot
N/A; selector-only behavior fix for GitHub click handling.

## Verification
- `npx eslint source/features/no-modals.tsx`
- `npm run build:typescript`

Manual browser verification is still needed because this depends on GitHub's live React issue timeline DOM and modal click handlers.
