### PR TITLE
`clean-pinned-issues` - Native alignment

### DIFF
--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -83,7 +83,7 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 			padding-top: 11px;
 
 			/* Hide "opened" */
-			[data-hovercard-type="user"] + span {
+			[data-hovercard-type='user'] + span {
 				display: none;
 			}
 		}

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -50,6 +50,8 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 		span[class^='PinnedIssue-module__Octicon'] {
 			vertical-align: text-bottom;
 			margin-left: -1.5em;
+			/* Pull icon a bit lower to align with the title */
+			line-height: 1.3;
 		}
 
 		/* Prevent title from wrapping below the octicon */

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -38,7 +38,9 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 
 		div[class^='PinnedIssue-module__contentContainer'] {
 			flex-direction: row;
-			align-items: center;
+
+			/* Align content to the top when the title wraps */
+			align-items: flex-start;
 		}
 
 		span[class^='PinnedIssue-module__Octicon'] {
@@ -50,14 +52,28 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 			display: contents;
 			> button {
 				order: 1;
+
+				/* Optically align the button to the title so it's not too near the border */
+				margin-block: 6px;
 			}
 		}
 
 		div[class^='PinnedIssue-module__metadataContainer'] {
-			align-items: center; /* Fix comments alignment when metadata takes multiple lines */
 			text-align: end;
 			margin-left: 8px;
-			flex-shrink: 0.5;
+
+			/* This makes the metadata shrink earlier than the title */
+			flex-basis: 200px;
+			flex-grow: 1;
+
+			/* Since it grows, the contentn should still be aligned right */
+			justify-content: flex-end;
+
+			/* Align content to the top when the title wraps */
+			align-items: flex-start;
+
+			/* Optically align the metadata to the title so it's not too near the border */
+			padding-top: 10px;
 		}
 	}
 }

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -20,6 +20,10 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 			border-style: hidden;
 		}
 
+		div [class*='PinnedIssueContainer'] {
+			padding-top: 4px !important;
+		}
+
 		div[class^='DragAndDropContainer']:has(> [class*='PinnedIssues']) {
 			display: table;
 		}
@@ -45,6 +49,12 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 
 		span[class^='PinnedIssue-module__Octicon'] {
 			vertical-align: text-bottom;
+			margin-left: -1.5em;
+		}
+
+		/* Prevent title from wrapping below the octicon */
+		a[class*='PinnedIssue-module__Link'] {
+			padding-left: 1.5em;
 		}
 
 		/* Move options button to the end */
@@ -54,26 +64,28 @@ html:not([rgh-OFF-clean-pinned-issues]) {
 				order: 1;
 
 				/* Optically align the button to the title so it's not too near the border */
-				margin-block: 6px;
+				margin-top: 6px;
 			}
 		}
 
 		div[class^='PinnedIssue-module__metadataContainer'] {
 			text-align: end;
 			margin-left: 8px;
+			line-height: 1.2;
 
-			/* This makes the metadata shrink earlier than the title */
-			flex-basis: 200px;
-			flex-grow: 1;
-
-			/* Since it grows, the contentn should still be aligned right */
+			/* Since it grows, the content should still be aligned right */
 			justify-content: flex-end;
 
 			/* Align content to the top when the title wraps */
 			align-items: flex-start;
 
 			/* Optically align the metadata to the title so it's not too near the border */
-			padding-top: 10px;
+			padding-top: 11px;
+
+			/* Hide "opened" */
+			[data-hovercard-type="user"] + span {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Follows https://github.com/refined-github/refined-github/pull/9284#issuecomment-4323812445


## Test URLs

https://github.com/refined-github/sandbox/issues


## Native

Notice the `...` top-aligned

<img width="688" height="348" alt="Screenshot 1" src="https://github.com/user-attachments/assets/4736313c-8ad9-4bad-933e-3adb5e033aca" />


## https://github.com/refined-github/refined-github/pull/9284


<img width="688" height="266" alt="Screenshot" src="https://github.com/user-attachments/assets/12e35705-c152-4d7b-b281-8bafc6ce8823" />



## This PR

Also notice the title _not_ wrapping below the left-hand icon

<img width="688" height="266" alt="pr" src="https://github.com/user-attachments/assets/8125935d-57fa-4b32-a4e6-050af4061910" />

## Further proposals

<details><summary>
I'd go one step further and avoid wrapping the right-hand text

</summary>

<img width="688" height="290" alt="Screenshot 2" src="https://github.com/user-attachments/assets/6611d422-52e7-496d-8771-8ae16791b6be" />
</details>
<details><summary>
or _always_ wrap it, but it looks weird sometimes
</summary>
<img width="688" height="266" alt="Screenshot 3" src="https://github.com/user-attachments/assets/0b2f08c9-ae2f-48b0-bbf4-35fc74ded083" />
</details>