### PR TITLE
`default-branch-button` - Hide native button

### DIFF
--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -17,3 +17,13 @@ button.rgh-highlight-non-default-branch svg,
 details.rgh-highlight-non-default-branch > summary svg {
 	color: var(--fgColor-accent, var(--color-accent-fg, fuchsia)) !important;
 }
+
+/* Remove bad native link https://github.com/refined-github/refined-github/issues/8662#issuecomment-4126171014 */
+/* It only appears in the sidebar */
+div[class^='ReposFileTreePane-module__FullWidthButtonGroup']:has(
+	.rgh-default-branch-button
+) {
+	> div:first-child {
+		display: none;
+	}
+}

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -88,10 +88,6 @@ async function add(branchSelector: HTMLElement): Promise<void> {
 		</a>
 	);
 
-	// Remove bad native link https://github.com/refined-github/refined-github/issues/8662#issuecomment-4126171014
-	// It only appears in the sidebar
-	$optional('[class*="prc"][aria-label="View file on default branch"]')?.remove();
-
 	selectorWrapper.before(defaultLink);
 	wrapButtons([defaultLink, selectorWrapper]);
 }


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/pull/9425#discussion_r3214950714

## Test URLs

https://github.com/refined-github/refined-github/blob/unwrap-notifications/.git-blame-ignore-revs

## Screenshot

<img width="313" height="459" alt="chrome_oOGceOhYyJ" src="https://github.com/user-attachments/assets/ac9a9bb5-1495-41e5-9d7e-7a5b63efb0f2" />