### PR TITLE
`no-modals` - Allow opening issues in new tab from site header

### DIFF
--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -19,7 +19,7 @@ function handleAlteredClick(event: DelegateEvent<MouseEvent, HTMLLIElement>): vo
 	}
 }
 
-function initNewIssueInNewTab(): void {
+function initNewIssueInNewTabOnce(): void {
 	delegate(
 		'li[aria-keyshortcuts="n"]:has(.octicon-issue-opened)',
 		'click',
@@ -53,7 +53,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	// No need to continuously register and unregister the handler
-	init: onetime(initNewIssueInNewTab)
+	init: onetime(initNewIssueInNewTabOnce),
 });
 
 /*

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -4,6 +4,7 @@ import {isAlteredClick} from 'filter-altered-clicks';
 
 import features from '../feature-manager.js';
 import {buildRepoUrl} from '../github-helpers/index.js';
+import onetime from '../helpers/onetime.js';
 
 function fix(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void {
 	event.stopImmediatePropagation();
@@ -18,12 +19,12 @@ function handleAlteredClick(event: DelegateEvent<MouseEvent, HTMLLIElement>): vo
 	}
 }
 
-function initNewIssueInNewTab(signal: AbortSignal): void {
+function initNewIssueInNewTab(): void {
 	delegate(
 		'li[aria-keyshortcuts="n"]:has(.octicon-issue-opened)',
 		'click',
 		handleAlteredClick,
-		{signal, capture: true},
+		{capture: true},
 	);
 }
 
@@ -51,7 +52,8 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
 	],
-	init: initNewIssueInNewTab
+	// No need to continuously register and unregister the handler
+	init: onetime(initNewIssueInNewTab)
 });
 
 /*

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -1,14 +1,31 @@
 import delegate, {type DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
+import {isAlteredClick} from 'filter-altered-clicks';
+
 import features from '../feature-manager.js';
+import {buildRepoUrl} from '../github-helpers/index.js';
 
 function fix(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void {
 	event.stopImmediatePropagation();
 	event.delegateTarget.removeAttribute('target');
 }
 
+function handleAlteredClick(event: DelegateEvent<MouseEvent, HTMLLIElement>): void {
+	if (isAlteredClick(event)) {
+		event.stopImmediatePropagation();
+		event.preventDefault();
+		window.open(buildRepoUrl('issues/new/choose'), '_blank');
+	}
+}
+
 function init(signal: AbortSignal): void {
+	delegate(
+		'li[aria-keyshortcuts="n"]:has(.octicon-issue-opened)',
+		'click',
+		handleAlteredClick,
+		{signal, capture: true},
+	);
 	delegate(
 		[
 			'a[href$="/issues/new/choose"]', // New issue button

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -1,6 +1,5 @@
 import delegate, {type DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
-
 import {isAlteredClick} from 'filter-altered-clicks';
 
 import features from '../feature-manager.js';
@@ -19,13 +18,16 @@ function handleAlteredClick(event: DelegateEvent<MouseEvent, HTMLLIElement>): vo
 	}
 }
 
-function init(signal: AbortSignal): void {
+function initNewIssueInNewTab(signal: AbortSignal): void {
 	delegate(
 		'li[aria-keyshortcuts="n"]:has(.octicon-issue-opened)',
 		'click',
 		handleAlteredClick,
 		{signal, capture: true},
 	);
+}
+
+function init(signal: AbortSignal): void {
 	delegate(
 		[
 			'a[href$="/issues/new/choose"]', // New issue button
@@ -45,6 +47,11 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalIssueOrPRList,
 	],
 	init,
+}, {
+	include: [
+		pageDetect.isRepo,
+	],
+	init: initNewIssueInNewTab
 });
 
 /*


### PR DESCRIPTION
- Closes #9302 
- follows https://github.com/refined-github/refined-github/pull/9301

## Test URLs

Here, any repo page


## Screenshot

<img width="566" height="364" alt="rg" src="https://github.com/user-attachments/assets/a9d7a367-4f45-412c-9511-96e83d82a21d" />
