### PR TITLE
AI SPAM

### DIFF
--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -1,12 +1,14 @@
 import features from '../feature-manager.js';
+import showToast from '../github-helpers/toast.js';
 import {isEditable} from '../helpers/dom-utils.js';
 
 async function handler({key, target}: KeyboardEvent): Promise<void> {
 	if (key === 'y' && !isEditable(target)) {
 		const url = location.href;
-		await navigator.clipboard.writeText(url);
-		// Log to ensure we're coping the new URL
-		console.log('Copied URL to the clipboard', url);
+		showToast(navigator.clipboard.writeText(url), {
+			message: url,
+			doneMessage: 'Copied to clipboard',
+		});
 	}
 }
 


### PR DESCRIPTION
## Description

Pressing `y` copies the URL to clipboard but previously only logged to console with no visual feedback. Now shows a toast notification with the URL being copied and a "Copied to clipboard" confirmation.

## Changes

- Replaced `console.log` with `showToast` from the existing toast helper
- Shows the URL as the loading message and "Copied to clipboard" as the success message

## Test URLs

- https://github.com/refined-github/refined-github/blob/main/.gitignore
- Any page — press `y` and verify the toast appears

Closes #9591