### PR TITLE
`clear-pr-merge-commit-message` - Clear redundant co-authors

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -16,7 +16,8 @@ const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().bas
 
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
-	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch(), getConversationAuthor());
+	const author = getConversationAuthor();
+	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch(), author ? [author] : []);
 
 	if (cleanedMessage === originalMessage.trim()) {
 		return;

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -6,6 +6,7 @@ import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {userHasPushAccess} from '../github-helpers/get-user-permission.js';
 import {expectToken} from '../github-helpers/github-token.js';
+import {getConversationAuthor} from '../github-helpers/index.js';
 import {getBranches} from '../github-helpers/pr-branches.js';
 import attachElement from '../helpers/attach-element.js';
 import cleanCommitMessage from '../helpers/clean-commit-message.js';
@@ -15,7 +16,7 @@ const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().bas
 
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
-	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch());
+	const cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch(), getConversationAuthor());
 
 	if (cleanedMessage === originalMessage.trim()) {
 		return;

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -17,7 +17,7 @@ const isPrAgainstDefaultBranch = async (): Promise<boolean> => getBranches().bas
 async function clear(messageField: HTMLTextAreaElement): Promise<void> {
 	const originalMessage = messageField.value;
 	const author = getConversationAuthor();
-	let cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch(), author ? [author] : []);
+	let cleanedMessage = cleanCommitMessage(originalMessage, !await isPrAgainstDefaultBranch(), [author]);
 
 	if (cleanedMessage === originalMessage.trim()) {
 		return;

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -1,7 +1,5 @@
 import {$closest, $closestOptional} from 'select-dom';
 
-import {is} from '../helpers/css-selectors.js';
-
 /**
 Given any element in a comment, returns the comment’s author
 
@@ -40,10 +38,10 @@ export default function getCommentAuthor(anyElementInsideComment: Element): stri
 		.alt // Occasionally ends with `[bot]`
 		.replace(/^@/, ''); // May or may not be present
 
-	const appLink = $closestOptional('a' + is(
-		'[href^="/apps/"]',
-		'[href^="https://github.com/apps/"]',
-	), avatar);
+	const appLink = $closestOptional([
+		'a[href^="/apps/"]',
+		'a[href^="https://github.com/apps/"]',
+	], avatar);
 
 	if (!name.endsWith('[bot]') && appLink) {
 		// Example: https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -1,6 +1,7 @@
 import {$closest, $closestOptional} from 'select-dom';
 
 import {is} from '../helpers/css-selectors.js';
+
 /**
 Given any element in a comment, returns the comment’s author
 

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -1,4 +1,6 @@
 import {$closest, $closestOptional} from 'select-dom';
+
+import {is} from '../helpers/css-selectors.js';
 /**
 Given any element in a comment, returns the comment’s author
 
@@ -37,7 +39,13 @@ export default function getCommentAuthor(anyElementInsideComment: Element): stri
 		.alt // Occasionally ends with `[bot]`
 		.replace(/^@/, ''); // May or may not be present
 
-	if (!name.endsWith('[bot]') && $closestOptional('[href^="https://github.com/apps/"]', avatar)) {
+	const appLink = $closestOptional(`a${is(
+		'[href^="/apps/"]',
+		// TODO: Drop after October 2026
+		'[href^="https://github.com/apps/"]',
+	)}`, avatar);
+
+	if (!name.endsWith('[bot]') && appLink) {
 		// Example: https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173
 		return name + '[bot]';
 	}

--- a/source/github-helpers/get-comment-author.ts
+++ b/source/github-helpers/get-comment-author.ts
@@ -40,11 +40,10 @@ export default function getCommentAuthor(anyElementInsideComment: Element): stri
 		.alt // Occasionally ends with `[bot]`
 		.replace(/^@/, ''); // May or may not be present
 
-	const appLink = $closestOptional(`a${is(
+	const appLink = $closestOptional('a' + is(
 		'[href^="/apps/"]',
-		// TODO: Drop after October 2026
 		'[href^="https://github.com/apps/"]',
-	)}`, avatar);
+	), avatar);
 
 	if (!name.endsWith('[bot]') && appLink) {
 		// Example: https://github.com/webpack/webpack/pull/15926#issuecomment-1170670173

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -211,16 +211,15 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
 
-export function getFirstComment(): Element | undefined {
-	return $optional([
+export function getFirstComment(): Element {
+	return $([
 		'.react-issue-body', // Issues
 		'.js-command-palette-pull-body', // PRs
 	]);
 }
 
-export function getConversationAuthor(): string | undefined {
-	const firstComment = getFirstComment();
-	return firstComment ? getCommentAuthor(firstComment) : undefined;
+export function getConversationAuthor(): string {
+	return getCommentAuthor(getFirstComment());
 }
 
 export function isOwnConversation(): boolean {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -8,6 +8,7 @@ import compareVersions from 'tiny-version-compare';
 import type {RequireAtLeastOne} from 'type-fest';
 
 import {is} from '../helpers/css-selectors.js';
+import getCommentAuthor from './get-comment-author.js';
 import {branchSelector} from './selectors.js';
 
 // Re-export for convenience
@@ -210,20 +211,17 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
 
-// Note: `a.author` only exists on PR pages, and issue pages have no equivalent selector.
+export function getFirstComment(): Element | undefined {
+	return $optional([
+		'.react-issue-body', // Issues
+		'.react-issue-comment', // Issues (React view)
+		'.TimelineItem:has(a.author)', // PRs
+	]);
+}
+
 export function getConversationAuthor(): string | undefined {
-	const element = $optional('a.author');
-	if (!element) {
-		return undefined;
-	}
-
-	const name = (element.textContent ?? '').trim();
-	// Bots linked via apps don't seem to include [bot] in their link text
-	if (!name.endsWith('[bot]') && element.getAttribute('href')?.startsWith('/apps/')) {
-		return name + '[bot]';
-	}
-
-	return name;
+	const firstComment = getFirstComment();
+	return firstComment ? getCommentAuthor(firstComment) : undefined;
 }
 
 export function isOwnConversation(): boolean {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -211,7 +211,7 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
 
-export function getFirstComment(): Element {
+export function getConversationBody(): Element {
 	return $([
 		'.react-issue-body', // Issues
 		'.js-command-palette-pull-body', // PRs
@@ -219,7 +219,7 @@ export function getFirstComment(): Element {
 }
 
 export function getConversationAuthor(): string {
-	return getCommentAuthor(getFirstComment());
+	return getCommentAuthor(getConversationBody());
 }
 
 export function isOwnConversation(): boolean {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -210,11 +210,20 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
 }
 
-function getConversationAuthor(): string | undefined {
-	return $optional([
-		'.js-command-palette-pull-body .author', // PR conversation
-		'[data-testid="issue-body-header-author"]', // Issue conversation
-	])?.textContent;
+// Note: `a.author` only exists on PR pages, and issue pages have no equivalent selector.
+export function getConversationAuthor(): string | undefined {
+	const element = $optional('a.author');
+	if (!element) {
+		return undefined;
+	}
+
+	const name = (element.textContent ?? '').trim();
+	// Bots linked via apps don't seem to include [bot] in their link text
+	if (!name.endsWith('[bot]') && element.getAttribute('href')?.startsWith('/apps/')) {
+		return name + '[bot]';
+	}
+
+	return name;
 }
 
 export function isOwnConversation(): boolean {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -214,7 +214,6 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 export function getFirstComment(): Element | undefined {
 	return $optional([
 		'.react-issue-body', // Issues
-		'.react-issue-comment', // Issues (React view)
 		'.TimelineItem:has(a.author)', // PRs
 	]);
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -214,7 +214,7 @@ export function scrollIntoViewIfNeeded(element: Element): void {
 export function getFirstComment(): Element | undefined {
 	return $optional([
 		'.react-issue-body', // Issues
-		'.TimelineItem:has(a.author)', // PRs
+		'.js-command-palette-pull-body', // PRs
 	]);
 }
 

--- a/source/helpers/clean-commit-message.test.ts
+++ b/source/helpers/clean-commit-message.test.ts
@@ -85,7 +85,7 @@ test('cleanCommitMessage', () => {
 		Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 	`,
 			false,
-			'dependabot[bot]',
+			['dependabot[bot]'],
 		),
 		'Should drop co-author whose privacy email matches the PR author',
 	);
@@ -98,7 +98,7 @@ test('cleanCommitMessage', () => {
 		${coauthors[2]}
 	`,
 			false,
-			'dependabot[bot]',
+			['dependabot[bot]'],
 		),
 		coauthors[2],
 		'Should drop only the matching co-author, and keep others',
@@ -111,7 +111,7 @@ test('cleanCommitMessage', () => {
 		Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 	`,
 			false,
-			'someone-else',
+			['someone-else'],
 		),
 		'Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>',
 		'Should keep co-author when privacy email username does not match PR author',
@@ -124,7 +124,7 @@ test('cleanCommitMessage', () => {
 		${coauthors[0]}
 	`,
 			false,
-			'Me',
+			['Me'],
 		),
 		coauthors[0],
 		'Should keep co-author when email is not a GitHub privacy email, even if the name matches PR author',
@@ -137,7 +137,7 @@ test('cleanCommitMessage', () => {
 		Co-authored-by: someuser <someuser@users.noreply.github.com>
 	`,
 			false,
-			'someuser',
+			['someuser'],
 		),
 		'Should drop co-author with legacy privacy email without numeric prefix prior to July 18, 2017',
 	);

--- a/source/helpers/clean-commit-message.test.ts
+++ b/source/helpers/clean-commit-message.test.ts
@@ -79,6 +79,70 @@ test('cleanCommitMessage', () => {
 	);
 
 	assert.isEmpty(
+		cleanCommitMessage(
+			`
+		Some stuff happened
+		Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+	`,
+			false,
+			'dependabot[bot]',
+		),
+		'Should drop co-author whose privacy email matches the PR author',
+	);
+
+	assert.equal(
+		cleanCommitMessage(
+			`
+		Some stuff happened
+		Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+		${coauthors[2]}
+	`,
+			false,
+			'dependabot[bot]',
+		),
+		coauthors[2],
+		'Should drop only the matching co-author, and keep others',
+	);
+
+	assert.equal(
+		cleanCommitMessage(
+			`
+		Some stuff happened
+		Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+	`,
+			false,
+			'someone-else',
+		),
+		'Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>',
+		'Should keep co-author when privacy email username does not match PR author',
+	);
+
+	assert.equal(
+		cleanCommitMessage(
+			`
+		Some stuff happened
+		${coauthors[0]}
+	`,
+			false,
+			'Me',
+		),
+		coauthors[0],
+		'Should keep co-author when email is not a GitHub privacy email, even if the name matches PR author',
+	);
+
+	assert.isEmpty(
+		cleanCommitMessage(
+			`
+		Some stuff happened
+		Co-authored-by: someuser <someuser@users.noreply.github.com>
+	`,
+			false,
+			'someuser',
+		),
+		'Should drop co-author with legacy privacy email without numeric prefix prior to July 18, 2017',
+	);
+
+	assert.isEmpty(
 		cleanCommitMessage(`
 		Fixes #1345
 	`),

--- a/source/helpers/clean-commit-message.ts
+++ b/source/helpers/clean-commit-message.ts
@@ -1,8 +1,14 @@
-export default function cleanCommitMessage(message: string, closingKeywords = false): string {
+export default function cleanCommitMessage(message: string, closingKeywords = false, prAuthor?: string): string {
 	const preservedContent = new Set();
 
-	// This method ensures that "Co-authored-by" capitalization doesn't affect deduplication
+	// This method ensures that "Co-authored-by" capitalization doesn't affect deduplication.
+	// Also, drop co-authors whose username (extracted from their GitHub privacy email) matches the PR author.
 	for (const [, author] of message.matchAll(/co-authored-by: ([^\n]+)/gi)) {
+		const privacyEmailUsername = (/<(?:\d+\+)?([^@>]+)@users\.noreply\.github\.com>/i.exec(author))?.[1];
+		if (prAuthor && privacyEmailUsername === prAuthor) {
+			continue;
+		}
+
 		preservedContent.add('Co-authored-by: ' + author);
 	}
 

--- a/source/helpers/clean-commit-message.ts
+++ b/source/helpers/clean-commit-message.ts
@@ -1,11 +1,15 @@
-export default function cleanCommitMessage(message: string, closingKeywords = false, prAuthor?: string): string {
+function parseUserFromEmail(author: string): string | undefined {
+	return /<(?:\d+\+)?([^@>]+)@users\.noreply\.github\.com>/i.exec(author)?.[1];
+}
+
+export default function cleanCommitMessage(message: string, closingKeywords = false, excludeUsers: string[] = []): string {
 	const preservedContent = new Set();
 
 	// This method ensures that "Co-authored-by" capitalization doesn't affect deduplication.
-	// Also, drop co-authors whose username (extracted from their GitHub privacy email) matches the PR author.
+	// Also drops co-authors whose GitHub privacy email username is in `excludeUsers`.
 	for (const [, author] of message.matchAll(/co-authored-by: ([^\n]+)/gi)) {
-		const privacyEmailUsername = (/<(?:\d+\+)?([^@>]+)@users\.noreply\.github\.com>/i.exec(author))?.[1];
-		if (prAuthor && privacyEmailUsername === prAuthor) {
+		const username = parseUserFromEmail(author);
+		if (username && excludeUsers.includes(username)) {
 			continue;
 		}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this, plz.

1. Does this PR close/fix an existing issue? Write something like: Closes #10

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

If you haven't done so yet, check out the Contributing page in the wiki: https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines

-->

This PR is a follow-up to #9336 as discussed in https://github.com/refined-github/refined-github/pull/9336#issuecomment-4363668885 with @fregante. The idea is that if a PR author creates a PR, the author's own "Co-authored-by" commit messages added to the commit description at squash-merge time are redundant and can be removed. This also applies to bots, such as Dependabot, Renovate, pre-commit-ci, github-actions, and so on. In this case, we can remove them, as they also use private/noreply email addresses.

I've slightly adjusted the logic for `getConversationAuthor`, because the previous version wasn't working for me. Suggestions are welcome, thanks!


## Test URLs

I tested this in a PR on my profile repository at https://github.com/agriyakhetarpal/agriyakhetarpal/pull/1.

## Screenshot

Here is a video:

https://github.com/user-attachments/assets/31672abf-5c87-45c0-a779-65416df9a2fc

As it can be seen, `Co-authored-by: 74401230+agriyakhetarpal@users.noreply.github.com` was cleared and is absent. `example` (I added them as a co-author on commit five)'s co-author message is preserved. For users with accounts before July 18, 2017, their privacy emails are of a different kind and are preserved (commit seven). For the bot case, i.e., `github-actions[bot]`, its co-author message is preserved as well. Lastly, commit sign-offs are treated as separate from co-authoring and are thus preserved, too.

Thank you :)

