### PR TITLE
`closing-remarks` - Fix empty banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11254,22 +11254,6 @@
 				}
 			}
 		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"extraneous": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -130,7 +130,6 @@ async function init(signal: AbortSignal): Promise<void> {
 		return;
 	}
 
-	console.log('adding banner')
 	void addReleaseBanner(
 		<>
 			No <ExplanationLink>stable version tags</ExplanationLink> for this PR.

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -97,6 +97,8 @@ async function addReleaseBanner(text: string | JSX.Element, signal: AbortSignal)
 		});
 	}
 
+	// Create outside observer because `text` can be a document fragment, which can only be appended once
+	// https://github.com/refined-github/refined-github/pull/9808
 	const item = (
 		<TimelineItem>
 			{createBanner(bannerContent)}

--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -97,14 +97,16 @@ async function addReleaseBanner(text: string | JSX.Element, signal: AbortSignal)
 		});
 	}
 
+	const item = (
+		<TimelineItem>
+			{createBanner(bannerContent)}
+		</TimelineItem>
+	);
+
 	// Use observer because GitHub might remove the box
 	// https://github.com/refined-github/refined-github/issues/9460
 	observe(commentBoxHashPr, anchor => {
-		anchor.before(
-			<TimelineItem>
-				{createBanner(bannerContent)}
-			</TimelineItem>,
-		);
+		anchor.before(item);
 	}, {signal});
 }
 
@@ -126,6 +128,7 @@ async function init(signal: AbortSignal): Promise<void> {
 		return;
 	}
 
+	console.log('adding banner')
 	void addReleaseBanner(
 		<>
 			No <ExplanationLink>stable version tags</ExplanationLink> for this PR.


### PR DESCRIPTION
- followup to https://github.com/refined-github/refined-github/pull/9498

If the banner is removed by GitHub, a following insertion would be `text`-less. Presumably this has been a bug since that PR was merged but GitHub doesn't always remove the banner so it's hard to repro.


## Test URLs

https://github.com/refined-github/refined-github/pull/9798

## Screenshot of bug

<img width="643" height="171" alt="closing remarks" src="https://github.com/user-attachments/assets/1b9c6993-77cb-49a7-a765-5884c2bd10e1" />

