### PR TITLE
Detect React navigation and re-apply features

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -167,7 +167,7 @@ async function add(url: string, ...loaders: FeatureLoader[]): Promise<void> {
 			do {
 				document.documentElement.setAttribute('rgh-OFF-' + id, '');
 				log.info('↩️', 'Skipping', id);
-			} while (await oneEvent(document, 'turbo:render'));
+			} while (await oneEvent(document, ['turbo:render', 'soft-nav:react-done']));
 		} else {
 			log.info('↩️', 'Skipping', id);
 		}
@@ -232,7 +232,7 @@ async function add(url: string, ...loaders: FeatureLoader[]): Promise<void> {
 					}
 				}
 			});
-		} while (await oneEvent(document, 'turbo:render'));
+		} while (await oneEvent(document, ['turbo:render', 'soft-nav:react-done']));
 	});
 }
 

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -203,8 +203,6 @@ async function init(signal: AbortSignal): Promise<void> {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
-		// Workaround for https://github.com/refined-github/refined-github/issues/6554
-		pageDetect.isRepoIssueOrPRList,
 	],
 	shortcuts: {
 		h: 'Cycle through conversation activity filters',

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -34,34 +34,31 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 	);
 }
 
-function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
-	// Place before the update date ·
-	closestElement('[data-testid="results-list"] > div', repositoryLink)
-		.querySelector(':scope ul > span:last-of-type')!
-		.before(
-			<span
-				aria-hidden="true"
-				className="color-fg-muted mx-2 tmp-mx-2"
+function addSearchConversationLinks(stargazersLink: HTMLAnchorElement): void {
+	closestElement('li', stargazersLink).after(
+		<span
+			aria-hidden="true"
+			className="color-fg-muted mx-2 tmp-mx-2"
+		>
+			·
+		</span>,
+		<li className="d-flex text-small">
+			<a
+				className="Link--muted"
+				href={stargazersLink.href + '/issues'}
 			>
-				·
-			</span>,
-			<li className="d-flex text-small">
-				<a
-					className="Link--muted"
-					href={repositoryLink.href + '/issues'}
-				>
-					<IssueOpenedIcon />
-				</a>
-			</li>,
-			<li className="d-flex text-small ml-2 tmp-ml-2">
-				<a
-					className="Link--muted"
-					href={repositoryLink.href + '/pulls'}
-				>
-					<GitPullRequestIcon />
-				</a>
-			</li>,
-		);
+				<IssueOpenedIcon />
+			</a>
+		</li>,
+		<li className="d-flex text-small ml-2 tmp-ml-2">
+			<a
+				className="Link--muted"
+				href={stargazersLink.href + '/pulls'}
+			>
+				<GitPullRequestIcon />
+			</a>
+		</li>,
+	);
 }
 
 function init(signal: AbortSignal): void {
@@ -69,7 +66,7 @@ function init(signal: AbortSignal): void {
 }
 
 function initSearch(signal: AbortSignal): void {
-	observe('.search-title a', addSearchConversationLinks, {signal});
+	observe('a[class^="Repositories-module__stargazersLink"]', addSearchConversationLinks, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -35,13 +35,6 @@ function addConversationLinks(repositoryLink: HTMLAnchorElement): void {
 }
 
 function addSearchConversationLinks(repositoryLink: HTMLAnchorElement): void {
-	// Do not move to `includes` until React AJAX issues are resolved:
-	// https://github.com/refined-github/refined-github/pull/7524#issuecomment-2211692096
-	// https://github.com/refined-github/refined-github/issues/6554
-	if (new URLSearchParams(location.search).get('type') !== 'repositories') {
-		return;
-	}
-
 	// Place before the update date ·
 	closestElement('[data-testid="results-list"] > div', repositoryLink)
 		.querySelector(':scope ul > span:last-of-type')!
@@ -85,8 +78,9 @@ void features.add(import.meta.url, {
 	],
 	init,
 }, {
-	include: [
+	asLongAs: [
 		pageDetect.isGlobalSearchResults,
+		() => new URLSearchParams(location.search).get('type') === 'repositories',
 	],
 	init: initSearch,
 });

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -42,15 +42,6 @@ function wrapButtons(buttons: HTMLElement[]): void {
 }
 
 async function add(branchSelectorElement: HTMLElement): Promise<void> {
-	// Apply here instead of `excludes` due to React loading:
-	// 1. Visit branch
-	// 2. Click "Code" repo tab
-	// 3. You're on `main` but the button is wrapped
-	// TODO: Move to excludes after https://github.com/refined-github/refined-github/issues/6554
-	if (await isDefaultBranch()) {
-		return;
-	}
-
 	// The DOM varies between details-based DOM and React-based one
 	const selectorWrapper = branchSelectorElement.tagName === 'SUMMARY'
 		? branchSelectorElement.parentElement!
@@ -102,6 +93,9 @@ void features.add(import.meta.url, {
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile,
 		isRepoCommitListRoot,
+	],
+	exclude: [
+		isDefaultBranch,
 	],
 	requiresToken: true,
 	init,

--- a/source/features/no-self-reference.tsx
+++ b/source/features/no-self-reference.tsx
@@ -21,7 +21,6 @@ function underlineSelfReference(link: HTMLAnchorElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	// TODO: Revert #9086 after https://github.com/refined-github/refined-github/issues/6554
 	// Exclude reference to a comment on the same page
 	observe('.markdown-body:not(section[aria-label="Events"] *) a.issue-link:not([href*="#"])', underlineSelfReference, {
 		signal,

--- a/source/features/status-subscription.tsx
+++ b/source/features/status-subscription.tsx
@@ -199,8 +199,6 @@ function init(signal: AbortSignal): void {
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
-		// Workaround for https://github.com/refined-github/refined-github/issues/6554
-		pageDetect.isRepoIssueOrPRList,
 	],
 	awaitDomReady: true, // The sidebar is at the end of the page
 	init,


### PR DESCRIPTION
- extracted from https://github.com/refined-github/refined-github/pull/8881 by @SunsetTechuila 
- part of https://github.com/refined-github/refined-github/issues/6554

I want to test-drive just this listener, we can then address any issues separately. React navigation is _long_ overdue and this should cover most of the functionality. 

I think we don't really _need_ to unload features, with few exceptions, it's mostly a performance optimization. They're still unloaded when a regular pjax navigation happens. Our `delegate` and `observe` calls are natively deduplicated already, so it won't actually break anything if `init` is called twice in a row.

[Svelte components](https://github.com/refined-github/refined-github/issues/9810) will eventually enable us to have features that auto-update.