### PR TITLE
AI SPAM

### DIFF
--- a/source/features/list-prs-for-branch.tsx
+++ b/source/features/list-prs-for-branch.tsx
@@ -4,7 +4,7 @@ import features from '../feature-manager.js';
 import getCurrentGitRef from '../github-helpers/get-current-git-ref.js';
 import {addAfterBranchSelector, isPermalink, isRepoCommitListRoot} from '../github-helpers/index.js';
 import isDefaultBranch from '../github-helpers/is-default-branch.js';
-import {branchSelectorParent} from '../github-helpers/selectors.js';
+import {branchSelector} from '../github-helpers/selectors.js';
 import observe from '../helpers/selector-observer.js';
 import {pullRequestsAssociatedWithBranch, stateIcon} from './show-associated-branch-prs-on-fork.js';
 
@@ -20,7 +20,7 @@ const stateColorMap = {
 	DRAFT: '',
 };
 
-async function add(branchSelectorParent: HTMLDetailsElement): Promise<void | false> {
+async function add(branchSelector: HTMLElement): Promise<void | false> {
 	const getPr = await pullRequestsAssociatedWithBranch.get();
 	const currentBranch = getCurrentGitRef()!;
 	const prInfo = getPr[currentBranch];
@@ -31,7 +31,7 @@ async function add(branchSelectorParent: HTMLDetailsElement): Promise<void | fal
 	const StateIcon = stateIcon[prInfo.state];
 
 	addAfterBranchSelector(
-		branchSelectorParent,
+		branchSelector,
 		<a
 			data-issue-and-pr-hovercards-enabled
 			href={prInfo.url}
@@ -46,7 +46,7 @@ async function add(branchSelectorParent: HTMLDetailsElement): Promise<void | fal
 }
 
 async function init(signal: AbortSignal): Promise<false | void> {
-	observe(branchSelectorParent, add, {signal});
+	observe(branchSelector, add, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -1,7 +1,7 @@
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import mem from 'memoize';
-import {$, $optional, closestElement, closestElementOptional, elementExists} from 'select-dom';
+import {$, $optional, closestElementOptional, elementExists} from 'select-dom';
 import compareVersions from 'tiny-version-compare';
 import type {RequireAtLeastOne} from 'type-fest';
 
@@ -164,10 +164,15 @@ export function extractCurrentBranchFromBranchPicker(branchPicker: HTMLElement):
 		: branchPicker.title; // Branch name was clipped, so they placed it in the title attribute
 }
 
-export function addAfterBranchSelector(branchSelectorParent: HTMLDetailsElement, sibling: HTMLElement): void {
-	const row = closestElement('.position-relative', branchSelectorParent);
-	row.classList.add('d-flex', 'flex-shrink-0', 'gap-2');
-	row.append(sibling);
+export function addAfterBranchSelector(branchSelector: HTMLElement, sibling: HTMLElement): void {
+	const row = closestElementOptional('.position-relative', branchSelector);
+	if (row) {
+		row.classList.add('d-flex', 'flex-shrink-0', 'gap-2');
+		row.append(sibling);
+		return;
+	}
+
+	branchSelector.after(sibling);
 }
 
 /** Trigger a conversation update if the view is out of date */

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -48,9 +48,6 @@ export const branchSelector_ = [
 	[1, 'https://github.com/refined-github/sandbox/commits'],
 ] satisfies UrlMatch[];
 
-export const branchSelectorParent = 'details#branch-select-menu';
-export const branchSelectorParent_ = branchSelector_;
-
 // .color-fg-muted selects only files; some icon extensions use `img` tags
 export const directoryListingFileIcon =
 	'.react-directory-filename-column > :is(svg, img):is(.color-fg-muted, .octicon-file-symlink-file)';


### PR DESCRIPTION
Fixes #9151

## Summary

- Update `list-prs-for-branch` to observe the shared branch selector instead of the stale `details#branch-select-menu` wrapper.
- Keep `addAfterBranchSelector` working for the old `.position-relative` row layout while falling back to inserting after the matched branch picker for the current commit-list DOM.
- Remove the unused `branchSelectorParent` selector export.

## Verification

- `npm run build:typescript` passed.
- `npx eslint source/features/list-prs-for-branch.tsx source/github-helpers/index.ts source/github-helpers/selectors.ts` passed with one pre-existing warning in `source/github-helpers/selectors.ts` for an expired dated TODO.
- `git diff --check` passed.

## Poem

A tiny booger took its seat,
Beside a branch picker, tidy and neat.
No stale old menu could make it roam,
It found the live selector and settled home.
