### PR TITLE
Improve comment header wrapping on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -197,7 +197,7 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	row-gap: 2px;
 	justify-content: flex-start;
 
-	> [class*="ActivityHeader-module__narrowViewportWrapper"],
+	> [class*='ActivityHeader-module__narrowViewportWrapper'],
 	> div[data-testid='comment-header-left-side-items'] {
 		flex-grow: 1;
 		flex-basis: min-content;
@@ -208,7 +208,7 @@ div[class*='ActivityHeader-module__activityHeader'] {
 		}
 	}
 
-	> [class*="actionsWrapper"],
+	> [class*='actionsWrapper'],
 	> div[data-testid='comment-header-right-side-items'] {
 		flex-grow: 0;
 		flex-wrap: wrap;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -185,14 +185,19 @@ div[class^='PRIVATE_TreeView-item-visual']
 	}
 }
 
-/* Fix review thread header wrapping */
+/* Fix comment header wrapping */
 /* Info: https://github.com/refined-github/refined-github/issues/9186 */
 /* Test: https://github.com/refined-github/refined-github/pull/9182/changes#r3068791673 */
-div[class*='ActivityHeaderGridLayout'] {
+div[class*='ActivityHeaderGridLayout'],
+/* Info: https://github.com/refined-github/refined-github/issues/9623 */
+/* Test: https://github.com/refined-github/sandbox/issues/131 */
+div[class*='ActivityHeader-module__activityHeader'] {
 	display: flex;
 	flex-wrap: wrap;
 	row-gap: 2px;
+	justify-content: flex-start;
 
+	> [class*="ActivityHeader-module__narrowViewportWrapper"],
 	> div[data-testid='comment-header-left-side-items'] {
 		flex-grow: 1;
 		flex-basis: min-content;
@@ -203,14 +208,11 @@ div[class*='ActivityHeaderGridLayout'] {
 		}
 	}
 
+	> [class*="actionsWrapper"],
 	> div[data-testid='comment-header-right-side-items'] {
 		flex-grow: 0;
-
-		div[class^='ActivityHeader-module__BadgesGroupContainer'] {
-			flex-wrap: wrap;
-			justify-content: flex-start;
-			margin-left: 0;
-		}
+		flex-wrap: wrap;
+		margin-left: auto;
 	}
 }
 


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9623


## Screenshot

https://github.com/refined-github/sandbox/issues/131

All good at 320px

<img width="326" height="984" alt="Screenshot 2" src="https://github.com/user-attachments/assets/bbcdad3d-69d4-4609-a12b-2af55f498e50" />


## Screenshot review thread

320px just isn't enough for this view

https://github.com/refined-github/refined-github/pull/9182/changes#r3068791673
<img width="336" height="617" alt="Screenshot 3" src="https://github.com/user-attachments/assets/c5be2b5c-f96c-43e9-b7a7-1af2df43d253" />

but 450px is:

<img width="447" height="659" alt="Screenshot 4" src="https://github.com/user-attachments/assets/0b05ff43-97f5-4614-9d51-ea3a75641280" />
