### PR TITLE
Improve comment header wrapping on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -212,6 +212,7 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	> div[data-testid='comment-header-right-side-items'] {
 		flex-grow: 0;
 		flex-wrap: wrap;
+		flex-basis: max-content;
 		margin-left: auto;
 	}
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -185,14 +185,19 @@ div[class^='PRIVATE_TreeView-item-visual']
 	}
 }
 
-/* Fix review thread header wrapping */
+/* Fix comment header wrapping */
 /* Info: https://github.com/refined-github/refined-github/issues/9186 */
 /* Test: https://github.com/refined-github/refined-github/pull/9182/changes#r3068791673 */
-div[class*='ActivityHeaderGridLayout'] {
+div[class*='ActivityHeaderGridLayout'],
+/* Info: https://github.com/refined-github/refined-github/issues/9623 */
+/* Test: https://github.com/refined-github/sandbox/issues/131 */
+div[class*='ActivityHeader-module__activityHeader'] {
 	display: flex;
 	flex-wrap: wrap;
 	row-gap: 2px;
+	justify-content: flex-start;
 
+	> [class*='ActivityHeader-module__narrowViewportWrapper'],
 	> div[data-testid='comment-header-left-side-items'] {
 		flex-grow: 1;
 		flex-basis: min-content;
@@ -203,14 +208,11 @@ div[class*='ActivityHeaderGridLayout'] {
 		}
 	}
 
+	> [class*='actionsWrapper'],
 	> div[data-testid='comment-header-right-side-items'] {
 		flex-grow: 0;
-
-		div[class^='ActivityHeader-module__BadgesGroupContainer'] {
-			flex-wrap: wrap;
-			justify-content: flex-start;
-			margin-left: 0;
-		}
+		flex-wrap: wrap;
+		margin-left: auto;
 	}
 }
 


### PR DESCRIPTION
https://github.com/refined-github/refined-github/pull/9682 reverted due to https://github.com/refined-github/refined-github/commit/8a6ea09a09a97bddf9b4ff5cc89ba8984db29322#commitcomment-187525137, so this PR tries to reapply it, without bugs this time I swear 

- re closes https://github.com/refined-github/refined-github/issues/9623

## Test URL

https://github.com/refined-github/sandbox/issues/131
https://github.com/refined-github/refined-github/pull/9182/changes#r3068791673
https://github.com/e3kskoy7wqk/Firefox-for-windows-7/issues/159#issuecomment-4608057250


## Screenshot

Mobile views unchanged since the past PR https://github.com/refined-github/refined-github/pull/9682

Bugfix:

<img width="937" height="277" alt="Screenshot 7" src="https://github.com/user-attachments/assets/da35d91f-3337-4683-b979-a536807bedb4" />
