### PR TITLE
`mark-stacked-prs` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -460,6 +460,12 @@
 		"screenshot": "https://github.com/user-attachments/assets/145a7a97-7b8c-4ac4-8288-f72dcb4613ea"
 	},
 	{
+		"id": "mark-stacked-prs",
+		"description": "Groups stacked PRs in lists with a colored connector, indenting children under the root and adding a chevron on the root to collapse or expand the stack.",
+		"css": true,
+		"screenshot": "https://github.com/user-attachments/assets/fc350109-7330-46ff-a11c-4faa0f4c54c8"
+	},
+	{
 		"id": "more-dropdown-links",
 		"description": "Adds useful links to the repository navigation dropdown",
 		"css": true,

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -85,6 +85,7 @@
 	"locked-issue",
 	"mark-merge-commits-in-list",
 	"mark-private-orgs",
+	"mark-stacked-prs",
 	"more-dropdown-links",
 	"more-file-links",
 	"netiquette",

--- a/readme.md
+++ b/readme.md
@@ -227,6 +227,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "unclip-checks") [Automatically shows all checks without scrolling when expanding the checks panel.](https://github.com/user-attachments/assets/785fffab-43e8-4f79-8170-7c264111df9f)
 - [](# "pr-approvals-count") [Shows color-coded review counts in PR lists.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png)
 - [](# "highlight-non-default-base-branch") [Shows the base branch in PR lists if it’s not the default branch.](https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png)
+- [](# "mark-stacked-prs") [Groups stacked PRs in lists with a colored connector, indenting children under the root and adding a chevron on the root to collapse or expand the stack.](https://github.com/user-attachments/assets/fc350109-7330-46ff-a11c-4faa0f4c54c8)
 - [](# "hide-inactive-deployments") [Hides inactive deployments in PRs.](https://github.com/refined-github/refined-github/issues/1144)
 - [](# "previous-next-commit-buttons") [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
 - [](# "hidden-review-comments-indicator") [Adds comment indicators when comments are hidden in PR review.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128043-a10eaf9e-ff81-48db-b67c-ee823804c859.gif)

--- a/source/features/mark-stacked-prs.css
+++ b/source/features/mark-stacked-prs.css
@@ -3,7 +3,7 @@
 }
 
 .rgh-stack::before {
-	content: "";
+	content: '';
 	position: absolute;
 	left: 0;
 	top: 0;

--- a/source/features/mark-stacked-prs.css
+++ b/source/features/mark-stacked-prs.css
@@ -1,0 +1,74 @@
+.rgh-stack {
+	position: relative !important;
+}
+
+.rgh-stack::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: var(--rgh-stack-color, fuchsia);
+	z-index: 5;
+	pointer-events: none;
+}
+
+/* Flat indent for all non-root members */
+.rgh-stack-child > * {
+	padding-left: 24px !important;
+}
+
+.rgh-stack-child.js-issue-row {
+	padding-left: 24px !important;
+}
+
+.rgh-stack-hidden {
+	display: none !important;
+}
+
+/* Hide the verbose "To branch" badge from highlight-non-default-base-branch on stacked rows */
+.rgh-stack span.ml-2:has(> .commit-ref.user-select-contain.mb-n1) {
+	display: none !important;
+}
+
+.rgh-stack-chevron {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	background: transparent;
+	border: 0;
+	padding: 0 5px;
+	margin-right: 4px;
+	cursor: pointer;
+	color: var(--rgh-stack-color, fuchsia);
+	border-radius: 4px;
+	vertical-align: middle;
+	font: inherit;
+	line-height: 1;
+}
+
+.rgh-stack-chevron:hover {
+	background: var(--rgh-stack-color, fuchsia);
+	color: var(--fgColor-onEmphasis, #ffffff);
+}
+
+.rgh-stack-chevron:focus {
+	outline: none;
+}
+
+.rgh-stack-chevron:focus-visible {
+	outline: 2px solid var(--rgh-stack-color, fuchsia);
+	outline-offset: 1px;
+}
+
+.rgh-stack-chevron .octicon {
+	width: 14px;
+	height: 14px;
+	flex: none;
+}
+
+.rgh-stack-count {
+	font-size: 11px;
+	font-weight: 600;
+}

--- a/source/features/mark-stacked-prs.tsx
+++ b/source/features/mark-stacked-prs.tsx
@@ -323,9 +323,10 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Repo PR list: https://github.com/refined-github/sandbox/pulls
+- Stable demo with a 4-PR stack: https://github.com/giovaborgogno/stacked-prs-demo/pulls
+- Repo PR list (any repo with a stack): https://github.com/refined-github/sandbox/pulls
 - Global PR list: https://github.com/pulls
 
-To create a verifiable test scenario, open two PRs where PR_B's base branch is PR_A's head branch.
+The demo repo has four PRs forming a linear stack (#1 ← #2 ← #3 ← #4), where each PR's base branch is the previous PR's head branch.
 
 */

--- a/source/features/mark-stacked-prs.tsx
+++ b/source/features/mark-stacked-prs.tsx
@@ -323,10 +323,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Stable demo with a 4-PR stack: https://github.com/giovaborgogno/stacked-prs-demo/pulls
-- Repo PR list (any repo with a stack): https://github.com/refined-github/sandbox/pulls
-- Global PR list: https://github.com/pulls
+- https://github.com/giovaborgogno/stacked-prs-demo/pulls
 
-The demo repo has four PRs forming a linear stack (#1 ← #2 ← #3 ← #4), where each PR's base branch is the previous PR's head branch.
+A stable 4-PR linear stack (#1 ← #2 ← #3 ← #4) where each PR's base branch is the previous PR's head branch.
 
 */

--- a/source/features/mark-stacked-prs.tsx
+++ b/source/features/mark-stacked-prs.tsx
@@ -1,0 +1,331 @@
+import './mark-stacked-prs.css';
+
+import batchedFunction from 'batched-function';
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import ChevronDownIcon from 'octicons-plain-react/ChevronDown';
+import ChevronRightIcon from 'octicons-plain-react/ChevronRight';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import {expectToken} from '../github-helpers/github-token.js';
+import {detectStackParents, type PrInfo} from '../helpers/detect-stacked-prs.js';
+import observe from '../helpers/selector-observer.js';
+
+type Pr = {
+	link: HTMLAnchorElement;
+	owner: string;
+	repo: string;
+	number: number;
+};
+
+type Entry = {info: PrInfo; pr: Pr};
+
+const storagePrefix = 'rgh-stack-collapsed:';
+const stackRootAttribute = 'rghStackRoot';
+
+function storageKey(ownerRepo: string, rootNumber: number): string {
+	return `${storagePrefix}${ownerRepo}:${rootNumber}`;
+}
+
+function isStackCollapsed(ownerRepo: string, rootNumber: number): boolean {
+	return localStorage.getItem(storageKey(ownerRepo, rootNumber)) === '1';
+}
+
+function setStackCollapsed(ownerRepo: string, rootNumber: number, collapsed: boolean): void {
+	const key = storageKey(ownerRepo, rootNumber);
+	if (collapsed) {
+		localStorage.setItem(key, '1');
+	} else {
+		localStorage.removeItem(key);
+	}
+}
+
+function buildQuery(prsByRepo: Map<string, Pr[]>): string {
+	return [...prsByRepo.values()].map(prs => {
+		const {owner, repo} = prs[0];
+		return `
+			${api.escapeKey('repo', owner, repo)}: repository(owner: "${owner}", name: "${repo}") {
+				${
+					prs.map(pr => `
+					${api.escapeKey('pr', pr.number)}: pullRequest(number: ${pr.number}) {
+						number
+						title
+						baseRefName
+						headRefName
+					}
+				`).join('\n')
+				}
+			}
+		`;
+	}).join('\n');
+}
+
+function findRow(prLink: HTMLAnchorElement): HTMLElement | undefined {
+	const row = prLink.closest('.js-issue-row, li');
+	return row instanceof HTMLElement ? row : undefined;
+}
+
+function colorForStack(rootNumber: number): string {
+	const hue = Math.round((rootNumber * 137.508) % 360);
+	return `hsl(${hue} 65% 45%)`;
+}
+
+function findChildRows(rootNumber: number): HTMLElement[] {
+	return [...document.querySelectorAll<HTMLElement>(`[data-rgh-stack-root="${rootNumber}"]`)];
+}
+
+function applyCollapsedState(rootNumber: number, collapsed: boolean): void {
+	for (const child of findChildRows(rootNumber)) {
+		child.classList.toggle('rgh-stack-hidden', collapsed);
+	}
+}
+
+function syncChevron(chevron: HTMLButtonElement, collapsed: boolean): void {
+	chevron.dataset.rghCollapsed = collapsed ? '1' : '';
+	const oldIcon = chevron.querySelector('.octicon');
+	if (oldIcon) {
+		const NewIcon = collapsed ? ChevronRightIcon : ChevronDownIcon;
+		const newIconElement = (<NewIcon/>) as unknown as Element;
+		oldIcon.replaceWith(newIconElement);
+	}
+}
+
+type ChevronContext = {
+	rootRow: HTMLElement;
+	ownerRepo: string;
+	rootNumber: number;
+	color: string;
+	childCount: number;
+};
+
+function ensureChevron(context: ChevronContext): void {
+	const {rootRow, ownerRepo, rootNumber, color, childCount} = context;
+	const collapsed = isStackCollapsed(ownerRepo, rootNumber);
+	let chevron = rootRow.querySelector<HTMLButtonElement>('.rgh-stack-chevron');
+
+	if (chevron) {
+		// Update count in case stack membership changed across renders
+		const countSpan = chevron.querySelector('.rgh-stack-count');
+		if (countSpan) {
+			countSpan.textContent = `+${childCount}`;
+		}
+	} else {
+		const titleLink = rootRow.querySelector<HTMLAnchorElement>('a[data-hovercard-type="pull_request"]');
+		// The title link is what selector-observer matched to invoke us, so it always exists,
+		// but its parent might not in some preview/legacy DOM variants.
+		const titleParent = titleLink ? titleLink.parentElement : null;
+		if (!titleParent) {
+			return;
+		}
+
+		const newChevron = (
+			<button
+				type="button"
+				className="rgh-stack-chevron"
+				aria-label="Toggle stack visibility"
+				style={{['--rgh-stack-color' as string]: color}}
+			>
+				<ChevronDownIcon/>
+				<span className="rgh-stack-count">{`+${childCount}`}</span>
+			</button>
+		) as unknown as HTMLButtonElement;
+
+		newChevron.addEventListener('click', event => {
+			event.preventDefault();
+			event.stopPropagation();
+			const newCollapsed = newChevron.dataset.rghCollapsed !== '1';
+			setStackCollapsed(ownerRepo, rootNumber, newCollapsed);
+			syncChevron(newChevron, newCollapsed);
+			applyCollapsedState(rootNumber, newCollapsed);
+		});
+
+		titleParent.prepend(newChevron);
+		chevron = newChevron;
+	}
+
+	syncChevron(chevron, collapsed);
+	applyCollapsedState(rootNumber, collapsed);
+}
+
+function buildByNumber(repoPrs: Pr[], repository: Record<string, PrInfo>): Map<number, Entry> {
+	const byNumber = new Map<number, Entry>();
+	for (const pr of repoPrs) {
+		const info = repository[api.escapeKey('pr', pr.number)];
+		byNumber.set(info.number, {info, pr});
+	}
+
+	return byNumber;
+}
+
+function reorderRows(members: number[], byNumber: Map<number, Entry>): void {
+	for (let index = 1; index < members.length; index++) {
+		const memberRow = findRow(byNumber.get(members[index])!.pr.link);
+		const previousRow = findRow(byNumber.get(members[index - 1])!.pr.link);
+		if (memberRow && previousRow && memberRow !== previousRow.nextElementSibling && previousRow.parentElement) {
+			previousRow.parentElement.insertBefore(memberRow, previousRow.nextElementSibling);
+		}
+	}
+}
+
+type StackContext = {
+	root: number;
+	members: number[];
+	byNumber: Map<number, Entry>;
+	color: string;
+	ownerRepo: string;
+};
+
+function applyStackStyling(context: StackContext): void {
+	const {root, members, byNumber, color, ownerRepo} = context;
+
+	for (const number_ of members) {
+		const entry = byNumber.get(number_)!;
+		const row = findRow(entry.pr.link);
+		if (!row) {
+			continue;
+		}
+
+		row.classList.add('rgh-stack');
+		row.style.setProperty('--rgh-stack-color', color);
+
+		if (number_ === root) {
+			row.classList.add('rgh-stack-root');
+			row.classList.remove('rgh-stack-child', 'rgh-stack-hidden');
+			row.removeAttribute('data-rgh-stack-root');
+		} else {
+			row.classList.add('rgh-stack-child');
+			row.classList.remove('rgh-stack-root');
+			row.dataset[stackRootAttribute] = String(root);
+		}
+	}
+
+	const rootEntry = byNumber.get(root);
+	if (!rootEntry) {
+		return;
+	}
+
+	const rootRow = findRow(rootEntry.pr.link);
+	if (rootRow) {
+		ensureChevron({
+			rootRow,
+			ownerRepo,
+			rootNumber: root,
+			color,
+			childCount: members.length - 1,
+		});
+	}
+}
+
+function processRepoStacks(repoPrs: Pr[], repository: Record<string, PrInfo>, ownerRepo: string): void {
+	const byNumber = buildByNumber(repoPrs, repository);
+	const parents = detectStackParents([...byNumber.values()].map(entry => entry.info));
+	if (parents.size === 0) {
+		return;
+	}
+
+	const inStack = new Set<number>();
+	for (const [child, parent] of parents) {
+		inStack.add(child);
+		inStack.add(parent);
+	}
+
+	const depthCache = new Map<number, number>();
+	const depthOf = (number_: number): number => {
+		if (depthCache.has(number_)) {
+			return depthCache.get(number_)!;
+		}
+
+		const p = parents.get(number_);
+		const d = p === undefined ? 0 : depthOf(p) + 1;
+		depthCache.set(number_, d);
+		return d;
+	};
+
+	const rootCache = new Map<number, number>();
+	const rootOf = (number_: number): number => {
+		if (rootCache.has(number_)) {
+			return rootCache.get(number_)!;
+		}
+
+		const p = parents.get(number_);
+		const r = p === undefined ? number_ : rootOf(p);
+		rootCache.set(number_, r);
+		return r;
+	};
+
+	const groups = new Map<number, number[]>();
+	for (const number_ of inStack) {
+		const root = rootOf(number_);
+		let group = groups.get(root);
+		if (!group) {
+			group = [];
+			groups.set(root, group);
+		}
+
+		group.push(number_);
+	}
+
+	for (const [root, members] of groups) {
+		members.sort((a, b) => depthOf(a) - depthOf(b) || a - b);
+		const color = colorForStack(root);
+		reorderRows(members, byNumber);
+		applyStackStyling({
+			root, members, byNumber, color, ownerRepo,
+		});
+	}
+}
+
+async function add(prLinks: HTMLAnchorElement[]): Promise<void> {
+	const prs = new Set<Pr>();
+	for (const link of prLinks) {
+		const [, owner, repo, , number] = link.pathname.split('/');
+		prs.add({
+			link,
+			owner,
+			repo,
+			number: Number(number),
+		});
+	}
+
+	const prsByRepo = Map.groupBy(prs, pr => `${pr.owner}/${pr.repo}`);
+	const data = await api.v4(buildQuery(prsByRepo));
+
+	for (const repoPrs of prsByRepo.values()) {
+		const {owner, repo} = repoPrs[0];
+		const ownerRepo = `${owner}/${repo}`;
+		const repository = data[api.escapeKey('repo', owner, repo)] as Record<string, PrInfo>;
+		processRepoStacks(repoPrs, repository, ownerRepo);
+	}
+}
+
+async function init(signal: AbortSignal): Promise<false | void> {
+	await expectToken();
+	observe(
+		[
+			'.js-issue-row a[data-hovercard-type="pull_request"]', // Repo and global PR lists
+			'a[data-hovercard-type="pull_request"][data-testid="listitem-title-link"]', // Preview global PR list
+			'a[data-hovercard-type="pull_request"][data-testid="issue-pr-title-link"]', // Issue list
+		],
+		batchedFunction(add, {delay: 100}),
+		{signal},
+	);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isIssueOrPRList,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+- Repo PR list: https://github.com/refined-github/sandbox/pulls
+- Global PR list: https://github.com/pulls
+
+To create a verifiable test scenario, open two PRs where PR_B's base branch is PR_A's head branch.
+
+*/

--- a/source/helpers/detect-stacked-prs.test.ts
+++ b/source/helpers/detect-stacked-prs.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, test} from 'vitest';
+
+import {detectStackParents, type PrInfo} from './detect-stacked-prs.js';
+
+function pr(number: number, baseRefName: string, headRefName: string): PrInfo {
+	return {
+		number, title: `PR ${number}`, baseRefName, headRefName,
+	};
+}
+
+describe('detectStackParents', () => {
+	test('empty input', () => {
+		expect(detectStackParents([])).toEqual(new Map());
+	});
+
+	test('single PR has no relations', () => {
+		expect(detectStackParents([pr(1, 'main', 'feat-a')])).toEqual(new Map());
+	});
+
+	test('unrelated PRs targeting main', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'main', 'feat-b'),
+		])).toEqual(new Map());
+	});
+
+	test('linear stack of 2', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'feat-a', 'feat-b'),
+		])).toEqual(new Map([[2, 1]]));
+	});
+
+	test('linear stack of 4', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'feat-a', 'feat-b'),
+			pr(3, 'feat-b', 'feat-c'),
+			pr(4, 'feat-c', 'feat-d'),
+		])).toEqual(new Map([[2, 1], [3, 2], [4, 3]]));
+	});
+
+	test('fan-out within threshold (2 children)', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'feat-a', 'feat-b'),
+			pr(3, 'feat-a', 'feat-c'),
+		])).toEqual(new Map([[2, 1], [3, 1]]));
+	});
+
+	test('fan-out at threshold (3 children) is still grouped', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'feat-a', 'feat-b'),
+			pr(3, 'feat-a', 'feat-c'),
+			pr(4, 'feat-a', 'feat-d'),
+		])).toEqual(new Map([[2, 1], [3, 1], [4, 1]]));
+	});
+
+	test('integration branch (>3 children) is excluded', () => {
+		expect(detectStackParents([
+			pr(1, 'main', 'dev'),
+			pr(2, 'dev', 'feat-a'),
+			pr(3, 'dev', 'feat-b'),
+			pr(4, 'dev', 'feat-c'),
+			pr(5, 'dev', 'feat-d'),
+		])).toEqual(new Map());
+	});
+
+	test('sub-stack inside integration branch is preserved', () => {
+		// `dev` (PR 1) has 4 direct children → integration branch, dropped.
+		// PR 2 has 1 direct child (PR 6) → relation 6→2 preserved.
+		expect(detectStackParents([
+			pr(1, 'main', 'dev'),
+			pr(2, 'dev', 'feat-a'),
+			pr(3, 'dev', 'feat-b'),
+			pr(4, 'dev', 'feat-c'),
+			pr(5, 'dev', 'feat-d'),
+			pr(6, 'feat-a', 'sub-feat'),
+		])).toEqual(new Map([[6, 2]]));
+	});
+
+	test('configurable threshold', () => {
+		// With threshold = 1, a parent with 2 children gets dropped.
+		expect(detectStackParents([
+			pr(1, 'main', 'feat-a'),
+			pr(2, 'feat-a', 'feat-b'),
+			pr(3, 'feat-a', 'feat-c'),
+		], 1)).toEqual(new Map());
+	});
+
+	test('PR with same head and base is ignored', () => {
+		expect(detectStackParents([pr(1, 'feat-a', 'feat-a')])).toEqual(new Map());
+	});
+
+	test('parent missing from list means orphan child has no relation', () => {
+		// PR 2 thinks its base is feat-a, but PR 1 (head: feat-a) is not in the list.
+		expect(detectStackParents([pr(2, 'feat-a', 'feat-b')])).toEqual(new Map());
+	});
+});

