### PR TITLE
AI SPAM

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -7,7 +7,12 @@ import {$, $$, $$optional, closestElement, elementExists} from 'select-dom';
 import features from '../feature-manager.js';
 import getCommentAuthor from '../github-helpers/get-comment-author.js';
 import {registerHotkey} from '../github-helpers/hotkey.js';
-import {states, type State} from '../helpers/conversation-activity-filter.js';
+import {
+	inlineWidgetAnchorSelector,
+	shouldAppendWidgetToAnchor,
+	states,
+	type State,
+} from '../helpers/conversation-activity-filter.js';
 import delay from '../helpers/delay.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
@@ -157,7 +162,11 @@ async function addWidget(anchor: Element): Promise<void> {
 			onStateChange: applyState,
 		},
 	}));
-	position.after(container.firstElementChild!);
+	if (shouldAppendWidgetToAnchor(position)) {
+		position.append(container.firstElementChild!);
+	} else {
+		position.after(container.firstElementChild!);
+	}
 }
 
 function uncollapseTargetedComment(): void {
@@ -197,8 +206,7 @@ async function init(signal: AbortSignal): Promise<void> {
 	observe(
 		[
 			// Issue view
-			'[class^="HeaderMetadata-module__metadataContent"]',
-			'[class*="HeaderMetadata-module__smallMetadataRow"]',
+			...inlineWidgetAnchorSelector,
 			// PR view
 			'[class*="PullRequestHeaderSummary-module"] > .d-flex',
 			// Old PR view

--- a/source/helpers/conversation-activity-filter.test.ts
+++ b/source/helpers/conversation-activity-filter.test.ts
@@ -1,0 +1,19 @@
+import {assert, test} from 'vitest';
+
+import {shouldAppendWidgetToAnchor} from './conversation-activity-filter.js';
+
+test('shouldAppendWidgetToAnchor', () => {
+	const fixedIssueMetadata = document.createElement('div');
+	fixedIssueMetadata.className = 'HeaderMetadata-module__metadataContent__abcde';
+
+	const stickyIssueMetadata = document.createElement('div');
+	stickyIssueMetadata.className =
+		'HeaderMetadata-module__smallMetadataRow__abcde HeaderMetadata-module__smallMetadataRow_viewport__fghij';
+
+	const legacyPullRequestMetadata = document.createElement('div');
+	legacyPullRequestMetadata.className = 'flex-auto';
+
+	assert.isTrue(shouldAppendWidgetToAnchor(fixedIssueMetadata));
+	assert.isTrue(shouldAppendWidgetToAnchor(stickyIssueMetadata));
+	assert.isFalse(shouldAppendWidgetToAnchor(legacyPullRequestMetadata));
+});

--- a/source/helpers/conversation-activity-filter.ts
+++ b/source/helpers/conversation-activity-filter.ts
@@ -5,3 +5,12 @@ export const states = {
 } as const;
 
 export type State = keyof typeof states;
+
+export const inlineWidgetAnchorSelector = [
+	'[class^="HeaderMetadata-module__metadataContent"]',
+	'[class*="HeaderMetadata-module__smallMetadataRow"]',
+] as const;
+
+export function shouldAppendWidgetToAnchor(anchor: Element): boolean {
+	return anchor.matches(inlineWidgetAnchorSelector.join(','));
+}


### PR DESCRIPTION
Closes #9657

## Test URLs

https://github.com/refined-github/refined-github/issues/9656
https://github.com/refined-github/refined-github/issues/9666

## Screenshot

## Verification

- `npm run vitest`
- `npm run format:check`
- `npm run build:typescript`
- `npm run build:bundle`
- `npm run lint:biome`
- `npm run lint:eslint` (passes with existing TODO warnings outside the touched files)
- `npm test` (passes with the same existing TODO warnings)
- `git diff --check`

## Required AI note

This pull request was opened by an OpenAI GPT-5 coding agent.

A tiny booger sits unseen,
beside a header, oddly green;
it leaves the code and tests in peace,
while misplaced widgets find release.
