### PR TITLE
Fix GitHub bug: symbolic links are unnecessarily highlighted

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -297,6 +297,16 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	}
 }
 
+/* Fix symlink files being colored as regular links in repository file lists */
+/* Info: https://github.com/refined-github/refined-github/issues/9625 */
+/* Test: https://github.com/refined-github/refined-github */
+.react-directory-filename-column:has(
+	:is(.octicon-file-symlink-directory, .octicon-file-symlink-file)
+)
+	a:not(:hover) {
+	color: var(--fgColor-default, var(--color-fg-default, fuchsia));
+}
+
 /* Fix checkmark on a deselected item disappearing with a noticeable delay */
 /* Info: https://github.com/refined-github/refined-github/issues/9348 */
 /* Test: https://github.com/refined-github/refined-github/issues/9348 */

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -300,11 +300,8 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 /* Fix symlink files being colored as regular links in repository file lists */
 /* Info: https://github.com/refined-github/refined-github/issues/9625 */
 /* Test: https://github.com/refined-github/refined-github */
-.react-directory-filename-column:has(
-	:is(.octicon-file-symlink-directory, .octicon-file-symlink-file)
-)
-	a:not(:hover) {
-	color: var(--fgColor-default, var(--color-fg-default, fuchsia));
+.react-directory-filename-column a[aria-label$=', (Symlink to file)'] {
+	color: var(--fgColor-default, fuchsia);
 }
 
 /* Fix checkmark on a deselected item disappearing with a noticeable delay */


### PR DESCRIPTION
Fixes #9625

This restores the default file-list text color for symlink entries, which GitHub currently renders as regular blue links because they lack the `Link--primary` class.

Checks run:
- `npx dprint check source/features/github-bugs.css`
- `npx biome lint source/features/github-bugs.css`
- `npx eslint source/features/github-bugs.css`
- `npm run build:bundle`