### PR TITLE
`clean-conversation-headers` - Update and improve

### DIFF
--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -1,49 +1,22 @@
-/* TODO [2025-04-01]: Revert https://github.com/refined-github/refined-github/pull/8111 */
 :root .rgh-non-default-branch {
 	background-color: var(
 		--control-checked-bgColor-hover,
-		var(--color-state-hover-primary-bg, var(--color-accent-emphasis, fuchsia))
+		var(--color-state-hover-primary-bg, fuchsia)
 	);
 
 	&,
 	a {
 		color: var(
 			--control-checked-fgColor-rest,
-			var(
-				--color-state-hover-primary-text,
-				var(--color-fg-on-emphasis, fuchsia)
-			)
+			var(--color-state-hover-primary-text,fuchsia)
 		);
 	}
 }
 
 .rgh-clean-conversation-headers {
-	/* Removes: every text (but not icons) */
-	font-size: 0 !important;
-
-	/* Hide "from" */
-	:is(span[data-component='Tooltip'], button[id^='ref-picker'])
-		+ span:not([class]) {
-		font-size: 0;
-	}
-
-	/* Shows on PRs: [octocat] merged 1 commit into [master] from [feature] on [1 Jan] */
-	/* Doesn't show on PRs: octocat merged [1] commit into master from feature */
-	> [class]:not(.js-updating-pull-request-commits-count),
-	> relative-time {
-		font-size: 14px;
-	}
-
-	--margin: 4px;
-
 	/* Shows on PRs: [by ]octocat main ← feature */
 	&:not(.rgh-hide-author)::before {
 		content: 'by ';
-		font-size: 14px;
-	}
-
-	.author {
-		margin-right: var(--margin);
 	}
 
 	/* Removes on PRs: [octocat] merged 1 commit into master from feature */
@@ -54,21 +27,11 @@
 		}
 	}
 
-	[class^='PullRequestBranchName'],
-	/* TODO [2027-01-01]: Drop after legacy PR files view is removed */
-	.commit-ref,
-	/* TODO [2026-08-01]: Drop */
-	[class^='BranchName'] {
-		font-size: 12px !important;
-	}
-
-	span[class^='prc-TooltipV2'] ~ .rgh-arrow {
-		font-size: 0;
-		margin-left: calc(-1 * var(--margin));
-	}
-
-	relative-time {
-		margin-left: var(--margin);
+	/* Hide the default base branch in sticky headers */
+	&.rgh-sticky-pr-header .rgh-base-branch:not(.rgh-non-default-branch) {
+		&, & ~ .rgh-arrow {
+			display: none;
+		}
 	}
 
 	/* TODO [2027-01-01]: Drop after legacy PR files view is removed */

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -18,9 +18,20 @@
 }
 
 .rgh-clean-conversation-headers {
-	/* Shows on PRs: [by ]octocat main ← feature */
+	/* On merged PRs: merged [by ]user */
 	&:not(.rgh-hide-author)::before {
 		content: 'by ';
+		order: -3;
+	}
+
+	/* On merged PRs: merged [by user] */
+	a[data-hovercard-type='user'] {
+		order: -2;
+	}
+
+	/* On merged PRs: merged by user [on date] */
+	relative-time {
+		order: -1;
 	}
 
 	/* Removes on PRs: [octocat] merged 1 commit into master from feature */

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -8,7 +8,7 @@
 	a {
 		color: var(
 			--control-checked-fgColor-rest,
-			var(--color-state-hover-primary-text,fuchsia)
+			var(--color-state-hover-primary-text, fuchsia)
 		);
 	}
 }

--- a/source/features/clean-conversation-headers.css
+++ b/source/features/clean-conversation-headers.css
@@ -1,14 +1,18 @@
+/* TODO [2025-04-01]: Revert https://github.com/refined-github/refined-github/pull/8111 */
 :root .rgh-non-default-branch {
 	background-color: var(
 		--control-checked-bgColor-hover,
-		var(--color-state-hover-primary-bg, fuchsia)
+		var(--color-state-hover-primary-bg, var(--color-accent-emphasis, fuchsia))
 	);
 
 	&,
 	a {
 		color: var(
 			--control-checked-fgColor-rest,
-			var(--color-state-hover-primary-text, fuchsia)
+			var(
+				--color-state-hover-primary-text,
+				var(--color-fg-on-emphasis, fuchsia)
+			)
 		);
 	}
 }

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -9,7 +9,7 @@ import {$, closestElementOptional} from 'select-dom';
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {parseReferenceRaw} from '../github-helpers/pr-branches.js';
-import {assertNodeContent, removeTextNodeContaining} from '../helpers/dom-utils.js';
+import {assertNodeContent} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
 async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: string): Promise<void> {
@@ -21,12 +21,7 @@ async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: strin
 }
 
 function isStickyHeader(childElement: HTMLElement): boolean {
-	return Boolean(closestElementOptional([
-		'div[class*="stickyHeader"]',
-		// TODO [2027-01-01]: Drop after legacy PR files view is removed
-		'.sticky-content',
-		'.gh-header-sticky',
-	], childElement));
+	return Boolean(closestElementOptional('div[class*="stickyHeader"]', childElement));
 }
 
 /** The PR header username is the creator or the merger */
