### PR TITLE
`show-open-prs-of-forks` - Restore on fork deletion page

### DIFF
--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -87,6 +87,7 @@ void features.add(import.meta.url, {
 		pageDetect.isForkedRepo,
 	],
 	deduplicate: 'has-rgh',
+	requiresToken: true,
 	init: initHeadHint,
 }, {
 	asLongAs: [
@@ -96,6 +97,7 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoMainSettings,
 	],
 	deduplicate: 'has-rgh',
+	requiresToken: true,
 	init: initDeleteHint,
 });
 

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -76,7 +76,7 @@ async function initDeleteHint(): Promise<void | false> {
 		return false;
 	}
 
-	$('details-dialog[aria-label*="Delete"] .Box-body p:first-child').after(
+	$('#repo-delete-proceed-button-container').before(
 		<p className="flash flash-warn">
 			It will also abandon <a href={url}>your {getLinkCopy(count)}</a> in <strong>{getForkedRepo()!}</strong>{' '}
 			and you’ll no longer be able to edit {count === 1 ? 'it' : 'them'}.

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -86,7 +86,6 @@ void features.add(import.meta.url, {
 	asLongAs: [
 		pageDetect.isForkedRepo,
 	],
-	deduplicate: 'has-rgh',
 	requiresToken: true,
 	init: initHeadHint,
 }, {
@@ -96,7 +95,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoMainSettings,
 	],
-	deduplicate: 'has-rgh',
 	requiresToken: true,
 	init: initDeleteHint,
 });

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -9,6 +9,7 @@ import api from '../github-helpers/api.js';
 import {getForkedRepo, getLoggedInUser, getRepo} from '../github-helpers/index.js';
 import pluralize from '../helpers/pluralize.js';
 import GetPRs from './show-open-prs-of-forks.gql';
+import observe from '../helpers/selector-observer.js';
 
 const countPrs = new CachedFunction('prs-on-forked-repo', {
 	async updater(forkedRepo: string): Promise<{count: number; firstPr?: number}> {
@@ -53,17 +54,19 @@ async function getPrs(): Promise<[prCount: number, url: string] | []> {
 	return [count, url.href];
 }
 
-async function initHeadHint(): Promise<void | false> {
+async function initHeadHint(signal: AbortSignal): Promise<void | false> {
 	const [count, url] = await getPrs();
 	if (!count) {
 		return false;
 	}
 
-	$(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`).after(
-		' with ',
-		// The class is used by `quick-fork-deletion`
-		<a href={url} className="rgh-open-prs-of-forks">{pluralize(count, 'one open pull request', '$$+ open pull requests')}</a>,
-	);
+	// Use the observer because GitHub randomly updates the header and removes the hint after load
+	observe(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`, (repoHeader): void => {
+		repoHeader.after(
+			' with ',
+			<a href={url}>{pluralize(count, 'one open pull request', '$$+ open pull requests')}</a>,
+		);
+	}, {signal});
 }
 
 async function initDeleteHint(): Promise<void | false> {

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -10,10 +10,6 @@ import {getForkedRepo, getLoggedInUser, getRepo} from '../github-helpers/index.j
 import pluralize from '../helpers/pluralize.js';
 import GetPRs from './show-open-prs-of-forks.gql';
 
-function getLinkCopy(count: number): string {
-	return pluralize(count, 'one open pull request', 'at least $$ open pull requests');
-}
-
 const countPrs = new CachedFunction('prs-on-forked-repo', {
 	async updater(forkedRepo: string): Promise<{count: number; firstPr?: number}> {
 		const {search} = await api.v4(GetPRs, {
@@ -66,7 +62,7 @@ async function initHeadHint(): Promise<void | false> {
 	$(`[data-hovercard-type="repository"][href="/${getForkedRepo()!}"]`).after(
 		' with ',
 		// The class is used by `quick-fork-deletion`
-		<a href={url} className="rgh-open-prs-of-forks">{getLinkCopy(count)}</a>,
+		<a href={url} className="rgh-open-prs-of-forks">{pluralize(count, 'one open pull request', '$$+ open pull requests')}</a>,
 	);
 }
 
@@ -78,8 +74,7 @@ async function initDeleteHint(): Promise<void | false> {
 
 	$('#repo-delete-proceed-button-container').before(
 		<p className="flash flash-warn">
-			It will also abandon <a href={url}>your {getLinkCopy(count)}</a> in <strong>{getForkedRepo()!}</strong>{' '}
-			and you’ll no longer be able to edit {count === 1 ? 'it' : 'them'}.
+			It will also close your <a href={url}>{pluralize(count, 'open pull request', '$$+ open pull requests')}</a> in <strong>{getForkedRepo()!}</strong>.
 		</p>,
 	);
 }


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/8216


## Test URLs



1. Open https://github.com/pulls/authored?q=is%3Apr+%28author%3A%40me+OR+%28author%3A%40copilot+assignee%3A%40me%29%29+state%3Aopen++-user%3A%40me
2. Open any of your forks
3. Open settings page
4. Open console

For me that was https://github.com/fregante/node-sandboxed-module/settings


## Screenshot

<img width="496" height="365" alt="Screenshot 6" src="https://github.com/user-attachments/assets/070c2025-c76f-45d4-be49-e39d6b33d756" />

