### PR TITLE
AI SPAM

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -14,6 +14,48 @@ a[class*='PinnedIssue-module__Link'] code {
 	border-radius: 6px;
 }
 
+/* Restore tooltip arrows */
+/* Info: https://github.com/refined-github/refined-github/issues/9461 */
+tool-tip[popover] {
+	&::before {
+		content: '';
+		position: absolute;
+		width: 8px;
+		height: 8px;
+		background: inherit;
+		border: inherit;
+		rotate: 45deg;
+	}
+
+	&[data-direction^='n']::before {
+		bottom: -5px;
+		left: calc(50% - 4px);
+		border-top: 0;
+		border-left: 0;
+	}
+
+	&[data-direction^='s']::before {
+		top: -5px;
+		left: calc(50% - 4px);
+		border-right: 0;
+		border-bottom: 0;
+	}
+
+	&[data-direction='e']::before {
+		left: -5px;
+		top: calc(50% - 4px);
+		border-top: 0;
+		border-right: 0;
+	}
+
+	&[data-direction='w']::before {
+		right: -5px;
+		top: calc(50% - 4px);
+		border-bottom: 0;
+		border-left: 0;
+	}
+}
+
 /* Fix spacing of repo header button icons */
 /* Info: https://github.com/refined-github/refined-github/issues/5620 */
 .pagehead-actions


### PR DESCRIPTION
This restores small directional arrows on GitHub tooltip popovers through `github-bugs.css`. The new CSS uses the existing `tool-tip[popover]` and `data-direction` attributes so the arrow is drawn on the side that points back to the source element, without changing tooltip markup or behavior.

Verification: `npm ci --ignore-scripts --no-audit --no-fund`, `npm run lint:biome -- source/features/github-bugs.css`, and `git diff --check`.
