### PR TITLE
AI SPAM

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -17,3 +17,9 @@
 		min-width: 5em;
 	}
 }
+
+/* Fix SHA clipping at some resolutions (#9638) */
+.rgh-release-download-count [data-rgh-heat] {
+	white-space: nowrap;
+	overflow: visible;
+}


### PR DESCRIPTION
Fixes #9638

Added `white-space: nowrap` and `overflow: visible` to the SHA display element in release-download-count to prevent text clipping at certain viewport widths.