### PR TITLE
 Meta: Avoid unnecessary JSX fragments

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -18,10 +18,5 @@
     "refined-github/no-optional-chaining": {
       "count": 1
     }
-  },
-  "source/features/rgh-feature-descriptions.tsx": {
-    "refined-github/no-optional-chaining": {
-      "count": 1
-    }
   }
 }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -21,7 +21,7 @@
   },
   "source/features/rgh-feature-descriptions.tsx": {
     "refined-github/no-optional-chaining": {
-      "count": 2
+      "count": 1
     }
   }
 }

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -19,20 +19,18 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 		$('relative-time', repository).previousSibling,
 		'Updated',
 	).before(
-		<>
-			<a
-				className="Link--muted mr-3"
-				href={repositoryLink.href + '/issues'}
-			>
-				<IssueOpenedIcon />
-			</a>
-			<a
-				className="Link--muted mr-3"
-				href={repositoryLink.href + '/pulls'}
-			>
-				<GitPullRequestIcon />
-			</a>
-		</>,
+		<a
+			className="Link--muted mr-3"
+			href={repositoryLink.href + '/issues'}
+		>
+			<IssueOpenedIcon />
+		</a>,
+		<a
+			className="Link--muted mr-3"
+			href={repositoryLink.href + '/pulls'}
+		>
+			<GitPullRequestIcon />
+		</a>,
 	);
 }
 
