### PR TITLE
`sort-conversations-by-update-time` - Exclude new PR inbox beta

### DIFF
--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -17,7 +17,8 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 	}
 
 	// Exclude /pulls/ global pages since they're already sorted by update time #9604
-	if (/^[/]pulls[/]\w+$/.test(link.pathname)) {
+	// This also breaks the feature on the header button regardless of the PR inbox beta status. This is because the feature breaks the inbox, overriding the user's preference.
+	if (/^[/]pulls[/]\w+$/.test(link.pathname) || link.matches('[href="/pulls"][class*="appHeaderButton"]')) {
 		return;
 	}
 

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -16,6 +16,11 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 		return;
 	}
 
+	// Exclude /pulls/ global pages since they're already sorted by update time #9604
+	if (/^[/]pulls[/]\w+$/.test(link.pathname)) {
+		return;
+	}
+
 	// Pick only links to lists, not single issues
 	// + skip pagination links
 	// + skip pr/issue filter dropdowns (some are lazyloaded)


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9604


## Test URLs

https://github.com/pulls/inbox

## New sub-pages ignored

<img width="312" height="142" alt="Screenshot 2" src="https://github.com/user-attachments/assets/676f19d7-3c50-466c-9da0-cd9f3bd9368e" />

## Header link ignored

I can't find a way to detect the new PR UI, so we just have to disable it on the main button at least. Hopefully they'll realize this issue (`/pulls` **redirects** to `/pulls/inbox`) and will just update the link instead.

<img width="791" height="144" alt="sym" src="https://github.com/user-attachments/assets/c375fcb1-fcc2-415e-8a90-375e9ca585be" />
