### PR TITLE
`clean-repo-sidebar` - Restore feature

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -16,7 +16,7 @@
 
 	@media (width >= 768px) {
 		/* Hide redundant "+ 123 releases/deployments/contributors" links */
-		.tmp-mt-3:has(> a[text="small"]) {
+		.tmp-mt-3:has(> a[text='small']) {
 			display: none;
 		}
 

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,4 +1,5 @@
-[rgh-clean-repo-sidebar] :is([class*='PageLayout'], .Layout-sidebar) {
+/* TODO: Remove .Layout-sidebar after August 2026 */
+[rgh-clean-repo-sidebar] :is([class*='PageLayout-Pane'], .Layout-sidebar) {
 	/* Hide "About" header */
 	.BorderGrid-row:first-child h2 {
 		display: none;

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,6 +1,6 @@
-[rgh-clean-repo-sidebar] {
+[rgh-clean-repo-sidebar] :is([class*='PageLayout'], .Layout-sidebar) {
 	/* Hide "About" header */
-	.Layout-sidebar .BorderGrid-row:first-child h2 {
+	.BorderGrid-row:first-child h2 {
 		display: none;
 	}
 
@@ -10,18 +10,18 @@
 	}
 
 	/* Align the top of the repo root sidebar with the main page content */
-	.Layout-sidebar .BorderGrid-row:first-child h2 + p.f4 {
+	.BorderGrid-row:first-child h2 + p.f4 {
 		margin-top: 0 !important;
 	}
 
 	@media (width >= 768px) {
-		/* Hide "Releases" header */
-		.Layout-sidebar h2 [href$='/releases'] {
+		/* Hide redundant "+ 123 releases/deployments/contributors" links */
+		.tmp-mt-3:has(> a[text="small"]) {
 			display: none;
 		}
 
 		/* Align data section with latest tag/release link #5428 */
-		.Layout-sidebar .Link--muted .octicon {
+		.Link--muted .octicon {
 			margin-right: 4px !important;
 		}
 	}
@@ -32,14 +32,12 @@
 	 * Hide "+ 123 contributors" link
 	 * Don't hide "Create new release" link #8442
 	 */
-	.Layout-sidebar
-		.BorderGrid-cell
-		> .mt-3:not(:has(> a[href$='releases/new'])) {
+	.BorderGrid-cell > .mt-3:not(:has(> a[href$='releases/new'])) {
 		display: none;
 	}
 
 	/* Hide Code of conduct links */
-	.Layout-sidebar .Link--muted {
+	.Link--muted {
 		[href$='/code-of-conduct.md' i],
 		[href$='/code_of_conduct.md' i] {
 			display: none;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -5,13 +5,11 @@ import * as pageDetect from 'github-url-detection';
 import {$, $optional, closestElement, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
-import {buildRepoUrl} from '../github-helpers/index.js';
 
 // The h2 is to avoid hiding website links that include '/releases' #4424
-// TODO: It's broken
-const releasesSidebarSelector = '.Layout-sidebar .BorderGrid-cell h2 a[href$="/releases"]';
+// It's broken: https://github.com/refined-github/refined-github/issues/9339
 async function cleanReleases(): Promise<void> {
-	const sidebarReleases = await elementReady(releasesSidebarSelector, {waitForChildren: false});
+	const sidebarReleases = await elementReady('[class*="PageLayout"] .BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
 		return;
 	}
@@ -20,21 +18,7 @@ async function cleanReleases(): Promise<void> {
 	if (!elementExists('.octicon-tag', releasesSection)) {
 		// Hide the whole section if there's no releases
 		releasesSection.hidden = true;
-		return;
 	}
-
-	// Collapse "Releases" section into previous section
-	releasesSection.classList.add('border-0', 'pt-md-0');
-	closestElement('.BorderGrid-row', sidebarReleases)
-		.previousElementSibling! // About’s .BorderGrid-row
-		.firstElementChild! // About’s .BorderGrid-cell
-		.classList
-		.add('border-0', 'pb-0');
-
-	// Point to releases page; the user sees the same content, but there's more below
-	$optional('a.Link--primary[href*="/releases/tag/"]', releasesSection)
-		// The link is missing on tagged-but-no-releases repos
-		?.setAttribute('href', buildRepoUrl('releases'));
 }
 
 async function hideLanguageHeader(): Promise<void> {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -9,7 +9,9 @@ import features from '../feature-manager.js';
 // The h2 is to avoid hiding website links that include '/releases' #4424
 // It's broken: https://github.com/refined-github/refined-github/issues/9339
 async function cleanReleases(): Promise<void> {
-	const sidebarReleases = await elementReady('[class*="PageLayout"] .BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
+	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] .BorderGrid-cell h2 a[href$="/releases"]', {
+		waitForChildren: false,
+	});
 	if (!sidebarReleases) {
 		return;
 	}
@@ -24,7 +26,11 @@ async function cleanReleases(): Promise<void> {
 async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
-	const lastSidebarHeader = $optional('.Layout-sidebar .BorderGrid-row:last-of-type h2');
+	const lastSidebarHeader = $optional([
+		'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type h2',
+		// TODO [2026-09-01]: Drop old selector
+		'.Layout-sidebar .BorderGrid-row:last-of-type h2',
+	]);
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
@@ -35,17 +41,28 @@ async function hideEmptyMeta(): Promise<void> {
 	await domLoaded;
 
 	if (!pageDetect.canUserAdminRepo()) {
-		$optional('.Layout-sidebar .BorderGrid-cell > .text-italic')?.remove();
+		$optional([
+			'[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic',
+			// TODO [2026-09-01]: Drop old selector
+			'.Layout-sidebar .BorderGrid-cell > .text-italic',
+		])?.remove();
 	}
 }
 
 async function moveReportLink(): Promise<void> {
 	await domLoaded;
 
-	const reportLink = $optional('.Layout-sidebar a[href^="/contact/report-content"]')?.parentElement;
+	const reportLink = $optional([
+		'[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]',
+		// TODO [2026-09-01]: Drop old selector
+		'.Layout-sidebar a[href^="/contact/report-content"]',
+	])?.parentElement;
 	if (reportLink) {
 		// Your own repos don't include this link
-		$('.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell').append(reportLink);
+		$([
+			'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell',
+			'.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell',
+		]).append(reportLink);
 	}
 }
 


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9339


## Test URLs


https://github.com/refined-github/refined-github

## Screenshot

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="246" height="775" alt="Screenshot 19" src="https://github.com/user-attachments/assets/fcff5005-2469-4094-8f15-505a3661c9a1" />
 <td valign=top>
<img width="246" height="658" alt="Screenshot 20" src="https://github.com/user-attachments/assets/9589108f-a0f0-4fb9-bdbb-d962bcd3f1f6" />
</table>