### PR TITLE
`table-input` `collapsible-content-button` - Fix overflow

### DIFF
--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -59,9 +59,17 @@ function append(container: HTMLElement): void {
 	];
 
 	// TODO: ensure it's added only once before both `table-input` and `collapsible-content-button`
-	const divider = $('[data-component="ActionBar.VerticalDivider"]', container).cloneNode(true);
+	const divider = $([
+		'[data-component="ActionBar.VerticalDivider"]', // React component
+		'.ActionBar-divider',	// Still used in gists, PRs, etc
+	], container).cloneNode(true);
 	// Sizing copied from GitHub, except the excessive 2em (see `fuchsia` docs)
-	divider.style.padding = '0 var(--base-size-8, 2em)';
+	divider.style.margin = 'auto var(--base-size-8, 2em)';
+
+	// Old style only
+	divider.style.top = 'initial';
+	divider.style.bottom = 'initial';
+	divider.style.transform = 'initial';
 
 	container.parentElement!.append(
 		divider ?? '',

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -2,12 +2,11 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import FoldDownIcon from 'octicons-plain-react/FoldDown';
-import {$, $closest} from 'select-dom';
+import {$, $closest, $optional} from 'select-dom';
 import {insertTextIntoField} from 'text-field-edit';
 
 import features from '../feature-manager.js';
-import {triggerActionBarOverflow} from '../github-helpers/index.js';
-import {actionBarSelectors} from '../github-helpers/selectors.js';
+import {actionBar} from '../github-helpers/selectors.js';
 import {isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import smartBlockWrap from '../helpers/smart-block-wrap.js';
@@ -59,13 +58,13 @@ function append(container: HTMLElement): void {
 		'rgh-collapsible-content-btn',
 	];
 
-	const divider = $([
-		'hr[data-targets="action-bar.items"]', // TODO: remove after March 2025
-		'[class^="Toolbar-module__divider"]',
-	], container).cloneNode(true);
+	// TODO: ensure it's added only once before both `table-input` and `collapsible-content-button`
+	const divider = $('[data-component="ActionBar.VerticalDivider"]', container).cloneNode(true);
+	// Sizing copied from GitHub, except the excessive 2em (see `fuchsia` docs)
+	divider.style.padding = '0 var(--base-size-8, 2em)';
 
-	container.append(
-		divider,
+	container.parentElement!.append(
+		divider ?? '',
 		<button
 			type="button"
 			className={classes.join(' ')}
@@ -75,18 +74,10 @@ function append(container: HTMLElement): void {
 			<FoldDownIcon />
 		</button>,
 	);
-
-	if (container.getAttribute('aria-label') === 'Formatting tools') {
-		return;
-	}
-
-	// Only needed on the old version
-	// TODO: remove after March 2025
-	triggerActionBarOverflow(container);
 }
 
 function init(signal: AbortSignal): void {
-	observe(actionBarSelectors, append, {signal});
+	observe(actionBar, append, {signal});
 	delegate('.rgh-collapsible-content-btn', 'click', addContentToDetails, {signal});
 }
 

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -72,7 +72,7 @@ function append(container: HTMLElement): void {
 	divider.style.transform = 'initial';
 
 	container.parentElement!.append(
-		divider ?? '',
+		divider,
 		<button
 			type="button"
 			className={classes.join(' ')}

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -63,13 +63,16 @@ function append(container: HTMLElement): void {
 		'[data-component="ActionBar.VerticalDivider"]', // React component
 		'.ActionBar-divider',	// Still used in gists, PRs, etc
 	], container).cloneNode(true);
-	// Sizing copied from GitHub, except the excessive 2em (see `fuchsia` docs)
-	divider.style.margin = 'auto var(--base-size-8, 2em)';
 
-	// Old style only
-	divider.style.top = 'initial';
-	divider.style.bottom = 'initial';
-	divider.style.transform = 'initial';
+	Object.assign(divider.style, {
+		// Sizing copied from GitHub, except the excessive 2em (see `fuchsia` docs)
+		margin: 'auto var(--base-size-8, 2em)',
+
+		// Old style only
+		top: 'initial',
+		bottom: 'initial',
+		transform: 'initial',
+	});
 
 	container.parentElement!.append(
 		divider,

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -2,7 +2,7 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import FoldDownIcon from 'octicons-plain-react/FoldDown';
-import {$, $closest, $optional} from 'select-dom';
+import {$, $closest} from 'select-dom';
 import {insertTextIntoField} from 'text-field-edit';
 
 import features from '../feature-manager.js';

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -56,6 +56,10 @@ function append(container: HTMLElement): void {
 		'tooltipped',
 		'tooltipped-sw',
 		'rgh-collapsible-content-btn',
+
+		// Old view only
+		'my-auto',
+		'flex-shrink-0',
 	];
 
 	// TODO: ensure it's added only once before both `table-input` and `collapsible-content-button`

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -12,7 +12,6 @@ function getHash(type: 'issue' | 'pr'): string {
 }
 
 function linkify(item: HTMLElement): void {
-	console.log(item);
 	if (item instanceof HTMLAnchorElement) {
 		// Only PR lists are already linked
 		item.hash = getHash('pr');

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -8,7 +8,7 @@ import {$, $closestOptional} from 'select-dom';
 import {insertTextIntoField} from 'text-field-edit';
 
 import features from '../feature-manager.js';
-import {actionBarSelectors} from '../github-helpers/selectors.js';
+import {actionBar} from '../github-helpers/selectors.js';
 import {isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import smartBlockWrap from '../helpers/smart-block-wrap.js';
@@ -35,10 +35,10 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	field.selectionEnd = field.value.indexOf('<td>', cursorPosition) + '<td>'.length;
 }
 
-function append(container: HTMLElement): void {
+function add(container: HTMLElement): void {
 	container.classList.add('d-flex');
 
-	container.append(
+	container.parentElement!.append(
 		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm">
 			<summary
 				id="rgh-table-input-button"
@@ -78,7 +78,7 @@ function append(container: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe(actionBarSelectors, append, {signal});
+	observe(actionBar, add, {signal});
 	delegate('.rgh-tic', 'click', addTable, {signal});
 }
 

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -39,7 +39,7 @@ function add(container: HTMLElement): void {
 	container.classList.add('d-flex');
 
 	container.parentElement!.append(
-		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm">
+		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm my-auto">
 			<summary
 				id="rgh-table-input-button"
 				className="Button Button--iconOnly Button--invisible Button--medium"

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -195,13 +195,6 @@ export function triggerRepoNavOverflow(): void {
 	globalThis.dispatchEvent(new Event('resize'));
 }
 
-export function triggerActionBarOverflow(child: Element): void {
-	const parent = $closest('action-bar', child);
-	const placeholder = document.createElement('div');
-	parent.replaceWith(placeholder);
-	placeholder.replaceWith(parent);
-}
-
 export function multilineAriaLabel(...lines: string[]): string {
 	return lines.join('\n');
 }

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -259,7 +259,7 @@ export const usernameLinksSelector_ = [
 
 export const actionBar = [
 	'[data-component="ActionBar"]', // React component
-	'[data-target="action-bar.itemContainer"]', // Still used in gists, PRs, etc
+	'action-bar', // Still used in gists, PRs, etc
 ];
 export const actionBar_ = requiresLogin;
 

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -257,7 +257,10 @@ export const usernameLinksSelector_ = [
 	[1, 'https://github.com/refined-github/refined-github/issues/7747'],
 ];
 
-export const actionBar = '[data-component="ActionBar"]';
+export const actionBar = [
+	'[data-component="ActionBar"]', // React component
+	'[data-target="action-bar.itemContainer"]', // Still used in gists, PRs, etc
+];
 export const actionBar_ = requiresLogin;
 
 export const prMergeabilityBoxHeader

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -257,11 +257,8 @@ export const usernameLinksSelector_ = [
 	[1, 'https://github.com/refined-github/refined-github/issues/7747'],
 ];
 
-export const actionBarSelectors = [
-	'[data-target="action-bar.itemContainer"]', // TODO: remove after March 2025
-	'[aria-label="Formatting tools"]',
-];
-export const actionBarSelectors_ = requiresLogin;
+export const actionBar = '[data-component="ActionBar"]';
+export const actionBar_ = requiresLogin;
 
 export const prMergeabilityBoxHeader
 	= 'section[aria-label="Conflicts"] div[class^="MergeBoxSectionHeader-module__wrapper"]';


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9390
- fixes https://github.com/refined-github/refined-github/issues/9358

finally 😍 

## Test URLs

Here or https://github.com/refined-github/refined-github/issues/new?assignees=&labels=bug&projects=&template=1_bug_report.yml


## Screenshot

There's occasionally a 3px overlap with the `...` button but it's very minor, see:

<img width="432" height="68" alt="Screenshot 11" src="https://github.com/user-attachments/assets/0c08575b-9b27-40a8-8ea9-e30d3ef0e6ef" />

<img width="597" height="68" alt="Screenshot 10" src="https://github.com/user-attachments/assets/8dd3b94d-fda7-46ee-8c80-21bbadfaa793" />

