### PR TITLE
`repo-header-info` - Don't show in unrelated places

### DIFF
--- a/source/features/repo-header-info.css
+++ b/source/features/repo-header-info.css
@@ -1,5 +1,6 @@
 html:not([rgh-OFF-repo-header-info]) {
-	nav[data-component='Breadcrumbs']
+	.GlobalNav
+		nav[data-component='Breadcrumbs']
 		ol:not(.rgh-repo-header-info-updated)
 		li:last-child {
 		/* Matches the `isSmallDevice` JS check */

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -67,7 +67,7 @@ async function add(breadcrumbs: HTMLElement): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe('.loaded nav[data-component="Breadcrumbs"] ol', add, {signal});
+	observe('.loaded .GlobalNav nav[data-component="Breadcrumbs"] ol', add, {signal});
 }
 
 void features.addCssFeature(import.meta.url);


### PR DESCRIPTION
- caused by https://github.com/refined-github/refined-github/pull/9823


## Test URLs

https://github.com/refined-github/refined-github/commits/main/source/features/clean-conversation-sidebar.tsx

## Before

<img width="626" height="282" alt="Screenshot" src="https://github.com/user-attachments/assets/05c87f5e-ea60-4451-b9c6-8f7031f8ba3c" />

## After

<img width="626" height="263" alt="Screenshot 10" src="https://github.com/user-attachments/assets/247d551d-475f-49d3-9be0-be9808ddd77e" />
