### PR TITLE
Add `auto-load-notifications`: auto-load all pages on ungrouped notification views

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -32,6 +32,12 @@
 		"screenshot": "https://user-images.githubusercontent.com/1402241/230362566-12493c80-bffe-4c7a-b9ba-4a11b1358ab0.png"
 	},
 	{
+		"id": "auto-load-notifications",
+		"description": "Automatically loads all pages of notifications when a search filter is active, appending them to the list with a loading indicator.",
+		"css": true,
+		"screenshot": null
+	},
+	{
 		"id": "avoid-accidental-submissions",
 		"description": "Disables the <kbd>enter</kbd>-to-submit shortcut in some commit/PR/issue title fields to avoid accidental submissions. Use <kbd>ctrl</kbd> <kbd>enter</kbd> instead.",
 		"screenshot": "https://user-images.githubusercontent.com/723651/125863341-6cf0bce0-f120-4cec-ac1f-1ce35920e7a7.gif"

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -5,6 +5,7 @@
 	"actions-run-removal",
 	"align-issue-labels",
 	"archive-forks-link",
+	"auto-load-notifications",
 	"avoid-accidental-submissions",
 	"batch-mark-files-as-viewed",
 	"bugs-tab",

--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -33,6 +33,7 @@ const noScreenshotExceptions = new Set([
 	'monospace-textareas',
 	'new-tab-links',
 
+	'auto-load-notifications', // TODO: Add gif showing notifications loading across pages
 	'hide-navigation-hover-highlight', // TODO: Add side-by-side gif
 	'hide-inactive-deployments', // TODO: side-by-side png
 	'esc-to-deselect-line', // TODO Add gif with key overlay

--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 ### Notifications
 
+- [](# "auto-load-notifications") Automatically loads all pages of notifications when a search filter is active, appending them to the list with a loading indicator.
 - [](# "open-all-notifications") [Adds a button to the notification page to open all your unread notifications at once.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257085496-17e5c6fa-6bad-443d-96d2-d97e73cd1a5e.png)
 - [](# "unread-anywhere") 🔥 [Adds a button to the global header to open your unread notifications from any page.](https://github.com/user-attachments/assets/978ac1fe-db98-40f9-9b56-7d289849aa2f)
 - [](# "select-all-notifications-shortcut") Adds a shortcut to select all visible notifications: <kbd>a</kbd>.

--- a/source/features/auto-load-notifications.tsx
+++ b/source/features/auto-load-notifications.tsx
@@ -1,0 +1,73 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import {$$optional, $optional} from 'select-dom';
+
+import features from '../feature-manager.js';
+import LoadingIcon from '../github-helpers/icon-loading.js';
+import {fetchDomUncached} from '../helpers/fetch-dom.js';
+import {waitForElement} from '../helpers/selector-observer.js';
+
+async function init(signal: AbortSignal): Promise<void> {
+	if (!new URLSearchParams(location.search).has('query')) {
+		return;
+	}
+
+	const nextLink = await waitForElement('a[aria-label="Next"]', {signal});
+	if (!nextLink) {
+		return;
+	}
+
+	const notificationList = $optional('ul.js-navigation-container');
+	const paginationNav = $optional('nav[aria-label="Pagination"]');
+	const paginationCounts = $optional('.js-notifications-list-paginator-counts');
+	if (!notificationList || !paginationNav) {
+		return;
+	}
+
+	const status = (
+		<div className="d-flex flex-items-center flex-justify-center py-3">
+			<LoadingIcon />
+			<span className="ml-2">Loading more notifications…</span>
+		</div>
+	);
+	paginationNav.before(status);
+	paginationNav.hidden = true;
+	if (paginationCounts) {
+		paginationCounts.hidden = true;
+	}
+
+	let nextUrl: string = nextLink.href;
+
+	while (nextUrl && !signal.aborted) {
+		// eslint-disable-next-line no-await-in-loop
+		const nextPage = await fetchDomUncached(nextUrl);
+		for (const item of $$optional('.notifications-list-item', nextPage)) {
+			notificationList.append(item);
+		}
+
+		nextUrl = $optional<HTMLAnchorElement>('a[aria-label="Next"]', nextPage)?.href ?? '';
+	}
+
+	paginationNav.remove();
+	paginationCounts?.remove();
+	status.replaceWith(
+		<p className="color-fg-muted text-center py-3 f6">
+			Done loading all notifications
+		</p>,
+	);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isNotifications,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/notifications?query=repo%3Aowner%2Frepo
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -42,6 +42,7 @@ import './features/hide-navigation-hover-highlight.js';
 import './features/selection-in-new-tab.js';
 import './features/quick-comment-hiding.js';
 import './features/quick-comment-edit.js';
+import './features/auto-load-notifications.js';
 import './features/open-all-notifications.js';
 import './features/copy-on-y.js';
 import './features/profile-hotkey.js';


### PR DESCRIPTION
Adds a new `auto-load-notifications` feature that automatically loads all subsequent pages of notifications when the list is in ungrouped/filtered mode (i.e. a `query=` filter is active).

- Shows a spinner at the bottom of the list while fetching additional pages
- Appends each page's notification items directly to the existing list
- Hides the pagination controls and page count while loading; removes them once complete
- Replaces the spinner with a "Done loading all notifications" message when finished
- Does nothing on the default grouped inbox view (no `query=` param)

This pairs especially well with the existing `select-notifications` feature — being able to select by type/status across all pages at once makes bulk actions much more useful.