### PR TITLE
Drop bug fix: PR title width on small & medium screens

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -156,22 +156,6 @@ div[class^='prc-PageHeader-Description']
 	height: 32px;
 }
 
-/* Fix PR title width on small & medium screens */
-/* Info: https://github.com/refined-github/refined-github/issues/9180 */
-/* Test: https://github.com/refined-github/refined-github/pull/9179/changes */
-react-app[app-name='pull-requests'] {
-	@media (max-width: 1011px) {
-		div[class^='prc-PageHeader-TitleArea'] {
-			grid-area: 2 / 1 / auto / -1;
-		}
-	}
-	@container (width <= 1011px) {
-		div[class^='prc-PageHeader-TitleArea'] {
-			grid-area: 2 / 1 / auto / -1;
-		}
-	}
-}
-
 /* Fix checks state icon alignment in file tree sidebar */
 /* Info: https://github.com/refined-github/refined-github/issues/9198 */
 /* Test: https://github.com/refined-github/refined-github/pull/8958/changes */


### PR DESCRIPTION
- reverts https://github.com/refined-github/refined-github/pull/9181

Can't repro, they fixed it


## Test URLs

https://github.com/refined-github/refined-github/pull/9181/changes

## Screenshot

<img width="380" height="300" alt="Screenshot 5" src="https://github.com/user-attachments/assets/32c479f6-f2c8-4052-bbd2-990d138f2124" />

