### PR TITLE
Meta: Upgrade to TS7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
 				"@types/dom-navigation": "^1.0.7",
 				"@types/node": "^26.1.1",
 				"@types/react": "^17.0.52",
+				"@typescript/native": "npm:typescript@^7.0.2",
 				"browserslist": "^4.28.5",
 				"daily-version": "^2.0.0",
 				"dot-json": "^1.3.0",
@@ -106,7 +107,7 @@
 				"svelte-eslint-parser": "^1.8.0",
 				"type-fest": "^5.8.0",
 				"typed-query-selector": "^2.12.2",
-				"typescript": "^6.0.3",
+				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"unplugin-lightningcss": "^0.4.5",
 				"vite": "^8.1.4",
 				"vitest": "^4.1.10"
@@ -2581,6 +2582,396 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript/native": {
+			"name": "typescript",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
+			}
+		},
+		"node_modules/@typescript/old": {
+			"name": "typescript",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -9940,16 +10331,16 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"name": "@typescript/typescript6",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+			"integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
 			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+			"dependencies": {
+				"@typescript/old": "npm:typescript@^6"
 			},
-			"engines": {
-				"node": ">=14.17"
+			"bin": {
+				"tsc6": "bin/tsc6"
 			}
 		},
 		"node_modules/typescript-eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -651,9 +651,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -675,6 +675,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
@@ -2231,9 +2243,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+			"integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
@@ -2382,9 +2394,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -2570,18 +2582,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@typescript/native": {
@@ -3311,6 +3311,43 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
@@ -4246,9 +4283,9 @@
 			}
 		},
 		"node_modules/del/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4989,9 +5026,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "63.0.12",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.12.tgz",
-			"integrity": "sha512-99VfBHyoLlF9n5w9wh+jLWDBzCgYd3tfw3M/aynAd+H2ylGHWLbde/GPTuo/5az3jMAN0fH7QzCYvEOY6u+Ypg==",
+			"version": "63.0.13",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.13.tgz",
+			"integrity": "sha512-ahG1kWA8jYNwaQJtzJlnF+v4Gb9w5r+WL98gp+L8qjLN9ErpL5sevGuemN+fCYsU3Np27F36KmDc8UPi1ml/dg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@es-joy/jsdoccomment": "~0.88.0",
@@ -5244,18 +5281,6 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
 			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
@@ -5284,18 +5309,6 @@
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^5.0.1"
 			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
@@ -8932,9 +8945,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-			"integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+			"version": "3.9.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+			"integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -10493,24 +10506,7 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/unplugin-lightningcss": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/unplugin-lightningcss/-/unplugin-lightningcss-0.4.5.tgz",
-			"integrity": "sha512-PMm6POv3gt1HNbxYFItantjcP6dPG/BiV/9IXcVLVBv3BZ+pf7Eo4yE+siIGKoVMXjs3BfVXeETTw2Gv3D8iOw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lightningcss": "^1.31.1",
-				"unplugin": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
-			}
-		},
-		"node_modules/unplugin-lightningcss/node_modules/unplugin": {
+		"node_modules/unplugin": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
 			"integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
@@ -10563,6 +10559,23 @@
 				"webpack": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/unplugin-lightningcss": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/unplugin-lightningcss/-/unplugin-lightningcss-0.4.5.tgz",
+			"integrity": "sha512-PMm6POv3gt1HNbxYFItantjcP6dPG/BiV/9IXcVLVBv3BZ+pf7Eo4yE+siIGKoVMXjs3BfVXeETTw2Gv3D8iOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.31.1",
+				"unplugin": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
 			}
 		},
 		"node_modules/unrs-resolver": {
@@ -10827,43 +10840,6 @@
 				"vite": {
 					"optional": false
 				}
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.1.10",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/vscode-css-languageservice": {
@@ -11276,6 +11252,22 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"extraneous": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,9 @@
 		"array.prototype.tosorted": "npm:@nolyfill/array.prototype.tosorted@^1",
 		"es-iterator-helpers": "npm:@nolyfill/es-iterator-helpers@^1",
 		"hasown": "npm:@nolyfill/hasown@^1",
+		"is-core-module": "npm:@nolyfill/is-core-module@^1",
 		"is-regex": "npm:@nolyfill/is-regex@^1",
+		"object-keys": "npm:@nolyfill/object-keys@^1",
 		"object.assign": "npm:@nolyfill/object.assign@^1",
 		"object.entries": "npm:@nolyfill/object.entries@^1",
 		"object.fromentries": "npm:@nolyfill/object.fromentries@^1",
@@ -156,9 +158,8 @@
 		"object.values": "npm:@nolyfill/object.values@^1",
 		"string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@^1",
 		"string.prototype.padend": "npm:@nolyfill/string.prototype.padend@^1",
-		"is-core-module": "npm:@nolyfill/is-core-module@^1",
 		"string.prototype.repeat": "npm:@nolyfill/string.prototype.repeat@^1",
-		"object-keys": "npm:@nolyfill/object-keys@^1"
+		"typescript": "npm:@typescript/typescript6@^6.0.2"
 	},
 	"webExt": {
 		"sourceDir": "distribution",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"@types/dom-navigation": "^1.0.7",
 		"@types/node": "^26.1.1",
 		"@types/react": "^17.0.52",
+		"@typescript/native": "npm:typescript@^7.0.2",
 		"browserslist": "^4.28.5",
 		"daily-version": "^2.0.0",
 		"dot-json": "^1.3.0",
@@ -123,7 +124,7 @@
 		"svelte-eslint-parser": "^1.8.0",
 		"type-fest": "^5.8.0",
 		"typed-query-selector": "^2.12.2",
-		"typescript": "^6.0.3",
+		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"unplugin-lightningcss": "^0.4.5",
 		"vite": "^8.1.4",
 		"vitest": "^4.1.10"


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

At this point there isn't a huge advantage in TS7 since:

- rollup uses sucrase
- TS-ESLint does not yet support TS7

This just brings the typechecking time from 6s to 1s, but it hardly makes a difference in watch mode.

So these are the two blocker issues:

- https://github.com/rollup/plugins/issues/2016
- https://github.com/typescript-eslint/typescript-eslint/issues/10940