### PR TITLE
`clear-pr-merge-commit-message` - Add Undo button

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -13,13 +13,6 @@ import observe from '../helpers/selector-observer.js';
 
 const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().base.branch === await getDefaultBranch();
 
-function setFieldValue(field: HTMLTextAreaElement, value: string): void {
-	// Do not use `text-field-edit` #6348
-	field.value = value;
-	// Trigger `fit-textareas` if enabled
-	field.dispatchEvent(new Event('input', {bubbles: true}));
-}
-
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
 	let cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch());
@@ -29,7 +22,8 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	}
 
 	cleanedMessage = cleanedMessage ? cleanedMessage + '\n' : '';
-	setFieldValue(messageField, cleanedMessage);
+	// Do not use `text-field-edit` #6348
+	messageField.value = cleanedMessage;
 
 	const anchor = $closest('div[data-has-label]', messageField);
 	attachElement(anchor, {
@@ -53,7 +47,8 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	let isUndoing = false;
 	function toggleUndoRedo({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
 		isUndoing = !isUndoing;
-		setFieldValue(messageField, isUndoing ? originalMessage : cleanedMessage);
+		// Do not use `text-field-edit` #6348
+		messageField.value = isUndoing ? originalMessage : cleanedMessage;
 		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';
 	}
 }

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -25,6 +25,14 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	// Do not use `text-field-edit` #6348
 	messageField.value = cleanedMessage;
 
+	let isUndoing = false;
+	function toggleUndoRedo({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
+		isUndoing = !isUndoing;
+		// Do not use `text-field-edit` #6348
+		messageField.value = isUndoing ? originalMessage : cleanedMessage;
+		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';
+	}
+
 	const anchor = $closest('div[data-has-label]', messageField);
 	attachElement(anchor, {
 		after: () => (
@@ -43,14 +51,6 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 			</div>
 		),
 	});
-
-	let isUndoing = false;
-	function toggleUndoRedo({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
-		isUndoing = !isUndoing;
-		// Do not use `text-field-edit` #6348
-		messageField.value = isUndoing ? originalMessage : cleanedMessage;
-		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';
-	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -30,20 +30,37 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const anchor = messageField.closest('div[data-has-label]')!;
 
 	attachElement(anchor, {
-		after: () => (
-			<div className="flex-self-stretch">
-				<p className="note">
-					The description field was cleared by{' '}
-					<a
-						target="_blank"
-						href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message"
-						rel="noreferrer"
-					>
-						Refined GitHub
-					</a>.
-				</p>
-			</div>
-		),
+		after() {
+			let isUndone = false;
+			const toggleLink = (
+				<a
+					href="#"
+					onClick={event => {
+						event.preventDefault();
+						isUndone = !isUndone;
+						// Do not use `text-field-edit` #6348
+						messageField.value = isUndone ? originalMessage : (cleanedMessage ? cleanedMessage + '\n' : '');
+						messageField.dispatchEvent(new Event('input', {bubbles: true}));
+						toggleLink.textContent = isUndone ? 'Redo' : 'Undo';
+					}}
+				>Undo</a>
+			);
+			return (
+				<div className="flex-self-stretch">
+					<p className="note">
+						The description field was cleared by{' '}
+						<a
+							target="_blank"
+							href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message"
+							rel="noreferrer"
+						>
+							Refined GitHub
+						</a>
+						. {toggleLink}
+					</p>
+				</div>
+			);
+		},
 	});
 }
 

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -29,38 +29,31 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 
 	const anchor = messageField.closest('div[data-has-label]')!;
 
+	let isUndone = false;
+	function onToggleClick({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
+		isUndone = !isUndone;
+		// Do not use `text-field-edit` #6348
+		messageField.value = isUndone ? originalMessage : (cleanedMessage ? cleanedMessage + '\n' : '');
+		messageField.dispatchEvent(new Event('input', {bubbles: true}));
+		currentTarget.textContent = isUndone ? 'Redo' : 'Undo';
+	}
+
 	attachElement(anchor, {
-		after() {
-			let isUndone = false;
-			const toggleLink = (
-				<a
-					href="#"
-					onClick={event => {
-						event.preventDefault();
-						isUndone = !isUndone;
-						// Do not use `text-field-edit` #6348
-						messageField.value = isUndone ? originalMessage : (cleanedMessage ? cleanedMessage + '\n' : '');
-						messageField.dispatchEvent(new Event('input', {bubbles: true}));
-						toggleLink.textContent = isUndone ? 'Redo' : 'Undo';
-					}}
-				>Undo</a>
-			);
-			return (
-				<div className="flex-self-stretch">
-					<p className="note">
-						The description field was cleared by{' '}
-						<a
-							target="_blank"
-							href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message"
-							rel="noreferrer"
-						>
-							Refined GitHub
-						</a>
-						. {toggleLink}
-					</p>
-				</div>
-			);
-		},
+		after: () => (
+			<div className="flex-self-stretch">
+				<p className="note">
+					The description field was{' '}
+					<a
+						target="_blank"
+						href="https://github.com/refined-github/refined-github/wiki/Extended-feature-descriptions#clear-pr-merge-commit-message"
+						rel="noreferrer"
+					>
+						cleared
+					</a>
+					{' '}by Refined GitHub. <button type="button" className="btn-link" onClick={onToggleClick}>Undo</button>
+				</p>
+			</div>
+		),
 	});
 }
 

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -44,14 +44,14 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 					>
 						cleared
 					</a>
-					{' '}by Refined GitHub. <button type="button" className="btn-link" onClick={onClick}>Undo</button>
+					{' '}by Refined GitHub. <button type="button" className="btn-link" onClick={toggleUndoRedo}>Undo</button>
 				</p>
 			</div>
 		),
 	});
 
 	let isUndoing = false;
-	function onClick({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
+	function toggleUndoRedo({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
 		isUndoing = !isUndoing;
 		setFieldValue(messageField, isUndoing ? originalMessage : cleanedMessage);
 		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -28,7 +28,6 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	let isUndoing = false;
 	function toggleUndoRedo({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
 		isUndoing = !isUndoing;
-		// Do not use `text-field-edit` #6348
 		messageField.value = isUndoing ? originalMessage : cleanedMessage;
 		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';
 	}

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -13,31 +13,25 @@ import observe from '../helpers/selector-observer.js';
 
 const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().base.branch === await getDefaultBranch();
 
+function setFieldValue(field: HTMLTextAreaElement, value: string): void {
+	// Do not use `text-field-edit` #6348
+	field.value = value;
+	// Trigger `fit-textareas` if enabled
+	field.dispatchEvent(new Event('input', {bubbles: true}));
+}
+
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
-	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch());
+	let cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch());
 
 	if (cleanedMessage === originalMessage.trim()) {
 		return;
 	}
 
-	// Do not use `text-field-edit` #6348
-	messageField.value = cleanedMessage ? cleanedMessage + '\n' : '';
-
-	// Trigger `fit-textareas` if enabled
-	messageField.dispatchEvent(new Event('input', {bubbles: true}));
+	cleanedMessage = cleanedMessage ? cleanedMessage + '\n' : '';
+	setFieldValue(messageField, cleanedMessage);
 
 	const anchor = messageField.closest('div[data-has-label]')!;
-
-	let isUndone = false;
-	function onToggleClick({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
-		isUndone = !isUndone;
-		// Do not use `text-field-edit` #6348
-		messageField.value = isUndone ? originalMessage : (cleanedMessage ? cleanedMessage + '\n' : '');
-		messageField.dispatchEvent(new Event('input', {bubbles: true}));
-		currentTarget.textContent = isUndone ? 'Redo' : 'Undo';
-	}
-
 	attachElement(anchor, {
 		after: () => (
 			<div className="flex-self-stretch">
@@ -50,11 +44,18 @@ async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 					>
 						cleared
 					</a>
-					{' '}by Refined GitHub. <button type="button" className="btn-link" onClick={onToggleClick}>Undo</button>
+					{' '}by Refined GitHub. <button type="button" className="btn-link" onClick={onClick}>Undo</button>
 				</p>
 			</div>
 		),
 	});
+
+	let isUndoing = false;
+	function onClick({currentTarget}: React.MouseEvent<HTMLButtonElement>): void {
+		isUndoing = !isUndoing;
+		setFieldValue(messageField, isUndoing ? originalMessage : cleanedMessage);
+		currentTarget.textContent = isUndoing ? 'Redo' : 'Undo';
+	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
This PR addresses the second part of and closes #9330. I have added an "Undo"/"Redo" toggle link to the note next to the merge-time message about PR commit descriptions. It is a link element that mutates between two states.

## Test URLs

Tested on a test PR on my own repository here: https://github.com/agriyakhetarpal/agriyakhetarpal/pull/1

I haven't added any test code for this; I'm not sure how to do so, and if there's a practical way. The clearing logic is already tested, and undo/redo is roughly two lines of state, which probably isn't worth testing on its own.

## Screenshot

I have a screen recording, if that helps!


https://github.com/user-attachments/assets/5654bafd-9884-437d-b271-1b6daa826f32


Thank you :)

