### PR TITLE
`action-used-by-link` - Fix style

### DIFF
--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -6,10 +6,8 @@ import {$, $$, closestElement} from 'select-dom';
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
 
-function getActionUrl(side: HTMLElement): URL {
-	const actionRepo = $('a:has(.octicon-repo)', side)
-		.pathname
-		.slice(1);
+function getActionUrl(repoLink: HTMLAnchorElement): URL {
+	const actionRepo = repoLink.pathname.slice(1);
 
 	const actionUrl = new URL('search', location.origin);
 	actionUrl.search = new URLSearchParams({
@@ -22,31 +20,26 @@ function getActionUrl(side: HTMLElement): URL {
 	return actionUrl;
 }
 
-function addUsageLink(resourcesList: HTMLElement): void {
-	const actionUrl = getActionUrl(resourcesList);
-	const sourceLink = $('a:has(.octicon-repo)', resourcesList);
-	const usageItem = closestElement('[data-component="ActionList.Item"]', sourceLink).cloneNode(true);
-	const usageLink = $('a', usageItem);
-	const label = $('[data-component="ActionList.Item.Label"]', usageItem);
-	const leadingVisual = $('[data-component="ActionList.LeadingVisual"]', usageItem);
-	const trailingVisual = $('[data-component="ActionList.TrailingVisual"]', usageItem);
-
-	for (const element of $$('[id]', usageItem)) {
-		element.removeAttribute('id');
+function cleanElement(element: HTMLElement): void {
+	for (const child of $$(['[id]', '[aria-labelledby]'], element)) {
+		child.removeAttribute('id');
+		child.removeAttribute('aria-labelledby');
 	}
+}
 
-	usageLink.removeAttribute('aria-labelledby');
-	usageLink.href = actionUrl.href;
-	usageLink.classList.add('rgh-action-used-by-link');
-	label.textContent = 'Usage examples';
-	leadingVisual.replaceChildren(<SearchIcon width={16} />);
-	trailingVisual.textContent = '';
+function addUsageLink(repoItem: HTMLElement): void {
+	const usageItem = repoItem.cloneNode(true);
+	cleanElement(usageItem);
+	const usageLink = $('a', usageItem);
+	usageLink.href = getActionUrl(usageLink).href;
+	$('[data-component="ActionList.Item.Label"]', usageItem).textContent = 'Usage examples';
+	$('[data-component="ActionList.LeadingVisual"]', usageItem).replaceChildren(<SearchIcon />);
 
-	resourcesList.append(usageItem);
+	closestElement('ul', repoItem).append(usageItem);
 }
 
 function init(signal: AbortSignal): void {
-	observe('[data-testid="resources"] > ul', addUsageLink, {signal});
+	observe('[data-testid="resources"] [data-component="ActionList.Item"]:has(.octicon-repo)', addUsageLink, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import SearchIcon from 'octicons-plain-react/Search';
-import {$} from 'select-dom';
+import {$, $$, closestElement} from 'select-dom';
 
 import features from '../feature-manager.js';
 import observe from '../helpers/selector-observer.js';
@@ -22,14 +22,27 @@ function getActionUrl(side: HTMLElement): URL {
 	return actionUrl;
 }
 
-function addUsageLink(side: HTMLElement): void {
-	const actionUrl = getActionUrl(side);
+function addUsageLink(resourcesList: HTMLElement): void {
+	const actionUrl = getActionUrl(resourcesList);
+	const sourceLink = $('a:has(.octicon-repo)', resourcesList);
+	const usageItem = closestElement('[data-component="ActionList.Item"]', sourceLink).cloneNode(true);
+	const usageLink = $('a', usageItem);
+	const label = $('[data-component="ActionList.Item.Label"]', usageItem);
+	const leadingVisual = $('[data-component="ActionList.LeadingVisual"]', usageItem);
+	const trailingVisual = $('[data-component="ActionList.TrailingVisual"]', usageItem);
 
-	side.after(
-		<a href={actionUrl.href} className="d-block mb-2 tmp-mb-2">
-			<SearchIcon width={14} className="color-fg-default mr-2 tmp-mr-2" />Usage examples
-		</a>,
-	);
+	for (const element of $$('[id]', usageItem)) {
+		element.removeAttribute('id');
+	}
+
+	usageLink.removeAttribute('aria-labelledby');
+	usageLink.href = actionUrl.href;
+	usageLink.classList.add('rgh-action-used-by-link');
+	label.textContent = 'Usage examples';
+	leadingVisual.replaceChildren(<SearchIcon width={16} />);
+	trailingVisual.textContent = '';
+
+	resourcesList.append(usageItem);
 }
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
﻿Fixes #9590

## Changes
- Add the "Usage examples" link as a Marketplace resources ActionList item instead of a standalone link below the list.
- Reuse the existing source-code resource item structure so spacing, icon alignment, and theme styles match GitHub's current resources list.
- Remove cloned ids/aria-labelledby before inserting the new item to avoid duplicate DOM ids.

## Verification
- `npm run build:typescript`
- `npx eslint source/features/action-used-by-link.tsx`
- `npm run lint:eslint` (0 errors, existing TODO warnings only)
- `npm run build:bundle`
- `git diff --check`
