### PR TITLE
Add `sticky-comment-box-header`

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -916,6 +916,12 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/238186901-cbc98b51-d173-40c6-b21e-5f0bae3d800c.png"
 	},
 	{
+		"id": "sticky-comment-box-header",
+		"description": "Makes the comment editor's toolbar (Write/Preview tabs and Markdown formatting buttons) sticky when editing or composing long comments.",
+		"css": true,
+		"screenshot": null
+	},
+	{
 		"id": "sticky-comment-header",
 		"description": "Makes the comment header sticky when scrolling through long comments. Requires <code>show-names</code> to be enabled.",
 		"css": true,

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -167,6 +167,7 @@
 	"small-user-avatars",
 	"sort-conversations-by-update-time",
 	"status-subscription",
+	"sticky-comment-box-header",
 	"sticky-comment-header",
 	"sticky-sidebar",
 	"stop-redirecting-in-notification-bar",

--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "open-all-conversations") [Lets you open all visible issues/PRs at once.](https://github.com/user-attachments/assets/0d890b01-d5ca-4247-8270-055dd6355606)
 - [](# "sticky-conversation-list-toolbar") [Makes the issue/PR list’s filters toolbar sticky.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261164103-875b70f7-5adc-4bb2-b158-8d5231d47da2.gif)
 - [](# "sticky-comment-header") [Makes the comment header sticky when scrolling through long comments. Requires `show-names` to be enabled.](https://github.com/user-attachments/assets/0d6deca0-0f49-4aa3-ab23-0cfbde4fa4e8)
+- [](# "sticky-comment-box-header") Makes the comment editor’s toolbar (Write/Preview tabs and Markdown formatting buttons) sticky when editing or composing long comments.
 - [](# "conversation-authors") [Highlights issues/PRs opened by you or the current repo’s collaborators.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png)
 - [](# "align-issue-labels") [In issue/PR lists, aligns the labels to the left, below each title.](https://github.com/user-attachments/assets/dca5dc12-7283-4704-a93f-5bfe5f2b1938)
 - [](# "sort-conversations-by-update-time") 🔥 Changes the default sort order of issues/PRs to `Recently updated`.

--- a/source/features/sticky-comment-box-header.css
+++ b/source/features/sticky-comment-box-header.css
@@ -1,0 +1,15 @@
+div.tabnav.CommentBox-header {
+	position: sticky !important;
+	z-index: 4;
+	top: calc(
+		var(--base-sticky-header-height, 0px) + 38px +
+			var(--rgh-issue-or-pr-sticky-header-height, 0px)
+	);
+}
+
+/*
+Test URLs:
+
+- https://github.com/refined-github/sandbox/issues/117 (edit a comment in a long thread)
+- https://github.com/refined-github/sandbox/pull/118 (edit a comment in a long PR)
+*/

--- a/source/features/sticky-comment-box-header.tsx
+++ b/source/features/sticky-comment-box-header.tsx
@@ -1,0 +1,14 @@
+import './sticky-comment-box-header.css';
+
+import features from '../feature-manager.js';
+
+void features.addCssFeature(import.meta.url);
+
+/*
+
+Test URLs:
+
+- https://github.com/refined-github/sandbox/issues/117 (edit a comment in a long thread)
+- https://github.com/refined-github/sandbox/pull/118 (edit a comment in a long PR)
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -31,6 +31,7 @@ import './features/clean-pinned-issues.js';
 import './features/hide-diff-signs.js';
 import './features/clean-rich-text-editor.js';
 import './features/sticky-comment-header.js';
+import './features/sticky-comment-box-header.js';
 
 // Disableable features
 import './features/useful-not-found-page.js';


### PR DESCRIPTION
## Summary

New CSS-only disableable feature: makes the comment editor's toolbar (the `Write`/`Preview` tabs and the Markdown formatting buttons) sticky while editing or composing long comments. Stacks below GitHub's global header, the existing `--rgh-issue-or-pr-sticky-header-height` offset, and the 38px sticky comment header from `sticky-comment-header`.

## Test plan

- [ ] Edit a long comment on a PR and confirm the toolbar pins below the existing sticky headers while scrolling
- [ ] Compose a new long comment on an issue and confirm the same
- [ ] Toggle the feature off in options and confirm the toolbar no longer sticks
- [ ] Verify on a gist (where `--rgh-issue-or-pr-sticky-header-height` is unset) that the fallback `0px` keeps things reasonable

Screenshot/GIF to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)