### PR TITLE
`github-actions-indicators` - Consistent placement

### DIFF
--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -111,6 +111,7 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 			// This class keeps the action on a single line. It natively exists if the item can be pinned (if current user has write access)
 			workflowLink.parentElement!.classList.add('ActionListItem--withActions');
 
+			// Move pin icon to the end so that its position remains visually consistent
 			const pinIcon = $optional('.ActionListItem-visual--trailing', workflowLink);
 			if (pinIcon) {
 				workflowLink.after(pinIcon);

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -2,7 +2,7 @@ import {parseCron} from '@fregante/mi-cron';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import PlayIcon from 'octicons-plain-react/Play';
-import {$} from 'select-dom';
+import {$, $optional} from 'select-dom';
 import {CachedFunction} from 'webext-storage-cache';
 
 import features from '../feature-manager.js';
@@ -110,6 +110,13 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 		} else {
 			// This class keeps the action on a single line. It natively exists if the item can be pinned (if current user has write access)
 			workflowLink.parentElement!.classList.add('ActionListItem--withActions');
+
+			const pinIcon = $optional('.ActionListItem-visual--trailing', workflowLink);
+			if (pinIcon) {
+				workflowLink.after(pinIcon);
+				pinIcon.classList.add('Button--iconOnly', 'flex-shrink-0');
+			}
+
 			workflowLink.after(
 				tooltipped(
 					{label: 'This workflow can be triggered manually', direction: 'sw'},

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -13,6 +13,7 @@ import removeHashFromUrlBar from '../helpers/history.js';
 import observe from '../helpers/selector-observer.js';
 import {tooltipped} from '../helpers/tooltip.js';
 import GetWorkflows from './github-actions-indicators.gql';
+import {appendBefore} from '../helpers/dom-utils.js';
 
 type Workflow = {
 	name: string;
@@ -92,6 +93,7 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 
 	if (workflow.manuallyDispatchable && workflowLink.pathname !== location.pathname) {
 		if (workflowLink.nextElementSibling) {
+			// User can trigger the workflow
 			const url = new URL(workflowLink.href);
 			url.hash = 'rgh-run-workflow';
 			workflowLink.after(
@@ -108,24 +110,26 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 				),
 			);
 		} else {
-			// This class keeps the action on a single line. It natively exists if the item can be pinned (if current user has write access)
-			workflowLink.parentElement!.classList.add('ActionListItem--withActions');
-
-			// Move pin icon to the end so that its position remains visually consistent
+			// User cannot trigger the workflow
+			const indicator = tooltipped(
+				{label: 'This workflow can be triggered manually', direction: 'sw'},
+				<div
+					className='ActionListItem-visual ActionListItem-visual--trailing'
+					style={{pointerEvents: 'initial'}}
+				>
+					<PlayIcon />
+				</div>,
+			);
 			const pinIcon = $optional('.ActionListItem-visual--trailing', workflowLink);
 			if (pinIcon) {
-				workflowLink.after(pinIcon);
-				pinIcon.classList.add('Button--iconOnly', 'flex-shrink-0');
+				// Enable tooltip
+				pinIcon.style.pointerEvents = 'auto';
+				// Add spacing between the icons
+				pinIcon.classList.add('gap-1');
+				pinIcon.prepend(indicator);
+			} else {
+				workflowLink.append(indicator);
 			}
-
-			workflowLink.after(
-				tooltipped(
-					{label: 'This workflow can be triggered manually', direction: 'sw'},
-					<div className="Button Button--iconOnly Button--invisible Button--medium color-bg-transparent">
-						<PlayIcon />
-					</div>,
-				),
-			);
 		}
 	}
 

--- a/source/features/github-actions-indicators.tsx
+++ b/source/features/github-actions-indicators.tsx
@@ -13,7 +13,6 @@ import removeHashFromUrlBar from '../helpers/history.js';
 import observe from '../helpers/selector-observer.js';
 import {tooltipped} from '../helpers/tooltip.js';
 import GetWorkflows from './github-actions-indicators.gql';
-import {appendBefore} from '../helpers/dom-utils.js';
 
 type Workflow = {
 	name: string;
@@ -125,7 +124,7 @@ async function addIndicators(workflowLink: HTMLAnchorElement): Promise<void> {
 				// Enable tooltip
 				pinIcon.style.pointerEvents = 'auto';
 				// Add spacing between the icons
-				pinIcon.classList.add('gap-1');
+				pinIcon.classList.add('gap-2');
 				pinIcon.prepend(indicator);
 			} else {
 				workflowLink.append(indicator);


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9454


## Test URLs

https://github.com/facebook/react/actions


## Screenshot
<table>
<tr>
 <th>Native
 <th>Before
 <th>After
<tr>
 <td valign=top>
<img width="313" height="196" alt="Screenshot 17" src="https://github.com/user-attachments/assets/09f1bcde-67fd-4d35-b38f-a134b585ea53" />
 <td valign=top>
<img width="313" height="196" alt="Screenshot 19" src="https://github.com/user-attachments/assets/bce051f6-debd-4984-a450-152978ba2c21" />
 <td valign=top>
<img width="313" height="196" alt="Screenshot 23" src="https://github.com/user-attachments/assets/47f4248b-26fb-4a1f-8ed5-d7c5c10697b0" />

</table>
