### PR TITLE
`conversation-authors` - Fix color for Enterprise

### DIFF
--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -16,7 +16,7 @@ a.rgh-own-conversation:hover {
 		--color-user-mention-fg,
 		fuchsia
 	) !important; /* Their :hover	uses !important... */
-	background-color: var(--bgColor-attention-muted, var(--color-attension-subtle, fuchsia));
+	background-color: var(--bgColor-attention-muted, var(--color-attention-subtle, fuchsia));
 }
 
 a.rgh-own-conversation:hover {

--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -16,7 +16,10 @@ a.rgh-own-conversation:hover {
 		--color-user-mention-fg,
 		fuchsia
 	) !important; /* Their :hover	uses !important... */
-	background-color: var(--bgColor-attention-muted, var(--color-attention-subtle, fuchsia));
+	background-color: var(
+		--bgColor-attention-muted,
+		var(--color-attention-subtle, fuchsia)
+	);
 }
 
 a.rgh-own-conversation:hover {

--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -16,7 +16,7 @@ a.rgh-own-conversation:hover {
 		--color-user-mention-fg,
 		fuchsia
 	) !important; /* Their :hover	uses !important... */
-	background-color: var(--bgColor-attention-muted, fuchsia);
+	background-color: var(--bgColor-attention-muted, var(--color-attension-subtle, fuchsia));
 }
 
 a.rgh-own-conversation:hover {


### PR DESCRIPTION
- The older version of GitHub (Enterprise) does not have a `bgColor` variable.
- Other CSS files also use the `--color-*` variables as a replacement, and this CSS follows suit.


## Test URLs

- https://github.com/refined-github/refined-github/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aclosed

## Screenshot

- Sorry for no screenshot. (isolated device)