### PR TITLE
`repo-wide-file-finder` - Avoid conflict with native shortcut

### DIFF
--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -20,6 +20,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	exclude: [
+		// TODO: Drop first two selectors in October 2026
 		() => elementExists(['[data-hotkey="t"]', '[data-hotkey="t,Shift+T"]', '[aria-label="Go to file"]']),
 		pageDetect.isPRFiles,
 		pageDetect.isFileFinder,

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -20,12 +20,11 @@ void features.add(import.meta.url, {
 		pageDetect.isRepo,
 	],
 	exclude: [
-		() => elementExists(['[data-hotkey="t"]', '[data-hotkey="t,Shift+T"]']),
-		// TODO: Detect empty repos differently or fail gracefully
-		pageDetect.isEmptyRepoRoot,
+		() => elementExists(['[data-hotkey="t"]', '[data-hotkey="t,Shift+T"]', '[aria-label="Go to file"]']),
 		pageDetect.isPRFiles,
 		pageDetect.isFileFinder,
 	],
+	awaitDomReady: true, // DOM-based filters
 	init,
 });
 


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9299


## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

See field focus without navigation:

<img width="884" height="275" alt="t" src="https://github.com/user-attachments/assets/60904531-c720-4314-ab32-a9c80217deba" />


