### PR TITLE
`clear-pr-merge-commit-message` - Preserve "Signed-off-by" lines

### DIFF
--- a/source/helpers/clean-commit-message.test.ts
+++ b/source/helpers/clean-commit-message.test.ts
@@ -8,6 +8,10 @@ test('cleanCommitMessage', () => {
 		'co-authored-by: Me <me@example.com>',
 		'Co-authored-by: You <you@example.com>',
 	];
+	const signoffs = [
+		'Signed-off-by: Me <me@example.com>',
+		'signed-off-by: Me <me@example.com>',
+	];
 	assert.isEmpty(cleanCommitMessage(''));
 	assert.isEmpty(cleanCommitMessage('clean me'));
 	assert.isEmpty(cleanCommitMessage(`
@@ -43,6 +47,35 @@ test('cleanCommitMessage', () => {
 	`),
 		coauthors[0],
 		'Should de-duplicate inconsistent co-authored-by casing',
+	);
+
+	assert.equal(
+		cleanCommitMessage(`
+		Some stuff happened
+		${signoffs[0]}
+	`),
+		signoffs[0],
+		'Should preserve signed-off-by',
+	);
+
+	assert.equal(
+		cleanCommitMessage(`
+		Some stuff happened
+		${signoffs[0]}
+		${signoffs[1]}
+	`),
+		signoffs[0],
+		'Should de-duplicate inconsistent signed-off-by casing',
+	);
+
+	assert.equal(
+		cleanCommitMessage(`
+		Some stuff happened
+		${coauthors[0]}
+		${signoffs[0]}
+	`),
+		coauthors[0] + '\n' + signoffs[0],
+		'Should preserve both co-authored-by and signed-off-by',
 	);
 
 	assert.isEmpty(

--- a/source/helpers/clean-commit-message.ts
+++ b/source/helpers/clean-commit-message.ts
@@ -7,6 +7,7 @@ export default function cleanCommitMessage(message: string, closingKeywords = fa
 	}
 
 	// Preserve "Signed-off-by" lines (DCO signoffs)
+	// https://github.com/refined-github/refined-github/issues/9330#issuecomment-4361024401
 	for (const [, signer] of message.matchAll(/signed-off-by: ([^\n]+)/gi)) {
 		preservedContent.add('Signed-off-by: ' + signer);
 	}

--- a/source/helpers/clean-commit-message.ts
+++ b/source/helpers/clean-commit-message.ts
@@ -6,6 +6,11 @@ export default function cleanCommitMessage(message: string, closingKeywords = fa
 		preservedContent.add('Co-authored-by: ' + author);
 	}
 
+	// Preserve "Signed-off-by" lines (DCO signoffs)
+	for (const [, signer] of message.matchAll(/signed-off-by: ([^\n]+)/gi)) {
+		preservedContent.add('Signed-off-by: ' + signer);
+	}
+
 	if (!closingKeywords) {
 		return [...preservedContent].join('\n');
 	}


### PR DESCRIPTION
Hi! This PR addresses one part of #9330 by not removing "Signed-off-by" lines (which are usually required by [DCO](https://wiki.linuxfoundation.org/dco)). I've added some test cases too, which were fairly straightforward.

## Test URLs

Tested on Dependabot's PRs opened on one of the projects I help maintain: https://github.com/pyodide/pyodide-cli/pull/60

## Screenshot

<img width="980" height="416" alt="Squash and merge dialog showing both Co-authored-by and Signed-off-by lines preserved in the Extended description field" src="https://github.com/user-attachments/assets/22843563-0e2b-4d91-bb8d-a89be6945306" />