@@ -61,9 +56,14 @@ async function maybeHideAuthor(summaryRow: HTMLElement): Promise<void> {
 }
 
 async function hideAuthorMetadata(summaryRow: HTMLElement): Promise<void> {
-	const infoNode = getHeaderUsername(summaryRow).nextSibling!.nextSibling!;
-	console.log(infoNode);
-	removeTextNodeContaining(infoNode, /^(wants to merge|^merged) \d+ commit/);
+	for (const child of summaryRow.childNodes) {
+		if (child instanceof Text && /^(wants to merge|^merged) \d+ commit/.test(child.textContent)) {
+			child.remove();
+			return;
+		}
+	}
+
+	throw new Error('Unable to find the PR metadata text node');
 }
 
 function replaceFromWithArrow(base: HTMLElement): void {
@@ -97,8 +97,8 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 	}
 
 	// This can be run asynchronously
-	void maybeHideAuthor(summaryRow);
 	void hideAuthorMetadata(summaryRow);
+	void maybeHideAuthor(summaryRow);
 
 	// Don't await https://github.com/refined-github/refined-github/issues/8331
 	void highlightNonDefaultBranchPrs(base, baseBranch);
@@ -109,14 +109,7 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
-		[
-			'.d-flex[class*="PullRequestHeaderSummary"]',
-			// TODO [2027-01-01]: Drop after legacy PR files view is removed
-			'.gh-header-meta > .flex-auto', // Real
-			// TODO [2026-08-01]: Drop
-			'.js-issues-results .rgh-conversation-activity-filter', // Helper in case it runs first and breaks the `>` selector, because it wraps the .flex-auto element
-			'[class^="StateLabel"] + div > span:first-child',
-		],
+		'.d-flex[class*="PullRequestHeaderSummary"]',
 		cleanPrHeader,
 		{signal},
 	);

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -20,29 +20,48 @@ async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: strin
 	}
 }
 
+function isStickyHeader(childElement: HTMLElement): boolean {
+	return Boolean(closestElementOptional([
+		'div[class*="stickyHeader"]',
+		// TODO [2027-01-01]: Drop after legacy PR files view is removed
+		'.sticky-content',
+		'.gh-header-sticky',
+	], childElement));
+}
+
+const prCreatorSelector = [
+	'.TimelineItem .author',
+	'.Timeline-Item [data-testid="author-avatar"] a:not([data-testid="github-avatar"])',
+] as const;
+async function getPrCreator(): Promise<string> {
+	return (await elementReady(prCreatorSelector))!.textContent;
+}
+
+// Hide if it's the same as the opener (always) or merger
+async function maybeHideAuthor(summaryRow: HTMLElement): Promise<void> {
+	// Extra author name is only shown on `isPRConversation`
+	if (!pageDetect.isPRConversation()) {
+		return;
+	}
+
+	// Keep author in sticky header
+	// https://github.com/refined-github/refined-github/issues/7802
+	if (isStickyHeader(summaryRow)) {
+		return;
+	}
+
+	// First link in the summary row is always the author
+	if ($('a', summaryRow).textContent === await getPrCreator()) {
+		summaryRow.classList.add('rgh-hide-author');
+	}
+}
+
 async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 	summaryRow.classList.add('rgh-clean-conversation-headers');
 
