### PR TITLE
Fix image line spacing in comments

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -264,7 +264,6 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
-
 /*
 
 Test URLs:

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -252,6 +252,19 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
+/* Add missing line spacing in comment images */
+/* Info: https://github.com/refined-github/refined-github/issues/9319 */
+/* Test: https://github.com/refined-github/refined-github/issues/9319 */
+.markdown-body {
+	p ~ a > img {
+		margin-bottom: var(--base-size-16);
+	}
+	p > a > img {
+		margin-block: var(--base-size-16);
+	}
+}
+
+
 /*
 
 Test URLs:


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9319


## Test URLs

https://github.com/refined-github/refined-github/issues/9319

## Screenshot
<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td valign=top><img width="221" height="375" alt="Screenshot 6" src="https://github.com/user-attachments/assets/b29da1ba-c194-4261-8f3c-7e84e5c7b735" />
	<td valign=top><img width="221" height="472" alt="Screenshot 5" src="https://github.com/user-attachments/assets/b26cb3fe-6250-44b5-a6a9-912a1f88c7f7" />
</table>


## DOM screenshot

For future reference:

<img width="246" height="300" alt="Screenshot 11" src="https://github.com/user-attachments/assets/f3a3fe72-df9e-45d0-b255-820f37820fd2" />
