### PR TITLE
`quick-comment-edit` - Fix misplacement in PRs 

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -89,8 +89,11 @@ async function init(signal: AbortSignal): Promise<void> {
 	const isUserModerator = await userIsModerator();
 
 	observe(
-		(isUserModerator ? '' : 'div[class*="viewerDidAuthor"] ')
-		+ 'button[data-component="IconButton"]:has(> .octicon-kebab-horizontal):not([id^="task-list"])',
+		// Scoped to comment headers; a bare kebab-button selector also matches unrelated menus like the PR checks section #9771
+		'div:is([class^="IssueBodyHeader"], [data-testid="comment-header"])'
+		+ (isUserModerator ? '' : '[class*="viewerDidAuthor" i]')
+		+ ' '
+		+ 'button[data-component="IconButton"]:has(> .octicon-kebab-horizontal)',
 		addQuickEditButton,
 		{signal},
 	);


### PR DESCRIPTION
Scope the `quick-comment-edit` feature to only comments and description

Closes #9771

## Test URLs
For moderators of this repo would the page you're currently on work just fine

## Screenshot
#### Removes the edit icon from the PR checks
<img width="816" height="238" alt="image" src="https://github.com/user-attachments/assets/df385527-345d-426c-8e51-b5107ce4c92a" />

#### While still maintaining the quick edit on description and comments
<img width="889" height="116" alt="image" src="https://github.com/user-attachments/assets/9c25708e-660d-42aa-b1bd-f234ce882970" />

#### (removed the user from the screenshot for privacy reasons)
<img width="771" height="163" alt="image" src="https://github.com/user-attachments/assets/4c29f1a8-4b29-4607-9c80-528af48f8720" />

#### And issues also still keep working
<img width="937" height="281" alt="image" src="https://github.com/user-attachments/assets/303df354-f798-40c3-b865-3ee4f7cd7b27" />

P.S. This feature has only been gone less than a day, and i already miss it. Thanks for all the work you guys are doing to make our lives easier on GitHub :)
