### PR TITLE
AI SPAM

### DIFF
--- a/source/features/cmd-enter.tsx
+++ b/source/features/cmd-enter.tsx
@@ -1,9 +1,27 @@
 import delegate, {type DelegateEvent} from 'delegate-it';
+import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import {$, $optional} from 'select-dom';
+import {$, $optional, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
+import {moduleKeySymbol} from '../github-helpers/hotkey.js';
 import {legacyCommentField} from '../github-helpers/selectors.js';
+import observe from '../helpers/selector-observer.js';
+
+function addShortcut(reopenButton: HTMLButtonElement): void {
+	const submitButton = $('.btn-primary[type="submit"]', reopenButton.form!);
+	if (elementExists('.rgh-cmd-enter-shortcut', submitButton)) {
+		return;
+	}
+
+	submitButton.append(
+		' ',
+		<span className="rgh-cmd-enter-shortcut text-normal" aria-hidden="true">
+			{moduleKeySymbol}
+			↵
+		</span>,
+	);
+}
 
 function handleKeyDown(event: DelegateEvent<KeyboardEvent>): void {
 	if (event.key !== 'Enter' || !(event.metaKey || event.ctrlKey)) {
@@ -20,6 +38,7 @@ function handleKeyDown(event: DelegateEvent<KeyboardEvent>): void {
 }
 
 function init(signal: AbortSignal): void {
+	observe('button[name="comment_and_open"]:disabled', addShortcut, {signal});
 	delegate(legacyCommentField, 'keydown', handleKeyDown, {signal});
 }
 

--- a/source/github-helpers/hotkey.tsx
+++ b/source/github-helpers/hotkey.tsx
@@ -29,3 +29,4 @@ export function addHotkey(button: HTMLAnchorElement | HTMLButtonElement | undefi
 
 // eslint-disable-next-line unicorn/prevent-abbreviations
 export const modKey = isMac ? 'cmd' : 'ctrl';
+export const moduleKeySymbol = isMac ? '⌘' : 'Ctrl';


### PR DESCRIPTION
Closes #9494

## Summary
- add a platform-aware visible shortcut label for cmd/ctrl-enter
- append the shortcut hint to the submit button handled by the `cmd-enter` feature
- avoid adding duplicate shortcut hints if the observed button is reprocessed

## Validation
- npm run build:typescript
- npx eslint source/features/cmd-enter.tsx source/github-helpers/hotkey.tsx

Note: dprint/biome do not process these TSX files in this repo configuration; both reported no matching files when scoped to the changed files.