### PR TITLE
`repo-header-info` - Reposition widget

### DIFF
--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -6,6 +6,10 @@ html:not([rgh-OFF-repo-header-info]) {
 			padding-right: 4em;
 		}
 	}
+	.rgh-repo-header-info-updated::after {
+		/* Hide breadcrumb's slash */
+		content: none;
+	}
 
 	.rgh-ci-link .commit-build-statuses {
 		font-size: 0;

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -1,7 +1,6 @@
 html:not([rgh-OFF-repo-header-info]) {
 	div[data-testid='top-nav-center']
-		li:last-child
-		> a[class*='prc-Breadcrumbs-Item']:not(.rgh-repo-header-info-updated) {
+		li:last-child:not(.rgh-repo-header-info-updated) {
 		/* Matches the `isSmallDevice` JS check */
 		@media (min-width: 500px) {
 			padding-right: 4em;

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -99,7 +99,7 @@ function markForked(repoLink: HTMLElement, forked?: {url: string}): void {
 	prepareForAddition(repoLink);
 	// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
 	$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
-	repoLink.after(
+	closestElement('li', repoLink).after(
 		<a
 			href={forked.url}
 			className="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -75,7 +75,7 @@ function addStars(repoLink: HTMLElement, stargazerCount: number, viewerHasStarre
 
 	prepareForAddition(repoLink);
 
-	repoLink.parentElement!.append(
+	closestElement('li', repoLink).after(
 		<a
 			href={buildRepoUrl('stargazers')}
 			title={tooltip}
@@ -117,7 +117,7 @@ function addCiStatus(anchor: HTMLElement, ciCommit: string | undefined): void {
 	prepareForAddition(anchor);
 
 	const endpoint = buildRepoUrl('commits/checks-statuses-rollups');
-	anchor.parentElement!.append(
+	closestElement('li', anchor).after(
 		// Hide in small viewports
 		<span
 			className="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
@@ -140,12 +140,12 @@ function addCiStatus(anchor: HTMLElement, ciCommit: string | undefined): void {
 async function add(repoLink: HTMLElement): Promise<void> {
 	const info = await getRepositoryInfo();
 
-	repoLink.parentElement!.classList.add('rgh-repo-header-info-updated');
+	closestElement('li', repoLink).classList.add('rgh-repo-header-info-updated');
 
 	markPrivate(repoLink, info.isPrivate);
+	addCiStatus(repoLink, info.ciCommit);
 	addStars(repoLink, info.stargazerCount, info.viewerHasStarred);
 	markForked(repoLink, info.forked);
-	addCiStatus(repoLink, info.ciCommit);
 }
 
 async function init(signal: AbortSignal): Promise<void> {

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -75,7 +75,7 @@ function addStars(repoLink: HTMLElement, stargazerCount: number, viewerHasStarre
 
 	prepareForAddition(repoLink);
 
-	repoLink.after(
+	repoLink.parentElement!.append(
 		<a
 			href={buildRepoUrl('stargazers')}
 			title={tooltip}
@@ -140,7 +140,7 @@ function addCiStatus(anchor: HTMLElement, ciCommit: string | undefined): void {
 async function add(repoLink: HTMLElement): Promise<void> {
 	const info = await getRepositoryInfo();
 
-	repoLink.classList.add('rgh-repo-header-info-updated');
+	repoLink.parentElement!.classList.add('rgh-repo-header-info-updated');
 
 	markPrivate(repoLink, info.isPrivate);
 	addStars(repoLink, info.stargazerCount, info.viewerHasStarred);


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9755

## Test URLs

here

## Screenshot


<img width="383" height="55" alt="new" src="https://github.com/user-attachments/assets/4c9f5fa8-c221-4344-9986-00b2b548524d" />
