### PR TITLE
`small-user-avatars` - Restore mention avatars in Safari

### DIFF
--- a/source/github-helpers/get-user-avatar.ts
+++ b/source/github-helpers/get-user-avatar.ts
@@ -26,7 +26,8 @@ export default function getUserAvatar(username: string, size: number): string | 
 	// Enterprise can only use /$username.png
 	const isBot = username.endsWith('[bot]') || cleanName.includes('/');
 	const url = pageDetect.isEnterprise() || !isBot
-		? `/${cleanName}.png`
+		// Use full URLs: https://github.com/refined-github/refined-github/issues/9571
+		? `${location.origin}/${cleanName}.png`
 		: `https://avatars.githubusercontent.com/${cleanName}`;
 	// Why use a 2x size: https://github.com/refined-github/refined-github/pull/4973#discussion_r735133613
 	return url + `?size=${size * 2}`;


### PR DESCRIPTION
- Fixes https://github.com/refined-github/refined-github/issues/9571

## Test URLs

https://github.com/refined-github/refined-github/releases

## Screenshot

<img width="377" height="205" alt="Screenshot 13" src="https://github.com/user-attachments/assets/d2cc48b8-d1b6-45f1-bba4-96dce3f0c721" />

