### PR TITLE
`reactions-avatars` - Restore support for some GitHub Apps

### DIFF
--- a/source/github-helpers/get-user-avatar.ts
+++ b/source/github-helpers/get-user-avatar.ts
@@ -2,26 +2,16 @@ import * as pageDetect from 'github-url-detection';
 import {$optional} from 'select-dom';
 
 export default function getUserAvatar(username: string, size: number): string | void {
-	let cleanName = username.replace('[bot]', '');
+	const cleanName = username.replace('[bot]', '');
 
 	if (/[^\w-]/.test(cleanName)) {
 		throw new TypeError(`Expected a username, got ${cleanName}`);
 	}
 
 	// Find image on page. Saves a request and a redirect + add support for bots
-	const existingAvatar = $optional(`[href="/${cleanName}" i] img`);
+	const existingAvatar = $optional(`[href="/${cleanName}" i] img`) ?? $optional(`[href="/apps/${cleanName}" i] img`);
 	if (existingAvatar) {
 		return existingAvatar.src;
-	}
-
-	if (
-		[
-			'Copilot',
-			'copilot-coding-agent-docs',
-			'copilot-swe-agent',
-		].includes(cleanName)
-	) {
-		cleanName = 'in/1143301';
 	}
 
 	// Bots don't have a /$username.png URL

--- a/source/github-helpers/get-user-avatar.ts
+++ b/source/github-helpers/get-user-avatar.ts
@@ -2,16 +2,29 @@ import * as pageDetect from 'github-url-detection';
 import {$optional} from 'select-dom';
 
 export default function getUserAvatar(username: string, size: number): string | void {
-	const cleanName = username.replace('[bot]', '');
+	let cleanName = username.replace('[bot]', '');
 
 	if (/[^\w-]/.test(cleanName)) {
 		throw new TypeError(`Expected a username, got ${cleanName}`);
 	}
 
 	// Find image on page. Saves a request and a redirect + add support for bots
-	const existingAvatar = $optional(`[href="/${cleanName}" i] img`) ?? $optional(`[href="/apps/${cleanName}" i] img`);
+	const existingAvatar = $optional([
+		`[href="/${cleanName}" i] img`,
+		`[href="/apps/${cleanName}" i] img`,
+	]);
 	if (existingAvatar) {
 		return existingAvatar.src;
+	}
+
+	if (
+		[
+			'Copilot',
+			'copilot-coding-agent-docs',
+			'copilot-swe-agent',
+		].includes(cleanName)
+	) {
+		cleanName = 'in/1143301';
 	}
 
 	// Bots don't have a /$username.png URL


### PR DESCRIPTION
- Fixes #9722

~I also removed the hard-coded logic for GitHub Copilot. That code was added in #8866. I checked the test URLs in that PR, and it works well. Please let me know if I missed anything.~

I didn't use AI.

## Test URLs

- https://github.com/raycast/extensions/pull/29237
- https://github.com/refined-github/refined-github/issues/7761
- https://github.com/refined-github/refined-github/pull/8848#issuecomment-3732149089

## Screenshot

|Before|After|
|:-:|:-:|
|<img width="891" height="513" alt="image" src="https://github.com/user-attachments/assets/7ea7a14c-8e97-451e-baff-297c505daa09" />|<img width="885" height="513" alt="image" src="https://github.com/user-attachments/assets/c2c23822-b9bc-4515-975d-173a86693b8a" />|
