### PR TITLE
AI SPAM

### DIFF
--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -5,6 +5,18 @@ import features from '../feature-manager.js';
 import {isEditable} from '../helpers/dom-utils.js';
 import {viewedToggleSelector} from './batch-mark-files-as-viewed.js';
 
+const itemSelectors = [
+	'div[class*="targetable" i][id^="diff-"]', // Files in diffs
+	'.js-minimizable-comment-group', // Legacy comments
+	'.react-issue-body', // New issue view: issue description
+	'.react-issue-comment', // New issue view: comments
+] as const;
+
+const permalinkSelectors = [
+	'a[href*="#issue-"]', // Issue description permalink
+	'a[href*="#issuecomment-"]', // Issue comment permalink
+] as const;
+
 const isCommentGroupMinimized = (comment: HTMLElement): boolean =>
 	elementExists('.minimized-comment:not(.d-none)', comment)
 	|| Boolean(closestElementOptional([
@@ -12,13 +24,47 @@ const isCommentGroupMinimized = (comment: HTMLElement): boolean =>
 		'details.js-resolvable-timeline-thread-container:not([open])', // Review comments
 	], comment));
 
+function getItemHash(item: HTMLElement): string | undefined {
+	if (item.id) {
+		return '#' + item.id;
+	}
+
+	const link = $optional(permalinkSelectors, item);
+	return link instanceof HTMLAnchorElement ? link.hash : undefined;
+}
+
+function getCurrentItem(items: HTMLElement[]): HTMLElement | undefined {
+	const targetElement = $optional(':target');
+	const itemFromTarget = targetElement && closestElementOptional(itemSelectors, targetElement);
+	if (itemFromTarget) {
+		return itemFromTarget;
+	}
+
+	return items.find(item => getItemHash(item) === location.hash);
+}
+
+function focusItem(item: HTMLElement): void {
+	const hash = getItemHash(item);
+	if (!hash) {
+		return;
+	}
+
+	if (item.id || $optional(hash)) {
+		// Make item a target without pushing to history
+		location.replace(hash);
+	} else {
+		item.scrollIntoView();
+		history.replaceState(history.state, document.title, hash);
+	}
+}
+
 function runShortcuts(event: KeyboardEvent): void {
 	if (!'jkx'.includes(event.key) || isEditable(event.target)) {
 		return;
 	}
 
 	event.preventDefault();
-	const targetElement = $optional(':target');
+	const targetElement = $optional(':target') ?? undefined;
 
 	if (event.key === 'x') {
 		// The event handler is quite broad, there's no guarantee that the intention is to toggle "Viewed"
@@ -26,10 +72,7 @@ function runShortcuts(event: KeyboardEvent): void {
 		return;
 	}
 
-	const items = $$([
-		'div[class*="targetable" i][id^="diff-"]', // Files in diffs
-		'.js-minimizable-comment-group', // Comments (to be `.filter()`ed)
-	])
+	const items = $$(itemSelectors)
 		.filter(element =>
 			element.classList.contains('js-minimizable-comment-group')
 				? !isCommentGroupMinimized(element)
@@ -38,8 +81,8 @@ function runShortcuts(event: KeyboardEvent): void {
 
 	// `j` goes to the next item, `k` goes back an item
 	const direction = event.key === 'j' ? 1 : -1;
-	// Without `targetElement`, it will start from -1
-	const currentIndex = items.indexOf(targetElement!);
+	// Without a current item, it will start from -1
+	const currentIndex = items.indexOf(getCurrentItem(items)!);
 
 	// Start at 0 if nothing is; clamp index
 	const chosenItemIndex = Math.min(
@@ -48,8 +91,7 @@ function runShortcuts(event: KeyboardEvent): void {
 	);
 
 	if (currentIndex !== chosenItemIndex) {
-		// Make item a target without pushing to history
-		location.replace('#' + items[chosenItemIndex].id);
+		focusItem(items[chosenItemIndex]);
 	}
 }
 
@@ -75,5 +117,6 @@ Test URLs:
 
 https://github.com/refined-github/refined-github/pull/4030#discussion_r584184640
 https://github.com/refined-github/refined-github/pull/8517/changes
+https://github.com/refined-github/refined-github/issues/7856
 
 */


### PR DESCRIPTION
Fixes #9270

## Summary

- Adds React issue body/comment containers to `keyboard-navigation`.
- Resolves the current navigation item from either `:target` or the current issue/comment permalink hash.
- Falls back to scrolling the React issue container when the permalink target is not on the container itself, while preserving existing PR file and legacy comment behavior.

## Test plan

- `npm run build:typescript`
- `npm run lint`
- `npm run vitest`
- `DPRINT_CACHE_DIR=/private/tmp/rgh-dprint-cache npm run format:check`
- `npm test`

`npm run lint` and `npm test` pass with the existing repository TODO warnings.

## Manual test URLs

- https://github.com/refined-github/refined-github/issues/7856
- https://github.com/download-directory/download-directory.github.io/issues/141
- https://github.com/refined-github/refined-github/pull/4030#discussion_r584184640
- https://github.com/refined-github/refined-github/pull/8517/changes

## AI note

Tiny boogers, swept aside,
Shortcuts found their path with pride.
