### PR TITLE
AI SPAM

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,5 +1,5 @@
-/* TODO: Remove .Layout-sidebar after August 2026 */
-[rgh-clean-repo-sidebar] :is([class*='PageLayout-Pane'], .Layout-sidebar) {
+/* TODO: Remove [class*='PageLayout-Pane'] after August 2026 */
+[rgh-clean-repo-sidebar] :is([class*='PageLayout-Pane'], [class*='PageLayout-Pane']) {
 	/* Hide "About" header */
 	.BorderGrid-row:first-child h2 {
 		display: none;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -33,7 +33,7 @@ async function hideLanguageHeader(): Promise<void> {
 	const lastSidebarHeader = $optional([
 		'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type h2',
 		// TODO [2026-09-01]: Drop old selector
-		'.Layout-sidebar .BorderGrid-row:last-of-type h2',
+		'[class*='PageLayout-Pane'] .BorderGrid-row:last-of-type h2',
 	]);
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
@@ -48,7 +48,7 @@ async function hideEmptyMeta(): Promise<void> {
 		$optional([
 			'[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic',
 			// TODO [2026-09-01]: Drop old selector
-			'.Layout-sidebar .BorderGrid-cell > .text-italic',
+			'[class*='PageLayout-Pane'] .BorderGrid-cell > .text-italic',
 		])?.remove();
 	}
 }
@@ -59,13 +59,13 @@ async function moveReportLink(): Promise<void> {
 	const reportLink = $optional([
 		'[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]',
 		// TODO [2026-09-01]: Drop old selector
-		'.Layout-sidebar a[href^="/contact/report-content"]',
+		'[class*='PageLayout-Pane'] a[href^="/contact/report-content"]',
 	])?.parentElement;
 	if (reportLink) {
 		// Your own repos don't include this link
 		$([
 			'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell',
-			'.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell',
+			'[class*='PageLayout-Pane'] .BorderGrid-row:last-of-type .BorderGrid-cell',
 		]).append(reportLink);
 	}
 }

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer.js';
 const selectors = [
 	// `isRepoHome` repository description
 	// https://github.com/refined-github/sandbox
-	'.Layout-sidebar .f4.my-3',
+	'[class*='PageLayout-Pane'] .f4.my-3',
 
 	// `isCommitList` commit description
 	// https://github.com/refined-github/sandbox/commits/buncha-files/

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -16,7 +16,7 @@ div[class^='prc-PageLayout-Pane']:has(
 	> rails-partial[data-partial-name='codeViewRepoRoute.Sidebar']
 ),
 /* Old `isRepoRoot` - Remove after August 2026 */
-.Layout-sidebar .BorderGrid {
+[class*='PageLayout-Pane'] .BorderGrid {
 	--rgh-sticky-sidebar-offset: 0;
 }
 

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -13,7 +13,7 @@ const minimumViewportWidthForSidebar = 768; // Less than this, the layout is sin
 const sidebarSelector = [
 	'#partial-discussion-sidebar', // `isDiscussion`, `isPRConversation`
 	'div[class^="prc-PageLayout-Pane"]:has(> rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"])', // `isRepoRoot`
-	'.Layout-sidebar .BorderGrid', // Old `isRepoRoot` - Remove after August 2026
+	'[class*='PageLayout-Pane'] .BorderGrid', // Old `isRepoRoot` - Remove after August 2026
 ];
 
 let sidebar: HTMLElement | undefined;


### PR DESCRIPTION
Fixes #9589

Replaced deprecated `.Layout-sidebar` CSS class with `[class*='PageLayout-Pane']` across 5 files to restore sidebar styling.

Files modified:
- clean-repo-sidebar.css/tsx
- parse-backticks.tsx
- sticky-sidebar.css/tsx