### PR TITLE
`new-tab-links` - Remove bad links from New Issue modal

### DIFF
--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -5,6 +5,20 @@ import features from '../feature-manager.js';
 import {buildRepoUrl} from '../github-helpers/index.js';
 import onAlteredClick from '../helpers/on-altered-click.js';
 import onetime from '../helpers/onetime.js';
+import observe from '../helpers/selector-observer.js';
+
+function disableLink(link: HTMLAnchorElement): void {
+	if (link.getAttribute('href') !== location.pathname) {
+		throw new Error('The template chooser bug might have been fixed');
+	}
+
+	link.removeAttribute('href');
+}
+
+function initDeadLinksOnce(): void {
+	// Explanation: https://github.com/refined-github/refined-github/issues/9615
+	observe('div[data-testid="repository-and-template-picker-dialog"] a', disableLink);
+}
 
 function openSearchResultInNewTab(event: DelegateEvent<PointerEvent, HTMLElement>): void {
 	event.stopImmediatePropagation();
@@ -57,6 +71,8 @@ void features.add(import.meta.url, {
 		pageDetect.isNewIssue,
 	],
 	init: initIssueTemplate,
+}, {
+	init: onetime(initDeadLinksOnce),
 });
 
 /*

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -2,15 +2,6 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
-import observe from '../helpers/selector-observer.js';
-
-function disableLink(link: HTMLAnchorElement): void {
-	if (link.getAttribute('href') !== location.pathname) {
-		throw new Error('The template chooser bug might have been fixed');
-	}
-
-	link.removeAttribute('href');
-}
 
 function fix(event: DelegateEvent<MouseEvent, HTMLAnchorElement>): void {
 	event.stopImmediatePropagation();
@@ -30,10 +21,6 @@ function init(signal: AbortSignal): void {
 	);
 }
 
-function disableDeadLinks(signal: AbortSignal): void {
-	// Explanation: https://github.com/refined-github/refined-github/issues/9615
-	observe('div[data-testid="repository-and-template-picker-dialog"] a', disableLink, {signal});
-}
 
 void features.add(import.meta.url, {
 	include: [
@@ -42,8 +29,6 @@ void features.add(import.meta.url, {
 		pageDetect.isGlobalIssueOrPRList,
 	],
 	init,
-}, {
-	init: disableDeadLinks,
 });
 
 /*

--- a/source/features/no-modals.tsx
+++ b/source/features/no-modals.tsx
@@ -21,7 +21,6 @@ function init(signal: AbortSignal): void {
 	);
 }
 
-
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isIssue,


### PR DESCRIPTION
Moves code from https://github.com/refined-github/refined-github/pull/9620

Feels like `new-tab-links` is better suited here since it specifically "handles altered clicks on bad React components".

In the future, if the links receive real `href` values, we will be able to just  change the `init` to _enable_ them instead of _blocking_ them