### PR TITLE
AI SPAM

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -53,6 +53,10 @@ const menuItemClass = 'rgh-conversation-activity-filter-menu-item';
 const hiddenClassName = 'rgh-conversation-activity-filtered-event';
 const collapsedClassName = 'rgh-conversation-activity-collapsed-comment';
 const botClassName = 'rgh-conversation-activity-bot-comment';
+const issueHeaderMetadataSelector = [
+	'[class^="HeaderMetadata-module__metadataContent"]',
+	'[class*="HeaderMetadata-module__smallMetadataRow"]',
+] as const;
 const timelineItem = [
 	'.js-timeline-item',
 	// React issue pages
@@ -263,7 +267,11 @@ async function addWidget(anchor: Element): Promise<void> {
 		</action-menu>
 	);
 
-	position.after(menu);
+	if (issueHeaderMetadataSelector.some(selector => anchor.matches(selector))) {
+		anchor.append(menu);
+	} else {
+		position.after(menu);
+	}
 }
 
 function uncollapseTargetedComment(): void {
@@ -300,8 +308,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe(
 		[
 			// Issue view
-			'[class^="HeaderMetadata-module__metadataContent"]',
-			'[class*="HeaderMetadata-module__smallMetadataRow"]',
+			...issueHeaderMetadataSelector,
 			// PR view
 			'[class*="PullRequestHeaderSummary-module"] > .d-flex',
 			// Old PR view


### PR DESCRIPTION
## Summary

- share the React issue header metadata selector list used by `conversation-activity-filter`
- append the activity filter menu inside React issue metadata rows so normal and sticky issue headers keep the control inline
- keep PR and legacy header placement on the existing sibling insertion path

Fixes https://github.com/refined-github/refined-github/issues/9657

## Validation

- `npm run lint:eslint -- source/features/conversation-activity-filter.tsx` (passes with existing repo warnings outside this change)
- DOM fixture validation from the original patch handoff confirmed normal and sticky React issue headers place the menu as a direct metadata-row child, while the PR header path remains unchanged
