### PR TITLE
Fix image line spacing in comments /3

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -262,6 +262,9 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	p ~ animated-image > a > img {
 		margin-bottom: var(--base-size-8);
 	}
+	p > a > img[style*="display: block"] {
+		margin-block: var(--base-size-16);
+	}
 }
 
 /* Fix checkmark on a deselected item disappearing with a noticeable delay */

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -262,7 +262,7 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	p ~ animated-image > a > img {
 		margin-bottom: var(--base-size-8);
 	}
-	p > a > img[style*="display: block"] {
+	p > a > img[style*='display: block'] {
 		margin-block: var(--base-size-16);
 	}
 }


### PR DESCRIPTION
- restores https://github.com/refined-github/refined-github/pull/9320
- reverts https://github.com/refined-github/refined-github/pull/9380
- avoids https://github.com/refined-github/refined-github/issues/9335


## Test URLs

- https://github.com/refined-github/refined-github
- https://github.com/refined-github/refined-github/issues/9319

## Screenshot

<table>
<tr>
	<th>Touched
	<th>Untouched
<tr>
	<td valign=top><img width="226" height="183" alt="Screenshot 8" src="https://github.com/user-attachments/assets/778415e3-85a9-43df-867e-7da927a9d903" />
	<td valign=top><img width="363" height="190" alt="Screenshot 7" src="https://github.com/user-attachments/assets/864c5477-8ca6-4f8f-a40e-24219258d122" />
</table>
