### PR TITLE
AI SPAM

### DIFF
--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -1,6 +1,7 @@
 html:not([rgh-OFF-repo-header-info]) {
 	div[data-testid='top-nav-center']
-		li:last-child
+		> nav > :is(ol, ul)
+		> li:last-child
 		> a[class*='prc-Breadcrumbs-Item']:not(.rgh-repo-header-info-updated) {
 		/* Matches the `isSmallDevice` JS check */
 		@media (min-width: 500px) {

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -151,7 +151,7 @@ async function add(repoLink: HTMLElement): Promise<void> {
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
 		[
-			'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
+			'.loaded div[data-testid="top-nav-center"] > nav > :is(ol, ul) > li:last-child > a[class*="prc-Breadcrumbs-Item"]',
 			// TODO [2026-08-01]: Remove
 			// Desktop
 			'.AppHeader-context-item:not([data-hovercard-type])',


### PR DESCRIPTION
## Summary

- Restrict `repo-header-info` to the top-level repo breadcrumb item in GitHub’s new header
- Avoid matching nested dropdown list items under `top-nav-center`
- Keep the matching CSS padding selector aligned with the JS observer selector

Fixes #9755

## Test plan

- `npm exec -- dprint check source/features/repo-header-info.tsx source/features/repo-header-info.css`
- `npm exec -- eslint source/features/repo-header-info.tsx source/features/repo-header-info.css`
- `npm run build:typescript`
- `npm exec -- biome lint source/features/repo-header-info.tsx source/features/repo-header-info.css`
- `npm exec -- vitest --run build/features.test.ts`
- `git diff --check`