### PR TITLE
`show-open-prs-of-forks` - Fix spacing

### DIFF
--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -65,9 +65,7 @@ async function initHeadHint(): Promise<void | false> {
 
 	$(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`).after(
 		// The class is used by `quick-fork-deletion`
-		<>
-			with <a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a>
-		</>,
+		<> with <a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a></>,
 	);
 }
 


### PR DESCRIPTION
Currently there's no spacing between the repo link and "with ..." which looks a bit odd, this is just a quick PR to add a space before the "with"

## Screenshot
Before:
<img width="442" height="23" alt="image" src="https://github.com/user-attachments/assets/09d1ee40-2341-4bfc-ba20-8fdf1d7cd8f3" />

After:
<img width="442" height="23" alt="image" src="https://github.com/user-attachments/assets/bb3f1136-5084-43a0-ad1e-9b68ebb3d60f" />