### PR TITLE
`related-issues-count` - Exclude current issue

### DIFF
--- a/source/helpers/related-issues-count.ts
+++ b/source/helpers/related-issues-count.ts
@@ -1,10 +1,14 @@
+import * as pageDetect from 'github-url-detection';
+
 import api from '../github-helpers/api.js';
 import {getFeatureRelatedIssuesQuery} from './rgh-links.js';
 
 async function getOpenRelatedIssuesCount(featureId: string): Promise<number> {
 	const query = `${getFeatureRelatedIssuesQuery(featureId)} repo:refined-github/refined-github`;
 	const response = await api.v3(`/search/issues?q=${encodeURIComponent(query)}`);
-	return response.total_count;
+	// Don't count the current issue if we're on it
+	const adjustment = pageDetect.isOpenConversation() ? -1 : 0;
+	return response.total_count as number + adjustment;
 }
 
 export default getOpenRelatedIssuesCount;


### PR DESCRIPTION
I thought about _not_ counting the current page in the number, but I think it's not worth trying to make this number _exact_ because it just isn't.

Re: https://github.com/refined-github/refined-github/pull/9650#issuecomment-4587401691