### PR TITLE
[User was blocked for this AI PR]

### DIFF
--- a/source/features/tag-changes-link.tsx
+++ b/source/features/tag-changes-link.tsx
@@ -134,7 +134,7 @@ async function init(): Promise<void> {
 			}
 
 			lastLink.parentElement!.after(
-				<div className={'rgh-changelog-link ' + (pageDetect.isReleases() ? 'mb-md-2 mr-3 mr-md-0' : 'mr-4 mb-2')}>
+				<div className={'rgh-changelog-link ' + (pageDetect.isReleases() ? 'mb-2 mr-3 mr-md-0' : 'mr-4 mb-2')}>
 					{compareLink}
 				</div>,
 			);


### PR DESCRIPTION
## Summary
- keep bottom spacing on the inserted tag compare link in the releases list
- preserve the existing desktop and non-release tag layouts

Closes #9459

## Validation
- `npm run build:typescript`
- `npm run lint:biome -- source/features/tag-changes-link.tsx source/features/tag-changes-link.css`
- `npm run format:check`
- `npm run build:bundle`
- `npm run lint:eslint -- source/features/tag-changes-link.tsx`
- `git diff --check`
