### PR TITLE
Meta: Readable `no-restricted-syntax`

### DIFF
--- a/eslint-rules/byo.js
+++ b/eslint-rules/byo.js
@@ -9,6 +9,10 @@ const rule = {
 	},
 	create(context) {
 		const [selector, message] = context.options;
+		if (typeof selector !== 'string' || typeof message !== 'string') {
+			return {};
+		}
+
 		return {
 			[selector](node) {
 				context.report({
@@ -26,6 +30,8 @@ const byo = {
 			if (typeof property === 'string') {
 				return rule;
 			}
+
+			return undefined;
 		},
 		has(_target, property) {
 			return typeof property === 'string';

--- a/eslint-rules/byo.js
+++ b/eslint-rules/byo.js
@@ -3,12 +3,20 @@ const rule = {
 	meta: {
 		type: 'problem',
 		schema: [
-			{type: 'string'},
-			{type: 'string'},
+			{
+				type: 'object',
+				properties: {
+					selector: {type: 'string'},
+					message: {type: 'string'},
+				},
+				required: ['selector', 'message'],
+				additionalProperties: false,
+			},
 		],
 	},
 	create(context) {
-		const [selector, message] = context.options;
+		const [options] = context.options;
+		const {selector, message} = options ?? {};
 		if (typeof selector !== 'string' || typeof message !== 'string') {
 			return {};
 		}

--- a/eslint-rules/byo.js
+++ b/eslint-rules/byo.js
@@ -2,8 +2,10 @@
 const rule = {
 	meta: {
 		type: 'problem',
-		schema: [
-			{
+		schema: {
+			type: 'array',
+			minItems: 1,
+			items: {
 				type: 'object',
 				properties: {
 					selector: {type: 'string'},
@@ -12,23 +14,35 @@ const rule = {
 				required: ['selector', 'message'],
 				additionalProperties: false,
 			},
-		],
+		},
 	},
 	create(context) {
-		const [options] = context.options;
-		const {selector, message} = options ?? {};
-		if (typeof selector !== 'string' || typeof message !== 'string') {
-			return {};
+		/** @type {Map<string, string[]>} */
+		const messagesBySelector = new Map();
+		for (const option of context.options) {
+			const {selector, message} = option ?? {};
+			if (typeof selector !== 'string' || typeof message !== 'string') {
+				continue;
+			}
+
+			const messages = messagesBySelector.get(selector) ?? [];
+			messages.push(message);
+			messagesBySelector.set(selector, messages);
 		}
 
-		return {
-			[selector](node) {
-				context.report({
-					node,
-					message,
-				});
-			},
-		};
+		return Object.fromEntries(
+			[...messagesBySelector.entries()].map(([selector, messages]) => [
+				selector,
+				(node) => {
+					for (const message of messages) {
+						context.report({
+							node,
+							message,
+						});
+					}
+				},
+			]),
+		);
 	},
 };
 

--- a/eslint-rules/byo.js
+++ b/eslint-rules/byo.js
@@ -1,0 +1,36 @@
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+	meta: {
+		type: 'problem',
+		schema: [
+			{type: 'string'},
+			{type: 'string'},
+		],
+	},
+	create(context) {
+		const [selector, message] = context.options;
+		return {
+			[selector](node) {
+				context.report({
+					node,
+					message,
+				});
+			},
+		};
+	},
+};
+
+const byo = {
+	rules: new Proxy({}, {
+		get(_target, property) {
+			if (typeof property === 'string') {
+				return rule;
+			}
+		},
+		has(_target, property) {
+			return typeof property === 'string';
+		},
+	}),
+};
+
+export default byo;

--- a/eslint-rules/byo.test.js
+++ b/eslint-rules/byo.test.js
@@ -1,0 +1,71 @@
+import {RuleTester} from 'eslint';
+import {test} from 'vitest';
+
+import byo from './byo.js';
+
+test('byo supports one or more selector/message objects', () => {
+	const ruleTester = new RuleTester({
+		languageOptions: {
+			ecmaVersion: 'latest',
+			sourceType: 'module',
+		},
+	});
+
+	ruleTester.run('byo/multi-config', byo.rules.anything, {
+		valid: [
+			{
+				code: 'baz();',
+				options: [
+					{
+						selector: 'Identifier[name=foo]',
+						message: 'No foo',
+					},
+					{
+						selector: 'Identifier[name=bar]',
+						message: 'No bar',
+					},
+				],
+			},
+		],
+		invalid: [
+			{
+				code: 'foo();',
+				options: [
+					{
+						selector: 'Identifier[name=foo]',
+						message: 'No foo',
+					},
+				],
+				errors: [{message: 'No foo'}],
+			},
+			{
+				code: 'foo(); bar();',
+				options: [
+					{
+						selector: 'Identifier[name=foo]',
+						message: 'No foo',
+					},
+					{
+						selector: 'Identifier[name=bar]',
+						message: 'No bar',
+					},
+				],
+				errors: [{message: 'No foo'}, {message: 'No bar'}],
+			},
+			{
+				code: 'foo();',
+				options: [
+					{
+						selector: 'Identifier[name=foo]',
+						message: 'No foo 1',
+					},
+					{
+						selector: 'Identifier[name=foo]',
+						message: 'No foo 2',
+					},
+				],
+				errors: [{message: 'No foo 1'}, {message: 'No foo 2'}],
+			},
+		],
+	});
+});

--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -14,14 +14,6 @@ const restrictedSyntax = [
 		message: 'Use `$()` instead of non-null `$optional()`. Use it as `import {expectElement as $}`',
 	},
 	{
-		selector: 'TSNonNullExpression > CallExpression > [name=$]',
-		message: 'Unused null expression: !',
-	},
-	{
-		selector: 'TSNonNullExpression > CallExpression > [name=$closest]',
-		message: 'Unused null expression: ! — $closest() already throws when the element is not found',
-	},
-	{
 		message: 'Init functions wrapped with onetime() must have a name ending with "Once"',
 		selector:
 			'ObjectExpression > Property[key.name=init] > CallExpression[callee.name=onetime]:not([arguments.0.name=/Once$/])',

--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -1,38 +1,46 @@
-const restrictedSyntax = [
-	{
+const restrictedSyntax = {
+	'byo/selectors-array-for-complex-strings': ['error', {
 		selector:
 			':matches([callee.name=delegate], [callee.name=$], [callee.name=$$], [callee.name=$optional], [callee.name=$closest], [callee.name=$closestOptional], [callee.name=observe], [callee.property.name=querySelector], [callee.property.name=querySelectorAll])[arguments.0.value=/,/][arguments.0.value.length>=20]:not([arguments.0.value=/:has|:is|:not/])',
 		message: 'Instead of a single string, pass an array of selectors and add comments to each selector',
-	},
-	{
+	}],
+	'byo/selectors-string-for-single-array-item': ['error', {
 		selector:
 			':matches([callee.name=delegate], [callee.name=$], [callee.name=$$], [callee.name=$optional], [callee.name=$closest], [callee.name=$closestOptional], [callee.name=observe], [callee.property.name=querySelector], [callee.property.name=querySelectorAll])[arguments.0.type=ArrayExpression][arguments.0.elements.length=1]:not([arguments.0.value=/:has|:is/])',
 		message: "If it's a single selector, use a single string instead of an array",
-	},
-	{
+	}],
+	'byo/no-non-null-optional': ['error', {
 		selector: 'TSNonNullExpression > CallExpression > [name=$optional]',
 		message: 'Use `$()` instead of non-null `$optional()`. Use it as `import {expectElement as $}`',
-	},
-	{
+	}],
+	'byo/no-non-null-expect-element': ['error', {
+		selector: 'TSNonNullExpression > CallExpression > [name=$]',
+		message: 'Unused null expression: !',
+	}],
+	'byo/no-non-null-closest': ['error', {
+		selector: 'TSNonNullExpression > CallExpression > [name=$closest]',
+		message: 'Unused null expression: ! — $closest() already throws when the element is not found',
+	}],
+	'byo/onetime-init-requires-once-name': ['error', {
 		message: 'Init functions wrapped with onetime() must have a name ending with "Once"',
 		selector:
 			'ObjectExpression > Property[key.name=init] > CallExpression[callee.name=onetime]:not([arguments.0.name=/Once$/])',
-	},
-	{
+	}],
+	'byo/once-function-no-signal': ['error', {
 		message:
 			'Init functions that run once, cannot accept a signal: https://github.com/refined-github/refined-github/pull/8072',
 		selector: 'FunctionDeclaration[id.name=/Once$/] > Identifier[name=signal]',
-	},
-	{
+	}],
+	'byo/prefer-element-exists': ['error', {
 		message: 'Use `elementExists` for checking if an element exists',
 		selector: '*[test.type="CallExpression"][test.callee.name="$optional"],'
 			+ '*[test.type="UnaryExpression"][test.operator="!"][test.argument.type="CallExpression"][test.argument.callee.name="$optional"]',
-	},
-	{
+	}],
+	'byo/data-hotkey-imports-tooltip': ['error', {
 		message: 'JSX elements with `data-hotkey` must import `tooltip.js`',
 		selector: String.raw`Program:has(JSXAttribute[name.name="data-hotkey"])
 			:not(:has(ImportDeclaration[source.value=/\/helpers\/tooltip\.js$/]))`,
-	},
-];
+	}],
+};
 
 export default restrictedSyntax;

--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -21,12 +21,11 @@ const restrictedSyntax = {
 		selector: 'TSNonNullExpression > CallExpression > [name=$closest]',
 		message: 'Unused null expression: ! — $closest() already throws when the element is not found',
 	}],
-	'byo/onetime-init-requires-once-name': ['error', {
+	'byo/init-once': ['error', {
 		message: 'Init functions wrapped with onetime() must have a name ending with "Once"',
 		selector:
 			'ObjectExpression > Property[key.name=init] > CallExpression[callee.name=onetime]:not([arguments.0.name=/Once$/])',
-	}],
-	'byo/once-function-no-signal': ['error', {
+	}, {
 		message:
 			'Init functions that run once, cannot accept a signal: https://github.com/refined-github/refined-github/pull/8072',
 		selector: 'FunctionDeclaration[id.name=/Once$/] > Identifier[name=signal]',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ import xo from 'xo';
 
 import cssDocumentation from './eslint-rules/css-documentation.js';
 import cssRequireFuchsiaFallback from './eslint-rules/css-require-fuchsia-fallback.js';
+import byoPlugin from './eslint-rules/byo.js';
 import noOptionalChaining from './eslint-rules/no-optional-chaining.js';
 
 import restrictedSyntax from './eslint-rules/restricted-syntax.js';
@@ -298,9 +299,12 @@ export default defineConfig([
 	},
 	{
 		plugins: {
+			byo: byoPlugin,
 			'refined-github': refinedGithubPlugin,
 		},
 		rules: {
+			'byo/unused-null-expression': ['error', 'TSNonNullExpression > CallExpression > [name=$]', 'Unused null expression: !'],
+			'byo/unused-null-expression-closest': ['error', 'TSNonNullExpression > CallExpression > [name=$closest]', 'Unused null expression: ! — $closest() already throws when the element is not found'],
 			'refined-github/select-dom': 'error',
 		},
 	},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,9 +7,9 @@ import {defineConfig} from 'eslint/config';
 import {fileURLToPath} from 'node:url';
 import xo from 'xo';
 
+import byoPlugin from './eslint-rules/byo.js';
 import cssDocumentation from './eslint-rules/css-documentation.js';
 import cssRequireFuchsiaFallback from './eslint-rules/css-require-fuchsia-fallback.js';
-import byoPlugin from './eslint-rules/byo.js';
 import noOptionalChaining from './eslint-rules/no-optional-chaining.js';
 
 import restrictedSyntax from './eslint-rules/restricted-syntax.js';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -303,8 +303,14 @@ export default defineConfig([
 			'refined-github': refinedGithubPlugin,
 		},
 		rules: {
-			'byo/unused-null-expression': ['error', 'TSNonNullExpression > CallExpression > [name=$]', 'Unused null expression: !'],
-			'byo/unused-null-expression-closest': ['error', 'TSNonNullExpression > CallExpression > [name=$closest]', 'Unused null expression: ! — $closest() already throws when the element is not found'],
+			'byo/unused-null-expression': ['error', {
+				selector: 'TSNonNullExpression > CallExpression > [name=$]',
+				message: 'Unused null expression: !',
+			}],
+			'byo/unused-null-expression-closest': ['error', {
+				selector: 'TSNonNullExpression > CallExpression > [name=$closest]',
+				message: 'Unused null expression: ! — $closest() already throws when the element is not found',
+			}],
 			'refined-github/select-dom': 'error',
 		},
 	},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,10 +93,6 @@ export default defineConfig([
 					],
 				}],
 
-				'no-restricted-syntax': [
-					'error',
-					...restrictedSyntax,
-				],
 				'no-alert': 'off',
 				'n/prefer-global/process': 'off',
 				'no-use-extend-native/no-use-extend-native': 'off', // False positives on ES2024 static methods (Map.groupBy, Object.groupBy, etc.)
@@ -303,14 +299,7 @@ export default defineConfig([
 			'refined-github': refinedGithubPlugin,
 		},
 		rules: {
-			'byo/unused-null-expression': ['error', {
-				selector: 'TSNonNullExpression > CallExpression > [name=$]',
-				message: 'Unused null expression: !',
-			}],
-			'byo/unused-null-expression-closest': ['error', {
-				selector: 'TSNonNullExpression > CallExpression > [name=$closest]',
-				message: 'Unused null expression: ! — $closest() already throws when the element is not found',
-			}],
+			...restrictedSyntax,
 			'refined-github/select-dom': 'error',
 		},
 	},


### PR DESCRIPTION
This will make it easier to:

- toggle "restricted syntax" rules per file/folder
- set each rule as error or warning
- understand each error from the rule name without having to read the error message
- avoid ambiguous `eslint-disable-next-line no-restricted-syntax` that hide the error message as well as disable _all_ rule at once

Related to:

- #9496 

## Before

What was the error even about?

<img width="548" height="42" alt="Screenshot 11" src="https://github.com/user-attachments/assets/03ae1b72-7316-4b94-89e1-f97f7a0d3a41" />


## After

oooh, I see now


<img width="548" height="42" alt="Screenshot" src="https://github.com/user-attachments/assets/5f3f44e4-1612-429a-ad14-6c46721f15f6" />


