### PR TITLE
`rgh-feature-descriptions` - Extract svelte component

### DIFF
--- a/build/features.test.ts
+++ b/build/features.test.ts
@@ -215,6 +215,18 @@ function validateTsx(file: FeatureFile): void {
 	}
 }
 
+function validateSvelte(file: FeatureFile): void {
+	assert(
+		file.tsx.exists(),
+		'Does not match any existing features. The filename should match the feature that uses it.',
+	);
+
+	assert(
+		file.tsx.contents().includes(`from './${file.name}';`),
+		`Should be imported by \`${file.tsx.name}\``,
+	);
+}
+
 describe('features', () => {
 	const featuresDirectoryContents = readdirSync('source/features/');
 	test.each(featuresDirectoryContents)('%s', (filename: string) => {
@@ -222,18 +234,25 @@ describe('features', () => {
 			return;
 		}
 
+		const file = new FeatureFile(filename);
+
 		if (filename.endsWith('.gql')) {
-			validateGql(new FeatureFile(filename));
+			validateGql(file);
 			return;
 		}
 
 		if (filename.endsWith('.css')) {
-			validateCss(new FeatureFile(filename));
+			validateCss(file);
 			return;
 		}
 
 		if (filename.endsWith('.tsx')) {
-			validateTsx(new FeatureFile(filename));
+			validateTsx(file);
+			return;
+		}
+
+		if (filename.endsWith('.svelte')) {
+			validateSvelte(file);
 			return;
 		}
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -18,5 +18,10 @@
     "refined-github/no-optional-chaining": {
       "count": 1
     }
+  },
+  "source/features/rgh-feature-descriptions.svelte": {
+    "refined-github/no-optional-chaining": {
+      "count": 1
+    }
   }
 }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -18,10 +18,5 @@
     "refined-github/no-optional-chaining": {
       "count": 1
     }
-  },
-  "source/features/rgh-feature-descriptions.svelte": {
-    "refined-github/no-optional-chaining": {
-      "count": 1
-    }
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import sveltePlugin from 'eslint-plugin-svelte';
 import {defineConfig} from 'eslint/config';
 import {fileURLToPath} from 'node:url';
 import selectDom from 'select-dom/eslint-plugin';
+import globals from 'globals';
 import xo from 'xo';
 
 import cssDocumentation from './eslint-rules/css-documentation.js';
@@ -296,7 +297,7 @@ export default defineConfig([
 				parser: '@typescript-eslint/parser',
 			},
 			globals: {
-				browser: 'readonly',
+				...globals.browser,
 				chrome: 'readonly',
 				location: 'readonly',
 			},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,9 +5,9 @@ import byoPlugin from 'eslint-plugin-byo';
 import pluginPromise from 'eslint-plugin-promise';
 import sveltePlugin from 'eslint-plugin-svelte';
 import {defineConfig} from 'eslint/config';
+import globals from 'globals';
 import {fileURLToPath} from 'node:url';
 import selectDom from 'select-dom/eslint-plugin';
-import globals from 'globals';
 import xo from 'xo';
 
 import cssDocumentation from './eslint-rules/css-documentation.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
 				"eslint-plugin-svelte": "^3.18.0",
 				"fast-ignore": "^2.0.0",
 				"filenamify": "^7.0.1",
+				"globals": "^17.6.0",
 				"highlight.js": "^11.11.1",
 				"lightningcss": "^1.32.0",
 				"linkedom": "^0.18.12",
@@ -5747,19 +5748,6 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/eslint-config-xo/node_modules/globals": {
-			"version": "17.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-			"integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint-formatter-pretty": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-7.1.0.tgz",
@@ -7292,6 +7280,19 @@
 				}
 			}
 		},
+		"node_modules/eslint-plugin-svelte/node_modules/globals": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint-plugin-unicorn": {
 			"version": "63.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-63.0.0.tgz",
@@ -7324,6 +7325,19 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=9.38.0"
+			}
+		},
+		"node_modules/eslint-plugin-unicorn/node_modules/globals": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-rule-docs": {
@@ -8003,9 +8017,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"version": "17.6.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+			"integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13214,19 +13228,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/xo/node_modules/globals": {
-			"version": "17.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-			"integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xo/node_modules/globby": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 		"eslint-plugin-svelte": "^3.18.0",
 		"fast-ignore": "^2.0.0",
 		"filenamify": "^7.0.1",
+		"globals": "^17.6.0",
 		"highlight.js": "^11.11.1",
 		"lightningcss": "^1.32.0",
 		"linkedom": "^0.18.12",

