### PR TITLE
Hide superfluous clock icon on PR lists

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -191,6 +191,11 @@ a[class^='IssueItem-module__authorCreatedLink'] {
 			.ml-1 {
 				margin-left: 0 !important;
 			}
+
+			/* Hide clock icon https://github.com/refined-github/refined-github/issues/9667 */
+			.issue-meta-section {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9667


## Test URLs

https://github.com/refined-github/sandbox/pulls?q=sort%3Aupdated-desc+is%3Apr+review%3Aapproved+

## Screenshot

<table>
<tr>
 <th>Before
 <th>After
<tr>

 <td valign=top><img width="365" height="243" alt="Screenshot 4" src="https://github.com/user-attachments/assets/0efc14b2-c37d-4733-8aa6-f3335ff92056" />
 <td valign=top>
<img width="365" height="224" alt="Screenshot 3" src="https://github.com/user-attachments/assets/fcd78a06-a927-429c-a96d-d6d691252d8b" />
</table>