### PR TITLE
`quick-file-edit` - Support symbolic links

### DIFF
--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -3,7 +3,7 @@ import './quick-file-edit.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import PencilIcon from 'octicons-plain-react/Pencil';
-import {$, closestElement} from 'select-dom';
+import {$} from 'select-dom';
 
 import features from '../feature-manager.js';
 import GitHubFileUrl from '../github-helpers/github-file-url.js';

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -13,7 +13,7 @@ import {wrap} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
 async function linkifyIcon(fileIcon: Element): Promise<void> {
-	const fileLink = $('a.Link--primary', closestElement('.react-directory-filename-column', fileIcon));
+	const fileLink = $('.react-directory-filename-cell a', closestElement('.react-directory-filename-column', fileIcon));
 
 	const url = new GitHubFileUrl(fileLink.href).assign({
 		route: 'edit',

--- a/source/features/quick-file-edit.tsx
+++ b/source/features/quick-file-edit.tsx
@@ -13,7 +13,7 @@ import {wrap} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
 async function linkifyIcon(fileIcon: Element): Promise<void> {
-	const fileLink = $('.react-directory-filename-cell a', closestElement('.react-directory-filename-column', fileIcon));
+	const fileLink = $('.react-directory-filename-cell a', fileIcon.parentElement!);
 
 	const url = new GitHubFileUrl(fileLink.href).assign({
 		route: 'edit',

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -52,7 +52,8 @@ export const branchSelectorParent = 'details#branch-select-menu';
 export const branchSelectorParent_ = branchSelector_;
 
 // .color-fg-muted selects only files; some icon extensions use `img` tags
-export const directoryListingFileIcon = '.react-directory-filename-column > :is(:is(svg, img).color-fg-muted, .octicon-file-symlink-file)';
+export const directoryListingFileIcon =
+	'.react-directory-filename-column > :is(:is(svg, img).color-fg-muted, .octicon-file-symlink-file)';
 export const directoryListingFileIcon_ = [
 	[18, 'https://github.com/refined-github/refined-github'],
 	[3, 'https://github.com/refined-github/refined-github/tree/main/.github'],

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -52,7 +52,7 @@ export const branchSelectorParent = 'details#branch-select-menu';
 export const branchSelectorParent_ = branchSelector_;
 
 // .color-fg-muted selects only files; some icon extensions use `img` tags
-export const directoryListingFileIcon = '.react-directory-filename-column > :is(svg, img).color-fg-muted';
+export const directoryListingFileIcon = '.react-directory-filename-column > :is(:is(svg, img).color-fg-muted, .octicon-file-symlink-file)';
 export const directoryListingFileIcon_ = [
 	[18, 'https://github.com/refined-github/refined-github'],
 	[3, 'https://github.com/refined-github/refined-github/tree/main/.github'],

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -53,7 +53,7 @@ export const branchSelectorParent_ = branchSelector_;
 
 // .color-fg-muted selects only files; some icon extensions use `img` tags
 export const directoryListingFileIcon =
-	'.react-directory-filename-column > :is(:is(svg, img).color-fg-muted, .octicon-file-symlink-file)';
+	'.react-directory-filename-column > :is(svg, img):is(.color-fg-muted, .octicon-file-symlink-file)';
 export const directoryListingFileIcon_ = [
 	[18, 'https://github.com/refined-github/refined-github'],
 	[3, 'https://github.com/refined-github/refined-github/tree/main/.github'],


### PR DESCRIPTION
Fix #9624

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot

https://github.com/user-attachments/assets/0d2a26af-2d3a-4e0f-ad87-a897fa2a551e

