### PR TITLE
Replace outdated `.Layout-sidebar` class selectors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,7 @@ export default defineConfig([
 			'select-dom/prefer': ['error', {
 				allowReadabilityExceptions: true,
 			}],
+			'@stylistic/quotes': ['error', 'single', {avoidEscape: true}],
 			'@stylistic/operator-linebreak': 'off', // `dprint` conflict
 			'@stylistic/function-paren-newline': 'off', // Awful
 			'@stylistic/jsx-quotes': 'off', // Keep existing quote style in JSX

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,5 +1,4 @@
-/* TODO: Remove .Layout-sidebar after August 2026 */
-[rgh-clean-repo-sidebar] :is([class*='PageLayout-Pane'], .Layout-sidebar) {
+[rgh-clean-repo-sidebar] [class*='PageLayout-Pane'] {
 	/* Hide "About" header */
 	.BorderGrid-row:first-child h2 {
 		display: none;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -42,9 +42,7 @@ async function hideEmptyMeta(): Promise<void> {
 
 	if (!pageDetect.canUserAccessRepoSettings()) {
 		// Selector only matches if it's empty
-		$optional([
-			'[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic',
-		])?.remove();
+		$optional('[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic')?.remove();
 	}
 }
 
@@ -52,13 +50,9 @@ async function moveReportLink(): Promise<void> {
 	await domLoaded;
 
 	// Your own repos don't include this link
-	const reportLink = $optional([
-		'[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]',
-	])?.parentElement;
+	const reportLink = $optional('[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]')?.parentElement;
 	if (reportLink) {
-		$([
-			'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell',
-		]).append(reportLink);
+		$('[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell').append(reportLink);
 	}
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -44,8 +44,6 @@ async function hideEmptyMeta(): Promise<void> {
 		// Selector only matches if it's empty
 		$optional([
 			'[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic',
-			// TODO [2026-09-01]: Drop old selector
-			'.Layout-sidebar .BorderGrid-cell > .text-italic',
 		])?.remove();
 	}
 }
@@ -56,13 +54,10 @@ async function moveReportLink(): Promise<void> {
 	// Your own repos don't include this link
 	const reportLink = $optional([
 		'[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]',
-		// TODO [2026-09-01]: Drop old selector
-		'.Layout-sidebar a[href^="/contact/report-content"]',
 	])?.parentElement;
 	if (reportLink) {
 		$([
 			'[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell',
-			'.Layout-sidebar .BorderGrid-row:last-of-type .BorderGrid-cell',
 		]).append(reportLink);
 	}
 }

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -31,7 +31,7 @@ async function cleanReleases(): Promise<void> {
 async function hideLanguageHeader(): Promise<void> {
 	await domLoaded;
 
-	const languageHeader = $('[class*=\'PageLayout-Pane\'] .BorderGrid-row:has(.Progress-item) h2');
+	const languageHeader = $("[class*='PageLayout-Pane'] .BorderGrid-row:has(.Progress-item) h2");
 	assertNodeContent(languageHeader.firstChild, 'Languages');
 	languageHeader.classList.add('sr-only');
 }
@@ -42,7 +42,7 @@ async function hideEmptyMeta(): Promise<void> {
 
 	if (!pageDetect.canUserAccessRepoSettings()) {
 		// Selector only matches if it's empty
-		$optional('[class*=\'PageLayout-Pane\'] .BorderGrid-cell > .text-italic')?.remove();
+		$optional("[class*='PageLayout-Pane'] .BorderGrid-cell > .text-italic")?.remove();
 	}
 }
 
@@ -50,9 +50,9 @@ async function moveReportLink(): Promise<void> {
 	await domLoaded;
 
 	// Your own repos don't include this link
-	const reportLink = $optional('[class*=\'PageLayout-Pane\'] a[href^="/contact/report-content"]')?.parentElement;
+	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
 	if (reportLink) {
-		$('[class*=\'PageLayout-Pane\'] .BorderGrid-row:last-of-type .BorderGrid-cell').append(reportLink);
+		$("[class*='PageLayout-Pane'] .BorderGrid-row:last-of-type .BorderGrid-cell").append(reportLink);
 	}
 }
 

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer.js';
 const selectors = [
 	// `isRepoHome` repository description
 	// https://github.com/refined-github/sandbox
-	'[class*=\'PageLayout-Pane\'] .f4.my-3',
+	"[class*='PageLayout-Pane'] .f4.my-3",
 
 	// `isCommitList` commit description
 	// https://github.com/refined-github/sandbox/commits/buncha-files/

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -8,7 +8,7 @@ import observe from '../helpers/selector-observer.js';
 const selectors = [
 	// `isRepoHome` repository description
 	// https://github.com/refined-github/sandbox
-	'.Layout-sidebar .f4.my-3',
+	'[class*=\'PageLayout-Pane\'] .f4.my-3',
 
 	// `isCommitList` commit description
 	// https://github.com/refined-github/sandbox/commits/buncha-files/

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -14,9 +14,7 @@ Exclusively use simple sums and use `0px` instead of `0`
 /* `isRepoRoot` */
 div[class^='prc-PageLayout-Pane']:has(
 	> rails-partial[data-partial-name='codeViewRepoRoute.Sidebar']
-),
-/* Old `isRepoRoot` - Remove after August 2026 */
-.Layout-sidebar .BorderGrid {
+) {
 	--rgh-sticky-sidebar-offset: 0;
 }
 

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -13,7 +13,6 @@ const minimumViewportWidthForSidebar = 768; // Less than this, the layout is sin
 const sidebarSelector = [
 	'#partial-discussion-sidebar', // `isDiscussion`, `isPRConversation`
 	'div[class^="prc-PageLayout-Pane"]:has(> rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"])', // `isRepoRoot`
-
 ];
 
 let sidebar: HTMLElement | undefined;

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -13,7 +13,7 @@ const minimumViewportWidthForSidebar = 768; // Less than this, the layout is sin
 const sidebarSelector = [
 	'#partial-discussion-sidebar', // `isDiscussion`, `isPRConversation`
 	'div[class^="prc-PageLayout-Pane"]:has(> rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"])', // `isRepoRoot`
-	'.Layout-sidebar .BorderGrid', // Old `isRepoRoot` - Remove after August 2026
+
 ];
 
 let sidebar: HTMLElement | undefined;


### PR DESCRIPTION
Replaces all remaining .Layout-sidebar selectors with the newer [class*='PageLayout-Pane'] pattern. The old class was removed by GitHub's latest redesign.

Closes #9589