### PR TITLE
Add load failure banner to options page

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -34,6 +34,9 @@ customizeNoAllUrlsErrorMessage(
 );
 
 handleMessages({
+	async ping(): Promise<string> {
+		return 'pong';
+	},
 	async openUrls(urls: string[], {tab}: chrome.runtime.MessageSender) {
 		for (const url of urls) {
 			void chrome.tabs.create({

--- a/source/helpers/tooltip.tsx
+++ b/source/helpers/tooltip.tsx
@@ -81,7 +81,11 @@ export function tooltipped(
 	element.append(tooltip);
 
 	queueMicrotask(() => {
-		console.assert(element.isConnected, 'Element must be attached to the document before the tooltip');
+		// TODO: Replace with https://github.com/sindresorhus/ts-extras/issues/75
+		if (!element.isConnected) {
+			throw new Error('Element must be attached to the document before the tooltip');
+		}
+
 		attachToDocument(tooltip);
 	});
 

--- a/source/options.css
+++ b/source/options.css
@@ -233,3 +233,9 @@ summary:hover {
 .OptionsSyncPerDomain-picker:has([value='default']:not(:checked)) ~ #action {
 	display: none;
 }
+
+.js-background-fail-banner {
+	padding: 1em;
+	border: 1px solid var(--rgh-red);
+	background: color-mix(in srgb, var(--rgh-red) 10%, transparent);
+}

--- a/source/options.html
+++ b/source/options.html
@@ -24,6 +24,10 @@
 	<!-- Captures and ignores native enter-to-submit action -->
 	<button hidden>Capture Submit</button>
 
+	<p hidden class="js-background-fail-banner">
+		It seems that the background page failed to load. This breaks some features. Please <a href="https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml">report it</a>.
+	</p>
+
 	<details id="token">
 		<summary><strong>🔑 Personal token</strong></summary>
 		<div>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -7,6 +7,8 @@ import {isChrome, isFirefox} from 'webext-detect';
 import type {SyncedForm} from 'webext-options-sync-per-domain';
 import 'webext-bugs/target-blank';
 
+import {messageRuntime} from 'webext-msg';
+
 import {startFeatureIdentification} from './helpers/bisect.js';
 import clearCacheHandler from './helpers/clear-cache-handler.js';
 import {doesBrowserActionOpenOptions} from './helpers/feature-utils.js';
@@ -102,6 +104,12 @@ async function fetchHotfixes(event: MouseEvent): Promise<void> {
 	}
 }
 
+async function validateBackgroundPage(): Promise<void> {
+	if (await messageRuntime({ping: true}) !== 'pong') {
+		$('.js-background-fail-banner').hidden = false;
+	}
+}
+
 async function generateDom(): Promise<void> {
 	// Generate list
 	await initFeatureList();
@@ -129,6 +137,8 @@ async function generateDom(): Promise<void> {
 
 	// Show stored CSS hotfixes
 	void showStoredCssHotfixes();
+
+	void validateBackgroundPage();
 }
 
 function addEventListeners(): void {


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9760
- improves detection of issues like https://github.com/refined-github/refined-github/issues/9737

## Test URLs

options page

## Screenshot

<img width="777" height="238" alt="Screenshot" src="https://github.com/user-attachments/assets/8dcc2a7b-18d4-4693-b2d8-b886c38d7ca5" />
<img width="777" height="238" alt="Screenshot 1" src="https://github.com/user-attachments/assets/5cf3e5e9-fe3c-4647-94e5-22cadd9fb99a" />