--- a/source/helpers/detect-stacked-prs.ts
+++ b/source/helpers/detect-stacked-prs.ts
@@ -1,0 +1,66 @@
+export type PrInfo = {
+	number: number;
+	title: string;
+	baseRefName: string;
+	headRefName: string;
+};
+
+// A parent with more direct children than this is treated as an integration branch
+// (e.g. `dev` in GitFlow with N feature PRs targeting it) and excluded from stack grouping.
+export const defaultMaxDirectChildren = 3;
+
+/**
+ * Given PR info for all visible PRs in a list, returns a map of `child# → parent#`
+ * representing detected stack relationships. A parent is detected when its `headRefName`
+ * matches another visible PR's `baseRefName`.
+ *
+ * Parents with more than `maxDirectChildren` direct children are excluded from the
+ * result — they are likely integration branches (e.g. `dev` in GitFlow) where features
+ * fan out, not stack roots.
+ */
+export function detectStackParents(
+	prs: PrInfo[],
+	maxDirectChildren: number = defaultMaxDirectChildren,
+): Map<number, number> {
+	const byHead = new Map<string, PrInfo>();
+	for (const pr of prs) {
+		byHead.set(pr.headRefName, pr);
+	}
+
+	const parents = new Map<number, number>();
+	for (const pr of prs) {
+		const parent = byHead.get(pr.baseRefName);
+		if (parent && parent.number !== pr.number) {
+			parents.set(pr.number, parent.number);
+		}
+	}
+
+	const childCount = new Map<number, number>();
+	for (const parent of parents.values()) {
+		childCount.set(parent, (childCount.get(parent) ?? 0) + 1);
+	}
+
+	const integrationParents = new Set<number>();
+	for (const [parent, count] of childCount) {
+		if (count > maxDirectChildren) {
+			integrationParents.add(parent);
+		}
+	}
+
+	if (integrationParents.size === 0) {
+		return parents;
+	}
+
+	const toRemove: number[] = [];
+	for (const [child, parent] of parents) {
+		if (integrationParents.has(parent)) {
+			toRemove.push(child);
+		}
+	}
+
+	for (const child of toRemove) {
+		parents.delete(child);
+	}
+
+	return parents;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -81,6 +81,7 @@ import './features/show-user-top-repositories.js';
 import './features/hide-user-forks.js';
 import './features/user-profile-follower-badge.js';
 import './features/highlight-non-default-base-branch.js';
+import './features/mark-stacked-prs.js';
 import './features/mark-private-orgs.js';
 import './features/linkify-commit-sha.js';
 import './features/warning-for-disallow-edits.js';


### PR DESCRIPTION
## Test URLs

- https://github.com/giovaborgogno/stacked-prs-demo/pulls

A stable 4-PR linear stack (#1 ← #2 ← #3 ← #4) where each PR's base branch is the previous PR's head branch. The demo repo will stay open as long as this feature lives.

## Screenshot

![mark-stacked-prs-demo](https://github.com/user-attachments/assets/fc350109-7330-46ff-a11c-4faa0f4c54c8)

## What it does

Groups stacked PRs in PR/issue lists. For each pair of visible PRs where one's `baseRefName` matches another's `headRefName`, the feature:

- Reorders the rows so the stack root is on top with its descendants directly below.
- Paints a vertical color bar on the left of every member of the stack (color hashed from the root number, so different stacks get different hues).
- Indents non-root members so the hierarchy is visible at a glance.
- Adds a chevron on the root with a `+N` indicator. Clicking it collapses or expands the stack. State persists in `localStorage` keyed by `repo:rootNumber`.
- Hides the redundant "To `branch`" badge from `highlight-non-default-base-branch` on stacked rows (the visual grouping already conveys that information).

## Integration branch handling

A parent with more than **3 direct children** is treated as an integration branch (e.g. `dev` in GitFlow with several feature PRs targeting it) and excluded from stack grouping. Sub-stacks inside such a branch are still detected — for example, if `dev` has 4 features and one of them has its own child PR, that child is grouped under its real parent.

The threshold lives in `source/helpers/detect-stacked-prs.ts` as `defaultMaxDirectChildren`.

## Tests

Pure detection logic is in `source/helpers/detect-stacked-prs.ts` with **12 unit tests** in the sibling `.test.ts` covering:

- Empty / single / unrelated PRs
- Linear stacks
- Fan-out within and at the threshold
- Integration branches (children dropped)
- Sub-stacks preserved inside integration branches
- Configurable threshold
- Edge cases (self-reference, parent missing from list)

## Notes for review

- Uses `localStorage` directly for the collapse state instead of `webext-storage` — the state is per-page-UI, single context (content script), and synchronous. Happy to migrate if preferred.
- The chevron is prepended to the title link's parent. GitHub's React occasionally re-renders that subtree; `selector-observer` re-fires `add()`, the chevron is recreated, and the persisted state is reapplied — so the experience is stable but there could be a minor flicker on re-renders.
- Threshold is hardcoded at 3. Could be made configurable via Refined GitHub options if there is interest.