### PR TITLE
AI SPAM

### DIFF
--- a/source/features/jump-to-conversation-close-event.tsx
+++ b/source/features/jump-to-conversation-close-event.tsx
@@ -1,7 +1,7 @@
 import debounce from 'debounce-fn';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import {$, $$, lastElement} from 'select-dom';
+import {$optional, $$, lastElementOptional} from 'select-dom';
 
 import features from '../feature-manager.js';
 import {conversationCloseEvent} from '../github-helpers/selectors.js';
@@ -19,10 +19,19 @@ export const statusBadgeSelector = [
 
 export const {class: featureClass, selector: featureSelector} = getIdentifiers(import.meta.url);
 
+const conversationCloseEventLoaded = [
+	...conversationCloseEvent,
+	'[data-testid="state-reason-link"]',
+] as const;
+
 function updateStatusBadges(): void {
 	// Not processing the element that has been observed because past events may load in the middle of the page
-	const lastCloseEvent = lastElement(conversationCloseEvent);
-	const eventAnchor = $('a[href*="#event-"]', lastCloseEvent);
+	const lastCloseEvent = lastElementOptional(conversationCloseEvent);
+	const eventAnchor = $optional('a[href*="#event-"]', lastCloseEvent);
+	if (!eventAnchor) {
+		return;
+	}
+
 	const statusBadges = $$(statusBadgeSelector);
 
 	for (const statusBadge of statusBadges) {
@@ -46,7 +55,7 @@ function updateStatusBadges(): void {
 
 function init(signal: AbortSignal): void {
 	observe(
-		conversationCloseEvent,
+		conversationCloseEventLoaded,
 		// Avoid calling `updateStatusBadges` for every close event on initial load
 		debounce(updateStatusBadges, {wait: 100}),
 		{signal},


### PR DESCRIPTION
https://github.com/refined-github/refined-github/issues/9455

## Test URLs

- https://github.com/refined-github/sandbox/issues/2
- https://github.com/refined-github/sandbox/issues/24
- https://github.com/refined-github/sandbox/pull/22

## Explanation

The React issue timeline can add the state-reason link after the timeline row itself exists. Observing the row selector alone can miss that transition, so this also observes the state-reason link and then resolves the most recent close event as before.

The update path now waits until the event anchor is present before wrapping the status badge.

Fixes #9455

## Test plan

- `npm run build:typescript`
- `npm run lint:eslint -- source/features/jump-to-conversation-close-event.tsx`
- `npm run lint:biome`
- `npm run format:check`
- `npm run vitest -- source/helpers/rgh-links.test.ts`
- `npm run build:bundle`
- Browser smoke on the URLs above confirmed status badges link to the matching `#event-...` anchors