### PR TITLE
AI SPAM

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -48,8 +48,12 @@ export function getCommitHash(commit: HTMLElement): string {
 
 function updateCommitIcon(commit: HTMLElement, replace: boolean): void {
 	if (replace) {
+		const isCondensedTimelineItem = commit.classList.contains('TimelineItem--condensed');
+
 		// Align icon to the line; rem used to match the native units
-		$('.octicon-git-commit', commit).replaceWith(<GitMergeIcon style={{marginLeft: '0.5rem'}} />);
+		$('.octicon-git-commit', commit).replaceWith(
+			<GitMergeIcon style={isCondensedTimelineItem ? {marginLeft: '0.5rem'} : undefined} />,
+		);
 	} else {
 		$(commitTitleInLists, commit).prepend(<GitMergeIcon className="mr-1 tmp-mr-1" />);
 	}


### PR DESCRIPTION
Closes #9577

Keeps the old `0.5rem` nudge only for condensed PR timeline rows. On the non-condensed event row from the issue, the replacement merge icon now uses the native position instead of shifting right.

## Test URLs

https://github.com/refined-github/refined-github/pull/9523#commits-pushed-47b8135

## Screenshot

No fresh browser screenshot from me yet. I checked the code path against the issue URL and ran:

- `npx.cmd eslint source/features/mark-merge-commits-in-list.tsx`
- `npm.cmd run build:typescript`
- `npm.cmd run build:bundle`