### PR TITLE
Fix image line spacing in comments (GIF support)

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -256,9 +256,11 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 /* Info: https://github.com/refined-github/refined-github/issues/9319 */
 /* Test: https://github.com/refined-github/refined-github/issues/9319 */
 .markdown-body {
-	p ~ a > img,
-	p ~ animated-image > a > img {
+	p ~ a > img {
 		margin-bottom: var(--base-size-16);
+	}
+	p ~ animated-image > a > img {
+		margin-bottom: var(--base-size-8);
 	}
 	p > a > img {
 		margin-block: var(--base-size-16);

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -256,7 +256,8 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 /* Info: https://github.com/refined-github/refined-github/issues/9319 */
 /* Test: https://github.com/refined-github/refined-github/issues/9319 */
 .markdown-body {
-	p ~ a > img {
+	p ~ a > img,
+	p ~ animated-image > a > img {
 		margin-bottom: var(--base-size-16);
 	}
 	p > a > img {


### PR DESCRIPTION
Continues:

- #9319 
- #9320


## Test URLs

text

<img src="https://github.com/user-attachments/assets/f417264f-f230-4156-b020-16e4390562bd">

text

## Screenshot


<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td valign=top><img width="38" height="237" alt="Screenshot 16" src="https://github.com/user-attachments/assets/180d5c60-4bb9-4c4e-aa4f-623c5d75ac0f" />
	<td valign=top><img width="38" height="237" alt="Screenshot 15" src="https://github.com/user-attachments/assets/b0ed909d-419d-442b-ad8c-69a28bcd775d" />
</table>




