### PR TITLE
`expand-collapse-files-buttons` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -287,6 +287,11 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/261160123-9c4f894b-38c0-446f-af50-9beca7ff1f74.png"
 	},
 	{
+		"id": "expand-collapse-files-buttons",
+		"description": "Adds \"Collapse all\" / \"Expand all\" buttons to the PR Files toolbar.",
+		"screenshot": null
+	},
+	{
 		"id": "extend-conversation-status-filters",
 		"description": "Lets you toggle between is:open/is:closed/is:merged filters in searches.",
 		"screenshot": "https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif"

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -289,7 +289,7 @@
 	{
 		"id": "expand-collapse-files-buttons",
 		"description": "Adds \"Collapse all\" / \"Expand all\" buttons to the PR Files toolbar.",
-		"screenshot": null
+		"screenshot": "https://github.com/user-attachments/assets/73cfc9ac-c603-401e-bf5e-1b073ba0867b"
 	},
 	{
 		"id": "extend-conversation-status-filters",

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -49,6 +49,7 @@
 	"esc-to-cancel",
 	"esc-to-deselect-line",
 	"expand-all-hidden-comments",
+	"expand-collapse-files-buttons",
 	"extend-conversation-status-filters",
 	"extend-diff-expander",
 	"file-age-color",

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png)
 - [](# "new-or-deleted-file") [Indicates with an icon whether files in commits and PRs are being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
 - [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
+- [](# "expand-collapse-files-buttons") Adds "Collapse all" / "Expand all" buttons to the PR Files toolbar.
 - [](# "same-branch-author-commits") [Preserves current branch and path when viewing all commits by an author.](https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png)
 - [](# "easy-toggle-commit-messages") [Enables toggling commit messages by clicking on the commit box.](https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif)
 - [](# "link-to-compare-diff") [Linkifies the "X files changed" text on compare pages to allow jumping to the diff.](https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png)

--- a/readme.md
+++ b/readme.md
@@ -277,7 +277,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit as a single change.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257035884-732ee7ff-22c5-4049-af7d-f11117d2bbe4.png)
 - [](# "new-or-deleted-file") [Indicates with an icon whether files in commits and PRs are being added or removed.](https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png)
 - [](# "easy-toggle-files") [Enables toggling file diffs by clicking on their header bar.](https://user-images.githubusercontent.com/47531779/99855419-be173e00-2b7e-11eb-9a55-0f6251aeb0ef.gif)
-- [](# "expand-collapse-files-buttons") Adds "Collapse all" / "Expand all" buttons to the PR Files toolbar.
+- [](# "expand-collapse-files-buttons") [Adds "Collapse all" / "Expand all" buttons to the PR Files toolbar.](https://github.com/user-attachments/assets/73cfc9ac-c603-401e-bf5e-1b073ba0867b)
 - [](# "same-branch-author-commits") [Preserves current branch and path when viewing all commits by an author.](https://user-images.githubusercontent.com/44045911/148764372-ee443213-e61a-4227-9219-0ee54ed832e8.png)
 - [](# "easy-toggle-commit-messages") [Enables toggling commit messages by clicking on the commit box.](https://user-images.githubusercontent.com/1402241/152121837-ca13bf8a-9b7f-4517-8e8d-b58bb135523b.gif)
 - [](# "link-to-compare-diff") [Linkifies the "X files changed" text on compare pages to allow jumping to the diff.](https://user-images.githubusercontent.com/46634000/157072587-0335357a-18c7-44c4-ae6e-237080fb36b4.png)

--- a/source/features/expand-collapse-files-buttons.tsx
+++ b/source/features/expand-collapse-files-buttons.tsx
@@ -1,0 +1,81 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import FoldIcon from 'octicons-plain-react/Fold';
+import UnfoldIcon from 'octicons-plain-react/Unfold';
+import {$$, $optional} from 'select-dom';
+
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+
+const fileSelector = '.js-file' as const;
+const chevronSelector = 'button.js-details-target' as const;
+const loadDiffSelector = '.js-diff-load' as const;
+
+function expandAll(): void {
+	// Snapshot the lists first: clicking `.js-diff-load` removes the link and
+	// adds `.Details--on` to its file, which would otherwise re-shuffle what
+	// the second selector matches mid-loop.
+	const filesToLoad = $$(`${fileSelector}:has(${loadDiffSelector})`);
+	const filesToExpand = $$(`${fileSelector}:not(.Details--on):not(:has(${loadDiffSelector}))`);
+
+	for (const file of filesToLoad) {
+		$optional(loadDiffSelector, file)?.click();
+	}
+
+	for (const file of filesToExpand) {
+		$optional<HTMLButtonElement>(chevronSelector, file)?.click();
+	}
+}
+
+function collapseAll(): void {
+	for (const file of $$(`${fileSelector}.Details--on`)) {
+		$optional<HTMLButtonElement>(chevronSelector, file)?.click();
+	}
+}
+
+function addButtons(toolbar: HTMLElement): void {
+	toolbar.append(
+		<div className="BtnGroup ml-2 rgh-expand-collapse-files-buttons">
+			<button
+				type="button"
+				className="btn btn-sm BtnGroup-item"
+				onClick={collapseAll}
+			>
+				<FoldIcon className="mr-1" />
+				Collapse all
+			</button>
+			<button
+				type="button"
+				className="btn btn-sm BtnGroup-item"
+				onClick={expandAll}
+			>
+				<UnfoldIcon className="mr-1" />
+				Expand all
+			</button>
+		</div>,
+	);
+}
+
+function init(signal: AbortSignal): void {
+	observe('.pr-toolbar', addButtons, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRFiles,
+	],
+	exclude: [
+		pageDetect.isPRFile404,
+		pageDetect.isPRCommit,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+- Many files: https://github.com/refined-github/refined-github/pull/9325/files
+- Few files: https://github.com/refined-github/sandbox/pull/55/files
+
+*/

--- a/source/features/expand-collapse-files-buttons.tsx
+++ b/source/features/expand-collapse-files-buttons.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import FoldIcon from 'octicons-plain-react/Fold';
 import UnfoldIcon from 'octicons-plain-react/Unfold';
-import {$$, $optional} from 'select-dom';
+import {$, $$} from 'select-dom';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
@@ -19,17 +19,17 @@ function expandAll(): void {
 	const filesToExpand = $$(`${fileSelector}:not(.Details--on):not(:has(${loadDiffSelector}))`);
 
 	for (const file of filesToLoad) {
-		$optional(loadDiffSelector, file)?.click();
+		$(loadDiffSelector, file).click();
 	}
 
 	for (const file of filesToExpand) {
-		$optional<HTMLButtonElement>(chevronSelector, file)?.click();
+		$<HTMLButtonElement>(chevronSelector, file).click();
 	}
 }
 
 function collapseAll(): void {
 	for (const file of $$(`${fileSelector}.Details--on`)) {
-		$optional<HTMLButtonElement>(chevronSelector, file)?.click();
+		$<HTMLButtonElement>(chevronSelector, file).click();
 	}
 }
 

--- a/source/features/expand-collapse-files-buttons.tsx
+++ b/source/features/expand-collapse-files-buttons.tsx
@@ -35,7 +35,9 @@ function collapseAll(): void {
 
 function addButtons(toolbar: HTMLElement): void {
 	toolbar.append(
-		<div className="BtnGroup ml-2 rgh-expand-collapse-files-buttons">
+		// `flex-self-center` aligns the group with the rest of the diffbar
+		// items, which sit on the baseline of the toolbar row.
+		<div className="BtnGroup ml-2 flex-self-center rgh-expand-collapse-files-buttons">
 			<button
 				type="button"
 				className="btn btn-sm BtnGroup-item"

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -219,3 +219,4 @@ import './features/actions-run-removal.js';
 import './features/new-milestone-button.js';
 import './features/no-self-reference.js';
 import './features/cmd-enter.js';
+import './features/expand-collapse-files-buttons.js';


### PR DESCRIPTION
Closes #9346.

Adds two buttons — "Collapse all" and "Expand all" — to the PR Files toolbar, alongside the existing diff/file-filter controls. Same effect the modifier-click affordance in `toggle-everything-with-alt` already provides, just discoverable: no key combo to remember, no hidden hint.

- **Collapse all** — clicks the chevron on every `.js-file.Details--on`
- **Expand all** — first clicks every `.js-diff-load` (so GitHub-hidden large diffs actually load, not just reveal an empty header), then expands any remaining still-collapsed files

Selectors are snapshotted before each pass so the in-flight DOM swap of "Load diff" → diff body doesn't make the second pass re-collapse what was just opened.

## Test URLs

- Many files: https://github.com/refined-github/refined-github/pull/9325/files
- Few files: https://github.com/refined-github/sandbox/pull/55/files

## Screenshot

<img width="571" height="384" alt="image" src="https://github.com/user-attachments/assets/c6bcb08c-766b-4866-b5de-9f5beb234ebc" />


