### PR TITLE
`unreleased-commits` - Fix icons alignment 

### DIFF
--- a/source/features/unreleased-commits.tsx
+++ b/source/features/unreleased-commits.tsx
@@ -86,7 +86,7 @@ async function createLink(
 			href={buildRepoUrl('compare', `${latestTag}...${await getDefaultBranch()}`)}
 			aria-label={label}
 		>
-			<TagIcon className="v-align-middle" />
+			<TagIcon />
 			{' '}
 			{aheadBy === undeterminableAheadBy || <sup className="ml-n2 tmp-ml-n2">+{aheadBy}</sup>}
 		</a>
@@ -108,7 +108,7 @@ async function createLinkGroup(latestTag: string, aheadBy: number): Promise<HTML
 			aria-label="Draft a new release"
 			data-turbo-frame="repo-content-turbo-frame"
 		>
-			<PlusIcon className="v-align-middle" />
+			<PlusIcon />
 		</a>,
 	]);
 }


### PR DESCRIPTION



## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

| Before | After |
|--------|--------|
| <img width="160" height="64" alt="github com_refined-github_refined-github" src="https://github.com/user-attachments/assets/f75baf7a-3f01-4779-8567-efd2a6182cfe" /> | <img width="160" height="64" alt="github com_refined-github_refined-github (1)" src="https://github.com/user-attachments/assets/3a8c54a7-34c0-477f-8173-6d2d0647ce50" /> | 