### PR TITLE
`unread-anywhere` - Avoid double indicator on profiles

### DIFF
--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -92,13 +92,13 @@ async function addButton(nativeLink: HTMLAnchorElement): Promise<void> {
 	nativeLink.style.width = '30px'; // Reduce width of native button
 	button.setAttribute('data-variant', 'invisible'); // Enables hover style
 	button.classList.add(...classes);
+	removeNotificationIndicator(button);
+
 	addToolTip({
 		label: 'Open unread notifications',
 		shortcut: 'g u',
 		direction: 'sw',
 	}, button);
-
-	removeNotificationIndicator(button);
 }
 
 // No signal, created once per load

--- a/source/helpers/tooltip.tsx
+++ b/source/helpers/tooltip.tsx
@@ -59,8 +59,13 @@ Align tooltip behavior with native
 https://github.com/refined-github/refined-github/pull/9668
 */
 function attachToDocument(tooltip: HTMLElement): void {
-	lastElement('#js-repo-pjax-container, #js-pjax-container, #repo-content-turbo-frame, #repo-content-pjax-container, [data-turbo-body]')
-		.append(tooltip);
+	lastElement([
+		'#js-repo-pjax-container',
+		'#js-pjax-container',
+		'#repo-content-turbo-frame',
+		'#repo-content-pjax-container',
+		'[data-turbo-body]', // User profile
+	]).append(tooltip);
 }
 
 /**

--- a/source/helpers/tooltip.tsx
+++ b/source/helpers/tooltip.tsx
@@ -59,7 +59,7 @@ Align tooltip behavior with native
 https://github.com/refined-github/refined-github/pull/9668
 */
 function attachToDocument(tooltip: HTMLElement): void {
-	lastElement('#js-repo-pjax-container, #js-pjax-container, #repo-content-turbo-frame, #repo-content-pjax-container')
+	lastElement('#js-repo-pjax-container, #js-pjax-container, #repo-content-turbo-frame, #repo-content-pjax-container, [data-turbo-body]')
 		.append(tooltip);
 }
 


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9695

It was due to https://github.com/refined-github/refined-github/pull/9668

## Test URLs

https://github.com/fregante

## Screenshot

<img width="105" height="61" alt="Screenshot" src="https://github.com/user-attachments/assets/82a7f2c4-2a2d-4973-965d-fc005ec5f050" />
