### PR TITLE
Add DiffsHub button

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -241,7 +241,8 @@
 	},
 	{
 		"id": "diffshub-button",
-		"description": "Adds a button to open PR, compare, and commit diffs on DiffsHub."
+		"description": "Adds a button to open PR, compare, and commit diffs on DiffsHub.",
+		"screenshot": "https://github.com/user-attachments/assets/0a14121a-4f92-42d6-9e1f-34af0076f4dc"
 	},
 	{
 		"id": "dim-bots",

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -240,6 +240,10 @@
 		"screenshot": "https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252176294-9130783c-51aa-4df9-9c35-9b87c179199a.png"
 	},
 	{
+		"id": "diffshub-button",
+		"description": "Adds a button to open PR, compare, and commit diffs on DiffsHub."
+	},
+	{
 		"id": "dim-bots",
 		"description": "Dims commits and PRs by bots to reduce noise.",
 		"css": true,

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -40,6 +40,7 @@
 	"cross-deleted-pr-branches",
 	"deep-reblame",
 	"default-branch-button",
+	"diffshub-button",
 	"dim-bots",
 	"download-folder-button",
 	"easy-toggle-commit-messages",

--- a/readme.md
+++ b/readme.md
@@ -267,7 +267,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 - [](# "patch-diff-links") [Adds links to `.patch` and `.diff` files in commits.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png)
 - [](# "more-file-links") [Adds links to view the raw version, the blame, and the history of files in PRs and commits.](https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png)
-- [](# "diffshub-button") Adds a button to open PR, compare, and commit diffs on DiffsHub.
+- [](# "diffshub-button") [Adds a button to open PR, compare, and commit diffs on DiffsHub.](https://github.com/user-attachments/assets/0a14121a-4f92-42d6-9e1f-34af0076f4dc)
 - [](# "one-click-diff-options") [Adds "Hide whitespace" button to Compare pages and a keyboard shortcut to PRs and Compare pages: <kbd>d</kbd> <kbd>w</kbd>.](https://github.com/user-attachments/assets/0b92992a-69a4-4de1-ab2a-cb6508870b4a)
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif)
 - [](# "hide-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)

--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 
 - [](# "patch-diff-links") [Adds links to `.patch` and `.diff` files in commits.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257011950-51712338-ffba-4b71-ad8f-9a0f142afb85.png)
 - [](# "more-file-links") [Adds links to view the raw version, the blame, and the history of files in PRs and commits.](https://user-images.githubusercontent.com/46634000/145016304-aec5a8b8-4cdb-48e6-936f-b214a3fb4b49.png)
+- [](# "diffshub-button") Adds a button to open PR, compare, and commit diffs on DiffsHub.
 - [](# "one-click-diff-options") [Adds "Hide whitespace" button to Compare pages and a keyboard shortcut to PRs and Compare pages: <kbd>d</kbd> <kbd>w</kbd>.](https://github.com/user-attachments/assets/0b92992a-69a4-4de1-ab2a-cb6508870b4a)
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif)
 - [](# "hide-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)

--- a/source/features/diffshub-button.tsx
+++ b/source/features/diffshub-button.tsx
@@ -1,0 +1,138 @@
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import DiffIcon from 'octicons-plain-react/Diff';
+import {$closestOptional, elementExists} from 'select-dom';
+
+import features from '../feature-manager.js';
+import {getCleanPathname} from '../github-helpers/index.js';
+import {tooltipped} from '../helpers/tooltip.js';
+import observe from '../helpers/selector-observer.js';
+
+function getDiffsHubUrl(pathname = getCleanPathname()): string {
+	const url = new URL(location.href);
+	url.hostname = 'diffshub.com';
+	url.protocol = 'https:';
+	url.pathname = pathname;
+	return url.href;
+}
+
+function cloneTab(tab: HTMLAnchorElement, href: string): HTMLAnchorElement {
+	const clone = tab.cloneNode(false);
+	clone.classList.add('rgh-diffshub-button');
+	clone.classList.remove('selected', 'prc-TabNav-Selected-LYsaH');
+	clone.removeAttribute('aria-selected');
+	clone.removeAttribute('role');
+	clone.removeAttribute('tabindex');
+	clone.removeAttribute('data-discover');
+	clone.removeAttribute('data-hydro-click');
+	clone.removeAttribute('data-hydro-click-hmac');
+	clone.removeAttribute('id');
+	clone.href = href;
+	clone.dataset.turbo = 'false';
+	return clone;
+}
+
+function addPrTab(filesTab: HTMLAnchorElement): void {
+	if (elementExists('.rgh-diffshub-button', filesTab.parentElement!)) {
+		return;
+	}
+
+	const pathname = getCleanPathname().replace(/\/files$/, '');
+	const tab = cloneTab(filesTab, getDiffsHubUrl(pathname));
+	tab.append(<DiffIcon className="mr-2" />, ' DiffsHub');
+
+	filesTab.after(tooltipped('Open this pull request on DiffsHub', tab));
+}
+
+function addCompareButton(referencePicker: HTMLElement): void {
+	const rangeEditor = $closestOptional('.range-editor', referencePicker);
+	if (!rangeEditor || elementExists('.rgh-diffshub-button', rangeEditor)) {
+		return;
+	}
+
+	const nextElement = referencePicker.nextElementSibling;
+	// The swap button might not have been added yet.
+	const insertionPoint = nextElement?.textContent.trim() === 'Swap'
+		? nextElement
+		: referencePicker;
+
+	insertionPoint.after(
+		tooltipped(
+			'Open this comparison on DiffsHub',
+			<a
+				href={getDiffsHubUrl()}
+				className="btn btn-sm rgh-diffshub-button ml-2"
+				data-turbo="false"
+			>
+				<DiffIcon /> DiffsHub
+			</a>,
+		),
+	);
+}
+
+function addCommitButton(searchInput: HTMLElement): void {
+	const toolbar = $closestOptional('.position-sticky', searchInput);
+	const controls = $closestOptional('.width-full', searchInput);
+	if (!toolbar || !controls || elementExists('.rgh-diffshub-button', toolbar)) {
+		return;
+	}
+
+	controls.append(
+		tooltipped(
+			'Open this commit on DiffsHub',
+			<a
+				href={getDiffsHubUrl()}
+				className="btn btn-sm rgh-diffshub-button"
+				data-turbo="false"
+			>
+				<DiffIcon /> DiffsHub
+			</a>,
+		),
+	);
+}
+
+function initCommit(signal: AbortSignal): void {
+	observe('input[placeholder="Search within code"]', addCommitButton, {signal});
+}
+
+function initCompare(signal: AbortSignal): void {
+	observe('.range-editor .d-inline-block + .range-cross-repo-pair', addCompareButton, {signal});
+}
+
+function initPrTabs(signal: AbortSignal): void {
+	observe([
+		'a#prs-files-anchor-tab',
+		'[aria-label="Pull request tabs"] [role="tablist"] a[href$="/files"]',
+		'[aria-label="Pull request tabs"] [role="tablist"] a[href$="/changes"]',
+		'[aria-label="Pull request navigation tabs"] [role="tablist"] a[href$="/files"]',
+		'[aria-label="Pull request navigation tabs"] [role="tablist"] a[href$="/changes"]',
+	], addPrTab, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPR,
+	],
+	exclude: [
+		pageDetect.isPRFile404,
+	],
+	init: initPrTabs,
+}, {
+	include: [
+		pageDetect.isCompare,
+	],
+	init: initCompare,
+}, {
+	include: [
+		pageDetect.isSingleCommit,
+	],
+	init: initCommit,
+});
+
+/*
+# Test URLs
+
+- PR: https://github.com/refined-github/refined-github/pull/6261
+- Compare: https://github.com/rancher/rancher/compare/v2.6.5...v2.6.6
+- Single commit: https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -58,6 +58,7 @@ import './features/sort-conversations-by-update-time.js'; // Must be after globa
 import './features/pinned-issues-update-time.js';
 import './features/mark-pinned.js';
 import './features/default-branch-button.js';
+import './features/diffshub-button.js';
 import './features/one-click-diff-options.js';
 import './features/ci-link.js';
 import './features/sync-pr-commit-title.js';


### PR DESCRIPTION
### Background and motivation for this feature

The pierre computer company recently released [diffshub.com](https://diffshub.com). Which utilizes their diff and tree views to open github diffs which makes it much faster and better on performance than the default GitHub diff view.

[Mitchell Hashimoto also tweeted about his frustration with github's diff view comparing it to diffshub](https://x.com/mitchellh/status/2057229385963618787)


## What it does

- Adds a new button (tab) to the GitHub PR view that opens the diffshub site on the current PR
- Adds a new button to the github.com/org/repo/compare/<something>...<something> to open it on the diffshub site
- Adds a new button to individual commit view to

## Test URLs

- PR: https://github.com/refined-github/refined-github/pull/6261
- Compare: https://github.com/rancher/rancher/compare/v2.6.5...v2.6.6
- Single commit: https://github.com/rancher/rancher/commit/e82921075436c21120145927d5a66037661fcf4e

^^^^ These are the ones listed in the source file

While i used the bun rewrite to rust commit to demo in the video to show extremely large diffs working:

https://github.com/oven-sh/bun/commit/23427dbc12fdcff30c23a96a3d6a66d62fdc091d


## Screenshot

https://github.com/user-attachments/assets/a39dc6ef-b229-48bf-a773-e4c5662e08ef


#### Single commit page
<img width="647" height="172" alt="image" src="https://github.com/user-attachments/assets/64f26abe-9125-4787-af5e-994298d7607c" />

#### Compare page
<img width="722" height="223" alt="image" src="https://github.com/user-attachments/assets/3958ef07-4cb5-44ab-a129-58e19b39da40" />

#### PR Page
<img width="550" height="87" alt="image" src="https://github.com/user-attachments/assets/0a14121a-4f92-42d6-9e1f-34af0076f4dc" />


