### PR TITLE
`release-download-count` - Prevent hash from being clipped

### DIFF
--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -62,8 +62,11 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		// Add class to parent in order to define "columns"
 		assetSize.parentElement!.classList.add('rgh-release-download-count', 'gap-4');
 
+		const hash = $optional(':scope > div:has(clipboard-copy)', assetSize.parentElement!);
 		// Hide sha on mobile. They have the classes but they're not correct (they hide in mid sizes, but show on smallest and largest)
-		$optional(':scope > div:has(clipboard-copy)', assetSize.parentElement!)?.classList.add('d-none');
+		hash?.classList.add('d-none');
+		// Prevent sha from being clipped
+		hash?.style.setProperty('min-width', '100px');
 
 		// Add at the beginning of the line to avoid content shift
 		assetSize.parentElement!.prepend(


### PR DESCRIPTION
Fix #9638


## Test URLs

https://github.com/cli/cli/releases


## Screenshot

https://github.com/user-attachments/assets/579498a1-4389-4d33-9ef1-7fca885258d0

