### PR TITLE
AI SPAM

### DIFF
--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -61,7 +61,9 @@ function removeAllFilters(link: HTMLAnchorElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.table-list-header-toggle.states a', removeAllFilters, {signal});
+	// PRs page: uses the old .table-list-header-toggle.states a structure
+	// Issues page: uses the new React-based list view with tabsContainer-based links
+	observe('.table-list-header-toggle.states a, [class*="tabsContainer"] a', removeAllFilters, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -77,6 +79,7 @@ void features.add(import.meta.url, {
 Test URLs:
 
 - Regular: https://github.com/sindresorhus/refined-github/pulls
+- Issues: https://github.com/refined-github/refined-github/issues
 - "Merged" view: https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Amerged
 
 */


### PR DESCRIPTION
## What

The `extend-conversation-status-filters` feature selector `.table-list-header-toggle.states a` only matched the old GitHub DOM structure still used on the PRs list page. GitHub recently rolled out a new React-based list view on the Issues page that uses a different HTML structure (`ListItems-module__tabsContainer` with `SectionFilterLink` anchors), so the selector found no elements on `/issues` pages.

Updated the `observe()` call to use a combined selector that matches both:
- The old structure on PRs pages: `.table-list-header-toggle.states a`
- The new React list view on Issues pages: `[class*="tabsContainer"] a`

## Why

The feature was silently doing nothing on Issues pages, leaving the state filter links (Open/Closed) without the expected Refined GitHub cleanup (checkmark icons on the selected filter, octicon removal).

## Testing

- Before: feature works on `/pulls` pages, does nothing on `/issues` pages
- After: feature works on both `/issues` and `/pulls` pages
- The `addMergeLink` (Merged/Unmerged filter) correctly remains PR-only via the existing `!pageDetect.isPRList()` guard
- The `removeAllFilters` logic (octicons + checkmark cleanup) now applies to both pages
