### PR TITLE
`no-modals` - Remove bad links from New Issue modal

### DIFF
--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -2,6 +2,15 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
+import observe from '../helpers/selector-observer.js';
+
+function disableLink(link: HTMLAnchorElement): void {
+	if (link.getAttribute('href') !== location.pathname) {
+		throw new Error('The template chooser bug might have been fixed');
+	}
+
+	link.removeAttribute('href');
+}
 
 function fix(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void {
 	event.stopImmediatePropagation();
@@ -21,6 +30,11 @@ function init(signal: AbortSignal): void {
 	);
 }
 
+function disableDeadLinks(signal: AbortSignal): void {
+	// Explanation: https://github.com/refined-github/refined-github/issues/9615
+	observe('div[data-testid="repository-and-template-picker-dialog"] a', disableLink, {signal});
+}
+
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isIssue,
@@ -28,6 +42,8 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalIssueOrPRList,
 	],
 	init,
+}, {
+	init: disableDeadLinks,
 });
 
 /*


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9615


This is the consequence of us dropping `quick-new-issue` and leaving this modal around because the repo-picking view doesn't exist anywhere outside it

- https://github.com/refined-github/refined-github/issues/9302

## Test URLs

1. Left-click this: <img width="212" height="95" alt="Screenshot 19" src="https://github.com/user-attachments/assets/0a568da2-8b3e-480d-a7e2-9dde0bf91e72" />
2. cmd-click any of the options

## Screenshot

This shows cmd-clicks doing nothing, then a left-click working in the modal

<img width="805" height="484" alt="fixed" src="https://github.com/user-attachments/assets/71ee9d5c-d6c5-4221-8eaa-ac5da9070c87" />
