### PR TITLE
`closing-remarks` - Add support for large repos

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -109,8 +109,9 @@ async function addReleaseBanner(text: string | JSX.Element): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	const mergeCommit
-		= $(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`).textContent;
-	const tagName = await firstTag.get(mergeCommit);
+		= $(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i]`);
+	const [, hash] = /commit\/([a-f0-9]{40})/.exec(mergeCommit.pathname)!;
+	const tagName = await firstTag.get(hash);
 
 	if (tagName) {
 		const tagUrl = buildRepoUrl('releases/tag', tagName);


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9464


## Test URLs

https://github.com/npm/cli/pull/8184


## Before

<img width="808" height="156" alt="Screenshot" src="https://github.com/user-attachments/assets/5e1f2397-066e-4901-906e-f902d4900322" />

## After

<img width="808" height="156" alt="Screenshot 12" src="https://github.com/user-attachments/assets/c634a548-6325-497c-af9a-70bcaccd0dc7" />

