### PR TITLE
`rgh-linkify-features` - Only show count in conversations 

### DIFF
--- a/source/features/rgh-linkify-features.tsx
+++ b/source/features/rgh-linkify-features.tsx
@@ -15,7 +15,7 @@ import RelatedIssuesCount from '../helpers/related-issues-count.svelte';
 import {getFeatureUrl} from '../helpers/rgh-links.js';
 import observe from '../helpers/selector-observer.js';
 
-const shouldHideCount = debounce(() => pageDetect.isReleasesOrTags() || pageDetect.isSingleReleaseOrTag(), {
+const shouldShowCount = debounce(() => pageDetect.isIssue() || pageDetect.isPR(), {
 	wait: 100,
 	before: true,
 	after: false,
@@ -40,6 +40,7 @@ function linkifyFeature(possibleFeature: HTMLElement): void {
 		// - <a>
 		// - <code> > <a>
 		possibleLink.href = href;
+		possibleLink.title = '';
 		possibleLink.classList.add('color-fg-accent');
 		if (title) {
 			possibleLink.title = title;
@@ -64,7 +65,7 @@ function linkifyFeature(possibleFeature: HTMLElement): void {
 		anchorElement = possibleFeature.parentElement!;
 	}
 
-	if (anchorElement && !shouldHideCount()) {
+	if (anchorElement && shouldShowCount()) {
 		const sup = <sup />;
 		anchorElement.after(sup);
 		mount(RelatedIssuesCount, {


### PR DESCRIPTION
It's already strange that they're linked here (https://github.com/refined-github/refined-github/pull/5033) but I guess it didn't bother anyone for 4+ years.

But this is just too much:

<img width="977" height="374" alt="Screenshot" src="https://github.com/user-attachments/assets/2ea93bdb-f869-48ef-b199-a1e0f47cf88a" />

So since it was already limited in https://github.com/refined-github/refined-github/pull/9445, I guess we really only need the counter in issues and PRs anyway.

## Test URLs

https://github.com/refined-github/refined-github
