### PR TITLE
AI SPAM

### DIFF
--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -118,6 +118,10 @@ void features.add(import.meta.url, {
 
 		// Can't work on gists due to CORS: https://github.com/refined-github/refined-github/issues/8641
 		pageDetect.isGist,
+
+		// Avoid double notification indicator on profile pages
+		// https://github.com/refined-github/refined-github/issues/9695
+		pageDetect.isUserProfile,
 	],
 	init: onetime(initOnce),
 });


### PR DESCRIPTION
## Summary

Fixes #9695 — Double notification circle on user profile pages.

## Problem

On user profile pages, the `unread-anywhere` feature renders a duplicate notification indicator circle. GitHub renders notification indicators differently on profile pages, causing the observer to match and wrap multiple elements.

## Fix

Added `pageDetect.isUserProfile` to the feature's exclude list.

| Before | After |
|---|---|
| `isSmallDevice`, `pageDetect.isGist` | + `pageDetect.isUserProfile` |