@@ -48,30 +46,28 @@ function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
 	$closest('[data-testid="results-list"] > div', repositoryLink)
 		.querySelector('ul > span:last-of-type')!
 		.before(
-			<>
-				<span
-					aria-hidden="true"
-					className="color-fg-muted mx-2"
+			<span
+				aria-hidden="true"
+				className="color-fg-muted mx-2"
+			>
+				·
+			</span>,
+			<li className="d-flex text-small">
+				<a
+					className="Link--muted"
+					href={repositoryLink.href + '/issues'}
 				>
-					·
-				</span>
-				<li className="d-flex text-small">
-					<a
-						className="Link--muted"
-						href={repositoryLink.href + '/issues'}
-					>
-						<IssueOpenedIcon />
-					</a>
-				</li>
-				<li className="d-flex text-small ml-2">
-					<a
-						className="Link--muted"
-						href={repositoryLink.href + '/pulls'}
-					>
-						<GitPullRequestIcon />
-					</a>
-				</li>
-			</>,
+					<IssueOpenedIcon />
+				</a>
+			</li>,
+			<li className="d-flex text-small ml-2">
+				<a
+					className="Link--muted"
+					href={repositoryLink.href + '/pulls'}
+				>
+					<GitPullRequestIcon />
+				</a>
+			</li>,
 		);
 }
 

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -78,15 +78,16 @@ const getRghShortcutsContainer = memoize(
 			...[...shortcutMap]
 				.toSorted(([, a], [, b]) => a.localeCompare(b))
 				.map(([hotkey, description]) => {
+					const keys = hotkey.split(' ').map(key =>
+						<span className={chord.className}>
+							{upperCaseFirst(key)}
+						</span>,
+					);
 					const currentItem = shortcutItem.cloneNode(true);
 					currentItem.firstElementChild!.textContent = description;
 					currentItem.lastElementChild!.replaceChildren(
 						<kbd className={keybindingHint.className}>
-							{joinJsx(' ', hotkey.split(' ').map(key =>
-								<span className={chord.className}>
-									{upperCaseFirst(key)}
-								</span>,
-							))}
+							{joinJsx(' ', keys)}
 						</kbd>,
 					);
 					return currentItem;

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -10,6 +10,7 @@ import {isEditable} from '../helpers/dom-utils.js';
 import {shortcutMap} from '../helpers/feature-helpers.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
+import joinJsx from '../helpers/join-jsx.js';
 
 function splitKeys(keys: string): Array<string | JSX.Element> {
 	return keys.split(' ').flatMap(key => [
@@ -81,12 +82,11 @@ const getRghShortcutsContainer = memoize(
 					currentItem.firstElementChild!.textContent = description;
 					currentItem.lastElementChild!.replaceChildren(
 						<kbd className={keybindingHint.className}>
-							{hotkey.split(' ').flatMap((key, index) => [
-								index > 0 && ' ',
+							{joinJsx(' ', hotkey.split(' ').map(key =>
 								<span className={chord.className}>
 									{upperCaseFirst(key)}
 								</span>,
-							])}
+							))}
 						</kbd>,
 					);
 					return currentItem;

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -81,14 +81,12 @@ const getRghShortcutsContainer = memoize(
 					currentItem.firstElementChild!.textContent = description;
 					currentItem.lastElementChild!.replaceChildren(
 						<kbd className={keybindingHint.className}>
-							{hotkey.split(' ').map((key, index) => (
-								<>
-									{index > 0 && ' '}
-									<span className={chord.className}>
-										{upperCaseFirst(key)}
-									</span>
-								</>
-							))}
+							{hotkey.split(' ').flatMap((key, index) => [
+								index > 0 && ' ',
+								<span className={chord.className}>
+									{upperCaseFirst(key)}
+								</span>,
+							])}
 						</kbd>,
 					);
 					return currentItem;

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -19,7 +19,7 @@ import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import joinJsx from '../helpers/join-jsx.js';
 
-function getLinks(meta: FeatureMeta | undefined): JSX.Element[] {
+function getLinks(id: string, meta: FeatureMeta | undefined): JSX.Element[] {
 	// `meta` only exists for documented features.
 	// In this case, the file exists (on older commits) but the feature has since been deleted
 	if (!meta?.description) {
@@ -65,8 +65,8 @@ function getLinks(meta: FeatureMeta | undefined): JSX.Element[] {
 	return links;
 }
 
-function getLinksElement(meta: FeatureMeta | undefined): JSX.Element {
-	return <div className="no-wrap">{joinJsx(getLinks(meta), ' • ')}</div>;
+function getLinksElement(id: string, meta: FeatureMeta | undefined): JSX.Element {
+	return <div className="no-wrap">{joinJsx(getLinks(id, meta), ' • ')}</div>;
 }
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
@@ -118,7 +118,7 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						</div>
 					)}
 					{description && <div dangerouslySetInnerHTML={{__html: description}} className="h3" />}
-					{getLinksElement(meta)}
+					{getLinksElement(id, meta)}
 				</div>
 				{/* eslint-disable-next-line refined-github/no-optional-chaining -- Undocumented feature, no meta */}
 				{meta?.screenshot && (

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -19,7 +19,7 @@ import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import joinJsx from '../helpers/join-jsx.js';
 
-function getLinks(id: string, meta: FeatureMeta | undefined): JSX.Element[] {
+function getLinksElement(id: string, meta: FeatureMeta | undefined): JSX.Element {
 	const wasFeatureRemoved = !meta && !isFeaturePrivate(id);
 	const isCss = location.pathname.endsWith('.css');
 
@@ -58,7 +58,7 @@ function getLinks(id: string, meta: FeatureMeta | undefined): JSX.Element[] {
 
 	if (wasFeatureRemoved) {
 		links.push(
-			// This adds the full commit history
+			// This links to the full commit history, which will start with the commit that removed the file
 			<a
 				data-turbo-frame="repo-content-turbo-frame"
 				href={`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`}
@@ -68,11 +68,7 @@ function getLinks(id: string, meta: FeatureMeta | undefined): JSX.Element[] {
 		);
 	}
 
-	return links;
-}
-
-function getLinksElement(id: string, meta: FeatureMeta | undefined): JSX.Element {
-	return <div className="no-wrap">{joinJsx(getLinks(id, meta), ' • ')}</div>;
+	return <div className="no-wrap">{joinJsx(' • ', links)}</div>;
 }
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -13,8 +13,8 @@ import createBanner from '../github-helpers/banner.js';
 import {isFeaturePrivate} from '../helpers/feature-utils.js';
 import {brokenFeatures} from '../helpers/hotfix.js';
 import openOptions from '../helpers/open-options.js';
-import {createRghIssueLink} from '../helpers/rgh-links.js';
 import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
+import {createRghIssueLink} from '../helpers/rgh-links.js';
 import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -220,11 +220,11 @@ void features.add(import.meta.url, {
 
 /*
 
-Test URLs:
+## Test URLs
 
 - Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.tsx
 - CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.css
 - RGH feature: https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
 - CSS-only feature: https://github.com/refined-github/refined-github/blob/main/source/features/reactions-popup.css
-- Removed feature https://github.com/refined-github/refined-github/blob/55dfdfd903bd7d36e0c2f3dc46847bddc73544f5/source/features/latest-tag-button.tsx
+- Removed feature" https://github.com/refined-github/refined-github/blob/55dfdfd903bd7d36e0c2f3dc46847bddc73544f5/source/features/latest-tag-button.tsx
 */

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -17,8 +17,18 @@ import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
 import {createRghIssueLink} from '../helpers/rgh-links.js';
 import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
+import joinJsx from '../helpers/join-jsx.js';
 
-function getLinks(meta: FeatureMeta, featureRemoved: boolean): Array<JSX.Element | string> {
+function getLinks(meta: FeatureMeta | undefined): JSX.Element[] {
+	// `meta` only exists for documented features.
+	// In this case, the file exists (on older commits) but the feature has since been deleted
+	if (!meta?.description) {
+		return [
+			// This adds the full commit history
+			<a data-turbo-frame="repo-content-turbo-frame" href={`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`}>Commit history</a>,
+		];
+	}
+
 	const isCss = location.pathname.endsWith('.css');
 
 	const links = [];
@@ -32,32 +42,31 @@ function getLinks(meta: FeatureMeta, featureRemoved: boolean): Array<JSX.Element
 			},
 		});
 		links.push(relatedIssuesContainer);
-	}
 
-	if (!featureRemoved && meta.id) {
 		const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
 		newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-		newIssueUrl.searchParams.set('title', `\`${meta.id}\`: `);
+		newIssueUrl.searchParams.set('title', `\`${meta.id}\` `);
 		newIssueUrl.searchParams.set('labels', 'bug, help wanted');
 		links.push(
-			' • ',
 			<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>,
 		);
 	}
 
 	if (isCss && !meta.cssOnly) {
 		links.push(
-			' • ',
 			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a>,
 		);
 	} else if (meta.css && !isCss) {
 		links.push(
-			' • ',
 			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a>,
 		);
 	}
 
 	return links;
+}
+
+function getLinksElement(meta: FeatureMeta | undefined): JSX.Element {
+	return <div className="no-wrap">{joinJsx(getLinks(meta), ' • ')}</div>;
 }
 
 function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
@@ -68,7 +77,6 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 				? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
 				: undefined // The heck!?
 		);
-	const removedFeature = !description;
 
 	const oldNames = getOldFeatureNames(id);
 
@@ -78,18 +86,25 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 			<div className="Box-row d-flex gap-3 flex-wrap">
 				<div className="rgh-feature-description d-flex flex-column gap-2">
 					<h3>
-						{removedFeature && <span className="color-fg-muted">Feature removed: </span>}
-						<code>{id}</code>
-						<clipboard-copy
-							aria-label="Copy"
-							data-copy-feedback="Copied!"
-							value={id}
-							class="Link--onHover color-fg-muted d-inline-block ml-2"
-							tabindex="0"
-							role="button"
-						>
-							<CopyIcon className="v-align-baseline" />
-						</clipboard-copy>
+						{
+							description
+								? <>
+									<code>{id}</code>
+									<clipboard-copy
+										aria-label="Copy"
+										data-copy-feedback="Copied!"
+										value={id}
+										class="Link--onHover color-fg-muted d-inline-block ml-2"
+										tabindex="0"
+										role="button"
+									>
+										<CopyIcon className="v-align-baseline" />
+									</clipboard-copy>
+								</>
+								: <span className="color-fg-muted">
+									This feature is no longer part of Refined GitHub.
+								</span>
+						}
 					</h3>
 					{oldNames.length > 0 && (
 						<div className="color-fg-muted mt-n3">
@@ -103,8 +118,9 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						</div>
 					)}
 					{description && <div dangerouslySetInnerHTML={{__html: description}} className="h3" />}
-					<div className="no-wrap">{meta && getLinks(meta, removedFeature)}</div>
+					{getLinksElement(meta)}
 				</div>
+				{/* eslint-disable-next-line refined-github/no-optional-chaining -- Undocumented feature, no meta */}
 				{meta?.screenshot && (
 					<a href={meta.screenshot} className="flex-self-center">
 						<img
@@ -200,8 +216,8 @@ void features.add(import.meta.url, {
 
 Test URLs:
 
-- Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.tsx
-- CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/sync-pr-commit-title.css
+- Regular feature: https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.tsx
+- CSS counterpart: https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.css
 - RGH feature: https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
 - CSS-only feature: https://github.com/refined-github/refined-github/blob/main/source/features/reactions-popup.css
 - Removed feature https://github.com/refined-github/refined-github/blob/55dfdfd903bd7d36e0c2f3dc46847bddc73544f5/source/features/latest-tag-button.tsx

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -18,9 +18,55 @@ import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
 import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 
-function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
+function getLinks(meta: FeatureMeta, featureRemoved: boolean): Array<JSX.Element | string> {
 	const isCss = location.pathname.endsWith('.css');
 
+	const links = [];
+
+	if (meta.id) {
+		const relatedIssuesContainer = <span />;
+		mount(RelatedIssuesCount, {
+			target: relatedIssuesContainer,
+			props: {
+				featureId: meta.id,
+				labels: {
+					loading: 'Related issues',
+					single: '1 related issue',
+					plural: '$$ related issues',
+					zero: 'Related issues',
+				},
+			},
+		});
+		links.push(relatedIssuesContainer);
+	}
+
+	if (!featureRemoved && meta.id) {
+		const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
+		newIssueUrl.searchParams.set('template', '1_bug_report.yml');
+		newIssueUrl.searchParams.set('title', `\`${meta.id}\`: `);
+		newIssueUrl.searchParams.set('labels', 'bug, help wanted');
+		links.push(
+			' • ',
+			<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>,
+		);
+	}
+
+	if (isCss && !meta.cssOnly) {
+		links.push(
+			' • ',
+			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a>,
+		);
+	} else if (meta.css && !isCss) {
+		links.push(
+			' • ',
+			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a>,
+		);
+	}
+
+	return links;
+}
+
+function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
 	const description = meta
 		? meta.description + (meta.cssOnly ? ' This feature is CSS-only and cannot be disabled.' : '')
 		: (
@@ -31,13 +77,6 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 	const removedFeature = !description;
 
 	const oldNames = getOldFeatureNames(id);
-
-	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
-	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-	newIssueUrl.searchParams.set('title', `\`${id}\`: `);
-	newIssueUrl.searchParams.set('labels', 'bug, help wanted');
-
-	const relatedIssuesContainer = <span />;
 
 	infoBanner.before(
 		// Block and width classes required to avoid margin collapse
@@ -70,22 +109,7 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 						</div>
 					)}
 					{description && <div dangerouslySetInnerHTML={{__html: description}} className="h3" />}
-					<div className="no-wrap">
-						{relatedIssuesContainer}
-						{!removedFeature && (
-							<>
-								{' • '}
-								<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>
-							</>
-						)}
-						{
-							meta && isCss && !meta.cssOnly
-								? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a></>
-								: meta?.css && !isCss
-									? <> • <a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a></>
-									: undefined
-						}
-					</div>
+					<div className="no-wrap">{meta && getLinks(meta, removedFeature)}</div>
 				</div>
 				{meta?.screenshot && (
 					<a href={meta.screenshot} className="flex-self-center">
@@ -102,19 +126,6 @@ function addDescription(infoBanner: HTMLElement, id: string, meta: FeatureMeta |
 			</div>
 		</div>,
 	);
-
-	mount(RelatedIssuesCount, {
-		target: relatedIssuesContainer,
-		props: {
-			featureId: id,
-			labels: {
-				loading: 'Related issues',
-				single: '1 related issue',
-				plural: '$$ related issues',
-				zero: 'Related issues',
-			},
-		},
-	});
 }
 
 async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -20,45 +20,51 @@ import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import joinJsx from '../helpers/join-jsx.js';
 
 function getLinks(id: string, meta: FeatureMeta | undefined): JSX.Element[] {
-	// `meta` only exists for documented features.
-	// In this case, the file exists (on older commits) but the feature has since been deleted
-	if (!meta?.description) {
-		return [
-			// This adds the full commit history
-			<a data-turbo-frame="repo-content-turbo-frame" href={`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`}>Commit history</a>,
-		];
-	}
-
+	const wasFeatureRemoved = !meta && !isFeaturePrivate(id);
 	const isCss = location.pathname.endsWith('.css');
 
 	const links = [];
 
-	if (meta.id) {
-		const relatedIssuesContainer = <span />;
-		mount(RelatedIssuesCount, {
-			target: relatedIssuesContainer,
-			props: {
-				featureId: meta.id,
-			},
-		});
-		links.push(relatedIssuesContainer);
+	const relatedIssuesContainer = <span />;
+	mount(RelatedIssuesCount, {
+		target: relatedIssuesContainer,
+		props: {
+			featureId: id,
+		},
+	});
+	links.push(relatedIssuesContainer);
 
+	if (!wasFeatureRemoved) {
 		const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
 		newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-		newIssueUrl.searchParams.set('title', `\`${meta.id}\` `);
+		newIssueUrl.searchParams.set('title', `\`${id}\` `);
 		newIssueUrl.searchParams.set('labels', 'bug, help wanted');
 		links.push(
-			<a href={newIssueUrl.href} data-turbo-frame="repo-content-turbo-frame">Report bug</a>,
+			<a data-turbo-frame="repo-content-turbo-frame" href={newIssueUrl.href} >Report bug</a>,
 		);
 	}
 
-	if (isCss && !meta.cssOnly) {
+	if (meta) {
+		if (isCss && !meta.cssOnly) {
+			links.push(
+				<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a>,
+			);
+		} else if (meta.css && !isCss) {
+			links.push(
+				<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a>,
+			);
+		}
+	}
+
+	if (wasFeatureRemoved) {
 		links.push(
-			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.css', '.tsx')}>See .tsx file</a>,
-		);
-	} else if (meta.css && !isCss) {
-		links.push(
-			<a data-turbo-frame="repo-content-turbo-frame" href={location.pathname.replace('.tsx', '.css')}>See .css file</a>,
+			// This adds the full commit history
+			<a
+				data-turbo-frame="repo-content-turbo-frame"
+				href={`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`}
+			>
+				Commit history
+			</a>,
 		);
 	}
 

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -64,8 +64,9 @@ async function initHeadHint(): Promise<void | false> {
 	}
 
 	$(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`).after(
+		'with ',
 		// The class is used by `quick-fork-deletion`
-		<> with <a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a></>,
+		<a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a>,
 	);
 }
 

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -64,7 +64,7 @@ async function initHeadHint(): Promise<void | false> {
 	}
 
 	$(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`).after(
-		'with ',
+		' with ',
 		// The class is used by `quick-fork-deletion`
 		<a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a>,
 	);

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -129,18 +129,17 @@ async function init(): Promise<void | false> {
 				<div className="ml-1 d-flex flex-items-center gap-1">
 					<TagIcon />
 					<span className="d-flex flex-wrap gap-1">
-						{...targetTags.map(tag => (
-							<>
-								{' '}
-								{/* .markdown-title enables the background color */}
-								<a
-									className="Link--muted markdown-title"
-									href={buildRepoUrl('releases/tag', tag)}
-								>
-									<code>{tag}</code>
-								</a>
-							</>
-						))}
+						{...targetTags.map(tag => [
+							' ',
+							// .markdown-title enables the background color
+							<a
+								className="Link--muted markdown-title"
+								href={buildRepoUrl('releases/tag', tag)}
+							>
+								<code>{tag}</code>
+							</a>,
+
+						])}
 					</span>
 				</div>,
 			);

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -138,7 +138,6 @@ async function init(): Promise<void | false> {
 							>
 								<code>{tag}</code>
 							</a>,
-
 						])}
 					</span>
 				</div>,

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -12,6 +12,7 @@ import {buildRepoUrl, getRepo} from '../github-helpers/index.js';
 import delay from '../helpers/delay.js';
 import {getCommitHash} from './mark-merge-commits-in-list.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
+import joinJsx from '../helpers/join-jsx.js';
 
 type CommitTags = Record<string, string[]>;
 
@@ -125,20 +126,21 @@ async function init(): Promise<void | false> {
 				'[class^="Description-module__container"]',
 			], commit);
 
+			const tags = targetTags.map(tag =>
+			// .markdown-title enables the background color
+				<a
+					className="Link--muted markdown-title"
+					href={buildRepoUrl('releases/tag', tag)}
+				>
+					<code>{tag}</code>
+				</a>,
+			);
+
 			commitMeta.append(
 				<div className="ml-1 d-flex flex-items-center gap-1">
 					<TagIcon />
 					<span className="d-flex flex-wrap gap-1">
-						{...targetTags.map(tag => [
-							' ',
-							// .markdown-title enables the background color
-							<a
-								className="Link--muted markdown-title"
-								href={buildRepoUrl('releases/tag', tag)}
-							>
-								<code>{tag}</code>
-							</a>,
-						])}
+						{joinJsx(' ', tags)}
 					</span>
 				</div>,
 			);

--- a/source/github-helpers/prevent-link-loss.ts
+++ b/source/github-helpers/prevent-link-loss.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-params -- These match the native `String#replace` signature */
 import type {RepositoryInfo} from 'github-url-detection';
 
 import {getConversationNumber, getRepo} from './index.js';

--- a/source/helpers/join-jsx.tsx
+++ b/source/helpers/join-jsx.tsx
@@ -1,0 +1,17 @@
+import React from 'dom-chef';
+
+export default function joinJsx(
+	items: readonly JSX.Element[],
+	separator: React.ReactNode,
+): JSX.Element {
+	return (
+		<>
+			{items.map((item, index) => (
+				<>
+					{index > 0 && separator}
+					{item}
+				</>
+			))}
+		</>
+	);
+}

--- a/source/helpers/join-jsx.tsx
+++ b/source/helpers/join-jsx.tsx
@@ -1,8 +1,8 @@
 import React from 'dom-chef';
 
 export default function joinJsx(
-	items: readonly JSX.Element[],
 	separator: React.ReactNode,
+	items: readonly JSX.Element[],
 ): JSX.Element {
 	return (
 		<>

--- a/source/helpers/related-issues-count.svelte
+++ b/source/helpers/related-issues-count.svelte
@@ -39,7 +39,7 @@
 		count,
 		'1 open issue',
 		'$$ open issues',
-		'No open issues',
+		'Related issues',
 	)}
 	{#if mini}
 		{#if count > 0}

--- a/source/helpers/rgh-links.test.ts
+++ b/source/helpers/rgh-links.test.ts
@@ -3,7 +3,7 @@ import {assert, test} from 'vitest';
 import {getFeatureRelatedIssuesQuery, getFeatureRelatedIssuesUrl} from './rgh-links.js';
 
 test('getFeatureRelatedIssuesQuery', () => {
-	assert.equal(getFeatureRelatedIssuesQuery('comment-excess'), 'is:open ("comment-excess")');
+	assert.equal(getFeatureRelatedIssuesQuery('comment-excess'), 'is:open "comment-excess"');
 	assert.equal(
 		getFeatureRelatedIssuesQuery('closing-remarks'),
 		'is:open ("closing-remarks" OR "first-published-tag-for-merged-pr")',

--- a/source/helpers/rgh-links.tsx
+++ b/source/helpers/rgh-links.tsx
@@ -23,8 +23,9 @@ export function getFeatureUrl(id: FeatureId): string {
 
 export function getFeatureRelatedIssuesQuery(id: string): string {
 	const oldNames = getOldFeatureNames(id);
-	const searchTerms = [id, ...oldNames].map(name => `"${name}"`).join(' OR ');
-	return `is:open (${searchTerms})`;
+	const searchTerms = [id, ...oldNames].map(name => `"${name}"`);
+	const joinedTerms = searchTerms.length > 1 ? `(${searchTerms.join(' OR ')})` : searchTerms[0];
+	return `is:open ${joinedTerms}`;
 }
 
 export function getFeatureRelatedIssuesUrl(id: string): URL {

--- a/source/helpers/tooltip.tsx
+++ b/source/helpers/tooltip.tsx
@@ -20,7 +20,7 @@ function renderShortcut(shortcut: string): JSX.Element {
 	));
 	return (
 		<kbd className="rgh-shortcut">
-			{joinJsx(keys, ' ')}
+			{joinJsx(' ', keys)}
 		</kbd>
 	);
 }

--- a/source/helpers/tooltip.tsx
+++ b/source/helpers/tooltip.tsx
@@ -3,6 +3,7 @@ import './tooltip.css';
 import React from 'dom-chef';
 
 import {upperCaseFirst} from '../github-helpers/index.js';
+import joinJsx from './join-jsx.js';
 
 export type TooltipOptions = {
 	label: string;
@@ -12,16 +13,14 @@ export type TooltipOptions = {
 };
 
 function renderShortcut(shortcut: string): JSX.Element {
+	const keys = shortcut.split(' ').map(key => (
+		<span className="rgh-shortcut-chord" data-kbd-chord="true">
+			{upperCaseFirst(key)}
+		</span>
+	));
 	return (
 		<kbd className="rgh-shortcut">
-			{shortcut.split(' ').map((key, index) => (
-				<>
-					{index > 0 && ' '}
-					<span className="rgh-shortcut-chord" data-kbd-chord="true">
-						{upperCaseFirst(key)}
-					</span>
-				</>
-			))}
+			{joinJsx(keys, ' ')}
 		</kbd>
 	);
 }


### PR DESCRIPTION

## Test URLs

### Regular feature
https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.tsx
<img width="288" height="143" alt="Screenshot 4" src="https://github.com/user-attachments/assets/b0382f0b-960b-4f04-bbcd-9bd9dde12114" />

### CSS counterpart
https://github.com/refined-github/refined-github/blob/main/source/features/align-issue-labels.css
<img width="288" height="143" alt="Screenshot 5" src="https://github.com/user-attachments/assets/12577012-b3da-45c2-93d8-04b39db58aab" />

### RGH feature
https://github.com/refined-github/refined-github/blob/main/source/features/rgh-feature-descriptions.css
<img width="288" height="143" alt="Screenshot 6" src="https://github.com/user-attachments/assets/7bc03864-01c4-471e-913f-15d842cc5937" />

### CSS-only feature
https://github.com/refined-github/refined-github/blob/main/source/features/reactions-popup.css
<img width="288" height="143" alt="Screenshot 7" src="https://github.com/user-attachments/assets/853c5e5b-bb22-45a0-a887-b0fb365c9bf6" />

### Removed feature 
https://github.com/refined-github/refined-github/blob/55dfdfd903bd7d36e0c2f3dc46847bddc73544f5/source/features/latest-tag-button.tsx
<img width="288" height="104" alt="Screenshot 8" src="https://github.com/user-attachments/assets/5230804e-625c-4022-af8d-8688f8a0961c" />
