### PR TITLE
`repo-header-info` - Avoid duplicates, empty space

### DIFF
--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -4,7 +4,7 @@ html:not([rgh-OFF-repo-header-info]) {
 		li:last-child {
 		/* Matches the `isSmallDevice` JS check */
 		@media (min-width: 500px) {
-			padding-right: 4em;
+			padding-right: 6em;
 		}
 	}
 

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -1,6 +1,7 @@
 html:not([rgh-OFF-repo-header-info]) {
-	div[data-testid='top-nav-center']
-		li:last-child:not(.rgh-repo-header-info-updated) {
+	nav[data-component='Breadcrumbs']
+		ol:not(.rgh-repo-header-info-updated)
+		li:last-child {
 		/* Matches the `isSmallDevice` JS check */
 		@media (min-width: 500px) {
 			padding-right: 4em;
@@ -8,25 +9,16 @@ html:not([rgh-OFF-repo-header-info]) {
 	}
 
 	/* Hide breadcrumb's slash. Somehow this is added via both pseudo-element and element */
-	.rgh-repo-header-info-updated > span[class*='Breadcrumbs-ItemSeparator'],
-	.rgh-repo-header-info-updated::after {
-		content: none;
-		display: none;
+	.rgh-repo-header-info-updated li:not(.rgh-header-info) + li {
+		span[class*='Breadcrumbs-ItemSeparator'],
+		&::after {
+			content: none;
+			display: none;
+		}
 	}
 
 	/* Improve alignment */
 	.rgh-ci-link .commit-build-statuses {
 		font-size: 0;
-	}
-
-	/* The icon appears inside a clickable container, so it must be disabled */
-	.AppHeader-context-compact-mainItem .rgh-ci-link {
-		pointer-events: none;
-		margin-left: 0.3em;
-	}
-
-	/* The popup is cut off by the global bar #8495 */
-	.AppHeader-globalBar-start {
-		overflow: visible !important;
 	}
 }

--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -14,6 +14,7 @@ html:not([rgh-OFF-repo-header-info]) {
 		display: none;
 	}
 
+	/* Improve alignment */
 	.rgh-ci-link .commit-build-statuses {
 		font-size: 0;
 	}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -10,48 +10,49 @@
 
 	const {info}: {info: RepositoryInfo} = $props();
 </script>
-
-{#if info.forked}
-	<a
-		href={info.forked.url}
-		class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
-	>
-		<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
-	</a>
-{/if}
-
-{#if info.stargazerCount > 1}
-	<a
-		href={buildRepoUrl('stargazers')}
-		title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
-			info.viewerHasStarred ? ', including you' : ''
-		}`}
-		class="d-none d-sm-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
-	>
-		<DomChef
-			as={info.viewerHasStarred ? StarFillIcon : StarIcon}
-			width={12}
-			height={12}
-			color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
-		/>
-		<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
-	</a>
-{/if}
-
-{#if info.ciCommit}
-	<span
-		class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
-		title="CI status of latest commit"
-	>
-		<batch-deferred-content
-			hidden
-			data-url={buildRepoUrl('commits/checks-statuses-rollups')}
+<li class="d-none d-lg-flex">
+	{#if info.forked}
+		<a
+			href={info.forked.url}
+			class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
 		>
-			<input
-				name="oid"
-				value={info.ciCommit}
-				data-targets="batch-deferred-content.inputs"
+			<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
+		</a>
+	{/if}
+
+	{#if info.stargazerCount > 1}
+		<a
+			href={buildRepoUrl('stargazers')}
+			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
+				info.viewerHasStarred ? ', including you' : ''
+			}`}
+			class="d-none d-sm-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+		>
+			<DomChef
+				as={info.viewerHasStarred ? StarFillIcon : StarIcon}
+				width={12}
+				height={12}
+				color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
 			/>
-		</batch-deferred-content>
-	</span>
-{/if}
+			<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
+		</a>
+	{/if}
+
+	{#if info.ciCommit}
+		<span
+			class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+			title="CI status of latest commit"
+		>
+			<batch-deferred-content
+				hidden
+				data-url={buildRepoUrl('commits/checks-statuses-rollups')}
+			>
+				<input
+					name="oid"
+					value={info.ciCommit}
+					data-targets="batch-deferred-content.inputs"
+				/>
+			</batch-deferred-content>
+		</span>
+	{/if}
+</li>

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -11,22 +11,13 @@
 	const {info}: {info: RepositoryInfo} = $props();
 </script>
 
-{#if info.ciCommit}
-	<span
-		class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
-		title="CI status of latest commit"
+{#if info.forked}
+	<a
+		href={info.forked.url}
+		class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
 	>
-		<batch-deferred-content
-			hidden
-			data-url={buildRepoUrl('commits/checks-statuses-rollups')}
-		>
-			<input
-				name="oid"
-				value={info.ciCommit}
-				data-targets="batch-deferred-content.inputs"
-			/>
-		</batch-deferred-content>
-	</span>
+		<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
+	</a>
 {/if}
 
 {#if info.stargazerCount > 1}
@@ -47,11 +38,20 @@
 	</a>
 {/if}
 
-{#if info.forked}
-	<a
-		href={info.forked.url}
-		class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+{#if info.ciCommit}
+	<span
+		class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+		title="CI status of latest commit"
 	>
-		<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
-	</a>
+		<batch-deferred-content
+			hidden
+			data-url={buildRepoUrl('commits/checks-statuses-rollups')}
+		>
+			<input
+				name="oid"
+				value={info.ciCommit}
+				data-targets="batch-deferred-content.inputs"
+			/>
+		</batch-deferred-content>
+	</span>
 {/if}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -11,11 +11,11 @@
 	const {info}: {info: RepositoryInfo} = $props();
 </script>
 <!-- Order set because React rebuilds both breadcrumbs on resize, leaving this as the first child -->
-<li class="d-none d-lg-flex rgh-header-info" style:order="10">
+<li class="d-none d-md-flex rgh-header-info" style:order="10">
 	{#if info.forked}
 		<a
 			href={info.forked.url}
-			class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+			class="d-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
 		>
 			<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
 		</a>
@@ -27,7 +27,7 @@
 			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
 				info.viewerHasStarred ? ', including you' : ''
 			}`}
-			class="d-none d-sm-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+			class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
 		>
 			<DomChef
 				as={info.viewerHasStarred ? StarFillIcon : StarIcon}
@@ -41,7 +41,7 @@
 
 	{#if info.ciCommit}
 		<span
-			class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+			class="rgh-ci-link d-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
 			title="CI status of latest commit"
 		>
 			<batch-deferred-content

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -10,7 +10,8 @@
 
 	const {info}: {info: RepositoryInfo} = $props();
 </script>
-<li class="d-none d-lg-flex">
+<!-- Order set because React rebuilds both breadcrumbs on resize, leaving this as the first child -->
+<li class="d-none d-lg-flex rgh-header-info" style:order="10">
 	{#if info.forked}
 		<a
 			href={info.forked.url}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import RepoForkedIcon from 'octicons-plain-react/RepoForked';
+	import StarIcon from 'octicons-plain-react/Star';
+	import StarFillIcon from 'octicons-plain-react/StarFill';
+
+	import {buildRepoUrl} from '../github-helpers/index.js';
+	import abbreviateNumber from '../helpers/abbreviate-number.js';
+	import DomChef from '../helpers/dom-chef.svelte';
+	import type {RepositoryInfo} from './repo-header-info.js';
+
+	const {info}: {info: RepositoryInfo} = $props();
+</script>
+
+{#if info.ciCommit}
+	<span
+		class="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+		title="CI status of latest commit"
+	>
+		<batch-deferred-content
+			hidden
+			data-url={buildRepoUrl('commits/checks-statuses-rollups')}
+		>
+			<input
+				name="oid"
+				value={info.ciCommit}
+				data-targets="batch-deferred-content.inputs"
+			/>
+		</batch-deferred-content>
+	</span>
+{/if}
+
+{#if info.stargazerCount > 1}
+	<a
+		href={buildRepoUrl('stargazers')}
+		title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
+			info.viewerHasStarred ? ', including you' : ''
+		}`}
+		class="d-none d-sm-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+	>
+		<DomChef
+			as={info.viewerHasStarred ? StarFillIcon : StarIcon}
+			width={12}
+			height={12}
+			color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
+		/>
+		<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
+	</a>
+{/if}
+
+{#if info.forked}
+	<a
+		href={info.forked.url}
+		class="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
+	>
+		<DomChef as={RepoForkedIcon} class="m-0 tmp-m-0" width={12} height={12} />
+	</a>
+{/if}

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -57,7 +57,7 @@ async function add(breadcrumbs: HTMLElement): Promise<void> {
 
 	if (info.forked) {
 		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
-		$('.octicon-repo-forked', breadcrumbs).classList.add('d-lg-none');
+		$('.octicon-repo-forked', breadcrumbs).classList.add('d-md-none');
 	}
 
 	mount(RepoHeaderInfo, {

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -3,20 +3,17 @@ import './repo-header-info.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import LockIcon from 'octicons-plain-react/Lock';
-import RepoForkedIcon from 'octicons-plain-react/RepoForked';
-import StarIcon from 'octicons-plain-react/Star';
-import StarFillIcon from 'octicons-plain-react/StarFill';
 import {$, closestElement, closestElementOptional, elementExists} from 'select-dom';
+import {mount} from 'svelte';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {buildRepoUrl} from '../github-helpers/index.js';
-import abbreviateNumber from '../helpers/abbreviate-number.js';
 import {appendBefore, isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetRepoInfo from './repo-header-info.gql';
+import RepoHeaderInfo from './repo-header-info.svelte';
 
-type RepositoryInfo = {
+export type RepositoryInfo = {
 	forked?: {url: string};
 	isPrivate: boolean;
 	stargazerCount: number;
@@ -40,125 +37,52 @@ async function getRepositoryInfo(): Promise<RepositoryInfo> {
 		}
 	}
 
-	return {
-		...repository,
-		ciCommit,
-	};
+	return {...repository, ciCommit};
 }
 
-function prepareForAddition(element: HTMLElement): void {
-	if (!element.classList.contains('AppHeader-context-item')) {
-		closestElement('li', element).classList.add('d-flex');
-	}
-}
+async function add(repoLink: HTMLElement): Promise<void> {
+	const info = await getRepositoryInfo();
+	const li = closestElement('li', repoLink);
+	li.classList.add('rgh-repo-header-info-updated');
 
-function markPrivate(repoLink: HTMLElement, isPrivate: boolean): void {
 	// GitHub may already show this icon natively, so we match its position
-	if (isPrivate && !elementExists('.octicon-lock', repoLink)) {
+	if (info.isPrivate && !elementExists('.octicon-lock', repoLink)) {
 		appendBefore(
 			repoLink,
 			'.octicon-repo-forked',
 			<LockIcon className="ml-1 tmp-ml-1" width={12} height={12} />,
 		);
 	}
-}
 
-function addStars(repoLink: HTMLElement, stargazerCount: number, viewerHasStarred: boolean): void {
-	if (stargazerCount <= 1) {
-		return;
+	if (
+		info.forked
+		&& info.ciCommit
+		&& (info.stargazerCount > 1)
+		&& !repoLink.classList.contains('AppHeader-context-item')
+	) {
+		closestElement('li', repoLink).classList.add('d-flex');
 	}
 
-	let tooltip = `Repository starred by ${stargazerCount.toLocaleString('us')} people`;
-	if (viewerHasStarred) {
-		tooltip += ', including you';
+	if (info.forked) {
+		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
+		$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
 	}
 
-	prepareForAddition(repoLink);
-
-	closestElement('li', repoLink).after(
-		<a
-			href={buildRepoUrl('stargazers')}
-			title={tooltip}
-			// Hide in small viewports
-			className="d-none d-sm-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
-		>
-			{viewerHasStarred
-				// Use `color` because `fill` is overridden with `currentColor`
-				? <StarFillIcon width={12} height={12} color="var(--button-star-iconColor)" />
-				: <StarIcon width={12} height={12} />}
-			<span className="f5">{abbreviateNumber(stargazerCount)}</span>
-		</a>,
-	);
-}
-
-function markForked(repoLink: HTMLElement, forked?: {url: string}): void {
-	if (!forked) {
-		return;
+	if (info.ciCommit) {
+		// A parent is clipping the popup
+		closestElementOptional('.AppHeader-context-full', repoLink)?.style.setProperty('overflow', 'visible');
 	}
 
-	prepareForAddition(repoLink);
-	// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
-	$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
-	closestElement('li', repoLink).after(
-		<a
-			href={forked.url}
-			className="d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
-		>
-			<RepoForkedIcon className='m-0 tmp-m-0' width={12} height={12} />
-		</a>,
-	);
-}
-
-function addCiStatus(anchor: HTMLElement, ciCommit: string | undefined): void {
-	if (!ciCommit) {
-		return;
-	}
-
-	prepareForAddition(anchor);
-
-	const endpoint = buildRepoUrl('commits/checks-statuses-rollups');
-	closestElement('li', anchor).after(
-		// Hide in small viewports
-		<span
-			className="rgh-ci-link d-none d-sm-flex flex-items-center flex-justify-center p-1 tmp-p-1 Button Button--invisible"
-			title="CI status of latest commit"
-		>
-			<batch-deferred-content hidden data-url={endpoint}>
-				<input
-					name="oid"
-					value={ciCommit}
-					data-targets="batch-deferred-content.inputs"
-				/>
-			</batch-deferred-content>
-		</span>,
-	);
-
-	// A parent is clipping the popup
-	closestElementOptional('.AppHeader-context-full', anchor)?.style.setProperty('overflow', 'visible');
-}
-
-async function add(repoLink: HTMLElement): Promise<void> {
-	const info = await getRepositoryInfo();
-
-	closestElement('li', repoLink).classList.add('rgh-repo-header-info-updated');
-
-	markPrivate(repoLink, info.isPrivate);
-	addCiStatus(repoLink, info.ciCommit);
-	addStars(repoLink, info.stargazerCount, info.viewerHasStarred);
-	markForked(repoLink, info.forked);
+	mount(RepoHeaderInfo, {
+		target: li.parentElement!,
+		anchor: li.nextSibling ?? undefined,
+		props: {info},
+	});
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
-		[
-			'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
-			// TODO [2026-08-01]: Remove
-			// Desktop
-			'.AppHeader-context-item:not([data-hovercard-type])',
-
-			// Mobile. `> *:first-child` avoids finding our own element
-			'.AppHeader-context-compact-mainItem > span:first-child',
-		],
+		'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
 		add,
 		{signal},
 	);

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -3,7 +3,7 @@ import './repo-header-info.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import LockIcon from 'octicons-plain-react/Lock';
-import {$, closestElement, elementExists} from 'select-dom';
+import {$, elementExists} from 'select-dom';
 import {mount} from 'svelte';
 
 import features from '../feature-manager.js';
@@ -40,14 +40,14 @@ async function getRepositoryInfo(): Promise<RepositoryInfo> {
 	return {...repository, ciCommit};
 }
 
-async function add(repoLink: HTMLElement): Promise<void> {
+async function add(breadcrumbs: HTMLElement): Promise<void> {
 	const info = await getRepositoryInfo();
-	const li = closestElement('li', repoLink);
-	li.classList.add('rgh-repo-header-info-updated');
+	breadcrumbs.classList.add('rgh-repo-header-info-updated');
 
 	// GitHub may already show this icon natively, so we match its position
 	// It's generally missing when it's forked and private
-	if (info.isPrivate && !elementExists('.octicon-lock', repoLink)) {
+	if (info.isPrivate && !elementExists('.octicon-lock', breadcrumbs)) {
+		const repoLink = $(':scope > li:last-child a', breadcrumbs);
 		appendBefore(
 			repoLink,
 			'.octicon-repo-forked',
@@ -57,21 +57,17 @@ async function add(repoLink: HTMLElement): Promise<void> {
 
 	if (info.forked) {
 		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
-		$('.octicon-repo-forked', repoLink).classList.add('d-lg-none');
+		$('.octicon-repo-forked', breadcrumbs).classList.add('d-lg-none');
 	}
 
 	mount(RepoHeaderInfo, {
-		target: closestElement('ol', repoLink),
+		target: breadcrumbs,
 		props: {info},
 	});
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe(
-		'.loaded div[data-testid="top-nav-center"] li:last-child > a[class*="prc-Breadcrumbs-Item"]',
-		add,
-		{signal},
-	);
+	observe('.loaded nav[data-component="Breadcrumbs"] ol', add, {signal});
 }
 
 void features.addCssFeature(import.meta.url);

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -3,7 +3,7 @@ import './repo-header-info.css';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import LockIcon from 'octicons-plain-react/Lock';
-import {$, closestElement, closestElementOptional, elementExists} from 'select-dom';
+import {$, closestElement, elementExists} from 'select-dom';
 import {mount} from 'svelte';
 
 import features from '../feature-manager.js';
@@ -46,36 +46,22 @@ async function add(repoLink: HTMLElement): Promise<void> {
 	li.classList.add('rgh-repo-header-info-updated');
 
 	// GitHub may already show this icon natively, so we match its position
+	// It's generally missing when it's forked and private
 	if (info.isPrivate && !elementExists('.octicon-lock', repoLink)) {
 		appendBefore(
 			repoLink,
 			'.octicon-repo-forked',
-			<LockIcon className="ml-1 tmp-ml-1" width={12} height={12} />,
+			<LockIcon className="mr-1 tmp-mr-1 v-align-middle" width={12} height={12} />,
 		);
-	}
-
-	if (
-		info.forked
-		&& info.ciCommit
-		&& (info.stargazerCount > 1)
-		&& !repoLink.classList.contains('AppHeader-context-item')
-	) {
-		closestElement('li', repoLink).classList.add('d-flex');
 	}
 
 	if (info.forked) {
 		// Only show the clickable button at larger resolutions. Default to the native one on smaller screens
-		$('.octicon-repo-forked', repoLink).classList.add('d-sm-none');
-	}
-
-	if (info.ciCommit) {
-		// A parent is clipping the popup
-		closestElementOptional('.AppHeader-context-full', repoLink)?.style.setProperty('overflow', 'visible');
+		$('.octicon-repo-forked', repoLink).classList.add('d-lg-none');
 	}
 
 	mount(RepoHeaderInfo, {
-		target: li.parentElement!,
-		anchor: li.nextSibling ?? undefined,
+		target: closestElement('ol', repoLink),
 		props: {info},
 	});
 }


### PR DESCRIPTION
- part of #9810 
- fixes https://github.com/refined-github/refined-github/issues/9613
- fixes  <img width="300" src="https://github.com/user-attachments/assets/d1d89e9e-6590-4e3b-a6b0-445d89ec2351" />


## Test URLs


- Regular: https://github.com/refined-github/refined-github
- Fork: https://github.com/134130/refined-github
- Private: https://github.com/refined-github/private
- Private fork: https://github.com/refined-github/private-fork
- CI: https://github.com/refined-github/refined-github
- No CI: https://github.com/fregante/.github

## Screenshot

<img width="405" height="63" alt="Screenshot" src="https://github.com/user-attachments/assets/829baa4f-6702-4262-9be0-42b18654dfe8" />
