### PR TITLE
AI SPAM

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -46,6 +46,10 @@ function createReleaseUrl(): string {
 	return buildRepoUrl('releases/new');
 }
 
+function getCommitHashFromLink(commitLink: HTMLAnchorElement): string {
+	return commitLink.pathname.split('/commit/').at(1) ?? commitLink.textContent;
+}
+
 function addExistingTagLinkToHeader(tagName: string, tagUrl: string, discussionHeader: HTMLElement): void {
 	discussionHeader.parentElement!.append(
 		<span>
@@ -108,8 +112,10 @@ async function addReleaseBanner(text: string | JSX.Element): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	const mergeCommit
-		= $(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`).textContent;
+	const mergeCommitLink = $<HTMLAnchorElement>(
+		`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i]`,
+	);
+	const mergeCommit = getCommitHashFromLink(mergeCommitLink);
 	const tagName = await firstTag.get(mergeCommit);
 
 	if (tagName) {


### PR DESCRIPTION
## Summary
- read the merge commit hash from the commit link URL instead of the visible short SHA
- keep the existing branch_commits lookup and tag filtering behavior unchanged

Fixes #9464

## Validation
- `npx eslint source/features/closing-remarks.tsx`
- `npm run build:typescript`
- `npm run format:check`
- `npm run build:bundle`
- Verified `https://github.com/npm/cli/branch_commits/a96d8f6` returns 404 while the full SHA endpoint includes `branches-tag-list` and `v11.14.1`