### PR TITLE
`extensible-nav` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -298,6 +298,11 @@
 		"screenshot": "https://user-images.githubusercontent.com/1402241/152118201-f25034c7-6fae-4be0-bb3f-c217647e32b7.gif"
 	},
 	{
+		"id": "extensible-nav",
+		"description": "This is a core feature that enables other Refined GitHub features to extend or modify the repository navigation bar.",
+		"screenshot": null
+	},
+	{
 		"id": "file-age-color",
 		"description": "Highlights the most-recently-modified items in file lists.",
 		"screenshot": "https://user-images.githubusercontent.com/1402241/218314631-1442cc89-3616-40fc-abe2-9ba3d3697b6a.png"

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -300,6 +300,7 @@
 	{
 		"id": "extensible-nav",
 		"description": "This is a core feature that enables other Refined GitHub features to extend or modify the repository navigation bar.",
+		"css": true,
 		"screenshot": null
 	},
 	{

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -51,6 +51,7 @@
 	"expand-all-hidden-comments",
 	"extend-conversation-status-filters",
 	"extend-diff-expander",
+	"extensible-nav",
 	"file-age-color",
 	"fit-textareas",
 	"fix-no-pr-search",

--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -32,6 +32,7 @@ const noScreenshotExceptions = new Set([
 	'tab-size',
 	'monospace-textareas',
 	'new-tab-links',
+	'extensible-nav', // No visual or behavior change
 
 	'hide-navigation-hover-highlight', // TODO: Add side-by-side gif
 	'hide-inactive-deployments', // TODO: side-by-side png

--- a/readme.md
+++ b/readme.md
@@ -398,6 +398,11 @@ Refer to style guide in the wiki. Keep this message between sections.
 https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guidelines
 -->
 
+<!--
+Documented but hidden from the readme:
+- [](# "extensible-nav") This is a core feature that enables other Refined GitHub features to extend or modify the repository navigation bar.
+-->
+
 ### Previously part of Refined GitHub
 
 [GitHub took inspiration from Refined GitHub](https://github.blog/2018-08-28-announcing-paper-cuts/) and natively implemented dozens of its features, 🎉 so they've been [removed from this extension.](https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Amerged+label%3A%22implemented+by+github%22) You can also see [all the past features](https://github.com/refined-github/refined-github/pulls?q=is%3Apr+is%3Amerged+-label%3Ameta+in%3Atitle+drop+feature) of Refined GitHub in a single list.

--- a/source/features/extensible-nav.css
+++ b/source/features/extensible-nav.css
@@ -1,0 +1,8 @@
+.rgh-extensible-nav {
+	.UnderlineNav-octicon {
+		@media (max-width: 1100px) {
+			/* Somewhat match the native behavior for now. `mobile-tabs` would be better */
+			display: none !important;
+		}
+	}
+}

--- a/source/features/extensible-nav.css
+++ b/source/features/extensible-nav.css
@@ -1,8 +1,23 @@
 .rgh-extensible-nav {
+	/* TODO: Remove before shipping. Temporary indicator of successful replacement */
+	border-left: 1px solid var(--borderColor-muted, fuchsia);
 	.UnderlineNav-octicon {
 		@media (max-width: 1100px) {
 			/* Somewhat match the native behavior for now. `mobile-tabs` would be better */
 			display: none !important;
 		}
+	}
+}
+
+.rgh-extensible-nav-removed {
+	position: absolute;
+	top: -200px;
+	left: -2000px;
+	opacity: 0.0001;
+	width: 1px;
+	pointer-events: none;
+	> ul {
+		/* If we let the native nav "overflow" into the dropdown, we lose the `aria-current` attribute */
+		width: 2000px;
 	}
 }

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -1,33 +1,35 @@
 import React from 'react';
 import * as pageDetect from 'github-url-detection';
 
+import {$$, $optional} from 'select-dom';
+
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
-import {$$, $optional} from 'select-dom';
 
 function regenerate(nativeNav: HTMLElement): void {
 	const items = $$('a', nativeNav);
 	nativeNav.after(
 		<nav className='UnderlineNav px-4'>
-		<ul className='UnderlineNav-body'>
-			{items.map(item => {
-				const label = ($optional('[data-component="text"]', item) ?? item).textContent;
-				const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
-				const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
-				return (
-					<li key={item.href}>
-						<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
-							{label}
-							{counter && (
-								<span className='Counter'>{counter}</span>
-							)}
-						</a>
-					</li>
-				);
-			})}
-		</ul>
-		</nav>
-	)
+			<ul className='UnderlineNav-body'>
+				{items.map(item => {
+					const label = ($optional('[data-component="text"]', item) ?? item).textContent;
+					// Only a few items have counters
+					const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
+					const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
+					return (
+						<li key={item.href}>
+							<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
+								{label}
+								{counter && (
+									<span className='Counter'>{counter}</span>
+								)}
+							</a>
+						</li>
+					);
+				})}
+			</ul>
+		</nav>,
+	);
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -43,6 +43,8 @@ function regenerate(nativeNav: HTMLElement): void {
 			</ul>
 		</nav>,
 	);
+
+	nativeNav.classList.add('sr-only');
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import * as pageDetect from 'github-url-detection';
+
+import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+import {$$, $optional} from 'select-dom';
+
+function regenerate(nativeNav: HTMLElement): void {
+	const items = $$('a', nativeNav);
+	nativeNav.after(
+		<nav className='UnderlineNav px-4'>
+		<ul className='UnderlineNav-body'>
+			{items.map(item => {
+				const label = ($optional('[data-component="text"]', item) ?? item).textContent;
+				const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
+				const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
+				return (
+					<li key={item.href}>
+						<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
+							{label}
+							{counter && (
+								<span className='Counter'>{counter}</span>
+							)}
+						</a>
+					</li>
+				);
+			})}
+		</ul>
+		</nav>
+	)
+}
+
+function init(signal: AbortSignal): void {
+	observe('nav[aria-label="Repository"]', regenerate, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepo,
+	],
+	init,
+});

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -42,3 +42,12 @@ void features.add(import.meta.url, {
 	],
 	init,
 });
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github
+https://github.com/refined-github/refined-github/pulse
+
+*/

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -1,3 +1,4 @@
+import './extensible-nav.css';
 import React from 'react';
 import * as pageDetect from 'github-url-detection';
 
@@ -9,16 +10,28 @@ import observe from '../helpers/selector-observer.js';
 function regenerate(nativeNav: HTMLElement): void {
 	const items = $$('a', nativeNav);
 	nativeNav.after(
-		<nav className='UnderlineNav px-4'>
+		<nav className='UnderlineNav rgh-extensible-nav px-4'>
 			<ul className='UnderlineNav-body'>
 				{items.map(item => {
 					const label = ($optional('[data-component="text"]', item) ?? item).textContent;
 					// Only a few items have counters
 					const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
 					const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
+
+					// The icon may be missing if the feature runs too late and the link is found in the dropdown
+					let icon = $optional('[data-component="icon"]', item);
+					if (icon) {
+						icon = icon.cloneNode(true);
+						icon.classList.add(
+							// This class comes after d-none utility classes so they can't override it
+							'UnderlineNav-octicon',
+						);
+					}
+
 					return (
 						<li key={item.href}>
 							<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
+								{icon}
 								{label}
 								{counter && (
 									<span className='Counter'>{counter}</span>

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -17,7 +17,7 @@ import ShieldIcon from 'octicons-plain-react/Shield';
 
 import features from '../feature-manager.js';
 import onetime from '../helpers/onetime.js';
-import observe from '../helpers/selector-observer';
+import observe from '../helpers/selector-observer.js';
 
 let ready = false;
 

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -1,13 +1,36 @@
 import './extensible-nav.css';
-import React from 'react';
-import * as pageDetect from 'github-url-detection';
-import {$, $$, $optional} from 'select-dom';
 import elementReady from 'element-ready';
+import * as pageDetect from 'github-url-detection';
+import React from 'react';
+import {$, $$, $optional} from 'select-dom';
+import {assertPresent} from 'ts-extras';
+
+import AgentIcon from 'octicons-plain-react/Agent';
+import BookIcon from 'octicons-plain-react/Book';
+import CodeIcon from 'octicons-plain-react/Code';
+import GearIcon from 'octicons-plain-react/Gear';
+import GitPullRequestIcon from 'octicons-plain-react/GitPullRequest';
+import GraphIcon from 'octicons-plain-react/Graph';
+import IssueOpenedIcon from 'octicons-plain-react/IssueOpened';
+import PlayIcon from 'octicons-plain-react/Play';
+import ShieldIcon from 'octicons-plain-react/Shield';
 
 import features from '../feature-manager.js';
-import onetime from '../helpers/onetime';
+import onetime from '../helpers/onetime.js';
 
 let ready = false;
+
+const knownTabsIcons = new Map([
+	['code', CodeIcon],
+	['issues', IssueOpenedIcon],
+	['pull-requests', GitPullRequestIcon],
+	['agents', AgentIcon],
+	['actions', PlayIcon],
+	['wiki', BookIcon],
+	['security-and-quality', ShieldIcon],
+	['insights', GraphIcon],
+	['settings', GearIcon],
+]);
 
 function generateTab(item: HTMLAnchorElement): JSX.Element {
 	const label = ($optional('[data-component="text"]', item) ?? item).textContent;
@@ -15,15 +38,15 @@ function generateTab(item: HTMLAnchorElement): JSX.Element {
 	const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
 	const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
 
-	// The icon may be missing if the feature runs too late and the link is found in the dropdown
-	let icon = $optional('[data-component="icon"]', item);
-	if (icon) {
-		icon = icon.cloneNode(true);
-		icon.classList.add(
-			// This class comes after d-none utility classes so they can't override it
-			'UnderlineNav-octicon',
-		);
-	}
+	// Hard assertions will make the feature fail before it attempts to replace the native one.
+	// Being the repository's main navigation, we want to avoid breaking.
+	const itemId = item.getAttribute('data-tab-item');
+	assertPresent(itemId);
+	const Icon = knownTabsIcons.get(itemId);
+	assertPresent(Icon);
+
+	// `UnderlineNav-octicon` comes after d-none utility classes so they can't override it
+	const icon = <Icon className="UnderlineNav-octicon" />;
 
 	return (
 		<li key={item.href}>
@@ -31,7 +54,7 @@ function generateTab(item: HTMLAnchorElement): JSX.Element {
 				{icon}
 				{label}
 				{counter && (
-					<span className='Counter'>{counter}</span>
+					<span className="Counter">{counter}</span>
 				)}
 			</a>
 		</li>
@@ -42,14 +65,14 @@ async function initOnce(): Promise<void> {
 	const nativeNav = (await elementReady('nav[aria-label="Repository"]'))!;
 	const items = $$('a', nativeNav);
 	nativeNav.before(
-		<nav className='UnderlineNav rgh-extensible-nav px-4'>
-			<ul className='UnderlineNav-body'>
+		<nav className="UnderlineNav rgh-extensible-nav px-4">
+			<ul className="UnderlineNav-body">
 				{items.map(item => generateTab(item))}
 			</ul>
 		</nav>,
 	);
 
-	// nativeNav.classList.add('sr-only');
+	nativeNav.classList.add('sr-only');
 	ready = true;
 }
 

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -1,61 +1,77 @@
 import './extensible-nav.css';
 import React from 'react';
 import * as pageDetect from 'github-url-detection';
-
-import {$$, $optional} from 'select-dom';
+import {$, $$, $optional} from 'select-dom';
+import elementReady from 'element-ready';
 
 import features from '../feature-manager.js';
-import observe from '../helpers/selector-observer.js';
+import onetime from '../helpers/onetime';
 
-function regenerate(nativeNav: HTMLElement): void {
+let ready = false;
+
+function generateTab(item: HTMLAnchorElement): JSX.Element {
+	const label = ($optional('[data-component="text"]', item) ?? item).textContent;
+	// Only a few items have counters
+	const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
+	const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
+
+	// The icon may be missing if the feature runs too late and the link is found in the dropdown
+	let icon = $optional('[data-component="icon"]', item);
+	if (icon) {
+		icon = icon.cloneNode(true);
+		icon.classList.add(
+			// This class comes after d-none utility classes so they can't override it
+			'UnderlineNav-octicon',
+		);
+	}
+
+	return (
+		<li key={item.href}>
+			<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
+				{icon}
+				{label}
+				{counter && (
+					<span className='Counter'>{counter}</span>
+				)}
+			</a>
+		</li>
+	);
+}
+
+async function initOnce(): Promise<void> {
+	const nativeNav = (await elementReady('nav[aria-label="Repository"]'))!;
 	const items = $$('a', nativeNav);
-	nativeNav.after(
+	nativeNav.before(
 		<nav className='UnderlineNav rgh-extensible-nav px-4'>
 			<ul className='UnderlineNav-body'>
-				{items.map(item => {
-					const label = ($optional('[data-component="text"]', item) ?? item).textContent;
-					// Only a few items have counters
-					const counter = $optional('[data-component="counter"] [data-variant="secondary"]', item)?.textContent;
-					const selectedClass = item.hasAttribute('aria-current') ? 'selected' : '';
-
-					// The icon may be missing if the feature runs too late and the link is found in the dropdown
-					let icon = $optional('[data-component="icon"]', item);
-					if (icon) {
-						icon = icon.cloneNode(true);
-						icon.classList.add(
-							// This class comes after d-none utility classes so they can't override it
-							'UnderlineNav-octicon',
-						);
-					}
-
-					return (
-						<li key={item.href}>
-							<a href={item.href} className={'UnderlineNav-item ' + selectedClass}>
-								{icon}
-								{label}
-								{counter && (
-									<span className='Counter'>{counter}</span>
-								)}
-							</a>
-						</li>
-					);
-				})}
+				{items.map(item => generateTab(item))}
 			</ul>
 		</nav>,
 	);
 
-	nativeNav.classList.add('sr-only');
+	// nativeNav.classList.add('sr-only');
+	ready = true;
 }
 
-function init(signal: AbortSignal): void {
-	observe('nav[aria-label="Repository"]', regenerate, {signal});
+function updateCurrentTab(): void {
+	const currentTab = $('nav[aria-label="Repository"] a[aria-current]');
+	$('.rgh-extensible-nav .selected').classList.remove('selected');
+	$(`.rgh-extensible-nav a[href="${currentTab.href}"]`).classList.add('selected');
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepo,
 	],
-	init,
+	init: onetime(initOnce),
+}, {
+	asLongAs: [
+		() => ready,
+	],
+	include: [
+		pageDetect.isRepo,
+	],
+	init: updateCurrentTab,
 });
 
 /*

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -2,7 +2,7 @@ import './extensible-nav.css';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import React from 'react';
-import {$, $$, $optional} from 'select-dom';
+import {$, $$, $optional, elementExists} from 'select-dom';
 import {assertPresent} from 'ts-extras';
 
 import AgentIcon from 'octicons-plain-react/Agent';
@@ -17,6 +17,7 @@ import ShieldIcon from 'octicons-plain-react/Shield';
 
 import features from '../feature-manager.js';
 import onetime from '../helpers/onetime.js';
+import observe from '../helpers/selector-observer';
 
 let ready = false;
 
@@ -61,8 +62,12 @@ function generateTab(item: HTMLAnchorElement): JSX.Element {
 	);
 }
 
-async function initOnce(): Promise<void> {
-	const nativeNav = (await elementReady('nav[aria-label="Repository"]'))!;
+function replace(nativeNav: HTMLElement): void {
+	// Final check to avoid duplicates in any scenario.
+	if (elementExists('.rgh-extensible-nav')) {
+		return;
+	}
+
 	const items = $$('a', nativeNav);
 	nativeNav.before(
 		<nav className="UnderlineNav rgh-extensible-nav px-4">
@@ -72,8 +77,16 @@ async function initOnce(): Promise<void> {
 		</nav>,
 	);
 
-	nativeNav.classList.add('sr-only');
+	nativeNav.classList.add('rgh-extensible-nav-removed');
 	ready = true;
+}
+
+async function initOnce(): Promise<void> {
+	// Use `element-ready` to ensure that the native navigation is fully loaded before replacing it for the first time.
+	await elementReady('nav[aria-label="Repository"]');
+
+	// Use `observe` because GitHub occasionally removes and re-adds the entire header.
+	observe('nav[aria-label="Repository"]', replace);
 }
 
 function updateCurrentTab(): void {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -219,3 +219,4 @@ import './features/actions-run-removal.js';
 import './features/new-milestone-button.js';
 import './features/no-self-reference.js';
 import './features/cmd-enter.js';
+import './features/extensible-nav.js';


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9552
- for https://github.com/refined-github/refined-github/issues/8867




GitHub still ships the old `UnderlineNav` style, but here it is just in case they delete it in the future: https://gist.github.com/fregante/a718156c4187e42879a2033222394868 (the gist also includes the static HTML)

### Current status

<img width="861" height="98" src="https://github.com/user-attachments/assets/007a2fbb-1179-4583-abdb-b1320ce0a3c0" />

The .UnderlineNav class natively overflows, but we could already immediately consider wrapping the items on multiple lines instead.

<img width="609" height="99" src="https://github.com/user-attachments/assets/702f846b-3eb1-49df-ad5b-4c12e93dbed8" />

Current page is preserved:

<img width="841" height="111" alt="selected" src="https://github.com/user-attachments/assets/24938483-99f0-41b0-8ed3-f26f7251defa" />

### Tasks

- [x] Add icons
- [x] Avoid race condition on slow connections
- [x] Actually remove the native nav after successful duplication
- [x] Listen to "active page" change