### PR TITLE
`quick-file-edit` - Fix ` GitHub File Icons` conflict

### DIFF
--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -50,11 +50,8 @@ export const branchSelector_ = [
 export const branchSelectorParent = 'details#branch-select-menu';
 export const branchSelectorParent_ = branchSelector_;
 
-export const directoryListingFileIcon = [
-	// .color-fg-muted selects only files; some icon extensions use `img` tags
-	'.react-directory-filename-column > :is(svg, img).color-fg-muted',
-	'.js-navigation-container .octicon-file',
-];
+// .color-fg-muted selects only files; some icon extensions use `img` tags
+export const directoryListingFileIcon = '.react-directory-filename-column > :is(svg, img).color-fg-muted';
 export const directoryListingFileIcon_ = [
 	[18, 'https://github.com/refined-github/refined-github'],
 	[3, 'https://github.com/refined-github/refined-github/tree/main/.github'],

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -50,7 +50,11 @@ export const branchSelector_ = [
 export const branchSelectorParent = 'details#branch-select-menu';
 export const branchSelectorParent_ = branchSelector_;
 
-export const directoryListingFileIcon = '.react-directory-filename-column > .octicon-file';
+export const directoryListingFileIcon = [
+	// .color-fg-muted selects only files; some icon extensions use `img` tags
+	'.react-directory-filename-column > :is(svg, img).color-fg-muted',
+	'.js-navigation-container .octicon-file',
+];
 export const directoryListingFileIcon_ = [
 	[18, 'https://github.com/refined-github/refined-github'],
 	[3, 'https://github.com/refined-github/refined-github/tree/main/.github'],


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9453
- reverts https://github.com/refined-github/refined-github/pull/9418#discussion_r3214730002


## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<img width="539" height="190" alt="Screenshot 27" src="https://github.com/user-attachments/assets/bd49331a-3aa9-4540-b3e9-83f376c19a0f" />
