### PR TITLE
`prevent-link-loss` - Handle two-dot diff (range) links

### DIFF
--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -107,6 +107,7 @@ Test content:
 
 ```
 https://github.com/refined-github/refined-github/pull/6954/commits/32d1c8b2e1b6971709fe273cfdd1f959b51e8d85
+https://github.com/refined-github/refined-github/pull/6954/changes/32d1c8b2e1b6971709fe273cfdd1f959b51e8d85..5d28ba424368606c7b241840cf4386f23ce66ec3
 ```
 
 Test URLs:

--- a/source/github-helpers/prevent-link-loss.test.ts
+++ b/source/github-helpers/prevent-link-loss.test.ts
@@ -90,6 +90,29 @@ test('preventPrCommitLinkLoss', () => {
 		),
 		'[refined-github/shorten-repo-url@`3d8d1cc` (#33)](https://github.com/refined-github/shorten-repo-url/pull/33/commits/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658)',
 	);
+	assert.equal(
+		replacePrCommitLink(
+			'https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb',
+		),
+		'[refined-github/shorten-repo-url@`3d8d1cc..cb44a4e` (#33)](https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb)',
+		'It should handle two-dot diff (range) links',
+	);
+	assert.equal(
+		replacePrCommitLink(
+			replacePrCommitLink(
+				'https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb',
+			),
+		),
+		'[refined-github/shorten-repo-url@`3d8d1cc..cb44a4e` (#33)](https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb)',
+		'It should not apply diff (range) links twice',
+	);
+	assert.equal(
+		replacePrCommitLink(
+			'I like [turtles](https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb)',
+		),
+		'I like [turtles](https://github.com/refined-github/shorten-repo-url/pull/33/changes/3d8d1cc8d784c7d92788a8a21e2c30cf87be3658..cb44a4eb8cd5c66def3dc26dca0f386645fa29bb)',
+		'It should ignore Markdown diff (range) links',
+	);
 
 	// Test "this PR" behavior when on same PR
 	location.href = 'https://github.com/refined-github/refined-github/pull/3205';
@@ -106,6 +129,13 @@ test('preventPrCommitLinkLoss', () => {
 		),
 		'lorem ipsum dolor [`b0ac079` (this PR)](https://github.com/refined-github/refined-github/pull/3205/commits/b0ac07948f9d30a760bda25a7106011441abfd5d#r438059292) some random string',
 		'It should use "this PR" when on the same PR with hash',
+	);
+	assert.equal(
+		replacePrCommitLink(
+			'https://github.com/refined-github/refined-github/pull/3205/changes/1da152b3f8c51dd72d8ae6ad9cc96e0c2d8716f5..b0ac07948f9d30a760bda25a7106011441abfd5d',
+		),
+		'[`1da152b..b0ac079` (this PR)](https://github.com/refined-github/refined-github/pull/3205/changes/1da152b3f8c51dd72d8ae6ad9cc96e0c2d8716f5..b0ac07948f9d30a760bda25a7106011441abfd5d)',
+		'It should use "this PR" for diff (range) links on the same PR',
 	);
 
 	// When on PR 3205, a link to PR 44 should still show #44

--- a/source/github-helpers/prevent-link-loss.ts
+++ b/source/github-helpers/prevent-link-loss.ts
@@ -9,7 +9,7 @@ function getRepoReference(currentRepo: RepositoryInfo | undefined, repoNameWithO
 
 const escapeRegex = (string: string): string => string.replaceAll(/[\\^$.*+?()[\]{}|]/g, String.raw`\$&`);
 const prCommitPathnameRegex =
-	/[/]([^/]+[/][^/]+)[/]pull[/](\d+)[/](?:commits|changes)[/]([\da-f]{7})[\da-f]{33}(?:#[\w-]+)?\b/;
+	/[/]([^/]+[/][^/]+)[/]pull[/](\d+)[/](?:commits|changes)[/]([\da-f]{7})[\da-f]{33}(?:[.]{2}([\da-f]{7})[\da-f]{33})?(?:#[\w-]+)?\b/;
 export const prCommitUrlRegex = new RegExp(
 	String.raw`\b` + escapeRegex(location.origin) + prCommitPathnameRegex.source,
 	'gi',
@@ -33,6 +33,7 @@ export function preventPrCommitLinkLoss(
 	repoNameWithOwner: string,
 	pr: string,
 	commit: string,
+	commit2: string | undefined,
 	index: number,
 	fullText: string,
 ): string {
@@ -42,7 +43,8 @@ export function preventPrCommitLinkLoss(
 
 	const currentPr = getConversationNumber();
 	const prReference = currentPr && Number(pr) === currentPr ? '(this PR)' : `(#${pr})`;
-	return `[${getRepoReference(getRepo(), repoNameWithOwner, '@')}\`${commit}\` ${prReference}](${url})`;
+	const commitReference = commit2 ? `${commit}..${commit2}` : commit;
+	return `[${getRepoReference(getRepo(), repoNameWithOwner, '@')}\`${commitReference}\` ${prReference}](${url})`;
 }
 
 // To be used as replacer callback in string.replace() for compare links


### PR DESCRIPTION
## What this fixes

`prevent-link-loss` only matched the first commit of a two-dot diff (range) link of the form `/pull/N/changes/SHA1..SHA2`, leaving `..SHA2` dangling outside the generated Markdown link.

 For example:

`https://github.com/refined-github/refined-github/pull/6954/changes/32d1c8b2e1b6971709fe273cfdd1f959b51e8d85..5d28ba424368606c7b241840cf4386f23ce66ec3`

was converted to:

`32d1c8b (#6954)..5d28ba424368606c7b241840cf4386f23ce66ec3`

It now produces the full range:
  
`32d1c8b..5d28ba4 (#6954)`

`prCommitPathnameRegex` now optionally captures the second SHA; single-commit links are unaffected (the group is optional). Unit tests added for the range form, idempotency, Markdown-link skipping, and the "this PR" branch.

 ## 1. Related issue
 
No existing issue.

 ## 2. Pages affected/tested
  
Any comment field with a rich-text editor (issue/PR comments, reviews, PR body).



Disclosure: I asked Claude Opus 4.8 to fix the issue and write the tests, but did the rest (this PR description, etc.) manually.