### PR TITLE
AI SPAM

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -275,3 +275,12 @@ fieldset[class*='ReviewMenu-module__RadioGroup'] {
 		}
 	}
 }
+
+/* Allow comment headers to wrap on mobile */
+/* Info: https://github.com/refined-github/refined-github/issues/9623 */
+/* Test: https://github.com/refined-github/sandbox/issues/131 */
+@media (max-width: 768px) {
+	:is([data-testid='comment-header'], .timeline-comment-header) h3 {
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
Fixes #9623

## Test URLs

https://github.com/refined-github/sandbox/issues/131

## Screenshot

N/A - CSS-only mobile wrapping fix. I verified the change is limited to `source/refined-github.css`.