### PR TITLE
`clean-repo-sidebar` - Apply to mobile

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -16,11 +16,6 @@
 	}
 
 	@media (width >= 768px) {
-		/* Hide redundant "+ 123 releases/deployments/contributors" links */
-		.tmp-mt-3:has(> a[text='small']) {
-			display: none;
-		}
-
 		/* Align data section with latest tag/release link #5428 */
 		.Link--muted .octicon {
 			margin-right: 4px !important;
@@ -33,7 +28,8 @@
 	 * Hide "+ 123 contributors" link
 	 * Don't hide "Create new release" link #8442
 	 */
-	.BorderGrid-cell > .mt-3:not(:has(> a[href$='releases/new'])) {
+	.BorderGrid-cell
+		> :is(.tmp-mt-3, .mt-3):not(:has(> a[href$='releases/new'])) {
 		display: none;
 	}
 

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -29,7 +29,7 @@
 	 * Don't hide "Create new release" link #8442
 	 */
 	.BorderGrid-cell
-		> :is(.tmp-mt-3, .mt-3):not(:has(> a[href$='releases/new'])) {
+		> div:is(.tmp-mt-3, .mt-3):has(> a:not([href$='releases/new'])) {
 		display: none;
 	}
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -17,8 +17,12 @@ async function cleanReleases(): Promise<void> {
 	}
 
 	const releasesSection = closestElement('.BorderGrid-cell', sidebarReleases);
-	if (!elementExists('.octicon-tag', releasesSection)) {
+	if (
 		// Hide the whole section if there's no releases
+		!elementExists('.octicon-tag', releasesSection)
+		// Don't hide the section if it has a "Create new release" link
+		&& !elementExists('a[href$="releases/new"]', releasesSection)
+	) {
 		releasesSection.hidden = true;
 	}
 }


### PR DESCRIPTION
- closes #9597

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td valign="top">

<img width="742" height="909" alt="before_sidebar" src="https://github.com/user-attachments/assets/deea0f14-399d-4aae-83c4-2f34c5c56edc" />

</td>
<td valign="top">

<img width="725" height="906" alt="after_sidebar" src="https://github.com/user-attachments/assets/312b7c5b-c0f0-49e2-922c-c3e751555f5f" />

</td>
</tr>
</table>