### PR TITLE
AI SPAM

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,6 +119,7 @@ const rollup = {
 			targets: [
 				{src: './source/manifest.json', dest: 'distribution'},
 				{src: './source/*.+(html|png)', dest: 'distribution/assets'},
+				{src: './source/background-loader.js', dest: 'distribution/assets'},
 				{src: './source/options-preflight.js', dest: 'distribution/assets'},
 			],
 		}),

--- a/source/background-loader.js
+++ b/source/background-loader.js
@@ -1,0 +1,53 @@
+const backgroundPageLoadErrorsKey = 'backgroundPageLoadErrors';
+const storage = chrome.storage.session ?? chrome.storage.local;
+
+function serializeError(error) {
+	const serialized = {
+		message: error instanceof Error ? error.message : String(error),
+	};
+
+	if (error instanceof Error && error.stack) {
+		serialized.stack = error.stack;
+	}
+
+	return serialized;
+}
+
+async function storeBackgroundPageLoadError(error) {
+	const serialized = serializeError(error);
+	const storedErrors = await storage.get(backgroundPageLoadErrorsKey);
+	const errors = storedErrors[backgroundPageLoadErrorsKey] ?? [];
+
+	if (errors.some(storedError => storedError.message === serialized.message && storedError.stack === serialized.stack)) {
+		return;
+	}
+
+	await storage.set({
+		[backgroundPageLoadErrorsKey]: [
+			...errors,
+			serialized,
+		],
+	});
+}
+
+function backgroundPageLoadErrorListener(event) {
+	storeBackgroundPageLoadError(event.error ?? event.message);
+}
+
+globalThis.addEventListener('error', backgroundPageLoadErrorListener);
+Object.defineProperty(globalThis, 'removeBackgroundPageLoadErrorListener', {
+	configurable: true,
+	value() {
+		globalThis.removeEventListener('error', backgroundPageLoadErrorListener);
+	},
+});
+
+await storage.remove(backgroundPageLoadErrorsKey);
+
+try {
+	// eslint-disable-next-line import-x/extensions -- The loader is copied to `distribution/assets`, where the built file is `background.js`.
+	await import('./background.js');
+} catch (error) {
+	await storeBackgroundPageLoadError(error);
+	throw error;
+}

--- a/source/background.ts
+++ b/source/background.ts
@@ -115,3 +115,7 @@ chrome.runtime.onInstalled.addListener(async () => {
 	// Call after the reset above just in case we nuked Safari's base permissions
 	await showWelcomePage();
 });
+
+(globalThis as typeof globalThis & {
+	removeBackgroundPageLoadErrorListener?: () => void;
+}).removeBackgroundPageLoadErrorListener?.();

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -37,10 +37,10 @@
 	},
 	"options_page": "assets/options.html",
 	"background": {
-		"service_worker": "assets/background.js",
+		"service_worker": "assets/background-loader.js",
 		"type": "module",
 		"scripts": [
-			"assets/background.js"
+			"assets/background-loader.js"
 		]
 	},
 	"content_scripts": [

--- a/source/options.css
+++ b/source/options.css
@@ -239,3 +239,10 @@ summary:hover {
 	border: 1px solid var(--rgh-red);
 	background: color-mix(in srgb, var(--rgh-red) 10%, transparent);
 }
+
+.js-background-fail-error {
+	overflow: auto;
+	white-space: pre-wrap;
+	margin: 1em 0 0;
+	font-size: 12px;
+}

--- a/source/options.html
+++ b/source/options.html
@@ -24,9 +24,12 @@
 	<!-- Captures and ignores native enter-to-submit action -->
 	<button hidden>Capture Submit</button>
 
-	<p hidden class="js-background-fail-banner">
-		It seems that the background page failed to load. This breaks some features. Please <a href="https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml">report it</a>.
-	</p>
+	<div hidden class="js-background-fail-banner">
+		<p>
+			It seems that the background page failed to load. This breaks some features. Please <a href="https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml">report it</a>.
+		</p>
+		<pre hidden class="js-background-fail-error"></pre>
+	</div>
 
 	<details id="token">
 		<summary><strong>🔑 Personal token</strong></summary>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -22,6 +22,22 @@ import initTokenValidation from './options/token-validation.js';
 let syncedForm: SyncedForm | undefined;
 
 const {version} = chrome.runtime.getManifest();
+const backgroundPageLoadErrorsKey = 'backgroundPageLoadErrors';
+const backgroundPageLoadErrorsStorage = chrome.storage.session ?? chrome.storage.local;
+
+type BackgroundPageLoadError = {
+	message: string;
+	stack?: string;
+};
+
+async function getBackgroundPageLoadErrors(): Promise<BackgroundPageLoadError[]> {
+	const storedErrors: Record<string, BackgroundPageLoadError[] | undefined> = await backgroundPageLoadErrorsStorage.get(backgroundPageLoadErrorsKey);
+	return storedErrors[backgroundPageLoadErrorsKey] ?? [];
+}
+
+function formatBackgroundPageLoadError({message, stack}: BackgroundPageLoadError): string {
+	return stack ?? message;
+}
 
 async function findFeatureHandler(this: HTMLButtonElement): Promise<void> {
 	// TODO: Add support for GHE
@@ -105,9 +121,20 @@ async function fetchHotfixes(event: MouseEvent): Promise<void> {
 }
 
 async function validateBackgroundPage(): Promise<void> {
-	if (await messageRuntime({ping: true}) !== 'pong') {
-		$('.js-background-fail-banner').hidden = false;
+	try {
+		if (await messageRuntime({ping: true}) === 'pong') {
+			return;
+		}
+	} catch {}
+
+	const errors = await getBackgroundPageLoadErrors();
+	if (errors.length > 0) {
+		const errorField = $('.js-background-fail-error');
+		errorField.textContent = errors.map(error => formatBackgroundPageLoadError(error)).join('\n\n');
+		errorField.hidden = false;
 	}
+
+	$('.js-background-fail-banner').hidden = false;
 }
 
 async function generateDom(): Promise<void> {


### PR DESCRIPTION
## Summary

- add a plain background loader entrypoint that captures synchronous service worker load failures before the built background module runs
- store captured background load errors in extension storage so the options page can show the actual message/stack when the background ping fails
- clear the loader listener once the background page finishes loading successfully

Fixes #9767

## Validation

- `tsc --noEmit`
- `rollup -c`
- `eslint source/background-loader.js source/background.ts source/options.tsx source/options.html source/options.css rollup.config.js`
- `dprint check source/background-loader.js source/background.ts source/manifest.json source/options.tsx source/options.html source/options.css rollup.config.js`
- `biome lint source/background-loader.js source/background.ts source/options.tsx source/options.html source/options.css rollup.config.js`
- `vitest --run`
- manually simulated a synchronous background load error against the built loader and confirmed `backgroundPageLoadErrors` stores the error message and stack