### PR TITLE
`comments-time-machine-links` - Restore unnecessary notice suppression

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -50,8 +50,7 @@ async function showTimeMachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		// Selector note: isRepoFile and isRepoTree have different DOM for this element
-		const lastCommitDate = await elementReady('.Box-header relative-time', {waitForChildren: false});
+		const lastCommitDate = await elementReady('div[data-testid="latest-commit-details"] relative-time', {waitForChildren: false});
 		if (lastCommitDate && date > lastCommitDate.getAttribute('datetime')!) {
 			return false;
 		}

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -50,7 +50,10 @@ async function showTimeMachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		const lastCommitDate = await elementReady('div[data-testid="latest-commit-details"] relative-time', {waitForChildren: false});
+		const lastCommitDate = await elementReady(
+			'div[data-testid="latest-commit-details"] relative-time',
+			{waitForChildren: false},
+		);
 		if (lastCommitDate && date > lastCommitDate.getAttribute('datetime')!) {
 			return false;
 		}


### PR DESCRIPTION

## Test URLs

https://github.com/refined-github/refined-github/tree/sandbox/keep-branch

## Screenshot

<img width="1085" height="533" alt="chrome_iNRGmoAecT" src="https://github.com/user-attachments/assets/72a79440-e070-4546-b728-d2f030d3aa36" />