### PR TITLE
`prevent-link-loss` - Match `L` in compare link hash

### DIFF
--- a/source/github-helpers/prevent-link-loss.test.ts
+++ b/source/github-helpers/prevent-link-loss.test.ts
@@ -135,6 +135,12 @@ test('preventPrCompareLinkLoss', () => {
 	);
 	assert.equal(
 		replacePrCompareLink(
+			'lorem ipsum dolor https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15 some random string',
+		),
+		'lorem ipsum dolor [`26.5.24...26.6.1`#diff-31bc308e7c](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15) some random string',
+	);
+	assert.equal(
+		replacePrCompareLink(
 			'lorem ipsum dolor https://github.com/refined-github/refined-github/compare/main...incremental-tag-changelog-link#diff-5b3cf6bcc7c5b1373313553dc6f93a5eR7-R9 some random string',
 		),
 		'lorem ipsum dolor [`main...incremental-tag-changelog-link`#diff-5b3cf6bcc7](https://github.com/refined-github/refined-github/compare/main...incremental-tag-changelog-link#diff-5b3cf6bcc7c5b1373313553dc6f93a5eR7-R9) some random string',

--- a/source/github-helpers/prevent-link-loss.ts
+++ b/source/github-helpers/prevent-link-loss.ts
@@ -15,7 +15,7 @@ export const prCommitUrlRegex = new RegExp(
 	'gi',
 );
 
-const prComparePathnameRegex = /[/]([^/]+[/][^/]+)[/]compare[/](.+)(#diff-[\da-fR-]+)/;
+const prComparePathnameRegex = /[/]([^/]+[/][^/]+)[/]compare[/](.+)(#diff-[\da-fLR-]+)/;
 export const prCompareUrlRegex = new RegExp(
 	String.raw`\b` + escapeRegex(location.origin) + prComparePathnameRegex.source,
 	'gi',


### PR DESCRIPTION
On diff pages, clicking left side line numbers generates links end with `L123`. Currently, when `prevent-link-loss` converts the link, the `L123` part is left out of the link.

For example

```text
https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15
```

[https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15)

Converts to

```
[`26.5.24...26.6.1`#diff-31bc308e7c](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2)L14-L15
```

[`26.5.24...26.6.1`#diff-31bc308e7c](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2)L14-L15

Expected

```
[`26.5.24...26.6.1`#diff-31bc308e7c](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15)
```

[`26.5.24...26.6.1`#diff-31bc308e7c](https://github.com/refined-github/refined-github/compare/26.5.24...26.6.1#diff-31bc308e7c7d86220613f3cbc05182706b71911a5d654362c32ea919622764d2L14-L15)