### PR TITLE
`mobile-tabs-pr` - Improve sizing

### DIFF
--- a/source/features/mobile-tabs-pr.css
+++ b/source/features/mobile-tabs-pr.css
@@ -6,9 +6,13 @@
 		white-space: nowrap;
 		place-content: center center;
 		align-items: center;
-		padding: 0.7em 0;
+		padding: 0.7em 1em;
 		font-size: 13px;
 		gap: 0 5px;
+
+		/* Fit the text, but keep the icon + number on one line */
+		width: min-content;
+		min-width: 80px;
 
 		svg {
 			order: -2;
@@ -19,19 +23,8 @@
 		[data-variant='secondary'] {
 			order: -1;
 			margin: 0 !important;
-		}
-
-		&:first-child {
-			width: 13ch;
-		}
-
-		&[href$='/commits'],
-		&[href$='/checks'] {
-			width: 11ch;
-		}
-
-		&[href$='/changes'] {
-			width: 15ch;
+			/* Optical alignment */
+			margin-right: -0.5em !important;
 		}
 	}
 }


### PR DESCRIPTION
Something that has bothered me for a while is that tabs were manually sized instead of fitting the content. This is PR (partially) fixes it.

Minimal before/after

<img width="514" height="127" alt="Screenshot 5" src="https://github.com/user-attachments/assets/c9bc976b-a84c-4042-b4ee-b15bc790c090" />
<img width="514" height="127" alt="Screenshot 6" src="https://github.com/user-attachments/assets/a6bf9136-d535-462e-9bc1-95cc1306719f" />
