### PR TITLE
`repo-avatars`, `repo-header-info`, `ci-link` - Fix search

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -60,7 +60,7 @@ async function add(anchor: HTMLElement): Promise<void> {
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
 		[
-			'div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
+			'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
 			// TODO [2026-08-01]: Remove
 			// Desktop
 			'.AppHeader-context-item:not([data-hovercard-type])',

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -38,9 +38,9 @@ async function add(ownerLabel: HTMLElement): Promise<void> {
 function init(signal: AbortSignal): void {
 	observe(
 		[
+			'.loaded div[data-testid="top-nav-center"] li:first-child > a[class*="prc-Breadcrumbs-Item"]',
 			// TODO [2026-07-01]: Drop
 			'.AppHeader-context-full [role="listitem"]:first-child .AppHeader-context-item-label',
-			'div[data-testid="top-nav-center"] li:first-child > a[class*="prc-Breadcrumbs-Item"]',
 		],
 		add,
 		{signal},

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -96,7 +96,7 @@ async function add(repoLink: HTMLAnchorElement): Promise<void> {
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
 		[
-			'div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
+			'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
 			// TODO [2026-06-01]: Drop
 			'.AppHeader-context-full [role="listitem"]:last-child a.AppHeader-context-item',
 		],


### PR DESCRIPTION
Fixes #9723

I would prefer to move all logic unrelated to updating the DOM out of the `observe` callbacks, but that would be out of scope for a bug-fix PR. Also, removal TODOs should have the same date.

## Test URLs

See https://github.com/refined-github/refined-github/issues/9723#issuecomment-4694368977

## Screenshot
