### PR TITLE
`quick-review` - Fix opening "review now" link in a new tab

### DIFF
--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -169,7 +169,7 @@ function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
 	reviewMenuButton.click();
 }
 
-async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
+async function initDeepLinking(signal: AbortSignal): Promise<void> {
 	observe(reviewMenuButtonSelector, openReviewDialog, {signal});
 	// Cannot target the [popover] itself because observe() can't see hidden elements
 	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
@@ -198,7 +198,7 @@ void features.add(import.meta.url, {
 		() => location.hash === openReviewMenuDeepLinkSelector,
 		pageDetect.isPRFiles,
 	],
-	init: initNativeDeepLinking,
+	init: initDeepLinking,
 });
 
 /*

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,8 +1,9 @@
-import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
+import delegate, {type DelegateEvent} from 'delegate-it';
 import elementReady from 'element-ready';
+import {isAlteredClick} from 'filter-altered-clicks';
 import * as pageDetect from 'github-url-detection';
-import {$} from 'select-dom';
+import {$, $optional} from 'select-dom';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -30,7 +31,7 @@ const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
 const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
 
-async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
+async function quickApprove(event: React.MouseEvent): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
 	if (approval === null) {
 		return;
@@ -52,41 +53,37 @@ async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
 }
 
 async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {
-	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
-	await delay(300);
-
 	const quickReview = (
 		<span className="text-normal color-fg-muted">
 			{'– '}
-			{isNewFilesChangedExperienceEnabled()
-				? <button
-					className="btn-link Link--muted Link--inTextBlock tooltipped tooltipped-nw"
-					data-hotkey="v"
-					aria-label="Hotkey: V"
-					onClick={event => {
-						event.preventDefault(); // Fix our buttons being removed
-						void openReviewDialogWhenAvailable();
-						$(prFilesChangedTabSelector).click();
-					}}
-					onMouseEnter={() =>
-						// Trigger data preloading
-						$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}))
+			<a
+				href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
+				className="btn-link Link--muted Link--inTextBlock"
+				data-turbo-frame="repo-content-turbo-frame"
+				data-hotkey="v"
+				title="Hotkey: V"
+				onClick={event => {
+					if (isAlteredClick(event as unknown as MouseEvent)) {
+						return;
 					}
-				>
-					review now
-				</button>
-				// TODO: Drop after legacy PR files view is removed
-				: <a
-					href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
-					className="btn-link Link--muted Link--inTextBlock"
-					data-turbo-frame="repo-content-turbo-frame"
-					data-hotkey="v"
-					title="Hotkey: V"
-				>
-					review now
-				</a>}
+
+					event.preventDefault();
+					void openReviewDialogWhenAvailable();
+					$(prFilesChangedTabSelector).click();
+				}}
+				onMouseEnter={() =>
+					// Trigger data preloading
+					// TODO: Change `$optional` to `$()` once legacy PR files view is removed
+					$optional(prFilesChangedTabSelector)?.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}))
+				}
+			>
+				review now
+			</a>
 		</span>
 	);
+
+	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
+	await delay(300);
 	reviewersSection.append(quickReview);
 
 	// Can't approve own PRs and closed PRs
@@ -105,6 +102,7 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 			type="button"
 			className="btn-link Link--muted Link--inTextBlock rgh-quick-approve tooltipped tooltipped-nw"
 			aria-label="Hold alt to approve without confirmation"
+			onClick={quickApprove}
 		>
 			approve now
 		</button>,
@@ -113,7 +111,6 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButtons, {signal});
-	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 }
 
 async function openReviewDialogWhenAvailable(): Promise<void> {
@@ -123,7 +120,7 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 }
 
 function onReviewRequestedButtonClick(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
-	if (isNewFilesChangedExperienceEnabled()) {
+	if (isNewFilesChangedExperienceEnabled() && !isAlteredClick(event)) {
 		void openReviewDialogWhenAvailable();
 		return;
 	}
@@ -140,6 +137,7 @@ function initReviewRequestedButton(signal: AbortSignal): void {
 	);
 }
 
+// Legacy PR files view -- TODO: Drop after it is removed
 function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
 	if ('newState' in event && event.newState === 'open') {
 		$('textarea', event.delegateTarget).focus();
@@ -147,7 +145,6 @@ function focusReviewTextarea(event: DelegateEvent<Event, HTMLElement>): void {
 }
 
 async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> {
-	// Legacy PR files view -- TODO: Drop after it is removed
 	delegate(openReviewMenuDeepLinkSelector, 'toggle', focusReviewTextarea, {capture: true, signal});
 
 	const reviewDropdownButton = await elementReady([
@@ -159,12 +156,20 @@ async function initReviewButtonEnhancements(signal: AbortSignal): Promise<void> 
 	}
 }
 
-async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
-	// Legacy PR files view -- TODO: Drop after it is removed
-	// Cannot target the [popover] itself because observe() can't see hidden elements
-	const reviewButton = await waitForElement(`button[popovertarget="${openReviewMenuDeepLink}"]`, {signal});
+// Legacy PR files view -- TODO: Drop after it is removed
+async function openReviewPopup(button: HTMLButtonElement): Promise<void> {
 	await delay(100); // The popover appears immediately afterwards in the HTML, observe() might trigger too soon
-	(reviewButton!.popoverTargetElement as HTMLElement).showPopover();
+	(button.popoverTargetElement as HTMLElement).showPopover();
+}
+
+function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
+	reviewMenuButton.click();
+}
+
+async function initNativeDeepLinking(signal: AbortSignal): Promise<void> {
+	observe(reviewMenuButtonSelector, openReviewDialog, {signal});
+	// Cannot target the [popover] itself because observe() can't see hidden elements
+	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -67,6 +67,7 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 		<span className="text-normal color-fg-muted">
 			{'– '}
 			<a
+				// TODO: Change path to "changes" once Legacy PR files view is removed
 				href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
 				className="rgh-quick-review btn-link Link--muted Link--inTextBlock"
 				data-turbo-frame="repo-content-turbo-frame"

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -63,7 +63,10 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 				data-hotkey="v"
 				title="Hotkey: V"
 				onClick={event => {
-					if (isAlteredClick(event as unknown as MouseEvent)) {
+					if (
+						isAlteredClick(event as unknown as MouseEvent)
+						|| !isNewFilesChangedExperienceEnabled()
+					) {
 						return;
 					}
 

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -31,7 +31,7 @@ const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
 const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
 
-async function quickApprove(event: React.MouseEvent): Promise<void> {
+async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
 	if (approval === null) {
 		return;
@@ -52,28 +52,26 @@ async function quickApprove(event: React.MouseEvent): Promise<void> {
 	triggerConversationUpdate();
 }
 
+function handleReviewClick(event: DelegateEvent<MouseEvent>): void {
+	if (isAlteredClick(event) || !isNewFilesChangedExperienceEnabled()) {
+		return;
+	}
+
+	event.preventDefault();
+	void openReviewDialogWhenAvailable();
+	$(prFilesChangedTabSelector).click();
+}
+
 async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {
 	const quickReview = (
 		<span className="text-normal color-fg-muted">
 			{'– '}
 			<a
 				href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
-				className="btn-link Link--muted Link--inTextBlock"
+				className="rgh-quick-review btn-link Link--muted Link--inTextBlock"
 				data-turbo-frame="repo-content-turbo-frame"
 				data-hotkey="v"
 				title="Hotkey: V"
-				onClick={event => {
-					if (
-						isAlteredClick(event as unknown as MouseEvent)
-						|| !isNewFilesChangedExperienceEnabled()
-					) {
-						return;
-					}
-
-					event.preventDefault();
-					void openReviewDialogWhenAvailable();
-					$(prFilesChangedTabSelector).click();
-				}}
 				onMouseEnter={() =>
 					// Trigger data preloading
 					// TODO: Change `$optional` to `$()` once legacy PR files view is removed
@@ -105,7 +103,6 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 			type="button"
 			className="btn-link Link--muted Link--inTextBlock rgh-quick-approve tooltipped tooltipped-nw"
 			aria-label="Hold alt to approve without confirmation"
-			onClick={quickApprove}
 		>
 			approve now
 		</button>,
@@ -114,6 +111,8 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButtons, {signal});
+	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
+	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
 }
 
 async function openReviewDialogWhenAvailable(): Promise<void> {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -120,7 +120,7 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 }
 
 function onReviewRequestedButtonClick(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
-	if (isNewFilesChangedExperienceEnabled() && !isAlteredClick(event)) {
+	if (isNewFilesChangedExperienceEnabled()) {
 		void openReviewDialogWhenAvailable();
 		return;
 	}


### PR DESCRIPTION
Addresses https://github.com/refined-github/refined-github/pull/9259#discussion_r3213171431

## Test URLs

This PR

## Screenshot

<img width="1002" height="535" alt="chrome_5LpFDO7uRA" src="https://github.com/user-attachments/assets/113f1d6b-7722-4fcf-b46d-cb5f557c624c" />