### PR TITLE
Meta: Add more tooltips with shortcuts

### DIFF
--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -51,7 +51,7 @@ const restrictedSyntax = {
 			'JSXOpeningElement:has(JSXAttribute[name.name="data-hotkey"]) > JSXAttribute[name.name=/^(title|aria-label)$/]',
 		message:
 			"Elements with hotkeys require a mention in the tooltip, which requires: import addTooltip from '../helpers/tooltip.js';",
-	},{
+	}, {
 		message: 'JSX elements with `data-hotkey` must be wrapped in `tooltipped()`',
 		selector:
 			'JSXOpeningElement:not(:has(JSXAttribute[name.name="hidden"])) > JSXAttribute[name.name="data-hotkey"]:not(CallExpression[callee.name="tooltipped"] JSXAttribute[name.name="data-hotkey"])',

--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -46,16 +46,15 @@ const restrictedSyntax = {
 		selector: '*[test.type="CallExpression"][test.callee.name="$optional"],'
 			+ '*[test.type="UnaryExpression"][test.operator="!"][test.argument.type="CallExpression"][test.argument.callee.name="$optional"]',
 	}],
-	'byo/data-hotkey-imports-tooltip': ['error', {
-		message: 'JSX elements with `data-hotkey` must import `tooltip.js`',
-		selector: String.raw`Program:has(JSXAttribute[name.name="data-hotkey"])
-			:not(:has(ImportDeclaration[source.value=/\/helpers\/tooltip\.js$/]))`,
-	}],
 	'byo/prefer-tooltipped': ['error', {
 		selector:
 			'JSXOpeningElement:has(JSXAttribute[name.name="data-hotkey"]) > JSXAttribute[name.name=/^(title|aria-label)$/]',
 		message:
 			"Elements with hotkeys require a mention in the tooltip, which requires: import addTooltip from '../helpers/tooltip.js';",
+	},{
+		message: 'JSX elements with `data-hotkey` must be wrapped in `tooltipped()`',
+		selector:
+			'JSXOpeningElement:not(:has(JSXAttribute[name.name="hidden"])) > JSXAttribute[name.name="data-hotkey"]:not(CallExpression[callee.name="tooltipped"] JSXAttribute[name.name="data-hotkey"])',
 	}],
 };
 

--- a/eslint-rules/restricted-syntax.js
+++ b/eslint-rules/restricted-syntax.js
@@ -51,6 +51,12 @@ const restrictedSyntax = {
 		selector: String.raw`Program:has(JSXAttribute[name.name="data-hotkey"])
 			:not(:has(ImportDeclaration[source.value=/\/helpers\/tooltip\.js$/]))`,
 	}],
