### PR TITLE
`hide-diff-signs` - Fix ability to disable feature

### DIFF
--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -6,6 +6,6 @@ html:not([rgh-OFF-hide-diff-signs])
 		.blob-code-marker-cell /* Commit page */
 	)::before,
 /* React commit page */
-.diff-text-marker {
+html:not([rgh-OFF-hide-diff-signs]) .diff-text-marker {
 	visibility: hidden;
 }

--- a/source/features/hide-diff-signs.css
+++ b/source/features/hide-diff-signs.css
@@ -1,11 +1,12 @@
-html:not([rgh-OFF-hide-diff-signs])
+html:not([rgh-OFF-hide-diff-signs]) {
 	:is(
 		/* Edit page, probably upcoming DOM everywhere */
 		.diff-text-cell .diff-text,
 		.blob-code-inner /* Inline review blocks in PRs */,
 		.blob-code-marker-cell /* Commit page */
 	)::before,
-/* React commit page */
-html:not([rgh-OFF-hide-diff-signs]) .diff-text-marker {
-	visibility: hidden;
+	/* React commit page */
+	.diff-text-marker {
+		visibility: hidden;
+	}
 }


### PR DESCRIPTION
Prior to this fix, users were not able to disable the feature [hide diff signs](https://github.com/refined-github/refined-github/blob/main/source/features/hide-diff-signs.tsx). This fixes the ability to toggle this off via settings.

The `.diff-text-marker` is after the comma, it is a separate selector and is not protected by `html:not([rgh-OFF-hide-diff-signs])`. So React commit page diff markers are hidden unconditionally.



