### PR TITLE
`conventional-commits` - Support capitalized types

### DIFF
--- a/source/features/conventional-commits.tsx
+++ b/source/features/conventional-commits.tsx
@@ -36,7 +36,7 @@ function renderLabelInCommitTitle(commitTitleElement: HTMLElement): void {
 	}
 
 	commitTitleElement.prepend(
-		<span className="IssueLabel hx_IssueLabel mr-2 tmp-mr-2" rgh-conventional-commits={commit.rawType}>
+		<span className="IssueLabel hx_IssueLabel mr-2 tmp-mr-2" rgh-conventional-commits={commit.rawType.toLowerCase()}>
 			{commit.type}
 		</span>,
 
@@ -65,6 +65,7 @@ Test URLs:
 - Repo commits: https://github.com/refined-github/sandbox/commits/conventional-commits/
 - PR commits: https://github.com/refined-github/sandbox/pull/91/commits
 - Real data: https://github.com/conventional-changelog/standard-version/commits
+- Capitalized types: https://github.com/HMCL-dev/HMCL/commits/main/
 - Repo without conventional commits: https://github.com/refined-github/refined-github/commits
 
 */


### PR DESCRIPTION
Closes #9765

When upper-case types were added to the parser, `rawType` kept its original casing, but the CSS presets only match lowercase attribute values (`[rgh-conventional-commits='fix']`), so `Fix:`/`Feature:`/`Refactor:` commits fell through to the default white/gray label.

`rawType`'s only consumer is this attribute, so this lowercases it at the attribute site — the CSS contract is lowercase, and the visible label text (`commit.type`) is unaffected. Also added the reporter's URL to the Test URLs list.

Tested on:

- https://github.com/HMCL-dev/HMCL/commits/main/ — `Fix`/`Feature`/`Refactor` commits now get the preset colors (`Update`/`Remove` stay unlabeled as before, not conventional types)
- https://github.com/refined-github/sandbox/commits/conventional-commits/ — lowercase types unchanged
