### PR TITLE
`useful-not-found-page` - Drop redundant link

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -120,6 +120,11 @@ async function showMissingPartOnce(): Promise<void> {
 }
 
 async function showDefaultBranchLink(): Promise<void> {
+	if (pageDetect.isRepoRoot()) {
+		// https://github.com/refined-github/refined-github/issues/9423
+		return;
+	}
+
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (!urlToFileOnDefaultBranch) {
 		return;

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -121,6 +121,7 @@ async function showMissingPartOnce(): Promise<void> {
 
 async function showDefaultBranchLink(): Promise<void> {
 	if (pageDetect.isRepoRoot()) {
+		// The root is not a "file" and the link to it already appears in the breadcrumbs
 		// https://github.com/refined-github/refined-github/issues/9423
 		return;
 	}


### PR DESCRIPTION

- fixes https://github.com/refined-github/refined-github/issues/9423

## Test URLs

https://github.com/refined-github/refined-github/tree/quick-edit-icons


## Before

<img width="667" height="114" alt="Screenshot 2" src="https://github.com/user-attachments/assets/eca48d38-7258-4591-8235-5482764e5f24" />

## After

<img width="667" height="95" alt="Screenshot 3" src="https://github.com/user-attachments/assets/e53d9f79-5891-4f0f-a851-78a66f1ada8b" />
