### PR TITLE
Highlight comments by sponsors

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -219,6 +219,19 @@ a[class^='IssueItem-module__authorCreatedLink'] {
 	}
 }
 
+/* Highlight sponsor label in comments */
+/* Info: https://github.com/refined-github/refined-github/issues/7293 */
+/* Test: https://github.com/fregante/webext-storage-cache/issues/19#issuecomment-653229351 */
+span[data-testid='sponsor-label'] {
+	color: #db61a2; /* Matches color-gh-sponsor. Also hardcoded in the SVG below */
+	margin-top: 0.3em;
+	margin-right: 0.3em;
+	&::before {
+		content: url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' fill=\'%23db61a2\' width=\'12\' height=\'12\' viewBox=\'0 0 16 16\'%3E%3Cpath d=\'M7.655 14.916zh-.002l-.006-.003-.018-.01a22 22 0 0 1-3.744-2.584C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.044 5.231-3.886 6.818a22 22 0 0 1-3.433 2.414 7 7 0 0 1-.31.17l-.018.01-.008.004a.75.75 0 0 1-.69 0\'/%3E%3C/svg%3E');
+		margin-right: 0.3em;
+	}
+}
+
 /* Make the "Symbolic link" more noticeable */
 /* Info: https://github.com/refined-github/refined-github/pull/9419#discussion_r3214988559 */
 /* Test: https://github.com/wmluke/angular-flash/blob/0.1.14/app/components */


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/7293


Note that GitHub only shows this label on PUBLIC sponsors of "THIS" owner/org. 

For example if use `foo` sponsors YOU, you won't see the Sponsor label on your ORGANIZATION's repo, but only on YOUR repos.

Coloring the whole comment is more troublesome as well as it requires using `:has()`, which is not worth it in this case.

## Test URLs

https://github.com/fregante/webext-storage-cache/issues/19#issuecomment-653229351


 

## Screenshot

<img width="146" height="62" alt="Screenshot 1" src="https://github.com/user-attachments/assets/d99eecfb-c9fe-41fb-91da-6a5e1afbe130" />

