### PR TITLE
`conversation-activity-filter` - Hide resolved review threads

### DIFF
--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -13,7 +13,7 @@
 	.rgh-conversation-activity-collapsed-comment,
 	.js-resolvable-timeline-thread-container[data-resolved='true'],
 	.minimized-comment {
-		display: none;
+		display: none !important;
 		/* For debugging purposes */
 		/* display: block !important; */
 		/* outline: solid 5px #f00; */

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -80,7 +80,7 @@ function processSimpleComment(item: HTMLElement): void {
 	}
 }
 
-function processDissmissedReviewEvent(item: HTMLElement): void {
+function processDismissedReviewEvent(item: HTMLElement): void {
 	item.classList.add(hiddenClassName);
 
 	// Find and hide stale reviews referenced by dismissed review events
@@ -95,6 +95,7 @@ function processReview(review: HTMLElement): void {
 	const hasMainComment = elementExists('.js-comment[id^=pullrequestreview] .timeline-comment', review);
 
 	// Don't combine the selectors or use early returns without understanding what a thread or thread comment is
+	// Resolved thread are handled by the CSS thanks to [data-resolved="true"]
 	const unresolvedThreads = $$optional('.js-resolvable-timeline-thread-container[data-resolved="false"]', review);
 	const unresolvedThreadComments = $$optional('.timeline-comment-group:not(.minimized-comment)', review);
 
@@ -120,7 +121,7 @@ function processItem(item: HTMLElement): void {
 	if (elementExists('.js-comment[id^=pullrequestreview]', item)) {
 		processReview(item);
 	} else if (elementExists('.TimelineItem-badge .octicon-x', item)) {
-		processDissmissedReviewEvent(item);
+		processDismissedReviewEvent(item);
 	} else if (elementExists(comment, item)) {
 		processSimpleComment(item);
 	} else {
@@ -132,9 +133,9 @@ let currentState: State;
 
 function applyState(targetState: State): void {
 	const container = $([
-		// Current PR view
+		// PR
 		'[class^="prc-PageLayout-PageLayoutWrapper"]',
-		// Current issue view
+		// Issue
 		'[class*="IssueViewer-module__mainContainer"]',
 		// Old PR view - TODO: Drop after July 2026
 		'.js-issues-results',


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9375


## Test URLs

https://github.com/refined-github/refined-github/pull/9325#pullrequestreview-4210815535

## Before


<img width="654" height="381" alt="Screenshot" src="https://github.com/user-attachments/assets/21089184-a7c9-42c0-a017-cac6847e8c48" />

## After

<img width="654" height="381" alt="Screenshot 15" src="https://github.com/user-attachments/assets/de9dabb7-bea2-41e2-88fe-8230e465b266" />
