### PR TITLE
`extensible-nav` - Support more tabs

### DIFF
--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -8,12 +8,14 @@ import {assertPresent} from 'ts-extras';
 import AgentIcon from 'octicons-plain-react/Agent';
 import BookIcon from 'octicons-plain-react/Book';
 import CodeIcon from 'octicons-plain-react/Code';
+import CommentDiscussionIcon from 'octicons-plain-react/CommentDiscussion';
 import GearIcon from 'octicons-plain-react/Gear';
 import GitPullRequestIcon from 'octicons-plain-react/GitPullRequest';
 import GraphIcon from 'octicons-plain-react/Graph';
 import IssueOpenedIcon from 'octicons-plain-react/IssueOpened';
 import PlayIcon from 'octicons-plain-react/Play';
 import ShieldIcon from 'octicons-plain-react/Shield';
+import TableIcon from 'octicons-plain-react/Table';
 
 import features from '../feature-manager.js';
 import onetime from '../helpers/onetime.js';
@@ -31,6 +33,8 @@ const knownTabsIcons = new Map([
 	['security-and-quality', ShieldIcon],
 	['insights', GraphIcon],
 	['settings', GearIcon],
+	['discussions', CommentDiscussionIcon],
+	['projects', TableIcon],
 ]);
 
 function generateTab(item: HTMLAnchorElement): JSX.Element {


### PR DESCRIPTION
Fixes https://github.com/refined-github/refined-github/pull/9554#issuecomment-4512814384 (unrelated to userstyles)


## Test URLs

 

https://github.com/snawoot-proxies-forks/opera-proxy
https://github.com/stunndard/golangwin7patch
https://github.com/Eclipse-Community/r3dfox-old/tags

## Screenshot

By the way, the feature can be seen working by looking at the subtle vertical gray border on the left:

<img width="1002" height="103" alt="Screenshot" src="https://github.com/user-attachments/assets/013dec0e-2af2-4c4b-a9ec-32b1dd0d0dac" />