-	const prCreatorSelector = [
-		'.TimelineItem .author',
-		'.Timeline-Item [data-testid="author-avatar"] a:not([data-testid="github-avatar"])',
-	];
-
-	// Extra author name is only shown on `isPRConversation`
-	// Hide if it's the same as the opener (always) or merger
-	const shouldHideAuthor = pageDetect.isPRConversation()
-		// #7802
-		&& !closestElementOptional([
-			'div[class*="stickyHeader"]',
-			// TODO [2027-01-01]: Drop after legacy PR files view is removed
-			'.sticky-content',
-			'.gh-header-sticky',
-		], summaryRow)
-		// First link in the summary row is always the author
-		&& $('a', summaryRow).textContent === (await elementReady(prCreatorSelector))!.textContent;
-
-	if (shouldHideAuthor) {
-		summaryRow.classList.add('rgh-hide-author');
+	if (isStickyHeader(summaryRow)) {
+		// Add class here to avoid duplicating the selectors into the CSS file
+		summaryRow.classList.add('rgh-sticky-pr-header');
 	}
 
 	const base = $([
@@ -53,12 +72,18 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 		'[class^="BranchName"]',
 	], summaryRow);
 
+	// Add class here to avoid duplicating the selectors into the CSS file
+	base.classList.add('rgh-base-branch');
+
 	let baseBranch;
 	if (base.title) {
 		baseBranch = parseReferenceRaw(base.title, base.textContent).branch;
 	} else {
 		baseBranch = parseReferenceRaw(base.nextElementSibling!.textContent, base.textContent).branch;
 	}
+
+	// This can be run asynchronously
+	void maybeHideAuthor(summaryRow);
 
 	// Don't await https://github.com/refined-github/refined-github/issues/8331
 	void highlightNonDefaultBranchPrs(base, baseBranch);

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -9,7 +9,7 @@ import {$, $optional, closestElementOptional} from 'select-dom';
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {parseReferenceRaw} from '../github-helpers/pr-branches.js';
-import {assertNodeContent} from '../helpers/dom-utils.js';
+import {assertNodeContent, removeTextNodeContaining} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
 async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: string): Promise<void> {
@@ -27,6 +27,11 @@ function isStickyHeader(childElement: HTMLElement): boolean {
 		'.sticky-content',
 		'.gh-header-sticky',
 	], childElement));
+}
+
+/** The PR header username is the creator or the merger */
+function getHeaderUsername(summaryRow: HTMLElement): HTMLAnchorElement {
+	return $('a', summaryRow);
 }
 
 const prCreatorSelector = [
@@ -50,10 +55,25 @@ async function maybeHideAuthor(summaryRow: HTMLElement): Promise<void> {
 		return;
 	}
 
-	// First link in the summary row is always the author
-	if ($('a', summaryRow).textContent === await getPrCreator()) {
+	if (getHeaderUsername(summaryRow).textContent === await getPrCreator()) {
 		summaryRow.classList.add('rgh-hide-author');
 	}
+}
+
+async function hideAuthorMetadata(summaryRow: HTMLElement): Promise<void> {
+	const infoNode = getHeaderUsername(summaryRow).nextSibling!.nextSibling!;
+	console.log(infoNode);
+	removeTextNodeContaining(infoNode, /^wants to merge/);
+}
+
+function replaceFromWithArrow(base: HTMLElement): void {
+	const anchor = base.nextElementSibling!.nextElementSibling!;
+	assertNodeContent(anchor, 'from');
+	anchor.replaceWith(
+		<span className="rgh-arrow">
+			<ArrowLeftIcon className="v-align-middle mx-1 tmp-mx-1" />
+		</span>,
+	);
 }
 
 async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
@@ -64,13 +84,7 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 		summaryRow.classList.add('rgh-sticky-pr-header');
 	}
 
-	const base = $([
-		'[class^="PullRequestBranchName"]',
-		// TODO [2027-01-01]: Drop after legacy PR files view is removed
-		'.commit-ref',
-		// TODO [2026-08-01]: Drop
-		'[class^="BranchName"]',
-	], summaryRow);
+	const base = $('[class^="PullRequestBranchName"]', summaryRow);
 
 	// Add class here to avoid duplicating the selectors into the CSS file
 	base.classList.add('rgh-base-branch');
@@ -84,20 +98,13 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 
 	// This can be run asynchronously
 	void maybeHideAuthor(summaryRow);
+	void hideAuthorMetadata(summaryRow);
 
 	// Don't await https://github.com/refined-github/refined-github/issues/8331
 	void highlightNonDefaultBranchPrs(base, baseBranch);
 
 	// Shows on PRs: main [←] feature
