### PR TITLE
`open-issue-to-latest-comment` - Fix console error

### DIFF
--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -88,7 +88,7 @@ export const openPrsListLink_ = [
 
 export const commentsCountInLists = [
 	// Issue list:
-	'div[data-testid="list-row-comments"]',
+	'div[data-testid="list-row-comments"]:not(:empty)',
 	'div[class^="PinnedIssue-module__commentCountContainer"]',
 
 	// PR list


### PR DESCRIPTION



## Test URLs

https://github.com/sindresorhus/eslint-plugin-unicorn/issues?q=is%3Aissue%20is%3Aopen%20timer-delay

## Before

 
<img width="842" height="408" alt="Screenshot 7" src="https://github.com/user-attachments/assets/ac87e5b0-9258-41c6-ad6b-0285b93cbdd2" />

## After

<img width="842" height="408" alt="Screenshot 6" src="https://github.com/user-attachments/assets/7fd5dbcf-b5e1-4713-9e96-666eb8c8e135" />
