### PR TITLE
`small-user-avatars` - Avoid content shift on notifications page

### DIFF
--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -25,12 +25,10 @@ function createAvatar(username: string, size: number): JSX.Element {
 function addRepoAvatar(link: HTMLAnchorElement): void {
 	const [owner] = link.textContent.trim().split('/');
 	const size = 14;
-	const avatar = createAvatar(owner, size);
-	avatar.classList.add('d-none', 'd-xl-inline-block');
 
 	link.firstElementChild!.prepend(
-		<span className="ActionListItem-visual ActionListItem-visual--leading">
-			{avatar}
+		<span className="ActionListItem-visual ActionListItem-visual--leading d-none d-xl-inline-block">
+			{createAvatar(owner, size)}
 		</span>,
 	);
 }

--- a/source/features/small-user-avatars.tsx
+++ b/source/features/small-user-avatars.tsx
@@ -24,19 +24,17 @@ function createAvatar(username: string, size: number): JSX.Element {
 
 function addRepoAvatar(link: HTMLAnchorElement): void {
 	const [owner] = link.textContent.trim().split('/');
-	const size = 14;
 
 	link.firstElementChild!.prepend(
 		<span className="ActionListItem-visual ActionListItem-visual--leading d-none d-xl-inline-block">
-			{createAvatar(owner, size)}
+			{createAvatar(owner, 14)}
 		</span>,
 	);
 }
 
 function addAvatar(link: HTMLElement): void {
 	const username = link.textContent;
-	const size = 14;
-	const avatar = createAvatar(username, size);
+	const avatar = createAvatar(username, 14);
 	avatar.classList.add('v-align-text-bottom', 'mr-1', 'tmp-mr-1');
 
 	link.classList.add('d-inline-block', 'lh-condensed-ultra');


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9617


## Test URLs

https://github.com/notifications

## Screenshot

<img width="253" height="148" alt="ok now" src="https://github.com/user-attachments/assets/bce9bbf6-52ee-43c4-90de-1d6489db2300" />
