### PR TITLE
`repo-avatars` - Restore feature after window resize

### DIFF
--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -19,7 +19,7 @@ async function add(ownerLabel: HTMLElement): Promise<void> {
 		<img
 			className={cx(
 				'avatar mr-2 tmp-mr-2',
-				!pageDetect.isOrganizationProfile() && 'avatar-user'
+				!pageDetect.isOrganizationProfile() && 'avatar-user',
 			)}
 			src={source}
 			width={size}

--- a/source/features/repo-avatars.tsx
+++ b/source/features/repo-avatars.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
+import cx from 'clsx';
 
 import features from '../feature-manager.js';
 import getUserAvatar from '../github-helpers/get-user-avatar.js';
@@ -12,31 +13,25 @@ async function add(ownerLabel: HTMLElement): Promise<void> {
 	const size = 16;
 	const source = getUserAvatar(username, size)!;
 
-	const avatar = (
+	ownerLabel.parentElement!.classList.add('d-flex', 'flex-items-center');
+
+	ownerLabel.prepend(
 		<img
-			className='d-none d-md-block avatar mr-2 tmp-mr-2'
+			className={cx(
+				'avatar mr-2 tmp-mr-2',
+				!pageDetect.isOrganizationProfile() && 'avatar-user'
+			)}
 			src={source}
 			width={size}
 			height={size}
 			alt={`@${username}`}
-		/>
+		/>,
 	);
-
-	ownerLabel.parentElement!.classList.add('d-flex', 'flex-items-center');
-
-	ownerLabel.prepend(avatar);
-
-	if (!pageDetect.isOrganizationRepo()) {
-		avatar.classList.add('avatar-user');
-	}
 }
 
 function init(signal: AbortSignal): void {
-	observe(
-		'.loaded div[data-testid="top-nav-center"] li:first-child > a[class*="prc-Breadcrumbs-Item"]',
-		add,
-		{signal},
-	);
+	const username = getRepo()!.owner;
+	observe('.loaded nav[data-component="Breadcrumbs"] a[href="/' + username + '"]', add, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
It was removed due to https://github.com/refined-github/refined-github/pull/9823#discussion_r3569372542 and our `:first-child` selector


## Test URLs

here

## Before

<img width="395" height="59" alt="ava" src="https://github.com/user-attachments/assets/794f8459-e5bb-4a12-9f5e-cb21c754adec" />

## After

<img width="395" height="59" alt="before" src="https://github.com/user-attachments/assets/a860d0fa-b6bf-4c80-bd53-18c966c4a3e2" />
