### PR TITLE
`new-tab-links` - Improve detection

### DIFF
--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -8,7 +8,7 @@ import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
 
 function disableLink(link: HTMLAnchorElement): void {
-	if (link.getAttribute('href') !== location.pathname) {
+	if (link.getAttribute('href') !== location.pathname + location.search) {
 		throw new Error('The template chooser bug might have been fixed');
 	}
 

--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -7,8 +7,12 @@ import onAlteredClick from '../helpers/on-altered-click.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
 
+// Cache it just like their modal
+// https://github.com/refined-github/refined-github/issues/9641
+const {pathname} = location;
+
 function disableLink(link: HTMLAnchorElement): void {
-	if (link.getAttribute('href') !== location.pathname) {
+	if (link.getAttribute('href') !== pathname) {
 		throw new Error('The template chooser bug might have been fixed');
 	}
 

--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -15,9 +15,11 @@ function disableLink(link: HTMLAnchorElement): void {
 	link.removeAttribute('href');
 }
 
+export const newIssueModalDeadLinks = 'div[data-testid="repository-and-template-picker-dialog"] a';
+
 function initDeadLinksOnce(): void {
 	// Explanation: https://github.com/refined-github/refined-github/issues/9615
-	observe('div[data-testid="repository-and-template-picker-dialog"] a', disableLink);
+	observe(newIssueModalDeadLinks, disableLink);
 }
 
 function openSearchResultInNewTab(event: DelegateEvent<PointerEvent, HTMLElement>): void {

--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -8,7 +8,7 @@ import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
 
 function disableLink(link: HTMLAnchorElement): void {
-	if (link.getAttribute('href') !== location.pathname + location.search) {
+	if (link.getAttribute('href') !== location.pathname) {
 		throw new Error('The template chooser bug might have been fixed');
 	}
 

--- a/source/features/new-tab-links.tsx
+++ b/source/features/new-tab-links.tsx
@@ -7,7 +7,7 @@ import onAlteredClick from '../helpers/on-altered-click.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
 
-// Cache it just like their modal
+// Cache it just like their modal does
 // https://github.com/refined-github/refined-github/issues/9641
 const {pathname} = location;
 

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -5,6 +5,7 @@ import features from '../feature-manager.js';
 import SearchQuery from '../github-helpers/search-query.js';
 import {linksToConversationLists} from '../github-helpers/selectors.js';
 import observe from '../helpers/selector-observer.js';
+import {newIssueModalDeadLinks} from './new-tab-links.js';
 
 /** Keep the original URL on the element so that `shorten-links` can use it reliably #5890 */
 export function saveOriginalHref(link: HTMLAnchorElement): void {
@@ -13,6 +14,12 @@ export function saveOriginalHref(link: HTMLAnchorElement): void {
 
 async function updateLink(link: HTMLAnchorElement): Promise<void> {
 	if (link.host !== location.host) {
+		return;
+	}
+
+	// Avoid conflict with `new-tab-links` in New Issue modal
+	// https://github.com/refined-github/refined-github/pull/9640/changes#r3328459390
+	if (link.matches(newIssueModalDeadLinks)) {
 		return;
 	}
 


### PR DESCRIPTION
The modal links only use the `pathname`, but `sort-conversations-by-update-time` swoops in and adds the query to these dead links.


## Test URLs

https://github.com/refined-github/refined-github/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+


## Screenshot 

(notice no link in status bar)

<img width="352" height="481" alt="Screenshot 13" src="https://github.com/user-attachments/assets/1a0ff8af-6dca-46f9-b874-c05f7ed18d85" />

