### PR TITLE
`table-input` `collapsible-content-button` - Disable on mobile

### DIFF
--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -95,6 +95,8 @@ void features.add(import.meta.url, {
 		pageDetect.hasRichTextEditor,
 	],
 	exclude: [
+		// TODO: Fix feature https://github.com/refined-github/refined-github/issues/9358
+		// Temporary workaround just for mobile
 		isSmallDevice,
 	],
 	init,

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -8,6 +8,7 @@ import {insertTextIntoField} from 'text-field-edit';
 import features from '../feature-manager.js';
 import {triggerActionBarOverflow} from '../github-helpers/index.js';
 import {actionBarSelectors} from '../github-helpers/selectors.js';
+import {isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import smartBlockWrap from '../helpers/smart-block-wrap.js';
 
@@ -92,6 +93,9 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
+	],
+	exclude: [
+		isSmallDevice,
 	],
 	init,
 });

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -87,6 +87,8 @@ void features.add(import.meta.url, {
 		pageDetect.hasRichTextEditor,
 	],
 	exclude: [
+		// TODO: Fix feature https://github.com/refined-github/refined-github/issues/9358
+		// Temporary workaround just for mobile
 		isSmallDevice,
 	],
 	init,

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -9,6 +9,7 @@ import {insertTextIntoField} from 'text-field-edit';
 
 import features from '../feature-manager.js';
 import {actionBarSelectors} from '../github-helpers/selectors.js';
+import {isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import smartBlockWrap from '../helpers/smart-block-wrap.js';
 
@@ -84,6 +85,9 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRichTextEditor,
+	],
+	exclude: [
+		isSmallDevice,
 	],
 	init,
 });


### PR DESCRIPTION
part of #9358

## Test URLs

https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml&title=%60table-input%60%3A+&labels=bug%2C+help+wanted

## Screenshot

Not captured; local verification was static because this change disables `table-input` and `collapsible-content-button` on small screens through the existing `isSmallDevice` feature gate.

## Verification

- `npm run build:typescript`
- `npx eslint source/features/table-input.tsx source/features/collapsible-content-button.tsx --quiet`
- `git diff --check`