### PR TITLE
fix(safari): re-enable GHE support and update webext-dynamic-content-scripts

### DIFF
--- a/build/prepare-safari-release.sh
+++ b/build/prepare-safari-release.sh
@@ -28,11 +28,8 @@ trash distribution
 npm run build
 npx dot-json distribution/manifest.json version "$TAG"
 
-# For https://github.com/refined-github/refined-github/issues/7629
-# TODO: Drop after https://bugs.webkit.org/show_bug.cgi?id=277588
-npx dot-json distribution/manifest.json background.service_worker --delete
-npx dot-json distribution/manifest.json optional_host_permissions --delete
-npx dot-json distribution/manifest.json background.persistent false --json-value
+# Safari does not support having both `service_worker` and `scripts` in the background object
+npx dot-json distribution/manifest.json background.scripts --delete
 
 sed -i '' '/MARKETING_VERSION/d' $CONFIG_FILE
 sed -i '' '/CURRENT_PROJECT_VERSION/d' $CONFIG_FILE

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"webext-bugs": "^2.0.1",
 				"webext-content-scripts": "^2.7.3",
 				"webext-detect": "^5.3.1",
-				"webext-dynamic-content-scripts": "^10.0.4",
+				"webext-dynamic-content-scripts": "file:../webext-dynamic-content-scripts",
 				"webext-msg": "^1.0.0",
 				"webext-options-sync": "^4.3.0",
 				"webext-options-sync-per-domain": "^4.3.1",
@@ -114,6 +114,39 @@
 			"engines": {
 				"node": ">= 20",
 				"npm": ">= 10"
+			}
+		},
+		"../webext-dynamic-content-scripts": {
+			"version": "10.0.4",
+			"license": "MIT",
+			"dependencies": {
+				"content-scripts-register-polyfill": "^4.0.2",
+				"webext-content-scripts": "^2.7.0",
+				"webext-detect": "^5.0.2",
+				"webext-events": "^3.0.1",
+				"webext-patterns": "^1.5.0",
+				"webext-permissions": "^3.1.3",
+				"webext-polyfill-kinda": "^1.0.2"
+			},
+			"devDependencies": {
+				"@parcel/config-webextension": "^2.12.0",
+				"@sindresorhus/tsconfig": "^6.0.0",
+				"@types/chrome": "^0.0.268",
+				"@types/firefox-webext-browser": "^120.0.4",
+				"@types/jest": "^29.5.12",
+				"expect-puppeteer": "^10.0.0",
+				"jest": "^29.7.0",
+				"jest-chrome": "^0.8.0",
+				"jest-puppeteer": "^10.0.1",
+				"npm-run-all": "^4.1.5",
+				"parcel": "^2.12.0",
+				"puppeteer": "^21.3.6",
+				"typescript": "^5.5.2",
+				"vitest": "^1.6.0",
+				"xo": "^0.58.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -3602,20 +3635,6 @@
 			"integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/content-scripts-register-polyfill": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-4.0.2.tgz",
-			"integrity": "sha512-8hDm+tu3BkxHZP7EUIIIo/495F6QNXF7cI9Lwr4PQaiohw2wWmi9k2SE4W4kNrAaLnFw6RZ2ev8EmrQb+sCoGQ==",
-			"license": "MIT",
-			"dependencies": {
-				"webext-content-scripts": "^2.5.2",
-				"webext-patterns": "^1.3.0",
-				"webext-polyfill-kinda": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fregante"
-			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -10849,22 +10868,8 @@
 			}
 		},
 		"node_modules/webext-dynamic-content-scripts": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-10.0.4.tgz",
-			"integrity": "sha512-41n7/H7MIV7QpWrFjwhEQKhaj4xdicD8+2tZyKETcIw2Vzo29481VbBsRZWdHxhegshflC6RfFZs0LM5q0pqSw==",
-			"license": "MIT",
-			"dependencies": {
-				"content-scripts-register-polyfill": "^4.0.2",
-				"webext-content-scripts": "^2.7.0",
-				"webext-detect": "^5.0.2",
-				"webext-events": "^3.0.1",
-				"webext-patterns": "^1.5.0",
-				"webext-permissions": "^3.1.3",
-				"webext-polyfill-kinda": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fregante"
-			}
+			"resolved": "../webext-dynamic-content-scripts",
+			"link": true
 		},
 		"node_modules/webext-events": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"webext-bugs": "^2.0.1",
 		"webext-content-scripts": "^2.7.3",
 		"webext-detect": "^5.3.1",
-		"webext-dynamic-content-scripts": "^10.0.4",
+		"webext-dynamic-content-scripts": "file:../webext-dynamic-content-scripts",
 		"webext-msg": "^1.0.0",
 		"webext-options-sync": "^4.3.0",
 		"webext-options-sync-per-domain": "^4.3.1",

--- a/source/background.ts
+++ b/source/background.ts
@@ -1,7 +1,6 @@
 import 'webext-dynamic-content-scripts';
 import 'webext-bugs/options-menu-item';
 import {customizeNoAllUrlsErrorMessage} from 'webext-bugs/no-all-urls';
-import {isSafari} from 'webext-detect';
 import {handleMessages} from 'webext-msg';
 import addPermissionToggle from 'webext-permission-toggle';
 import {StorageItem} from 'webext-storage';
@@ -19,9 +18,7 @@ const {version, permissions} = chrome.runtime.getManifest();
 const welcomeShown = new StorageItem('welcomed', {defaultValue: false});
 
 // GHE support
-if (!isSafari()) {
-	addPermissionToggle();
-}
+addPermissionToggle();
 
 // Add "Reload without content scripts" functionality
 addReloadWithoutContentScripts();


### PR DESCRIPTION
Re-enables GHE support on Safari now that [WebKit#277588](https://bugs.webkit.org/show_bug.cgi?id=277588) is resolved, and cleans up the Safari build script accordingly.

Points webext-dynamic-content-scripts at a local build because the Safari fix it depends on isn't merged yet.

Requires https://github.com/fregante/webext-dynamic-content-scripts/pull/79