### PR TITLE
`clean-conversation-headers` - Don't break branch picker

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -80,12 +80,13 @@ async function hideAuthorMetadata(summaryRow: HTMLElement): Promise<void> {
 }
 
 function replaceFromWithArrow(base: HTMLElement): void {
-	const anchor = base.nextElementSibling!.nextElementSibling!;
+	const anchor = base.nextElementSibling!.nextElementSibling as HTMLElement;
 	assertNodeContent(anchor, 'from');
-	anchor.replaceWith(
-		<span className="rgh-arrow">
-			<ArrowLeftIcon className="v-align-middle mx-1 tmp-mx-1" />
-		</span>,
+	// Don't remove element, GitHub requires it to change the base
+	// https://github.com/refined-github/refined-github/issues/9688
+	anchor.hidden = true;
+	anchor.after(
+		<ArrowLeftIcon className="v-align-middle mx-1 tmp-mx-1 rgh-arrow" />,
 	);
 }
 


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9688


## Base branch


<img width="423" height="97" alt="Screenshot 1" src="https://github.com/user-attachments/assets/995a3aa0-d9f0-4ed6-8d28-cc5b942138b3" />

## Normal

<img width="423" height="97" alt="Screenshot 3" src="https://github.com/user-attachments/assets/ef9884ad-6767-41a5-892d-ecb4de74bdca" />
<img width="473" height="58" alt="Screenshot 4" src="https://github.com/user-attachments/assets/d87017cf-8140-48b7-9942-e0af6b023b31" />



## Non-default branch

https://github.com/Kenshin/simpread/pull/698
<img width="473" height="100" alt="Screenshot 5" src="https://github.com/user-attachments/assets/d1e80470-1cc5-40fc-a638-61041a868753" />
<img width="473" height="66" alt="Screenshot 6" src="https://github.com/user-attachments/assets/e9091f73-5553-4679-bc0f-cc8d981a1ab9" />