+	'byo/prefer-tooltipped': ['error', {
+		selector:
+			'JSXOpeningElement:has(JSXAttribute[name.name="data-hotkey"]) > JSXAttribute[name.name=/^(title|aria-label)$/]',
+		message:
+			"Elements with hotkeys require a mention in the tooltip, which requires: import addTooltip from '../helpers/tooltip.js';",
+	}],
 };
 
 export default restrictedSyntax;

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,7 +1,7 @@
 {
   "source/features/releases-tab.tsx": {
     "byo/prefer-tooltipped": {
-      "count": 1
+      "count": 2
     }
   }
 }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,2 +1,7 @@
 {
+  "source/features/releases-tab.tsx": {
+    "byo/prefer-tooltipped": {
+      "count": 1
+    }
+  }
 }

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -15,7 +15,6 @@ import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {appendBefore} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetReleasesCount from './releases-tab.gql';
-import {tooltipped} from '../helpers/tooltip.js';
 
 function detachHighlightFromCodeTab(codeTab: HTMLAnchorElement): void {
 	codeTab.dataset.selectedLinks = codeTab.dataset.selectedLinks!.replace('repo_releases ', '');
@@ -62,24 +61,19 @@ async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | v
 
 	repoNavigationBar.append(
 		<li className="d-flex">
-			{tooltipped(
-				{
-					label: '',
-					shortcut: 'g r',
-				},
-				<a
-					href={buildRepoUrl(type.toLowerCase())}
-					className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
-					data-hotkey="g r"
-					data-selected-links="repo_releases"
-					data-tab-item="rgh-releases-item"
-					data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
-				>
-					<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
-					<span data-content={type}>{type}</span>
-					<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
-				</a>,
-			)}
+			<a
+				href={buildRepoUrl(type.toLowerCase())}
+				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
+				data-hotkey="g r"
+				data-selected-links="repo_releases"
+				data-tab-item="rgh-releases-item"
+				data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
+				title="Hotkey: G R"
+			>
+				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
+				<span data-content={type}>{type}</span>
+				<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+			</a>
 		</li>,
 	);
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -15,6 +15,7 @@ import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {appendBefore} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetReleasesCount from './releases-tab.gql';
+import {tooltipped} from '../helpers/tooltip.js';
 
 function detachHighlightFromCodeTab(codeTab: HTMLAnchorElement): void {
 	codeTab.dataset.selectedLinks = codeTab.dataset.selectedLinks!.replace('repo_releases ', '');
@@ -61,19 +62,24 @@ async function addReleasesTab(repoNavigationBar: HTMLElement): Promise<false | v
 
 	repoNavigationBar.append(
 		<li className="d-flex">
-			<a
-				href={buildRepoUrl(type.toLowerCase())}
-				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
-				data-hotkey="g r"
-				data-selected-links="repo_releases"
-				data-tab-item="rgh-releases-item"
-				data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
-				title="Hotkey: G R"
-			>
-				<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
-				<span data-content={type}>{type}</span>
-				<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
-			</a>
+			{tooltipped(
+				{
+					label: '',
+					shortcut: 'g r',
+				},
+				<a
+					href={buildRepoUrl(type.toLowerCase())}
+					className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item rgh-releases-tab"
+					data-hotkey="g r"
+					data-selected-links="repo_releases"
+					data-tab-item="rgh-releases-item"
+					data-turbo-frame="repo-content-turbo-frame" /* Required for `data-selected-links` to work */
+				>
+					<TagIcon className="UnderlineNav-octicon d-none d-sm-inline" />
+					<span data-content={type}>{type}</span>
+					<span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>
+				</a>,
+			)}
 		</li>,
 	);
 

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -130,7 +130,7 @@ const createDropdown = onetime(() => (
 		{
 			tooltipped(
 				{
-					label: '',
+					label: 'Open the notifications filter dropdown',
 					shortcut: 'Shift+S',
 				},
 				<summary

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -21,6 +21,7 @@ import {botLinksNotificationSelectors} from '../github-helpers/selectors.js';
 import {is, not} from '../helpers/css-selectors.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
+import {tooltipped} from '../helpers/tooltip.js';
 
 const prIcons = [
 	'.octicon-git-pull-request',
@@ -126,16 +127,21 @@ const createDropdown = onetime(() => (
 		className="details-reset details-overlay position-relative rgh-select-notifications mr-2 tmp-mr-2"
 		onToggle={resetFilters}
 	>
-		<summary
-			className="h6" // `h6` matches "Select all" style
-			data-hotkey="Shift+S"
-			aria-haspopup="menu"
-			// Don't use tooltipped, it remains visible when the dropdown is open
-			title="Hotkey: Shift+S"
-			role="button"
-		>
-			Select by <span className="dropdown-caret ml-1 tmp-ml-1" />
-		</summary>
+		{
+			tooltipped(
+				{
+					label: '',
+					shortcut: 'Shift+S',
+				},
+				<summary
+					className="h6" // `h6` matches "Select all" style
+					data-hotkey="Shift+S"
+					aria-haspopup="menu"
+					role="button"
+				>
+					Select by <span className="dropdown-caret ml-1 tmp-ml-1" />
+				</summary>,
+			)}
 		<details-menu
 			className="SelectMenu left-0"
 			aria-label="Select by"


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9496


I'll also consider undoing https://github.com/refined-github/refined-github/pull/9451 partially since `aria-label` is lighter than `tooltipped()` and is preferable in cases where there's no hotkey/focus/overlap issues.