### PR TITLE
`display-issue-fields` - New feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -225,6 +225,12 @@
 		"screenshot": "https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif"
 	},
 	{
+		"id": "display-issue-fields",
+		"description": "Shows issue field values (like Priority) on each row of the issues list.",
+		"css": true,
+		"screenshot": null
+	},
+	{
 		"id": "download-folder-button",
 		"description": "Adds a button to download entire folders, via https://download-directory.github.io.",
 		"screenshot": "https://user-images.githubusercontent.com/46634000/158347358-49234bb8-b9e6-41be-92ed-c0c0233cbad2.png"

--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -228,7 +228,7 @@
 		"id": "display-issue-fields",
 		"description": "Shows issue field values (like Priority) on each row of the issues list.",
 		"css": true,
-		"screenshot": null
+		"screenshot": "https://github.com/user-attachments/assets/62f9ece9-36b4-4440-acbf-e58191f1a8f1"
 	},
 	{
 		"id": "download-folder-button",

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -37,6 +37,7 @@
 	"deep-reblame",
 	"default-branch-button",
 	"dim-bots",
+	"display-issue-fields",
 	"download-folder-button",
 	"easy-toggle-commit-messages",
 	"easy-toggle-files",

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "sticky-comment-header") [Makes the comment header sticky when scrolling through long comments. Requires `show-names` to be enabled.](https://github.com/user-attachments/assets/0d6deca0-0f49-4aa3-ab23-0cfbde4fa4e8)
 - [](# "conversation-authors") [Highlights issues/PRs opened by you or the current repo’s collaborators.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png)
 - [](# "align-issue-labels") [In issue/PR lists, aligns the labels to the left, below each title.](https://github.com/user-attachments/assets/dca5dc12-7283-4704-a93f-5bfe5f2b1938)
-- [](# "display-issue-fields") Shows issue field values (like Priority) on each row of the issues list.
+- [](# "display-issue-fields") [Shows issue field values (like Priority) on each row of the issues list.](https://github.com/user-attachments/assets/62f9ece9-36b4-4440-acbf-e58191f1a8f1)
 - [](# "last-update-sort") 🔥 Changes the default sort order of issues/PRs to `Recently updated`.
 - [](# "global-conversation-list-filters") [Adds filters for PRs _in your repos_ and _commented on by you_ in the global PR search.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png)
 - [](# "clean-conversation-sidebar") 🔥 [Hides empty sections (or just their "empty" label) in the issue/PR sidebar.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png)

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "sticky-comment-header") [Makes the comment header sticky when scrolling through long comments. Requires `show-names` to be enabled.](https://github.com/user-attachments/assets/0d6deca0-0f49-4aa3-ab23-0cfbde4fa4e8)
 - [](# "conversation-authors") [Highlights issues/PRs opened by you or the current repo’s collaborators.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/252804821-a412e05c-fb76-400b-85b5-5acbda538ab2.png)
 - [](# "align-issue-labels") [In issue/PR lists, aligns the labels to the left, below each title.](https://github.com/user-attachments/assets/dca5dc12-7283-4704-a93f-5bfe5f2b1938)
+- [](# "display-issue-fields") Shows issue field values (like Priority) on each row of the issues list.
 - [](# "last-update-sort") 🔥 Changes the default sort order of issues/PRs to `Recently updated`.
 - [](# "global-conversation-list-filters") [Adds filters for PRs _in your repos_ and _commented on by you_ in the global PR search.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253048449-2f7cc331-c379-4ec0-a542-441e8b4f8d79.png)
 - [](# "clean-conversation-sidebar") 🔥 [Hides empty sections (or just their "empty" label) in the issue/PR sidebar.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253054419-48c38c01-b1dc-42ca-9ff6-fd63392b5921.png)

--- a/source/features/display-issue-fields.css
+++ b/source/features/display-issue-fields.css
@@ -4,11 +4,11 @@
 	height: 20px;
 	padding: 0 8px;
 	border: 1px solid
-		var(--borderColor-muted, var(--color-border-muted, #d1d9e0b3));
+		var(--borderColor-muted, var(--color-border-muted, fuchsia));
 	border-radius: 2em;
 	font-size: 12px;
 	font-weight: 500;
 	line-height: 1;
 	white-space: nowrap;
-	color: var(--fgColor-muted, var(--color-fg-muted, #59636e));
+	color: var(--fgColor-muted, var(--color-fg-muted, fuchsia));
 }

--- a/source/features/display-issue-fields.css
+++ b/source/features/display-issue-fields.css
@@ -1,0 +1,14 @@
+.rgh-issue-field {
+	display: inline-flex;
+	align-items: center;
+	height: 20px;
+	padding: 0 8px;
+	border: 1px solid
+		var(--borderColor-muted, var(--color-border-muted, #d1d9e0b3));
+	border-radius: 2em;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1;
+	white-space: nowrap;
+	color: var(--fgColor-muted, var(--color-fg-muted, #59636e));
+}

--- a/source/features/display-issue-fields.tsx
+++ b/source/features/display-issue-fields.tsx
@@ -1,0 +1,192 @@
+import './display-issue-fields.css';
+import batchedFunction from 'batched-function';
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import {$optional, closestElement, elementExists} from 'select-dom';
+import {CachedFunction} from 'webext-storage-cache';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import {getRepo} from '../github-helpers/index.js';
+import observe from '../helpers/selector-observer.js';
+
+// https://docs.github.com/en/graphql/reference/unions#issuefieldvalue
+type FieldValue = {
+	__typename: string;
+	field?: {name: string};
+	name?: string; // `IssueFieldSingleSelectValue`: option name
+	color?: string; // `IssueFieldSingleSelectValue`: option color (enum or hex)
+	number?: number; // `IssueFieldNumberValue`
+	text?: string; // `IssueFieldTextValue`
+	date?: string; // `IssueFieldDateValue`
+	value?: string; // `IssueFieldMultiSelectValue`: comma-separated option names
+};
+
+type IssueFields = {
+	issueFieldValues: {
+		nodes: FieldValue[];
+	};
+};
+
+// Maps GitHub's single-select option color enum to Primer semantic color tokens, so the
+// badge reuses the exact tint GitHub shows in the issue sidebar (and adapts to dark mode).
+const colorTokens: Record<string, string> = {
+	gray: 'neutral',
+	blue: 'accent',
+	green: 'success',
+	yellow: 'attention',
+	orange: 'severe',
+	red: 'danger',
+	pink: 'sponsors',
+	purple: 'done',
+};
+
+const fieldValuesCache = new CachedFunction('issue-fields', {
+	async updater(issueNumbers: number[]): Promise<Record<string, IssueFields>> {
+		const {repository} = await api.v4(`
+			repository() {
+				${
+					issueNumbers.map(number => `
+						${api.escapeKey(number)}: issue(number: ${number}) {
+							issueFieldValues(first: 20) {
+								nodes {
+									__typename
+									... on IssueFieldValueCommon {
+										field {
+											... on IssueFieldCommon {
+												name
+											}
+										}
+									}
+									... on IssueFieldSingleSelectValue { name color }
+									... on IssueFieldNumberValue { number: value }
+									... on IssueFieldTextValue { text: value }
+									... on IssueFieldDateValue { date: value }
+									... on IssueFieldMultiSelectValue { value }
+								}
+							}
+						}
+					`).join('\n')
+				}
+			}
+		`);
+
+		return repository;
+	},
+	maxAge: {minutes: 10},
+	cacheKey: ([issues]) => `${getRepo()!.nameWithOwner}:${String(issues)}`,
+});
+
+function getIssueNumber(link: HTMLAnchorElement): number {
+	return Number(link.pathname.split('/', 5)[4]);
+}
+
+function renderValue(value: FieldValue): JSX.Element | undefined {
+	let label: string | undefined;
+	let token: string | undefined;
+
+	switch (value.__typename) {
+		case 'IssueFieldSingleSelectValue': {
+			label = value.name;
+			token = value.color ? colorTokens[value.color.toLowerCase()] : undefined;
+			break;
+		}
+
+		case 'IssueFieldNumberValue': {
+			label = value.number === undefined ? undefined : String(value.number);
+			break;
+		}
+
+		case 'IssueFieldTextValue': {
+			label = value.text;
+			break;
+		}
+
+		case 'IssueFieldDateValue': {
+			label = value.date;
+			break;
+		}
+
+		case 'IssueFieldMultiSelectValue': {
+			label = value.value ?? undefined;
+			break;
+		}
+
+		default: {
+			return;
+		}
+	}
+
+	if (!label) {
+		return;
+	}
+
+	const style = token
+		? {
+			color: `var(--fgColor-${token})`,
+			backgroundColor: `var(--bgColor-${token}-muted)`,
+			borderColor: `var(--borderColor-${token}-muted, var(--bgColor-${token}-muted))`,
+		}
+		: undefined;
+
+	return (
+		<span className="rgh-issue-field" style={style} title={value.field ? `${value.field.name}: ${label}` : label}>
+			{label}
+		</span>
+	);
+}
+
+async function add(issueLinks: HTMLAnchorElement[]): Promise<void> {
+	const linksByNumber = new Map(issueLinks.map(link => [getIssueNumber(link), link]));
+	const fields = await fieldValuesCache.get([...linksByNumber.keys()]);
+
+	for (const [number, link] of linksByNumber) {
+		const row = closestElement('li', link);
+		if (elementExists('.rgh-issue-field', row)) {
+			continue;
+		}
+
+		// The issue is missing only if it was transferred/deleted between the list render and this query
+		const issue = fields[api.escapeKey(number)];
+		const nodes = issue ? issue.issueFieldValues.nodes : [];
+		const badges = nodes.flatMap(value => {
+			const badge = renderValue(value);
+			return badge ? [badge] : [];
+		});
+		if (badges.length === 0) {
+			continue;
+		}
+
+		// Sit right after the issue type token; otherwise lead the `#123 · author …` line
+		const issueType = $optional('[class*="IssueTypeIndicator-module__container"]', row);
+		if (issueType) {
+			issueType.after(...badges);
+		} else {
+			const description = $optional('[class*="Description-module__container"]', row);
+			if (description) {
+				description.prepend(...badges);
+			}
+		}
+	}
+}
+
+function init(signal: AbortSignal): void {
+	observe('a[data-hovercard-type="issue"][data-testid="issue-pr-title-link"]', batchedFunction(add, {delay: 100}), {signal});
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isRepoIssueList,
+	],
+	requiresToken: true,
+	init,
+});
+
+/*
+
+Test URLs:
+
+Requires an organization with Issue fields enabled (public preview) and at least one field set on an issue:
+https://github.com/refined-github/sandbox/issues
+
+*/

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -56,6 +56,7 @@ import './features/global-conversation-list-filters.js';
 import './features/last-update-sort.js'; // Must be after global-conversation-list-filters and conversation-links-on-repo-lists
 import './features/pinned-issues-update-time.js';
 import './features/mark-pinned.js';
+import './features/display-issue-fields.js';
 import './features/default-branch-button.js';
 import './features/one-click-diff-options.js';
 import './features/sync-pr-commit-title.js';


### PR DESCRIPTION
Adds `display-issue-fields`: shows GitHub **issue field** values (e.g. Priority) as badges on each row of the repository issues list.

### Details
- Targets `isRepoIssueList`, `requiresToken: true`.
- Batches the visible issue numbers into one cached `issue.issueFieldValues` GraphQL query.
- Single-select values reuse Primer semantic color tokens (e.g. `YELLOW` → `attention`), so the badge matches the sidebar chip exactly and adapts to dark mode.
- Inserted right after the issue-type token (`IssueTypeIndicator`), falling back to the start of the metadata line for issues without a type.

### Requirements / scope
- Issue fields are an **org-level public preview** feature, so this is a no-op on personal-account repos and orgs not enrolled.

### Notes
This PR was opened with the help of Claude.

## Test URLs
https://github.com/nuxt/ui/issues?q=sort:updated-desc+is:issue+state:open+

## Screenshot
<img width="2464" height="1416" alt="CleanShot 2026-06-25 at 11 01 34@2x" src="https://github.com/user-attachments/assets/62f9ece9-36b4-4440-acbf-e58191f1a8f1" />
