### PR TITLE
AI SPAM

### DIFF
--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -16,6 +16,12 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 		return;
 	}
 
+	// The new global PR views are already sorted by update time, and adding
+	// `q=` redirects them back to the old search UI.
+	if (/^\/pulls\/(assigned|authored|inbox|mentioned|review-requested|reviews)\/?$/.test(link.pathname)) {
+		return;
+	}
+
 	// Pick only links to lists, not single issues
 	// + skip pagination links
 	// + skip pr/issue filter dropdowns (some are lazyloaded)

--- a/source/github-helpers/search-query.test.ts
+++ b/source/github-helpers/search-query.test.ts
@@ -99,6 +99,33 @@ test('parse label link', () => {
 	assert.isTrue(query.href.startsWith('https://github.com/owner/repo/issues?'));
 });
 
+test('parse global pull request list shortcuts', () => {
+	assert.equal(new SearchQuery('https://github.com/issues').get(), 'is:issue is:open author:@me archived:false');
+	assert.equal(new SearchQuery('https://github.com/pulls').get(), 'is:pr is:open author:@me archived:false');
+	assert.equal(new SearchQuery('https://github.com/pulls/assigned').get(), 'is:pr is:open assignee:@me archived:false');
+	assert.equal(new SearchQuery('https://github.com/pulls/authored').get(), 'is:pr is:open archived:false');
+	assert.equal(new SearchQuery('https://github.com/pulls/mentioned').get(), 'is:pr is:open mentions:@me archived:false');
+	assert.equal(
+		new SearchQuery('https://github.com/pulls/reviews').get(),
+		'is:pr is:open review-requested:@me archived:false',
+	);
+	assert.equal(
+		new SearchQuery('https://github.com/pulls/review-requested').get(),
+		'is:pr is:open review-requested:@me archived:false',
+	);
+});
+
+test('parse global lists for another user', () => {
+	assert.equal(
+		new SearchQuery('https://github.com/pulls?user=refined-github').get(),
+		'is:pr is:open user:refined-github archived:false',
+	);
+	assert.equal(
+		new SearchQuery('https://github.com/issues?user=refined-github').get(),
+		'is:issue is:open user:refined-github archived:false',
+	);
+});
+
 test('complex queries with multiple conditions', () => {
 	const query = SearchQuery.from({q: 'is:issue is:open label:bug author:user milestone:"Q1 2023"'});
 	assert.deepEqual(query.getQueryParts(), ['is:issue', 'is:open', 'label:bug', 'author:user', 'milestone:"Q1 2023"']);

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,5 +1,12 @@
 const queryPartsRegExp = /[^\s"()]+:[^"\s()]*(?:"[^"]*")?|\([^)]*\)|"[^"]*"|[^\s"():]+/g;
 const labelLinkRegex = /^(?:\/[^/]+){2}\/labels\/([^/]+)\/?$/;
+const querylessPathQueries = new Map([
+	['/pulls/assigned', ['is:pr', 'is:open', 'assignee:@me', 'archived:false']],
+	['/pulls/authored', ['is:pr', 'is:open', 'archived:false']],
+	['/pulls/mentioned', ['is:pr', 'is:open', 'mentions:@me', 'archived:false']],
+	['/pulls/review-requested', ['is:pr', 'is:open', 'review-requested:@me', 'archived:false']],
+	['/pulls/reviews', ['is:pr', 'is:open', 'review-requested:@me', 'archived:false']],
+]);
 
 function splitQueryString(query: string): string[] {
 	return query.match(queryPartsRegExp) ?? [];
@@ -22,6 +29,29 @@ function deduplicateKeywords(array: string[], ...keywords: string[]): string[] {
 
 function cleanQueryParts(parts: string[]): string[] {
 	return deduplicateKeywords(parts, 'is:issue', 'is:pr');
+}
+
+function getQuerylessListQuery(url: URL): string[] {
+	const pathname = url.pathname.replace(/\/$/, '') || '/';
+	const query = querylessPathQueries.get(pathname);
+	if (query) {
+		return [...query];
+	}
+
+	if (pathname === '/issues' || pathname === '/pulls') {
+		return [
+			pathname === '/pulls' ? 'is:pr' : 'is:issue',
+			'is:open',
+			url.searchParams.has('user') ? `user:${url.searchParams.get('user')!}` : 'author:@me',
+			'archived:false',
+		];
+	}
+
+	if (/(?:\/[^/]+){2}\/pulls$/.test(pathname)) {
+		return ['is:pr', 'is:open'];
+	}
+
+	return ['is:issue', 'is:open'];
 }
 
 type Source = Location | HTMLAnchorElement | Record<string, string>;
@@ -71,19 +101,7 @@ export default class SearchQuery {
 		// Query-less URLs imply some queries.
 		// When we explicitly set ?q=* they're overridden, so they need to be manually added again.
 
-		// Repo example: is:issue is:open
-		this.queryParts.push(/\/pulls\/?$/.test(this.url.pathname) ? 'is:pr' : 'is:issue', 'is:open');
-
-		// Header nav example: is:open is:issue author:you archived:false
-		if (this.url.pathname === '/issues' || this.url.pathname === '/pulls') {
-			if (this.url.searchParams.has('user')) { // #1211
-				this.queryParts.push('user:' + this.url.searchParams.get('user')!);
-			} else {
-				this.queryParts.push('author:@me');
-			}
-
-			this.queryParts.push('archived:false');
-		}
+		this.queryParts = getQuerylessListQuery(this.url);
 	}
 
 	getQueryParts(): string[] {


### PR DESCRIPTION
For #9604

## Test URLs

- https://github.com/pulls/authored
- https://github.com/pulls/reviews
- https://github.com/pulls/review-requested

## Screenshot / recording

This is https://github.com/pulls/authored with Refined GitHub enabled. It stays on the new /pulls/authored view instead of being rewritten to /pulls/search?q=....

![/pulls/authored stays on the new pull request list](https://raw.githubusercontent.com/iccccccccccccc/refined-github/pr-assets-refined-github-9608/media/pr-9608/github-pulls-authored-verification.png)

Short recording of the same flow:

![/pulls/authored verification recording](https://raw.githubusercontent.com/iccccccccccccc/refined-github/pr-assets-refined-github-9608/media/pr-9608/pulls-authored-before-after.gif)