### PR TITLE
AI SPAM

### DIFF
--- a/source/features/closing-remarks.tsx
+++ b/source/features/closing-remarks.tsx
@@ -16,7 +16,7 @@ import fetchDom from '../helpers/fetch-dom.js';
 import observe from '../helpers/selector-observer.js';
 import {getReleasesCount} from './releases-tab.js';
 
-function excludeNightliesAndJunk({textContent}: HTMLAnchorElement): boolean {
+function isVersionedTag({textContent}: HTMLAnchorElement): boolean {
 	// https://github.com/refined-github/refined-github/issues/7206
 	return !textContent.includes('nightly') && /\d[.]\d/.test(textContent);
 }
@@ -32,7 +32,12 @@ const firstTag = new CachedFunction('first-tag', {
 		const tagsAndBranches = await fetchDom(buildRepoUrl('branch_commits', commit));
 		const tags = $$optional('ul.branches-tag-list a', tagsAndBranches);
 		// eslint-disable-next-line unicorn/no-array-callback-reference -- Just this once, I swear
-		return tags.findLast(excludeNightliesAndJunk)?.textContent ?? false;
+		const preferredTag = tags.findLast(isVersionedTag) ?? tags.at(-1);
+		if (!preferredTag) {
+			return false;
+		}
+
+		return preferredTag.textContent ?? false;
 	},
 	cacheKey: ([commit]) => [getRepo()!.nameWithOwner, commit].join(':'),
 });


### PR DESCRIPTION
Closes #9831.

## What changed

- keep preferring the earliest stable-looking version tag;
- fall back to the earliest available tag when no version-like tag exists;
- preserve the existing no-tag result when the commit has no tags.

This prevents `closing-remarks` from reporting that a merged pull request has no tags when GitHub lists only a non-version tag for its merge commit.

## Root cause

The tag lookup filtered the complete GitHub tag list before selecting a result. When every tag failed the dotted-version/nightly preference, the filtered lookup returned `false` even though tags existed.

## Validation

- `npm test`
  - 545 tests passed; 31 skipped
  - TypeScript, ESLint, Biome, and production bundle passed
- `npm run format:check`
- `git diff --check`

The project-pinned npm 12 runtime warns that the available Node 25.6.1 runtime is outside npm's supported even-numbered release lines; all repository checks above still completed successfully.

## Test URLs

- Fallback-only tag: https://github.com/dregad/dokuwiki-plugin-cspheader/pull/1
  - GitHub currently lists only `release_2024-04-13`: https://github.com/dregad/dokuwiki-plugin-cspheader/branch_commits/98a9ef3a1996cd90eda4fcdfe89ba6576766670e
- Version preference remains intact: https://github.com/neovim/neovim/pull/22060
  - GitHub lists version tags followed by `stable` and `nightly`; the existing selection still resolves to `v0.9.0`: https://github.com/neovim/neovim/branch_commits/27b81af19c498892f4b0444ad29b7be842f8e7b8

## Screenshot

Not applicable; this changes tag selection without changing the banner layout.

## AI assistance

OpenAI Codex prepared and reviewed the one-file change against the repository guidance and live test URLs. No human review is claimed, so this PR remains Draft.

## Required poem

Boogers wait where tag lists sprawl,  
Versioned first, then one for all.
