### PR TITLE
Preserve existing rgh-link-date parameters in `comments-time-machine-links`

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -95,17 +95,18 @@ function addDateParameterToLink(link: HTMLAnchorElement): void {
 		return;
 	}
 
+	const searchParameters = new URLSearchParams(link.search);
+	if (searchParameters.has('rgh-link-date')) {
+		return;
+	}
+
 	const comment = $closest(commentSelector, link);
 	const relativeTime = $('relative-time', comment);
 	const timestamp = relativeTime.attributes.datetime.value;
 
 	saveOriginalHref(link);
 
-	const searchParameters = new URLSearchParams(link.search);
-	if (!searchParameters.has('rgh-link-date')) {
-		searchParameters.set('rgh-link-date', timestamp);
-	}
-
+	searchParameters.set('rgh-link-date', timestamp);
 	link.search = String(searchParameters);
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -102,7 +102,10 @@ function addDateParameterToLink(link: HTMLAnchorElement): void {
 	saveOriginalHref(link);
 
 	const searchParameters = new URLSearchParams(link.search);
-	searchParameters.set('rgh-link-date', timestamp);
+	if (!searchParameters.has('rgh-link-date')) {
+		searchParameters.set('rgh-link-date', timestamp);
+	}
+
 	link.search = String(searchParameters);
 }
 


### PR DESCRIPTION
Closes #9177

The `comments-time-machine-links` feature was replacing existing `rgh-link-date` URL parameters in comment links instead of preserving them when they were already present.

**Fix:** Added a check using `searchParameters.has('rgh-link-date')` before calling `searchParameters.set()`. If the parameter already exists, it is left untouched.

**Changes:**
- `source/features/comments-time-machine-links.tsx`: Only set `rgh-link-date` if not already present in the link's search params.

**Testing:**
- Ran `npm run lint` — no new errors introduced.
- Ran `npx tsc --noEmit` — TypeScript compiles cleanly.

*This PR was created with assistance from an AI agent (OpenClaw Worker subagent).*