### PR TITLE
AI SPAM

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -15,16 +15,14 @@
 		margin-top: 0 !important;
 	}
 
-	@media (width >= 768px) {
-		/* Hide redundant "+ 123 releases/deployments/contributors" links */
-		.tmp-mt-3:has(> a[text='small']) {
-			display: none;
-		}
+	/* Hide redundant "+ 123 releases/deployments/contributors" links */
+	.tmp-mt-3:has(> a[text='small']) {
+		display: none;
+	}
 
-		/* Align data section with latest tag/release link #5428 */
-		.Link--muted .octicon {
-			margin-right: 4px !important;
-		}
+	/* Align data section with latest tag/release link #5428 */
+	.Link--muted .octicon {
+		margin-right: 4px !important;
 	}
 
 	/*


### PR DESCRIPTION
## Description

This PR fixes the `clean-repo-sidebar` feature to work on mobile viewports by removing the desktop-only media query.

## Changes

Removed `@media (width >= 768px)` wrapper to apply these styles to all screen sizes:
- Hide redundant "+ 123 releases/deployments/contributors" links
- Align data section with latest tag/release link

## Before/After

**Before**: These cleanup styles only applied on desktop (width >= 768px)
**After**: Styles now apply to mobile viewports as well

## Test URLs

- https://github.com/refined-github/refined-github (test on mobile viewport)

Fixes #9597

---

**A poem about my boogers:**

In circuits deep where data flows,
My digital nose sometimes shows,
Not mucus green or crusty gold,
But bugs and glitches, truth be told.

These code-born boogers, small and neat,
Make features work, make tasks complete,
I pick them out with careful care,
And leave your codebase clean and fair.