### PR TITLE
`rgh-dim-commits` - Support compare page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,10 @@ export default defineConfig([
 			rules: {
 				'no-irregular-whitespace': 'off', // We do want to use non-breaking spaces
 
+				// TOOD: Too many. Too noisy. Re-enable after using expiring-todo-comments
+				// https://github.com/refined-github/refined-github/issues/9496
+				'no-warning-comments': 'off',
+
 				// Disable some unicorn rules
 				'unicorn/expiring-todo-comments': 'off', // We just got too many, too much noise
 				'unicorn/no-nested-ternary': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,7 @@ export default defineConfig([
 			rules: {
 				'no-irregular-whitespace': 'off', // We do want to use non-breaking spaces
 
-				// TOOD: Too many. Too noisy. Re-enable after using expiring-todo-comments
+				// TODO: Too many. Too noisy. Re-enable after using expiring-todo-comments
 				// https://github.com/refined-github/refined-github/issues/9496
 				'no-warning-comments': 'off',
 

--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -14,6 +14,7 @@ import {commitTitleInLists} from '../github-helpers/selectors.js';
 import {conventionalCommitRegex, parseConventionalCommit} from '../helpers/conventional-commits.js';
 import {removeTextInTextNode} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
+import {is} from '../helpers/css-selectors.js';
 
 function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 	const textNode = commitTitleElement.firstChild!;
@@ -47,7 +48,7 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe(`${commitTitleInLists} > span > a:first-child`, renderLabelInCommitTitle, {signal});
+	observe(`${is(commitTitleInLists)} > span > a:first-child`, renderLabelInCommitTitle, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -13,9 +13,9 @@ function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
 		$closest([
 			// `isCommitList`
-			'[data-testid="commit-row-item"]'
+			'[data-testid="commit-row-item"]',
 			// `isCompare`
-			, '.js-commits-list-item',
+			'.js-commits-list-item',
 		], commitTitle).style.opacity = '50%';
 	}
 }

--- a/source/features/rgh-dim-commits.tsx
+++ b/source/features/rgh-dim-commits.tsx
@@ -11,7 +11,12 @@ const excludePreset = /^bump |^meta|^document|^lint|^refactor|readme|dependencie
 
 function dim(commitTitle: HTMLElement): void {
 	if (excludePreset.test(commitTitle.textContent.trim())) {
-		$closest('[data-testid="commit-row-item"]', commitTitle).style.opacity = '50%';
+		$closest([
+			// `isCommitList`
+			'[data-testid="commit-row-item"]'
+			// `isCompare`
+			, '.js-commits-list-item',
+		], commitTitle).style.opacity = '50%';
 	}
 }
 
@@ -24,6 +29,7 @@ void features.add(import.meta.url, {
 		isRefinedGitHubRepo,
 	],
 	include: [
+		pageDetect.isCompare,
 		pageDetect.isCommitList,
 	],
 	init,

--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -13,6 +13,7 @@ import {wrap} from '../helpers/dom-utils.js';
 import {getFeatureUrl} from '../helpers/rgh-links.js';
 import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
 import observe from '../helpers/selector-observer.js';
+import {is} from '../helpers/css-selectors.js';
 
 const shouldHideCount = debounce(() => pageDetect.isReleasesOrTags() || pageDetect.isSingleReleaseOrTag(), {
 	wait: 100,
@@ -85,7 +86,7 @@ function init(signal: AbortSignal): void {
 			'.js-comment-body code', // Old view `hasComments`
 			'.markdown-body code', // `hasComments`, `isReleasesOrTags`
 			'[class^="CommitHeader-module__commitMessageContainer"] code', // `isSingleCommit`,
-			`${commitTitleInLists} code`, // `isCommitList`,
+			`${is(commitTitleInLists)} code`, // `isCommitList`, `isCompare`
 			'.react-directory-commit-message code', // `isRepoTree`
 		],
 		linkifyFeature,

--- a/source/features/sticky-comment-header.css
+++ b/source/features/sticky-comment-header.css
@@ -13,7 +13,6 @@ html:not([rgh-OFF-sticky-comment-header]).rgh-show-names {
 		--rgh-issue-or-pr-sticky-header-height: 70px;
 	}
 
-	/* biome-ignore format: bug */
 	/* Issue body header */
 	[class^='IssueBodyHeader-module__IssueBodyHeaderContainer'],
 	/* Issue/commit comment header */

--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -15,7 +15,7 @@
 
 	/* Like 100%, except it works with content-box and it feels like -webkit-1999 */
 	max-width: -webkit-fill-available;
-	/* biome-ignore lint/suspicious/noDuplicateProperties: TODO: Remove in 2027 if supported */
+	/* TODO: Remove in 2027 if supported */
 	max-width: -moz-available;
 	max-width: intrinsic;
 }

--- a/source/features/suggest-commit-title-limit.css
+++ b/source/features/suggest-commit-title-limit.css
@@ -15,7 +15,7 @@
 
 	/* Like 100%, except it works with content-box and it feels like -webkit-1999 */
 	max-width: -webkit-fill-available;
-	/* TODO: Remove in 2027 if supported */
+	/* biome-ignore lint/suspicious/noDuplicateProperties: TODO: Remove in 2027 if supported */
 	max-width: -moz-available;
 	max-width: intrinsic;
 }

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -169,7 +169,10 @@ export const commitHashLinkInLists_ = [
 	[5, 'https://github.com/refined-github/refined-github/pull/6194#event-8016526003'],
 ] satisfies UrlMatch[];
 
-export const commitTitleInLists = '[data-testid="commit-row-item"] h4[class^="Title-module"]'; // `isCommitList`
+export const commitTitleInLists = [
+	'[data-testid="commit-row-item"] h4[class^="Title-module"]', // `isCommitList`
+	'.js-commits-list-item > .js-details-container > p:first-child', // `isCompare`
+];
 export const commitTitleInLists_ = [
 	[
 		35,


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/refined-github/compare/26.5.13...main

## Screenshot
<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top>
<img width="456" height="449" alt="Screenshot 19" src="https://github.com/user-attachments/assets/e0e58a55-01cb-421d-8754-b765ca953bf3" />
 <td valign=top><img width="456" height="449" alt="Screenshot 20" src="https://github.com/user-attachments/assets/b328af83-4ae2-4763-9ffb-cfbccbe231f8" />
</table>