### PR TITLE
Fix extension stylesheet order (?)

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -53,11 +53,17 @@
 			"exclude_matches": [
 				"https://*/login/*"
 			],
-			"css": [
-				"assets/refined-github.css"
-			],
 			"js": [
 				"assets/content-script.js"
+			]
+		},
+		{
+			"matches": [
+				"https://github.com/*",
+				"https://gist.github.com/*"
+			],
+			"css": [
+				"assets/refined-github.css"
 			]
 		}
 	],


### PR DESCRIPTION
After re-reading https://github.com/refined-github/refined-github/issues/9335#issuecomment-4379889461, I realized that `document_start` is obviously the wrong time to add a stylesheet meant to _override_ the page's.

Now I don't know if this PR makes any difference nor if it works correctly on GHE.

- [ ] Verify injection order in all browsers
	- [ ] `main`
	- [ ] this PR
- [ ] ensure it works without issues on GHE