-	const anchor = $optional('.commit-ref-dropdown', summaryRow)?.nextSibling // TODO [2027-01-01]: Drop after legacy PR files view is removed
-		?? base.nextSibling!.nextSibling!;
-	assertNodeContent(anchor, 'from');
-
-	anchor.after(
-		<span className="rgh-arrow">
-			<ArrowLeftIcon className="v-align-middle mx-1 tmp-mx-1" />
-		</span>,
-	);
+	replaceFromWithArrow(base);
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -4,7 +4,7 @@ import React from 'dom-chef';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import ArrowLeftIcon from 'octicons-plain-react/ArrowLeft';
-import {$, $optional, closestElementOptional} from 'select-dom';
+import {$, closestElementOptional} from 'select-dom';
 
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
@@ -63,7 +63,7 @@ async function maybeHideAuthor(summaryRow: HTMLElement): Promise<void> {
 async function hideAuthorMetadata(summaryRow: HTMLElement): Promise<void> {
 	const infoNode = getHeaderUsername(summaryRow).nextSibling!.nextSibling!;
 	console.log(infoNode);
-	removeTextNodeContaining(infoNode, /^wants to merge/);
+	removeTextNodeContaining(infoNode, /^(wants to merge|^merged) \d+ commit/);
 }
 
 function replaceFromWithArrow(base: HTMLElement): void {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -9,7 +9,7 @@ import {$, closestElementOptional} from 'select-dom';
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
 import {parseReferenceRaw} from '../github-helpers/pr-branches.js';
-import {assertNodeContent} from '../helpers/dom-utils.js';
+import {assertNodeContent, wrap} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
 async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: string): Promise<void> {
@@ -17,6 +17,19 @@ async function highlightNonDefaultBranchPrs(base: HTMLElement, baseBranch: strin
 	const isDefaultBranch = baseBranch === await getDefaultBranch();
 	if (!isDefaultBranch && !wasDefaultBranch) {
 		base.classList.add('rgh-non-default-branch');
+	}
+}
+
+async function removeBaseRepo(base: HTMLElement): Promise<void> {
+	const textNode = base.firstChild;
+	if (!(textNode instanceof Text)) {
+		throw new TypeError('Expected a text node');
+	}
+
+	const crossRepoPr = textNode.textContent.indexOf(':');
+	if (crossRepoPr > 0) {
+		textNode.splitText(crossRepoPr + 1);
+		wrap(textNode, <span className="sr-only" />);
 	}
 }
 
@@ -102,6 +115,7 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 
 	// Don't await https://github.com/refined-github/refined-github/issues/8331
 	void highlightNonDefaultBranchPrs(base, baseBranch);
+	void removeBaseRepo(base);
 
 	// Shows on PRs: main [←] feature
 	replaceFromWithArrow(base);

--- a/source/features/conversation-activity-filter.css
+++ b/source/features/conversation-activity-filter.css
@@ -56,18 +56,8 @@
 	}
 }
 
-.rgh-conversation-activity-filter-wrapper {
-	display: flex;
-	align-items: center;
-}
-
 /* TODO [2026-08-01]: Remove */
 .gh-header-meta {
-	.rgh-conversation-activity-filter-wrapper {
-		display: block;
-		margin-bottom: 8px; /* Preserve centered vertical alignment with status badge */
-	}
-
 	.rgh-conversation-activity-filter {
 		display: inline;
 	}

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -13,7 +13,7 @@ import features from '../feature-manager.js';
 import getCommentAuthor from '../github-helpers/get-comment-author.js';
 import {registerHotkey} from '../github-helpers/hotkey.js';
 import delay from '../helpers/delay.js';
-import {isSmallDevice, wrap} from '../helpers/dom-utils.js';
+import {isSmallDevice} from '../helpers/dom-utils.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
 
@@ -192,7 +192,6 @@ async function addWidget(anchor: Element): Promise<void> {
 	}
 
 	await delay(100); // Let `clean-conversation-headers` run first
-	wrap(position, <div className="rgh-conversation-activity-filter-wrapper" />);
 	position.classList.add('rgh-conversation-activity-filter');
 
 	const baseId = crypto.randomUUID();

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -54,6 +54,7 @@ Test URLs:
 - ✏️ deleted (from fork): https://github.com/refined-github/sandbox/pull/149
 - 🔗 deleted and restored: https://github.com/refined-github/sandbox/pull/147
 - 🔗 deleted and restored (on fork): https://github.com/refined-github/sandbox/pull/150
-- 🔗 forks that are deleted before deleting the branch are not detectable
+- 🔗 deleted and repo deleted: https://github.com/refined-github/refined-github/pull/3227
+- 🔗 forks that are deleted before deleting the branch are not detectable sometimes
 
 */


### PR DESCRIPTION
Followup to https://github.com/refined-github/refined-github/issues/9166 and #9627 

- Closes https://github.com/refined-github/refined-github/issues/9505

The code for `clean-conversation-headers` is messy and it's causing some wrapping issues in the area. `conversation-activity-filter` also adds its own wrapper, making the DOM even more flimsy.

