### PR TITLE
Reduce starred repos list row height

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -232,11 +232,7 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 /* Info: https://github.com/refined-github/refined-github/pull/9296 */
 /* Test: https://github.com/xuhdev?tab=stars */
 #profile-lists-container .Box-row {
-	padding: 16px !important;
-
-	> .flex-row {
-		padding: 0 !important;
-	}
+	padding-block: 0;
 }
 
 /*

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -228,6 +228,17 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
+/* Reduce starred repos list row width */
+/* Info: https://github.com/refined-github/refined-github/pull/9296 */
+/* Test: https://github.com/xuhdev?tab=stars */
+#profile-lists-container .Box-row {
+	padding: 16px !important;
+
+	> .flex-row {
+		padding: 0 !important;
+	}
+}
+
 /*
 
 Test URLs:

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -228,7 +228,7 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
-/* Reduce starred repos list row width */
+/* Reduce starred repos list row height */
 /* Info: https://github.com/refined-github/refined-github/pull/9296 */
 /* Test: https://github.com/xuhdev?tab=stars */
 #profile-lists-container .Box-row {


### PR DESCRIPTION
I believe this is a bug because the padding is doubled and it wasn't always like this

<img width="394" height="115" alt="chrome_qkoeXelYCn" src="https://github.com/user-attachments/assets/6872570c-203c-4878-b57e-d32973f8e28e" />

## Test URLs

https://github.com/xuhdev?tab=stars

## Screenshot

| Before | <img width="923" height="834" alt="image" src="https://github.com/user-attachments/assets/8988bbae-e5b6-448e-8ef8-6c0d37e7b779" /> |
|--------|--------|
| **After** | <img width="915" height="590" alt="image" src="https://github.com/user-attachments/assets/a919764e-5ba8-47ad-a39b-0736a354b3ac" /> | 