### PR TITLE
`release-download-count` - Avoid duplicates, preserve hash

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -16,4 +16,10 @@
 	[data-rgh-heat] {
 		min-width: 5em;
 	}
+
+	/* Hide the native counter: https://github.com/refined-github/refined-github/issues/9769#issuecomment-4857658434 */
+	/* Their version doesn't have heat colors */
+	span[aria-label*="download"] {
+		display: none !important;
+	}
 }

--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -16,10 +16,4 @@
 	[data-rgh-heat] {
 		min-width: 5em;
 	}
-
-	/* Hide the native counter: https://github.com/refined-github/refined-github/issues/9769#issuecomment-4857658434 */
-	/* Their version doesn't have heat colors */
-	span[aria-label*="download"] {
-		display: none !important;
-	}
 }

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -68,12 +68,11 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 
 		const hash = $optional(':scope > div:has(clipboard-copy)', assetSize.parentElement!);
 		// Hide sha on mobile. They have the classes but they're not correct (they hide in mid sizes, but show on smallest and largest)
-		hash?.classList.add('d-none');
+		hash?.classList.add('d-none', 'd-md-flex');
 		// Prevent sha from being clipped
 		hash?.style.setProperty('min-width', '100px');
 
-		// Add at the beginning of the line to avoid content shift
-		assetSize.parentElement!.prepend(
+		const widget = (
 			<span className={cx(getClasses(assetSize))}>
 				<span
 					className="d-inline-block text-right"
@@ -82,8 +81,16 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 				>
 					{abbreviateNumber(downloadCount)} <DownloadIcon />
 				</span>
-			</span>,
+			</span>
 		);
+
+		if (hash) {
+			// Prefer placing it where the native count appears
+			hash.after(widget);
+		} else {
+			// Add at the beginning of the line to avoid content shift
+			assetSize.parentElement!.prepend(widget);
+		}
 
 		// Unset all margin we added `gap` like sane people.
 		// Unset via JS because we can't override utility classes.

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -84,9 +84,11 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 			</span>
 		);
 
-		if (hash) {
-			// Prefer placing it where the native count appears
-			hash.after(widget);
+		const nativeCount = $optional('span[aria-label*="download"]', assetSize.parentElement!);
+		// The native counter doesn't have heat colors, so we replace it anyway.
+		// https://github.com/refined-github/refined-github/issues/9769#issuecomment-4857658434
+		if (nativeCount) {
+			nativeCount.replaceWith(widget);
 		} else {
 			// Add at the beginning of the line to avoid content shift
 			assetSize.parentElement!.prepend(widget);


### PR DESCRIPTION
- fixes #9789 
- fixes https://github.com/refined-github/refined-github/issues/9769

## Test URLs

https://github.com/refined-github/refined-github/releases/tag/26.7

## Screenshot

Here's a page reload gif:

<img width="624" height="55" alt="count" src="https://github.com/user-attachments/assets/3d7c60a4-4fed-482e-9503-95e566be56d6" />


