### PR TITLE
`repo-header-info` - Add link to source of fork

### DIFF
--- a/source/features/repo-header-info.gql
+++ b/source/features/repo-header-info.gql
@@ -1,10 +1,10 @@
 query GetRepositoryInfo($owner: String!, $name: String!) {
-  repository(owner: $owner, name: $name) {
-    stargazerCount
-    isPrivate
-    viewerHasStarred
-    forked: parent {
-      url
-    }
-  }
+	repository(owner: $owner, name: $name) {
+		stargazerCount
+		isPrivate
+		viewerHasStarred
+		forked: parent {
+			url
+		}
+	}
 }

--- a/source/features/repo-header-info.gql
+++ b/source/features/repo-header-info.gql
@@ -1,8 +1,10 @@
 query GetRepositoryInfo($owner: String!, $name: String!) {
-	repository(owner: $owner, name: $name) {
-		stargazerCount
-		isFork
-		isPrivate
-		viewerHasStarred
-	}
+  repository(owner: $owner, name: $name) {
+    stargazerCount
+    isPrivate
+    viewerHasStarred
+    forked: parent {
+      url
+    }
+  }
 }

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -78,7 +78,6 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 		);
 	}
 
-	// GitHub may already show this icon natively, so we match its position
 	if (forked) {
 		prepareForAddition(repoLink);
 		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -13,7 +13,7 @@ import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import {buildRepoUrl, cacheByRepo} from '../github-helpers/index.js';
 import abbreviateNumber from '../helpers/abbreviate-number.js';
-import {isSmallDevice} from '../helpers/dom-utils.js';
+import {appendBefore, isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetRepositoryInfo from './repo-header-info.gql';
 
@@ -47,7 +47,9 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 
 	// GitHub may already show this icon natively, so we match its position
 	if (isPrivate && !elementExists('.octicon-lock', repoLink)) {
-		repoLink.append(
+		appendBefore(
+			repoLink,
+			'.octicon-repo-forked',
 			<LockIcon className="ml-1 tmp-ml-1" width={12} height={12} />,
 		);
 	}

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -54,21 +54,6 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 		);
 	}
 
-	// GitHub may already show this icon natively, so we match its position
-	if (forked) {
-		prepareForAddition(repoLink);
-		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
-		$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
-		repoLink.after(
-			<a
-				href={forked.url}
-				className="d-none d-sm-flex flex-items-center flex-justify-center mr-1 tmp-mr-1 p-1 tmp-p-1 Button Button--invisible"
-			>
-				<RepoForkedIcon className='m-0 tmp-m-0' width={12} height={12} />
-			</a>,
-		);
-	}
-
 	if (stargazerCount > 1) {
 		let tooltip = `Repository starred by ${stargazerCount.toLocaleString('us')} people`;
 		if (viewerHasStarred) {
@@ -89,6 +74,21 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 					? <StarFillIcon className="ml-1 tmp-ml-1" width={12} height={12} color="var(--button-star-iconColor)" />
 					: <StarIcon className="ml-1 tmp-ml-1" width={12} height={12} />}
 				<span className="f5">{abbreviateNumber(stargazerCount)}</span>
+			</a>,
+		);
+	}
+
+	// GitHub may already show this icon natively, so we match its position
+	if (forked) {
+		prepareForAddition(repoLink);
+		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
+		$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
+		repoLink.after(
+			<a
+				href={forked.url}
+				className="d-none d-sm-flex flex-items-center flex-justify-center mr-1 tmp-mr-1 p-1 tmp-p-1 Button Button--invisible"
+			>
+				<RepoForkedIcon className='m-0 tmp-m-0' width={12} height={12} />
 			</a>,
 		);
 	}

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -6,7 +6,7 @@ import LockIcon from 'octicons-plain-react/Lock';
 import RepoForkedIcon from 'octicons-plain-react/RepoForked';
 import StarIcon from 'octicons-plain-react/Star';
 import StarFillIcon from 'octicons-plain-react/StarFill';
-import {closestElement, elementExists} from 'select-dom';
+import {$, closestElement, elementExists} from 'select-dom';
 import {CachedFunction} from 'webext-storage-cache';
 
 import features from '../feature-manager.js';
@@ -18,7 +18,7 @@ import observe from '../helpers/selector-observer.js';
 import GetRepositoryInfo from './repo-header-info.gql';
 
 type RepositoryInfo = {
-	isFork: boolean;
+	forked?: {url: string};
 	isPrivate: boolean;
 	stargazerCount: number;
 	viewerHasStarred: boolean;
@@ -34,8 +34,14 @@ const repositoryInfo = new CachedFunction('stargazer-count', {
 	cacheKey: cacheByRepo,
 });
 
+function prepareForAddition(repoLink: HTMLAnchorElement): void {
+	if (!repoLink.classList.contains('AppHeader-context-item')) {
+		closestElement('li', repoLink).classList.add('d-flex');
+	}
+}
+
 async function add(repoLink: HTMLAnchorElement): Promise<void> {
-	const {isFork, isPrivate, stargazerCount, viewerHasStarred} = await repositoryInfo.get();
+	const {forked, isPrivate, stargazerCount, viewerHasStarred} = await repositoryInfo.get();
 
 	repoLink.classList.add('rgh-repo-header-info-updated');
 
@@ -47,9 +53,17 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 	}
 
 	// GitHub may already show this icon natively, so we match its position
-	if (isFork && !elementExists('.octicon-repo-forked', repoLink)) {
-		repoLink.append(
-			<RepoForkedIcon className="ml-1 tmp-ml-1" width={12} height={12} />,
+	if (forked) {
+		prepareForAddition(repoLink);
+		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
+		$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
+		repoLink.after(
+			<a
+				href={forked.url}
+				className="d-none d-sm-flex flex-items-center flex-justify-center mr-1 tmp-mr-1 p-1 tmp-p-1 Button Button--invisible"
+			>
+				<RepoForkedIcon className='m-0 tmp-m-0' width={12} height={12} />
+			</a>,
 		);
 	}
 
@@ -59,9 +73,7 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 			tooltip += ', including you';
 		}
 
-		if (!repoLink.classList.contains('AppHeader-context-item')) {
-			closestElement('li', repoLink).classList.add('d-flex');
-		}
+		prepareForAddition(repoLink);
 
 		repoLink.after(
 			<a
@@ -110,8 +122,7 @@ Test URLs
 
 - Regular: https://github.com/refined-github/refined-github
 - Fork: https://github.com/134130/refined-github
-- Fork with native icon: https://github.com/refined-github/fork
 - Private: https://github.com/refined-github/private
-- Private fork: https://github.com/refined-github/fork
+- Private fork: https://github.com/refined-github/private-fork
 
 */


### PR DESCRIPTION
- closes #9671 


## Test URLs


- Fork: https://github.com/134130/refined-github
- Private: https://github.com/refined-github/private
- Private fork: https://github.com/refined-github/private-fork


## Wide screen, clickable

<img width="641" height="83" alt="Screenshot 23" src="https://github.com/user-attachments/assets/dae3205e-db29-4e49-b4e4-4f1512b7e946" />

<img width="799" height="162" alt="header" src="https://github.com/user-attachments/assets/9a629087-c466-47cb-bcb8-7a1d5763bf71" />

## Tight screen, native

<img width="435" height="83" alt="Screenshot 21" src="https://github.com/user-attachments/assets/20cd4eb9-f371-437f-8e93-748acc7553bf" />

