### PR TITLE
`rgh-feature-description` - Open links in the same tab

### DIFF
--- a/source/helpers/rgh-links.tsx
+++ b/source/helpers/rgh-links.tsx
@@ -2,15 +2,15 @@ import React from 'dom-chef';
 
 import {getOldFeatureNames} from '../feature-data.js';
 
-export function createRghIssueLink(issueNumber: number | string): Element {
+export function createRghIssueLink(issueNumber: number | string, newTab = false): Element {
 	const issueUrl = `https://github.com/refined-github/refined-github/issues/${issueNumber}`;
 	return (
 		<a
-			target="_blank"
-			rel="noopener noreferrer"
 			data-hovercard-type="issue"
 			data-hovercard-url={issueUrl + '/hovercard'}
 			href={issueUrl}
+			target={newTab ? '_blank' : undefined}
+			rel={newTab ? 'noopener noreferrer' : undefined}
 		>
 			#{issueNumber}
 		</a>

--- a/source/options/feature-list.tsx
+++ b/source/options/feature-list.tsx
@@ -28,7 +28,7 @@ async function markLocalHotfixes(): Promise<void> {
 			input.disabled = true;
 			input.removeAttribute('name');
 			$(`.feature-name[for="${feature}"]`).after(
-				<span className="hotfix-notice">{' '}(Disabled due to {createRghIssueLink(relatedIssue)})</span>,
+				<span className="hotfix-notice">{' '}(Disabled due to {createRghIssueLink(relatedIssue, true)})</span>,
 			);
 		}
 	}


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/refined-github/blob/main/source/features/netiquette.tsx

## Screenshot

The issue link was opening in a new tab:

<img width="458" height="277" alt="Screenshot 16" src="https://github.com/user-attachments/assets/4c324b30-255b-4b2d-b6ab-e38baf89fdfa" />
