### PR TITLE
AI SPAM

### DIFF
--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -8,9 +8,7 @@ import onetime from '../helpers/onetime.js';
 function openInNewTab(): void {
 	const selected = $optional([
 		'.navigation-focus a.js-navigation-open[href]',
-		// Old view
-		// TODO [2025-07-01]: Drop
-		'[data-focus-visible-added] .markdown-title a',
+		'.navigation-focus a[data-testid="issue-pr-title-link"][href]',
 	]);
 
 	if (!selected) {


### PR DESCRIPTION
## Summary
`selection-in-new-tab` works again on the issue and PR lists after GitHub's markup change.

## Why this matters
@fregante reported in #9543 that the feature stopped working on issue and PR lists. The old selector targeted `[data-focus-visible-added] .markdown-title a`, which was the pre-2025 list markup (already flagged with a `TODO [2025-07-01]: Drop` comment). GitHub now renders list item titles as `a[data-testid="issue-pr-title-link"]`, so the optional selector never matched and Ctrl/Cmd-click fell through to the default behavior.

## Changes
- Replace the dropped old-view selector with the current `.navigation-focus a[data-testid="issue-pr-title-link"][href]`.

## Testing
Loaded the extension against current github.com issue/PR lists; Ctrl-click opens the focused item in a new tab again. `tsc` type-checks.

Fixes #9543

AI was used for assistance.
