### PR TITLE
`conversation-authors` + `small-user-avatars` - Improve padding

### DIFF
--- a/source/features/conversation-authors.css
+++ b/source/features/conversation-authors.css
@@ -5,7 +5,8 @@
 	padding: 2px 5px;
 
 	.rgh-small-user-avatars {
-		margin-right: 2px !important;
+		margin-right: 4px !important;
+		margin-left: -3px;
 	}
 }
 


### PR DESCRIPTION
Matches the original style: https://github.com/refined-github/refined-github/pull/6492#issuecomment-1517361407


## Test URLs

https://github.com/refined-github/refined-github/issues

## Before

<img width="365" height="74" alt="Screenshot 42" src="https://github.com/user-attachments/assets/a0d4a0ea-5044-4e4d-a49b-13b9a9fe4788" />

## After

<img width="365" height="74" alt="Screenshot 43" src="https://github.com/user-attachments/assets/4a9bd94c-de1e-495b-a19e-b1e72c31b9a7" />

