### PR TITLE
Hide site logo and `repo-avatars` in small viewports

### DIFF
--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -17,7 +17,7 @@ async function add(ownerLabel: HTMLElement): Promise<void> {
 
 	const avatar = (
 		<img
-			className={`avatar ${isOldNavbar ? 'ml-1' : ''} mr-2`}
+			className={`d-none d-md-block avatar ${isOldNavbar ? 'ml-1' : ''} mr-2`}
 			src={source}
 			width={size}
 			height={size}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -228,3 +228,12 @@ a[class^='CodeSizeDetails-module__PrimerLink'] {
 		text-decoration: underline;
 	}
 }
+
+/* Hide the header logo on small screens */
+/* Info: https://github.com/refined-github/refined-github/issues/5120 */
+/* Test: https://github.com/refined-github/refined-github */
+@media (max-width: 600px) {
+	a[class*="appHeaderHome"] {
+		display: none;
+	}
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -233,7 +233,7 @@ a[class^='CodeSizeDetails-module__PrimerLink'] {
 /* Info: https://github.com/refined-github/refined-github/issues/5120 */
 /* Test: https://github.com/refined-github/refined-github */
 @media (max-width: 600px) {
-	a[class*="appHeaderHome"] {
+	a[class*='appHeaderHome'] {
 		display: none;
 	}
 }


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/8947


## Test URLs

Here


## Screenshot

 
<img width="581" height="103" alt="Screenshot 18" src="https://github.com/user-attachments/assets/9bff4e58-ac97-4d29-8ea1-a0c6dc3b7712" />
