### PR TITLE
Add `publish-draft-release` feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -699,6 +699,11 @@
 		"screenshot": null
 	},
 	{
+		"id": "publish-draft-release",
+		"description": "Adds a button to publish a draft release, with a confirmation, without having to open the release editor.",
+		"screenshot": "https://github.com/user-attachments/assets/8afe1531-36f3-4bce-9489-5f3e6d6ebf31"
+	},
+	{
 		"id": "pull-request-hotkeys",
 		"description": "Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd>, and <kbd>g</kbd> <kbd>4</kbd>.",
 		"screenshot": "https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png"

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -119,6 +119,7 @@
 	"previous-next-commit-buttons",
 	"previous-version",
 	"profile-hotkey",
+	"publish-draft-release",
 	"pull-request-hotkeys",
 	"quick-comment-edit",
 	"quick-comment-hiding",

--- a/readme.md
+++ b/readme.md
@@ -291,6 +291,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "create-release-shortcut") Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
 - [](# "tag-changes-link") 🔥 [Adds a link to changes since last tag/release for each tag/release.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png)
+- [](# "publish-draft-release") Adds a button to publish a draft release, with a confirmation, without having to open the release editor.
 - [](# "confirm-release") [Adds a confirmation dialog when publishing a release, preventing accidental submissions.](https://github.com/user-attachments/assets/6cff805d-3825-43c4-ac20-38c76decd858)
 - [](# "link-to-changelog-file") [Adds a button to view the changelog file from the releases page.](https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png)
 

--- a/readme.md
+++ b/readme.md
@@ -291,7 +291,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "create-release-shortcut") Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
 - [](# "tag-changes-link") 🔥 [Adds a link to changes since last tag/release for each tag/release.](https://github-production-user-asset-6210df.s3.amazonaws.com/140871606/257036739-bebafb94-cb94-4053-9768-ff97306ab862.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/46634000/139236979-44533bfd-5c17-457d-bdc1-f9ec395f6a3a.png)
-- [](# "publish-draft-release") Adds a button to publish a draft release, with a confirmation, without having to open the release editor.
+- [](# "publish-draft-release") [Adds a button to publish a draft release, with a confirmation, without having to open the release editor.](https://github.com/user-attachments/assets/8afe1531-36f3-4bce-9489-5f3e6d6ebf31)
 - [](# "confirm-release") [Adds a confirmation dialog when publishing a release, preventing accidental submissions.](https://github.com/user-attachments/assets/6cff805d-3825-43c4-ac20-38c76decd858)
 - [](# "link-to-changelog-file") [Adds a button to view the changelog file from the releases page.](https://user-images.githubusercontent.com/46634000/139236982-a1bce2a2-f3aa-40a9-bca4-8756bc941210.png)
 

--- a/source/features/publish-draft-release.tsx
+++ b/source/features/publish-draft-release.tsx
@@ -1,0 +1,91 @@
+import delegate from 'delegate-it';
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import {elementExists} from 'select-dom';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import {getRepo} from '../github-helpers/index.js';
+import showToast from '../github-helpers/toast.js';
+import observe from '../helpers/selector-observer.js';
+
+const getReleaseEditLinkSelector = (): 'a' => `a[href^="/${getRepo()!.nameWithOwner}/releases/edit"]` as 'a';
+
+async function getCurrentDraftRelease(): Promise<AnyObject | undefined> {
+	// Drafts have no tag yet, so they can't be fetched via `releases/tags/:tag`.
+	// Find the draft whose page matches the one we're on instead.
+	for await (const page of api.v3paginated('releases')) {
+		const release = (page as unknown as AnyObject[]).find(candidate =>
+			candidate.draft && new URL(candidate.html_url).pathname === location.pathname,
+		);
+		if (release) {
+			return release;
+		}
+	}
+
+	return undefined;
+}
+
+async function publishRelease(): Promise<void> {
+	const release = await getCurrentDraftRelease();
+	if (!release) {
+		throw new Error('Could not find the draft release for this page');
+	}
+
+	const published = await api.v3(release.url, {
+		method: 'PATCH',
+		body: {
+			draft: false,
+		},
+	});
+
+	location.assign(published.html_url as string); // Visit the published release
+}
+
+async function onPublishClick(): Promise<void> {
+	if (!confirm('Publish this release? It will become public and watchers will be notified.')) {
+		return;
+	}
+
+	await showToast(publishRelease(), {
+		message: 'Publishing…',
+		doneMessage: 'Redirecting…',
+	});
+}
+
+function attachButton(editButton: HTMLAnchorElement): void {
+	if (!elementExists('[title="Draft"]')) {
+		return; // Only draft releases can be published
+	}
+
+	editButton.before(
+		<button
+			type="button"
+			className="Button Button--secondary Button--small ml-3 tmp-ml-3 mr-1 tmp-mr-1 rgh-publish-draft"
+		>
+			Publish release
+		</button>,
+	);
+}
+
+async function init(signal: AbortSignal): Promise<void> {
+	observe(getReleaseEditLinkSelector(), attachButton, {signal});
+	delegate('.rgh-publish-draft', 'click', onPublishClick, {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isSingleReleaseOrTag,
+	],
+	requiresToken: true,
+	init,
+});
+
+/*
+
+Test URLs:
+
+Draft releases are private, so a draft must exist in a repo you have push access to.
+The page looks like: https://github.com/$user/$repo/releases/tag/untagged-0000000000000000
+
+*/

--- a/source/features/publish-draft-release.tsx
+++ b/source/features/publish-draft-release.tsx
@@ -1,7 +1,7 @@
-import delegate from 'delegate-it';
+import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import {elementExists} from 'select-dom';
+import {$, closestElementOptional, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -11,12 +11,15 @@ import observe from '../helpers/selector-observer.js';
 
 const getReleaseEditLinkSelector = (): 'a' => `a[href^="/${getRepo()!.nameWithOwner}/releases/edit"]` as 'a';
 
-async function getCurrentDraftRelease(): Promise<AnyObject | undefined> {
+// On the releases list each release lives in its own `.Box`; the single-release page only has one release
+const getReleaseContainer = (element: Element): ParentNode => closestElementOptional('.Box', element) ?? document;
+
+async function getDraftRelease(releasePath: string): Promise<AnyObject | undefined> {
 	// Drafts have no tag yet, so they can't be fetched via `releases/tags/:tag`.
-	// Find the draft whose page matches the one we're on instead.
+	// Find the draft whose page matches the release being published instead.
 	for await (const page of api.v3paginated('releases')) {
 		const release = (page as unknown as AnyObject[]).find(candidate =>
-			candidate.draft && new URL(candidate.html_url).pathname === location.pathname,
+			candidate.draft && new URL(candidate.html_url).pathname === releasePath,
 		);
 		if (release) {
 			return release;
@@ -26,10 +29,11 @@ async function getCurrentDraftRelease(): Promise<AnyObject | undefined> {
 	return undefined;
 }
 
-async function publishRelease(): Promise<void> {
-	const release = await getCurrentDraftRelease();
+async function publishRelease(editLink: HTMLAnchorElement): Promise<void> {
+	const releasePath = editLink.pathname.replace('/releases/edit/', '/releases/tag/');
+	const release = await getDraftRelease(releasePath);
 	if (!release) {
-		throw new Error('Could not find the draft release for this page');
+		throw new Error('Could not find the draft release');
 	}
 
 	const published = await api.v3(release.url, {
@@ -42,26 +46,27 @@ async function publishRelease(): Promise<void> {
 	location.assign(published.html_url as string); // Visit the published release
 }
 
-async function onPublishClick(): Promise<void> {
+async function onPublishClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): Promise<void> {
 	if (!confirm('Publish this release? It will become public and watchers will be notified.')) {
 		return;
 	}
 
-	await showToast(publishRelease(), {
+	const editLink = $(getReleaseEditLinkSelector(), getReleaseContainer(event.delegateTarget));
+	await showToast(publishRelease(editLink), {
 		message: 'Publishing…',
 		doneMessage: 'Redirecting…',
 	});
 }
 
 function attachButton(editButton: HTMLAnchorElement): void {
-	if (!elementExists('[title="Draft"]')) {
+	if (!elementExists('[title="Draft"]', getReleaseContainer(editButton))) {
 		return; // Only draft releases can be published
 	}
 
 	editButton.before(
 		<button
 			type="button"
-			className="Button Button--secondary Button--small ml-3 tmp-ml-3 mr-1 tmp-mr-1 rgh-publish-draft"
+			className="Button Button--primary Button--small ml-3 tmp-ml-3 mr-1 tmp-mr-1 rgh-publish-draft"
 		>
 			Publish release
 		</button>,
@@ -75,6 +80,7 @@ async function init(signal: AbortSignal): Promise<void> {
 
 void features.add(import.meta.url, {
 	include: [
+		pageDetect.isReleases,
 		pageDetect.isSingleReleaseOrTag,
 	],
 	requiresToken: true,
@@ -86,6 +92,8 @@ void features.add(import.meta.url, {
 Test URLs:
 
 Draft releases are private, so a draft must exist in a repo you have push access to.
-The page looks like: https://github.com/$user/$repo/releases/tag/untagged-0000000000000000
+
+- Releases list: https://github.com/$user/$repo/releases
+- Single draft: https://github.com/$user/$repo/releases/tag/untagged-0000000000000000
 
 */

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -143,6 +143,7 @@ import './features/quick-label-removal.js';
 import './features/clean-conversation-headers.js';
 import './features/new-or-deleted-file.js';
 import './features/convert-release-to-draft.js';
+import './features/publish-draft-release.js';
 import './features/confirm-release.js';
 import './features/new-repo-disable-projects-and-wikis.js';
 import './features/table-input.js';


### PR DESCRIPTION
Adds a "Publish release" button on draft releases (next to "Edit release"), with a confirmation, so a draft can be published without opening the release editor first. Opposite of `convert-release-to-draft`.
Useful to use together with [Release Drafter GitHub action](https://github.com/release-drafter/release-drafter)

## Test URLs

- `/releases` page on a repo you have push access to and there are draft releases
- `/releases/tag/untagged-<hash>` page on a repo you have push access to

## Screenshot

<img width="1180" height="678" alt="publish-draft-release" src="https://github.com/user-attachments/assets/8afe1531-36f3-4bce-9489-5f3e6d6ebf31" />