--- a/source/features/rgh-feature-descriptions.svelte
+++ b/source/features/rgh-feature-descriptions.svelte
@@ -110,6 +110,7 @@
 			</div>
 		</div>
 
+		<!-- eslint-disable-next-line refined-github/no-optional-chaining -- Undocumented feature, no meta  -->
 		{#if meta?.screenshot}
 			<a href={meta.screenshot} class="flex-self-center">
 				<img

--- a/source/features/rgh-feature-descriptions.svelte
+++ b/source/features/rgh-feature-descriptions.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import CopyIcon from 'octicons-plain-react/Copy';
+	import * as pageDetect from 'github-url-detection';
+
+	import {getOldFeatureNames} from '../feature-data.js';
+	import {buildRepoUrl} from '../github-helpers/index.js';
+	import {isFeaturePrivate} from '../helpers/feature-utils.js';
+	import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
+	import DomChef from '../helpers/dom-chef.svelte';
+
+	// eslint-disable-next-line no-undef -- Global
+	const {id, meta}: {id: string; meta: FeatureMeta | undefined} = $props();
+
+	const wasFeatureRemoved = !meta && !isFeaturePrivate(id);
+	const isReportingBug = pageDetect.isNewIssue();
+	const pathname = isReportingBug
+		? buildRepoUrl('blob', 'main', 'source', 'features', `${id}.css`)
+		: location.pathname;
+	const isCss = pathname.endsWith('.css');
+
+	const description = meta
+		? meta.description + (meta.cssOnly ? ' This feature is CSS-only and cannot be disabled.' : '')
+		: isFeaturePrivate(id)
+			? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
+			: undefined;
+
+	const oldNames = getOldFeatureNames(id);
+
+	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
+	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
+	newIssueUrl.searchParams.set('title', `\`${id}\`  `);
+	newIssueUrl.searchParams.set('labels', 'bug, help wanted');
+</script>
+
+{#snippet featureLink(href: string, label: string)}
+	<a data-turbo-frame="repo-content-turbo-frame" {href}>{label}</a>
+{/snippet}
+
+<div class="Box mb-3 tmp-mb-3 d-inline-block width-full rgh-feature-description">
+	<div class="Box-row d-flex gap-3 flex-wrap">
+		<div class="rgh-feature-description d-flex flex-column gap-2">
+			<h3>
+				{#if description}
+					<code>{id}</code>
+					<clipboard-copy
+						aria-label="Copy"
+						data-copy-feedback="Copied!"
+						value={id}
+						class="Link--onHover color-fg-muted d-inline-block ml-2"
+						tabindex="0"
+						role="button"
+					>
+						<DomChef as={CopyIcon} class="v-align-baseline" />
+					</clipboard-copy>
+				{:else}
+					<span class="color-fg-muted">This feature is no longer part of Refined GitHub.</span>
+				{/if}
+			</h3>
+
+			{#if oldNames.length > 0}
+				<div class="color-fg-muted mt-n3 tmp-mt-n3">
+					<span class="text-small">previously named </span>
+					{#each oldNames as name, index (name)}
+						{#if index > 0}, {/if}<code>{name}</code>
+					{/each}
+				</div>
+			{/if}
+
+			{#if description}
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				<div class="h3">{@html description}</div>
+			{/if}
+
+			<div class="no-wrap">
+				<RelatedIssuesCount featureId={id} />
+				{#if !wasFeatureRemoved && !isReportingBug}
+					{@render featureLink(newIssueUrl.href, 'Report bug')}
+				{/if}
+				{#if meta}
+					{#if isCss && !meta.cssOnly}
+						{@render featureLink(pathname.replace('.css', '.tsx'), 'See .tsx file')}
+					{:else if meta.css && !isCss}
+						{@render featureLink(pathname.replace('.tsx', '.css'), 'See .css file')}
+					{/if}
+				{/if}
+				{#if wasFeatureRemoved}
+					{@render featureLink(
+						`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`,
+						'Commit history'
+					)}
+				{/if}
+			</div>
+		</div>
+
+		{#if meta?.screenshot}
+			<a href={meta.screenshot} class="flex-self-center">
+				<img
+					src={meta.screenshot}
+					class="d-block border"
+					style="max-height:100px;max-width:150px"
+					alt=""
+				/>
+			</a>
+		{/if}
+	</div>
+</div>

--- a/source/features/rgh-feature-descriptions.svelte
+++ b/source/features/rgh-feature-descriptions.svelte
@@ -1,42 +1,54 @@
 <script lang="ts">
-	import CopyIcon from 'octicons-plain-react/Copy';
 	import * as pageDetect from 'github-url-detection';
+	import CopyIcon from 'octicons-plain-react/Copy';
 
 	import {getOldFeatureNames} from '../feature-data.js';
 	import {buildRepoUrl} from '../github-helpers/index.js';
+	import DomChef from '../helpers/dom-chef.svelte';
 	import {isFeaturePrivate} from '../helpers/feature-utils.js';
 	import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
-	import DomChef from '../helpers/dom-chef.svelte';
 
 	// eslint-disable-next-line no-undef -- Global
 	const {id, meta}: {id: string; meta: FeatureMeta | undefined} = $props();
 
-	const wasFeatureRemoved = !meta && !isFeaturePrivate(id);
+	const wasFeatureRemoved = $derived(!meta && !isFeaturePrivate(id));
 	const isReportingBug = pageDetect.isNewIssue();
-	const pathname = isReportingBug
-		? buildRepoUrl('blob', 'main', 'source', 'features', `${id}.css`)
-		: location.pathname;
-	const isCss = pathname.endsWith('.css');
+	const pathname = $derived(
+		isReportingBug
+			? buildRepoUrl('blob', 'main', 'source', 'features', `${id}.css`)
+			: location.pathname,
+	);
+	const isCss = $derived(pathname.endsWith('.css'));
 
-	const description = meta
-		? meta.description + (meta.cssOnly ? ' This feature is CSS-only and cannot be disabled.' : '')
-		: isFeaturePrivate(id)
+	const description = $derived(
+		meta
+			? meta.description
+				+ (meta.cssOnly ? ' This feature is CSS-only and cannot be disabled.' : '')
+			: isFeaturePrivate(id)
 			? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
-			: undefined;
+			: undefined,
+	);
 
-	const oldNames = getOldFeatureNames(id);
+	const oldNames = $derived(getOldFeatureNames(id));
 
-	const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
-	newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-	newIssueUrl.searchParams.set('title', `\`${id}\`  `);
-	newIssueUrl.searchParams.set('labels', 'bug, help wanted');
+	const newIssueUrl = $derived.by(() => {
+		const url = new URL(
+			'https://github.com/refined-github/refined-github/issues/new',
+		);
+		url.searchParams.set('template', '1_bug_report.yml');
+		url.searchParams.set('title', `\`${id}\`  `);
+		url.searchParams.set('labels', 'bug, help wanted');
+		return url;
+	});
 </script>
 
 {#snippet featureLink(href: string, label: string)}
 	<a data-turbo-frame="repo-content-turbo-frame" {href}>{label}</a>
 {/snippet}
 
-<div class="Box mb-3 tmp-mb-3 d-inline-block width-full rgh-feature-description">
+<div
+	class="Box mb-3 tmp-mb-3 d-inline-block width-full rgh-feature-description"
+>
 	<div class="Box-row d-flex gap-3 flex-wrap">
 		<div class="rgh-feature-description d-flex flex-column gap-2">
 			<h3>
@@ -53,7 +65,9 @@
 						<DomChef as={CopyIcon} class="v-align-baseline" />
 					</clipboard-copy>
 				{:else}
-					<span class="color-fg-muted">This feature is no longer part of Refined GitHub.</span>
+					<span class="color-fg-muted">
+						This feature is no longer part of Refined GitHub.
+					</span>
 				{/if}
 			</h3>
 
@@ -74,19 +88,23 @@
 			<div class="no-wrap">
 				<RelatedIssuesCount featureId={id} />
 				{#if !wasFeatureRemoved && !isReportingBug}
+					•
 					{@render featureLink(newIssueUrl.href, 'Report bug')}
 				{/if}
 				{#if meta}
 					{#if isCss && !meta.cssOnly}
+						•
 						{@render featureLink(pathname.replace('.css', '.tsx'), 'See .tsx file')}
 					{:else if meta.css && !isCss}
+						•
 						{@render featureLink(pathname.replace('.tsx', '.css'), 'See .css file')}
 					{/if}
 				{/if}
 				{#if wasFeatureRemoved}
+					•
 					{@render featureLink(
 						`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`,
-						'Commit history'
+						'Commit history',
 					)}
 				{/if}
 			</div>
@@ -97,7 +115,7 @@
 				<img
 					src={meta.screenshot}
 					class="d-block border"
-					style="max-height:100px;max-width:150px"
+					style="max-height: 100px; max-width: 150px"
 					alt=""
 				/>
 			</a>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -3,149 +3,26 @@ import './rgh-feature-descriptions.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import AlertIcon from 'octicons-plain-react/Alert';
-import CopyIcon from 'octicons-plain-react/Copy';
 import InfoIcon from 'octicons-plain-react/Info';
 import delegate from 'delegate-it';
 import {mount} from 'svelte';
 
-import {featuresMeta, getNewFeatureName, getOldFeatureNames} from '../feature-data.js';
+import {featuresMeta, getNewFeatureName} from '../feature-data.js';
 import features from '../feature-manager.js';
 import createBanner from '../github-helpers/banner.js';
-import {buildRepoUrl, isRefinedGitHubRepo} from '../github-helpers/index.js';
-import {isFeaturePrivate} from '../helpers/feature-utils.js';
+import {isRefinedGitHubRepo} from '../github-helpers/index.js';
 import {brokenFeatures} from '../helpers/hotfix.js';
-import joinJsx from '../helpers/join-jsx.js';
 import openOptions from '../helpers/open-options.js';
-import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
 import {createRghIssueLink} from '../helpers/rgh-links.js';
 import observe from '../helpers/selector-observer.js';
 import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import {openInNewTab} from './prevent-comment-loss.js';
-
-function getLinksElement(id: string, meta: FeatureMeta | undefined): JSX.Element {
-	const wasFeatureRemoved = !meta && !isFeaturePrivate(id);
-	const isReportingBug = pageDetect.isNewIssue();
-	const pathname = isReportingBug
-		// Use .css so that it links to the .tsx file
-		? buildRepoUrl('blob', 'main', 'source', 'features', `${id}.css`)
-		: location.pathname;
-	const isCss = pathname.endsWith('.css');
-
-	const links = [];
-
-	const relatedIssuesContainer = <span />;
-	mount(RelatedIssuesCount, {
-		target: relatedIssuesContainer,
-		props: {
-			featureId: id,
-		},
-	});
-	links.push(relatedIssuesContainer);
-
-	if (!wasFeatureRemoved && !isReportingBug) {
-		const newIssueUrl = new URL('https://github.com/refined-github/refined-github/issues/new');
-		newIssueUrl.searchParams.set('template', '1_bug_report.yml');
-		newIssueUrl.searchParams.set('title', `\`${id}\`  `); // Trailing double-space to avoid triggering datalist autocomplete
-		newIssueUrl.searchParams.set('labels', 'bug, help wanted');
-		links.push(
-			<a data-turbo-frame="repo-content-turbo-frame" href={newIssueUrl.href}>Report bug</a>,
-		);
-	}
-
-	if (meta) {
-		if (isCss && !meta.cssOnly) {
-			links.push(
-				<a data-turbo-frame="repo-content-turbo-frame" href={pathname.replace('.css', '.tsx')}>See .tsx file</a>,
-			);
-		} else if (meta.css && !isCss) {
-			links.push(
-				<a data-turbo-frame="repo-content-turbo-frame" href={pathname.replace('.tsx', '.css')}>See .css file</a>,
-			);
-		}
-	}
-
-	if (wasFeatureRemoved) {
-		links.push(
-			// This links to the full commit history, which will start with the commit that removed the file
-			<a
-				data-turbo-frame="repo-content-turbo-frame"
-				href={`https://github.com/refined-github/refined-github/commits/main/source/features/${id}.tsx`}
-			>
-				Commit history
-			</a>,
-		);
-	}
-
-	return <div className="no-wrap">{joinJsx(' • ', links)}</div>;
-}
+import Description from './rgh-feature-descriptions.svelte';
 
 function addDescription(anchor: HTMLElement, id: string, meta: FeatureMeta | undefined): void {
-	const description = meta
-		? meta.description + (meta.cssOnly ? ' This feature is CSS-only and cannot be disabled.' : '')
-		: (
-			isFeaturePrivate(id)
-				? 'This feature applies only to "Refined GitHub" repositories and cannot be disabled.'
-				: undefined // The heck!?
-		);
-
-	const oldNames = getOldFeatureNames(id);
-
-	anchor.before(
-		// Block and width classes required to avoid margin collapse
-		<div className="Box mb-3 tmp-mb-3 d-inline-block width-full rgh-feature-description">
-			<div className="Box-row d-flex gap-3 flex-wrap">
-				<div className="rgh-feature-description d-flex flex-column gap-2">
-					<h3>
-						{
-							description
-								? <>
-									<code>{id}</code>
-									<clipboard-copy
-										aria-label="Copy"
-										data-copy-feedback="Copied!"
-										value={id}
-										class="Link--onHover color-fg-muted d-inline-block ml-2"
-										tabindex="0"
-										role="button"
-									>
-										<CopyIcon className="v-align-baseline" />
-									</clipboard-copy>
-								</>
-								: <span className="color-fg-muted">
-									This feature is no longer part of Refined GitHub.
-								</span>
-						}
-					</h3>
-					{oldNames.length > 0 && (
-						<div className="color-fg-muted mt-n3 tmp-mt-n3">
-							<span className="text-small">previously named </span>
-							{oldNames.map((name, index) => (
-								<React.Fragment key={name}>
-									{index > 0 && ', '}
-									<code>{name}</code>
-								</React.Fragment>
-							))}
-						</div>
-					)}
-					{description && <div dangerouslySetInnerHTML={{__html: description}} className="h3" />}
-					{getLinksElement(id, meta)}
-				</div>
-				{/* eslint-disable-next-line refined-github/no-optional-chaining -- Undocumented feature, no meta */}
-				{meta?.screenshot && (
-					<a href={meta.screenshot} className="flex-self-center">
-						<img
-							src={meta.screenshot}
-							className="d-block border"
-							style={{
-								maxHeight: 100,
-								maxWidth: 150,
-							}}
-						/>
-					</a>
-				)}
-			</div>
-		</div>,
-	);
+	const container = <div />;
+	mount(Description, {target: container, props: {id, meta}});
+	anchor.before(container);
 }
 
 async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {

--- a/source/helpers/dom-chef.svelte
+++ b/source/helpers/dom-chef.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import React from 'dom-chef';
+  import type { Action } from 'svelte/action';
+
+  // eslint-disable-next-line svelte/no-unused-svelte-ignore
+  // svelte-ignore custom_element_props_identifier -- No custom element here
+  const { as, ...props }: { as: (..._props: any[]) => HTMLElement; [key: string]: unknown } = $props();
+
+  const mount: Action<HTMLElement> = (node) => {
+    const element = React.createElement(as, props);
+		if (element instanceof DocumentFragment) {
+			throw new TypeError('The component must return a single root element');
+		}
+
+    node.replaceWith(element);
+    return { destroy: () => element.remove() };
+  };
+</script>
+<span use:mount></span>

--- a/source/helpers/dom-chef.svelte
+++ b/source/helpers/dom-chef.svelte
@@ -1,19 +1,22 @@
 <script lang="ts">
-  import React from 'dom-chef';
-  import type { Action } from 'svelte/action';
+	import React from 'dom-chef';
+	import type {Action} from 'svelte/action';
 
-  // eslint-disable-next-line svelte/no-unused-svelte-ignore
-  // svelte-ignore custom_element_props_identifier -- No custom element here
-  const { as, ...props }: { as: (..._props: any[]) => HTMLElement; [key: string]: unknown } = $props();
+	// eslint-disable-next-line svelte/no-unused-svelte-ignore
+	// svelte-ignore custom_element_props_identifier -- No custom element here
+	const {as, ...props}: {
+		as: (..._props: any[]) => HTMLElement;
+		[key: string]: unknown;
+	} = $props();
 
-  const mount: Action<HTMLElement> = (node) => {
-    const element = React.createElement(as, props);
+	const mount: Action<HTMLElement> = (node) => {
+		const element = React.createElement(as, props);
 		if (element instanceof DocumentFragment) {
 			throw new TypeError('The component must return a single root element');
 		}
 
-    node.replaceWith(element);
-    return { destroy: () => element.remove() };
-  };
+		node.replaceWith(element);
+		return {destroy: () => element.remove()};
+	};
 </script>
 <span use:mount></span>


### PR DESCRIPTION
- Retrying https://github.com/refined-github/refined-github/pull/9357
- Prepares `rgh-feature-descriptions` for #6554 

## Screenshots

<img width="872" height="277" alt="Screenshot" src="https://github.com/user-attachments/assets/b260da87-0627-41e4-a98c-cc2f6e4e35d5" />
<img width="938" height="452" alt="Screenshot 1" src="https://github.com/user-attachments/assets/370df953-d8ae-4a36-ba59-f2c25bad9c2d" />

<!--
extract the menu component into `source/features/conversation-activity-filter.svelte`
the component should be self-contained for its update logic and it should accept a callback that is triggered when the user changes state. note that the component is already half-managed by global listeners, so do not add any logic that isn't already there. for example do not move any event listeners. 
any rgh- classes used only by this component should be moved to the .svelte file. feel free to short them since they're no longer global.
note that this component will be used twice on the page, so make sure that its state is updated when the other one changes the page's state.
other than the rgh classes, do not change the dom at all.
you can use the icons via dom-chef.svelte component -->