### PR TITLE
AI SPAM

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,5 +1,7 @@
 /* Simulates fixed columns */
 .rgh-release-download-count {
+	gap: 8px;
+
 	& > span:not(:last-child) {
 		flex-basis: 0 !important;
 		min-width: 5em;
@@ -10,6 +12,15 @@
 		width: 7em;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	/* SHA / clipboard-copy column */
+	& > div:has(clipboard-copy) {
+		max-width: 8em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-size: 12px;
+		flex-shrink: 1;
 	}
 
 	/* Right-align on mobile */

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -79,10 +79,9 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 			</span>,
 		);
 
-		// Remove via JS because we can't override utility classes...
+		// Remove margin utility classes; spacing is handled by `gap` in CSS
 		for (const column of assetSize.parentElement!.children) {
-			column.classList.remove('ml-sm-3', 'ml-md-4');
-			column.classList.add('ml-lg-4');
+			column.classList.remove('ml-sm-3', 'ml-md-4', 'ml-lg-4');
 		}
 	}
 }


### PR DESCRIPTION
Fixes #9536

## Summary

The `release-download-count` feature had missing spacing between columns and an oversized SHA element in release asset rows.

## Changes

- **CSS**: Added `gap: 8px` to `.rgh-release-download-count` for consistent spacing between all columns
- **CSS**: Added constraints to the SHA/clipboard-copy column (`max-width: 8em`, `overflow: hidden`, `text-overflow: ellipsis`, `font-size: 12px`) to prevent it from taking too much space
- **TSX**: Replaced per-column margin class manipulation (`ml-sm-3`, `ml-md-4`, `ml-lg-4`) with simple removal of all margin classes, since spacing is now handled uniformly by the CSS `gap` property

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Tested against: https://github.com/refined-github/refined-github/releases/tag/26.5.20