### PR TITLE
`clean-conversation-headers` - Restore merge time

### DIFF
--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -31,7 +31,7 @@
 	/* Doesn't show on PRs: octocat merged [1] commit into master from feature */
 	> [class]:not(.js-updating-pull-request-commits-count),
 	> relative-time {
-			font-size: 14px;
+		font-size: 14px;
 	}
 
 	--margin: 4px;

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -29,8 +29,9 @@
 
 	/* Shows on PRs: [octocat] merged 1 commit into [master] from [feature] on [1 Jan] */
 	/* Doesn't show on PRs: octocat merged [1] commit into master from feature */
-	> [class]:not(.js-updating-pull-request-commits-count) {
-		font-size: 14px;
+	> [class]:not(.js-updating-pull-request-commits-count),
+	> relative-time {
+			font-size: 14px;
 	}
 
 	--margin: 4px;


### PR DESCRIPTION
Not sure if this was intentional, but the time is being hidden


## Test URLs

https://github.com/refined-github/refined-github/pull/1750

## Before

<img width="811" height="104" alt="Screenshot 23" src="https://github.com/user-attachments/assets/3a277b76-9abf-4f06-8ddd-1af28c6dc309" />


## After
<img width="811" height="104" alt="Screenshot 24" src="https://github.com/user-attachments/assets/b744af85-1d91-4dc9-8c96-bacd247ee686" />
