### PR TITLE
Revert "`show-names` - Fix parens wrapping"

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -23,7 +23,7 @@ async function dropExtraCopy(link: HTMLAnchorElement): Promise<void> {
 
 function createElement(element: HTMLAnchorElement, fullName: string): JSX.Element {
 	const nameElement = (
-		<span className="color-fg-muted css-truncate d-inline-block rgh-show-names no-wrap">
+		<span className="color-fg-muted css-truncate d-inline-block rgh-show-names">
 			{/* .css-truncate-target sets display: inline-block and confines bidi overrides #8191 */}
 			(<span className="css-truncate-target" style={{maxWidth: '200px'}}>{fullName}</span>)
 		</span>


### PR DESCRIPTION
#### Description

Reverts commit https://github.com/refined-github/refined-github/commit/17861148a4f7b37fe08e096cbf1d591230d49c4b because it makes all comment content overflow.

- Closes #9653 