### PR TITLE
`repo-header-info` - Remove extra slash

### DIFF
--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -7,7 +7,6 @@ html:not([rgh-OFF-repo-header-info]) {
 		}
 	}
 
-
 	/* Hide breadcrumb's slash. Somehow this is added via both pseudo-element and element */
 	.rgh-repo-header-info-updated > span[class*='Breadcrumbs-ItemSeparator'],
 	.rgh-repo-header-info-updated::after {

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -6,9 +6,13 @@ html:not([rgh-OFF-repo-header-info]) {
 			padding-right: 4em;
 		}
 	}
+
+
+	/* Hide breadcrumb's slash. Somehow this is added via both pseudo-element and element */
+	.rgh-repo-header-info-updated > span[class*='Breadcrumbs-ItemSeparator'],
 	.rgh-repo-header-info-updated::after {
-		/* Hide breadcrumb's slash */
 		content: none;
+		display: none;
 	}
 
 	.rgh-ci-link .commit-build-statuses {


### PR DESCRIPTION
- continues https://github.com/refined-github/refined-github/pull/9798

Somehow GitHub detects the children and auto-appends an SVG to it... even if there's already a dedicated `::after` selector for this.

## Test URLs

here

## Screenshot of issue

<img width="382" height="58" alt="Screenshot" src="https://github.com/user-attachments/assets/349b5d25-1025-47be-aafc-2c74316efda1" />

