### PR TITLE
Make collapsed diffs more visually distinct

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -276,12 +276,11 @@ fieldset[class*='ReviewMenu-module__RadioGroup'] {
 	}
 }
 
-
 /* Make collapsed diffs more visually distinct */
 /* Info: https://github.com/refined-github/refined-github/issues/7338 */
 /* Test: https://github.com/refined-github/refined-github/pull/7212/changes */
 /* Test: https://github.com/refined-github/refined-github/pull/7212/changes/b6ef35a9811a5e32d1758a74db75459b028e49d0 */
 /* Test: https://github.com/refined-github/refined-github/commit/b6ef35a9811a5e32d1758a74db75459b028e49d0 */
-[class*="HiddenDiffPatch-module__gridColumnTemplate"] {
-    margin-block: 6em;
+[class*='HiddenDiffPatch-module__gridColumnTemplate'] {
+	margin-block: 6em;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -275,3 +275,13 @@ fieldset[class*='ReviewMenu-module__RadioGroup'] {
 		}
 	}
 }
+
+
+/* Make collapsed diffs more visually distinct */
+/* Info: https://github.com/refined-github/refined-github/issues/7338 */
+/* Test: https://github.com/refined-github/refined-github/pull/7212/changes */
+/* Test: https://github.com/refined-github/refined-github/pull/7212/changes/b6ef35a9811a5e32d1758a74db75459b028e49d0 */
+/* Test: https://github.com/refined-github/refined-github/commit/b6ef35a9811a5e32d1758a74db75459b028e49d0 */
+[class*="HiddenDiffPatch-module__gridColumnTemplate"] {
+    margin-block: 6em;
+}


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/7338

Crazy to me that nobody picked this up for 2 years

## Test URLs


https://github.com/refined-github/refined-github/pull/7212/changes 
[`b6ef35a` (#7212)](https://github.com/refined-github/refined-github/pull/7212/changes/b6ef35a9811a5e32d1758a74db75459b028e49d0)
https://github.com/refined-github/refined-github/commit/b6ef35a9811a5e32d1758a74db75459b028e49d0 

## Screenshot

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="572" height="812" alt="Screenshot 15" src="https://github.com/user-attachments/assets/5c8971e5-dda5-44ed-9086-c9d386c4018b" /> 
 <td valign=top><img width="572" height="986" alt="Screenshot 14" src="https://github.com/user-attachments/assets/d12887aa-235b-4174-b342-25fae95de25c" />
</table>