### PR TITLE
AI SPAM

### DIFF
--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -57,6 +57,14 @@
 	}
 }
 
+.rgh-conversation-activity-filter-shortcut {
+	pointer-events: none;
+
+	kbd {
+		font-size: 11px;
+	}
+}
+
 .rgh-conversation-activity-filter-wrapper {
 	display: flex;
 	align-items: center;

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -146,7 +146,7 @@ function applyState(targetState: State): void {
 }
 
 function createMenuItems(currentState: State): JSX.Element[] {
-	return Object.entries(states).map(([itemState, label]) => (
+	const items = Object.entries(states).map(([itemState, label]) => (
 		<li data-targets="action-list.items" role="none" className="ActionListItem">
 			<button
 				data-state={itemState}
@@ -165,6 +165,18 @@ function createMenuItems(currentState: State): JSX.Element[] {
 			</button>
 		</li>
 	));
+
+	items.push(
+		<li role="none" className="ActionListItem rgh-conversation-activity-filter-shortcut">
+			<span className="ActionListContent">
+				<span className="ActionListItem-label color-fg-muted">
+					Press <kbd>h</kbd> to cycle filters
+				</span>
+			</span>
+		</li>,
+	);
+
+	return items;
 }
 
 async function addWidget(state: State, anchor: HTMLElement): Promise<void> {


### PR DESCRIPTION
## Test URLs

https://github.com/refined-github/refined-github/issues/9331

## Screenshot

N/A

## Description

Hi, Vandit here. This adds a muted hint row to the `conversation-activity-filter` dropdown so the `h` shortcut is discoverable where users choose the filter.

Closes #9331.

## Verification

- `npm run build:typescript`
- `npx biome lint source/features/conversation-activity-filter.tsx source/features/conversation-activity-filter.css`
- `npx dprint check source/features/conversation-activity-filter.tsx source/features/conversation-activity-filter.css`
- `npx eslint source/features/conversation-activity-filter.tsx source/features/conversation-activity-filter.css` (passes with the existing TODO warning in this file)
- `git diff --check`