### PR TITLE
`closing-remarks` - Restore in PR header

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -46,22 +46,20 @@ function createReleaseUrl(): string {
 	return buildRepoUrl('releases/new');
 }
 
-function addExistingTagLinkToHeader(tagName: string, tagUrl: string, discussionHeader: HTMLElement): void {
-	discussionHeader.parentElement!.append(
-		<span>
+function addTagToHeader(tagName: string, tagUrl: string, relativeTime: HTMLElement): void {
+	relativeTime.parentElement!.append(
+		<a
+			href={tagUrl}
+			className="text-bold Link--primary no-underline"
+			title={`${tagName} was the first Git tag to include this pull request`}
+		>
 			<TagIcon className="ml-2 mr-1 color-fg-muted" />
-			<a
-				href={tagUrl}
-				className="commit-ref"
-				title={`${tagName} was the first Git tag to include this pull request`}
-			>
-				{tagName}
-			</a>
-		</span>,
+			{tagName}
+		</a>,
 	);
 }
 
-function addExistingTagLinkFooter(tagName: string, tagUrl: string): void {
+function addTagToFooter(tagName: string, tagUrl: string): void {
 	const linkedTag = <a href={tagUrl} className="Link--primary text-bold">{tagName}</a>;
 	attachElement($(commentBoxHashPr), {
 		before: () => (
@@ -116,10 +114,10 @@ async function init(signal: AbortSignal): Promise<void> {
 		const tagUrl = buildRepoUrl('releases/tag', tagName);
 
 		// Add static box at the bottom
-		addExistingTagLinkFooter(tagName, tagUrl);
+		addTagToFooter(tagName, tagUrl);
 
 		// PRs have a regular and a sticky header
-		observe('#partial-discussion-header relative-time', addExistingTagLinkToHeader.bind(undefined, tagName, tagUrl), {
+		observe('[class*="PullRequestHeaderSummary"] relative-time', addTagToHeader.bind(undefined, tagName, tagUrl), {
 			signal,
 		});
 	} else {


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9410


## Test URLs

https://github.com/refined-github/refined-github/pull/9256

## Screenshot

<img width="584" height="96" alt="ours" src="https://github.com/user-attachments/assets/d8714da9-a719-469c-bd09-f429177af984" />

This new style matches the native one appearing in issues, including the hover state:

<img width="299" height="145" alt="native" src="https://github.com/user-attachments/assets/fe231659-e7a3-4bdd-a18b-c33b0e17a562" />
