### PR TITLE
`repo-header-info` - Fix site header overlap

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -819,6 +819,7 @@
 	{
 		"id": "repo-header-info",
 		"description": "Shows whether a repo is a fork and adds the number of stars to its header.",
+		"css": true,
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/267216946-404d79ab-46d7-4bc8-ba88-ae8f8029150d.png"
 	},
 	{

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -1,0 +1,7 @@
+html:not([rgh-OFF-repo-header-info]) {
+	div[data-testid='top-nav-center']
+		li:last-child
+		> a[class*='prc-Breadcrumbs-Item']:not(.rgh-repo-header-info-updated) {
+		padding-right: 4em;
+	}
+}

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -2,6 +2,9 @@ html:not([rgh-OFF-repo-header-info]) {
 	div[data-testid='top-nav-center']
 		li:last-child
 		> a[class*='prc-Breadcrumbs-Item']:not(.rgh-repo-header-info-updated) {
-		padding-right: 4em;
+			/* Matches the `isSmallDevice` JS check */
+			@media (min-width: 500px) {
+				padding-right: 4em;
+			}
 	}
 }

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -2,9 +2,9 @@ html:not([rgh-OFF-repo-header-info]) {
 	div[data-testid='top-nav-center']
 		li:last-child
 		> a[class*='prc-Breadcrumbs-Item']:not(.rgh-repo-header-info-updated) {
-			/* Matches the `isSmallDevice` JS check */
-			@media (min-width: 500px) {
-				padding-right: 4em;
-			}
+		/* Matches the `isSmallDevice` JS check */
+		@media (min-width: 500px) {
+			padding-right: 4em;
+		}
 	}
 }

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -1,3 +1,5 @@
+import './repo-header-info.css';
+
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import LockIcon from 'octicons-plain-react/Lock';
@@ -35,6 +37,8 @@ const repositoryInfo = new CachedFunction('stargazer-count', {
 
 async function add(repoLink: HTMLAnchorElement): Promise<void> {
 	const {isFork, isPrivate, stargazerCount, viewerHasStarred} = await repositoryInfo.get();
+
+	repoLink.classList.add('rgh-repo-header-info-updated');
 
 	// GitHub may already show this icon natively, so we match its position
 	if (isPrivate && !elementExists('.octicon-lock', repoLink)) {
@@ -89,6 +93,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	);
 }
 
+void features.addCssFeature(import.meta.url);
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.hasRepoHeader,


### PR DESCRIPTION
- part of https://github.com/refined-github/refined-github/issues/9433


## Test URLs

Here

## Before

<img width="1032" height="68" alt="Screenshot 24" src="https://github.com/user-attachments/assets/31f96fc4-d5cf-4430-a0f6-c2b0ea96b798" />


## After

<img width="1032" height="68" alt="Screenshot 25" src="https://github.com/user-attachments/assets/659ea4c3-1bdb-429e-8cae-7305a4bfc9dd" />

<img width="1157" height="1110" src="https://github.com/user-attachments/assets/71cf18c2-ecc7-4326-a537-5e791d80acd9" />

