### PR TITLE
Fix GitHub bug: keep "Symbolic Link" link visible on all screens

### DIFF
--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -128,10 +128,7 @@ function validateCss(file: FeatureFile): void {
 			`Should be imported by \`${entryPoint}\` or removed if it is not needed`,
 		);
 
-		// `github-bugs` has its own eslint rule for test URLs
-		if (file.id !== 'github-bugs') {
-			assert(/test url/i.test(file.contents().toString()), 'Should have test URLs');
-		}
+		assert(/test url/i.test(file.contents().toString()), 'Should have test URLs');
 
 		if (!isFeaturePrivate(file.name)) {
 			validateReadme(file.id);

--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -128,7 +128,10 @@ function validateCss(file: FeatureFile): void {
 			`Should be imported by \`${entryPoint}\` or removed if it is not needed`,
 		);
 
-		assert(/test url/i.test(file.contents().toString()), 'Should have test URLs');
+		// `github-bugs` has its own eslint rule for test URLs
+		if (file.id !== 'github-bugs') {
+			assert(/test url/i.test(file.contents().toString()), 'Should have test URLs');
+		}
 
 		if (!isFeaturePrivate(file.name)) {
 			validateReadme(file.id);

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -284,10 +284,11 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	transition: none !important;
 }
 
-/*
-
-Test URLs:
-
-MAKE SURE TO ADD A ISSUE REFERENCE + TEST URL FOR EACH NEW RULE
-
-*/
+/* Restores "Symbolic link" link in the gap between GitHub's media queries (1012 -> 1280) */
+/* Info: https://github.com/refined-github/refined-github/issues/9480 */
+/* Test: https://github.com/refined-github/refined-github/blob/55b7ce0fddd/CLAUDE.md */
+@media (max-width: 1280px) {
+	:root .react-code-size-details-banner {
+		display: flex !important;
+	}
+}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -277,13 +277,6 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
-/* Fix checkmark on a deselected item disappearing with a noticeable delay */
-/* Info: https://github.com/refined-github/refined-github/issues/9348 */
-/* Test: https://github.com/refined-github/refined-github/issues/9348 */
-.ActionListItem-singleSelectCheckmark {
-	transition: none !important;
-}
-
 /* Restores "Symbolic link" link in the gap between GitHub's media queries (1012 -> 1280) */
 /* Info: https://github.com/refined-github/refined-github/issues/9480 */
 /* Test: https://github.com/refined-github/refined-github/blob/55b7ce0fddd/CLAUDE.md */
@@ -292,3 +285,18 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 		display: flex !important;
 	}
 }
+
+/* Fix checkmark on a deselected item disappearing with a noticeable delay */
+/* Info: https://github.com/refined-github/refined-github/issues/9348 */
+/* Test: https://github.com/refined-github/refined-github/issues/9348 */
+.ActionListItem-singleSelectCheckmark {
+	transition: none !important;
+}
+
+/*
+
+Test URLs:
+
+MAKE SURE TO ADD A ISSUE REFERENCE + TEST URL FOR EACH NEW RULE
+
+*/


### PR DESCRIPTION

- fixes https://github.com/refined-github/refined-github/issues/9480



## Test URLs
https://github.com/refined-github/refined-github/blob/55b7ce0fddd89696b97f7bc33632ae7421fbbbdc/CLAUDE.md

## Screenshot

<img width="630" height="195" alt="resize" src="https://github.com/user-attachments/assets/3bf162ca-7dfc-4bc5-b31d-0d3a659aba1c" />

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="1212" height="355" alt="Screenshot" src="https://github.com/user-attachments/assets/166980e0-ef1a-47f5-889d-ee12ed5e4830" />
 <td valign=top><img width="1212" height="394" alt="Screenshot 1" src="https://github.com/user-attachments/assets/b6ad7c6c-6119-47b0-9f90-22c1c3881b39" />
</table>



