### PR TITLE
`release-download-count` - Restore support for GitHub Enterprise

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,6 +1,6 @@
 /* Simulates fixed columns */
 .rgh-release-download-count {
-	& > span:not(:last-child) {
+	& > span:not(:last-child, [data-view-component]) {
 		flex-basis: 0 !important;
 		min-width: 5em;
 	}

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -48,7 +48,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		const downloadCount = assets[assetLink.pathname.split('/').pop()!] ?? 0;
 
 		// Re-align the asset size
-		const assetSize = $(':scope > .flex-justify-end > span', closestElement('.Box-row', assetLink));
+		const assetSize = $(':scope > .flex-justify-end > span:has(+ span relative-time)', closestElement('.Box-row', assetLink));
 		assertNodeContent(assetSize.firstChild, /^\d+(\.\d+)? \w{2,5}$/);
 
 		assetSize.classList.replace('text-sm-left', 'text-md-right');


### PR DESCRIPTION
Fix `release-download-count` on GHES

GHES DOM looks like

```html
<span .../> <!-- SHA1 -->
<span .../> <!-- SHA1 copy button -->
<span .../> <!-- Size -->
<span .../> <!-- Date -->
```

while github.com DOM has a nested `<div>`:
```html
<div>
  <span .../> <!-- SHA1 -->
  <span .../> <!-- SHA1 copy button -->
</div>
<span .../> <!-- Size -->
<span .../> <!-- Date -->
```

This change:

- Fixes finding the assetSize column

- Fixes CSS by excluding the copy button column (data-view-component)
  for fixed-width (min-size) columns, which would become too large
  otherwise.

Closes #9210.