### PR TITLE
Improve comment header wrapping on mobile /2

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -197,12 +197,6 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	row-gap: 2px;
 	justify-content: flex-start;
 
-	[class*='authorLoginLink'] {
-		/* Override native `everywhere` value with causes the username to wrap before triggering `flex-wrap` */
-		/* https://github.com/refined-github/refined-github/pull/9682#issuecomment-4628292635 */
-		overflow-wrap: break-word;
-	}
-
 	/* Issue body */
 	div[class*='IssueBodyHeader-module__narrowViewportWrapper'],
 	/* Issue comment */
@@ -210,12 +204,27 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	/* Review comment (?) */
 	> div[data-testid='comment-header-left-side-items'] {
 		flex-grow: 1;
-		flex-basis: min-content;
+
+		/* Don't wrap inside until there's enough space */
+		flex-basis: max-content;
+
+		/* "Enough space" must always allow to *not* wrap below the avatar */
+		max-width: calc(100% - 32px);
 
 		a[class^='ActivityHeader-module__AuthorName'] {
 			overflow-wrap: break-word;
 			max-width: 100%;
 		}
+	}
+
+	/* Issue body */
+	[class*='IssueBodyHeader-module__titleSection'],
+	/* Issue comment */
+	[class*='ActivityHeader-module__TitleContainer'],
+	/* Hidden issue comment */
+	[class*='CommentHeaderContentContainer'] {
+		flex-wrap: wrap;
+		column-gap: 4px; /* `show-names` spacing */
 	}
 
 	> [class*='actionsWrapper'],
@@ -224,6 +233,15 @@ div[class*='ActivityHeader-module__activityHeader'] {
 		flex-grow: 0;
 		flex-basis: max-content;
 		margin-left: auto;
+	}
+
+	/* Limit length of "Edited by" username to avoid overflow */
+	[class*='MarkdownLastEditedBy-module__editorLogin'] {
+		max-width: 100px;
+		display: inline-block;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		vertical-align: bottom;
 	}
 }
 

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -197,7 +197,17 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	row-gap: 2px;
 	justify-content: flex-start;
 
-	> [class*='ActivityHeader-module__narrowViewportWrapper'],
+	[class*='authorLoginLink'] {
+		/* Override native `everywhere` value with causes the username to wrap before triggering `flex-wrap` */
+		/* https://github.com/refined-github/refined-github/pull/9682#issuecomment-4628292635 */
+		overflow-wrap: break-word;
+	}
+
+	/* Issue body */
+	div[class*='IssueBodyHeader-module__narrowViewportWrapper'],
+	/* Issue comment */
+	div[class*='CommentHeaderContentContainer'],
+	/* Review comment (?) */
 	> div[data-testid='comment-header-left-side-items'] {
 		flex-grow: 1;
 		flex-basis: min-content;
@@ -210,7 +220,6 @@ div[class*='ActivityHeader-module__activityHeader'] {
 
 	> [class*='actionsWrapper'],
 	> div[data-testid='comment-header-right-side-items'] {
-		flex-grow: 0;
 		flex-wrap: wrap;
 		flex-basis: max-content;
 		margin-left: auto;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -230,8 +230,8 @@ div[class*='ActivityHeader-module__activityHeader'] {
 
 	> [class*='actionsWrapper'],
 	> div[data-testid='comment-header-right-side-items'] {
-		flex-wrap: wrap;
 		flex-grow: 0;
+		flex-wrap: wrap;
 		flex-basis: max-content;
 		margin-left: auto;
 	}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -221,6 +221,7 @@ div[class*='ActivityHeader-module__activityHeader'] {
 	> [class*='actionsWrapper'],
 	> div[data-testid='comment-header-right-side-items'] {
 		flex-wrap: wrap;
+		flex-grow: 0;
 		flex-basis: max-content;
 		margin-left: auto;
 	}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -190,6 +190,7 @@ div[class^='PRIVATE_TreeView-item-visual']
 /* Test: https://github.com/refined-github/refined-github/pull/9182/changes#r3068791673 */
 div[class*='ActivityHeaderGridLayout'],
 /* Info: https://github.com/refined-github/refined-github/issues/9623 */
+/* Test: https://github.com/refined-github/sandbox/issues/151 */
 /* Test: https://github.com/refined-github/sandbox/issues/131 */
 div[class*='ActivityHeader-module__activityHeader'] {
 	display: flex;

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -31,8 +31,6 @@ function createElement(element: HTMLAnchorElement, fullName: string): JSX.Elemen
 
 	if (
 		element.matches([
-			'[data-testid="avatar-link"]', // Commment on React-based views
-			'[data-testid="issue-body-header-author"]',
 			'.feed-item-content *',
 			// PR event:
 			//  - https://github.com/refined-github/refined-github/pull/8970#event-22710755292


### PR DESCRIPTION
Follows https://github.com/refined-github/refined-github/pull/9682#issuecomment-4625199976

- https://github.com/refined-github/sandbox/issues/131
- https://github.com/refined-github/sandbox/issues/151

<img width="952" height="623" alt="headers" src="https://github.com/user-attachments/assets/de5b7b0b-013b-4327-b21a-a060f3c01516" />
