### PR TITLE
`quick-review` - Improve reliability

### DIFF
--- a/source/features/quick-review.svelte
+++ b/source/features/quick-review.svelte
@@ -9,9 +9,9 @@
 	import {getToken} from '../options-storage.js';
 
 	interface Props {
-		onReview: (_event: MouseEvent) => void;
+		onReview?: (_event: MouseEvent) => void;
 		onApprove: (_event: MouseEvent) => void;
-		onPreload: () => void;
+		onPreload?: () => void;
 	}
 
 	const {onReview, onApprove, onPreload}: Props = $props();

--- a/source/features/quick-review.svelte
+++ b/source/features/quick-review.svelte
@@ -50,7 +50,7 @@
 
 	{#await canApprovePromise then canApprove}
 		{#if canApprove}
-			-
+			–
 			<button
 				id={approveId}
 				type="button"
@@ -64,7 +64,6 @@
 				id="{approveId}-tooltip"
 				htmlFor={approveId}
 				label="Hold alt to approve without confirmation"
-				direction="nw"
 			/>
 		{/if}
 	{/await}

--- a/source/features/quick-review.svelte
+++ b/source/features/quick-review.svelte
@@ -16,7 +16,7 @@
 
 	const {onReview, onApprove, onPreload}: Props = $props();
 
-	const canApprove =
+	const canApprovePromise =
 		// Can't approve own PRs and closed PRs
 		getLoggedInUser() !== getConversationAuthor()
 		&& !isClosedConversation()
@@ -48,22 +48,24 @@
 		shortcut="v"
 	/>
 
-	{#if canApprove}
-		-
-		<button
-			id={approveId}
-			type="button"
-			class="btn-link Link--muted Link--inTextBlock rgh-quick-approve"
-			onclick={onApprove}
-			aria-labelledby="{approveId}-tooltip"
-		>
-			approve now
-		</button>
-		<Tooltip
-			id="{approveId}-tooltip"
-			htmlFor={approveId}
-			label="Hold alt to approve without confirmation"
-			direction="nw"
-		/>
-	{/if}
+	{#await canApprovePromise then canApprove}
+		{#if canApprove}
+			-
+			<button
+				id={approveId}
+				type="button"
+				class="btn-link Link--muted Link--inTextBlock rgh-quick-approve"
+				onclick={onApprove}
+				aria-labelledby="{approveId}-tooltip"
+			>
+				approve now
+			</button>
+			<Tooltip
+				id="{approveId}-tooltip"
+				htmlFor={approveId}
+				label="Hold alt to approve without confirmation"
+				direction="nw"
+			/>
+		{/if}
+	{/await}
 </span>

--- a/source/features/quick-review.svelte
+++ b/source/features/quick-review.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import {isClosedConversation} from 'github-url-detection';
+
+	import {
+		getConversationAuthor,
+		getLoggedInUser,
+	} from '../github-helpers/index.js';
+	import Tooltip from '../helpers/tooltip.svelte';
+	import {getToken} from '../options-storage.js';
+
+	interface Props {
+		onReview: (_event: MouseEvent) => void;
+		onApprove: (_event: MouseEvent) => void;
+		onPreload: () => void;
+	}
+
+	const {onReview, onApprove, onPreload}: Props = $props();
+
+	const canApprove =
+		// Can't approve own PRs and closed PRs
+		getLoggedInUser() !== getConversationAuthor()
+		&& !isClosedConversation()
+		// API required for this action
+		&& getToken();
+
+	const reviewId = 'rgh-quick-review';
+	const approveId = 'rgh-quick-approve';
+</script>
+
+<span class="text-normal color-fg-muted">
+	–
+	<a
+		id={reviewId}
+		href={location.pathname + `/files#review-changes-modal`}
+		class="rgh-quick-review btn-link Link--muted Link--inTextBlock"
+		data-turbo-frame="repo-content-turbo-frame"
+		data-hotkey="v"
+		onmouseenter={onPreload}
+		onclick={onReview}
+		aria-labelledby="{reviewId}-tooltip"
+	>
+		review now
+	</a>
+	<Tooltip
+		id="{reviewId}-tooltip"
+		htmlFor={reviewId}
+		label="Review now"
+		shortcut="v"
+	/>
+
+	{#if canApprove}
+		-
+		<button
+			id={approveId}
+			type="button"
+			class="btn-link Link--muted Link--inTextBlock rgh-quick-approve"
+			onclick={onApprove}
+			aria-labelledby="{approveId}-tooltip"
+		>
+			approve now
+		</button>
+		<Tooltip
+			id="{approveId}-tooltip"
+			htmlFor={approveId}
+			label="Hold alt to approve without confirmation"
+			direction="nw"
+		/>
+	{/if}
+</span>

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -17,6 +17,7 @@ import delay from '../helpers/delay.js';
 import {randomArrayItem} from '../helpers/math.js';
 import observe, {waitForElement} from '../helpers/selector-observer.js';
 import QuickReviewComponent from './quick-review.svelte';
+import onetime from '../helpers/onetime.js';
 
 const emojis = ['🚀', '🐿️', '⚡️', '🤌', '🥳', '🥰', '🤩', '🥸', '😎', '🤯', '🚢', '🛫', '🏳️', '🏁'];
 
@@ -26,7 +27,7 @@ const openReviewMenuDeepLink = 'review-changes-modal';
 const openReviewMenuDeepLinkSelector = `#${openReviewMenuDeepLink}`;
 const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
-const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
+const isNewFilesChangedExperienceEnabled = onetime((): boolean => $(prFilesChangedTabSelector).href.endsWith('changes'));
 
 async function quickApprove(event: MouseEvent): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
@@ -56,6 +57,7 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 }
 
 function handleReviewClick(event: MouseEvent): void {
+	// This only applies to the new experience
 	if (isAlteredClick(event) || !isNewFilesChangedExperienceEnabled()) {
 		return;
 	}
@@ -115,7 +117,9 @@ function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
 }
 
 async function initDeepLinking(signal: AbortSignal): Promise<void> {
+	// TODO [2027-01-01]: Drop after legacy PR files view is removed
 	observe(reviewMenuButtonSelector, openReviewDialog, {signal});
+
 	// Cannot target the [popover] itself because observe() can't see hidden elements
 	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,7 +1,7 @@
 import {mount} from 'svelte';
 import delegate, {type DelegateEvent} from 'delegate-it';
 import elementReady from 'element-ready';
-import {isAlteredClick} from 'filter-altered-clicks';
+import filterAlteredClicks from 'filter-altered-clicks';
 import * as pageDetect from 'github-url-detection';
 import {$} from 'select-dom';
 
@@ -17,7 +17,6 @@ import delay from '../helpers/delay.js';
 import {randomArrayItem} from '../helpers/math.js';
 import observe, {waitForElement} from '../helpers/selector-observer.js';
 import QuickReviewComponent from './quick-review.svelte';
-import onetime from '../helpers/onetime.js';
 
 const emojis = ['🚀', '🐿️', '⚡️', '🤌', '🥳', '🥰', '🤩', '🥸', '😎', '🤯', '🚢', '🛫', '🏳️', '🏁'];
 
@@ -27,7 +26,7 @@ const openReviewMenuDeepLink = 'review-changes-modal';
 const openReviewMenuDeepLinkSelector = `#${openReviewMenuDeepLink}`;
 const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
-const isNewFilesChangedExperienceEnabled = onetime((): boolean => $(prFilesChangedTabSelector).href.endsWith('changes'));
+const isOldPrFiles = (): boolean => $(prFilesChangedTabSelector).href.endsWith('files');
 
 async function quickApprove(event: MouseEvent): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
@@ -57,19 +56,13 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 }
 
 function handleReviewClick(event: MouseEvent): void {
-	// This only applies to the new experience
-	if (isAlteredClick(event) || !isNewFilesChangedExperienceEnabled()) {
-		return;
-	}
-
+	event.preventDefault();
 	void openReviewDialogWhenAvailable();
 	$(prFilesChangedTabSelector).click();
 }
 
 function preloadPrFilesTab(): void {
-	if (isNewFilesChangedExperienceEnabled()) {
-		$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
-	}
+	$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
 }
 
 async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {
@@ -78,11 +71,15 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 
 	mount(QuickReviewComponent, {
 		target: reviewersSection,
-		props: {
-			onReview: handleReviewClick,
-			onApprove: quickApprove,
-			onPreload: preloadPrFilesTab,
-		},
+		props: isOldPrFiles()
+			? {
+				onApprove: quickApprove,
+			}
+			: {
+				onReview: filterAlteredClicks(handleReviewClick),
+				onApprove: quickApprove,
+				onPreload: preloadPrFilesTab,
+			},
 	});
 }
 

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -134,8 +134,8 @@ async function initDeepLinking(signal: AbortSignal): Promise<void> {
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	// "h3" required to exclude "x more reviewers without write access"
-	observe('[aria-label="Select reviewers"] h3.discussion-sidebar-heading', addSidebarReviewButtons, {signal});
+	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading:not(#collapsible-reviewers-without-write)', addSidebarReviewButtons, {signal});
+
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
 	delegate('section[aria-label="Review Request Banner"] a[type="button"]', 'click', onReviewRequestedButtonClick, {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -31,7 +31,7 @@ const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
 const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
 
-async function quickApprove(event: DelegateEvent<MouseEvent>): Promise<void> {
+async function quickApprove(event: MouseEvent): Promise<void> {
 	const approval = event.altKey ? '' : prompt('Approve instantly? You can add a custom message or leave empty');
 	if (approval === null) {
 		return;
@@ -58,7 +58,7 @@ async function openReviewDialogWhenAvailable(): Promise<void> {
 	reviewMenuButton!.click();
 }
 
-function handleReviewClick(event: DelegateEvent<MouseEvent>): void {
+function handleReviewClick(event: MouseEvent): void {
 	if (isAlteredClick(event) || !isNewFilesChangedExperienceEnabled()) {
 		return;
 	}
@@ -97,14 +97,14 @@ async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
 	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
 }
 
-function onReviewRequestedButtonClick(event: DelegateEvent<PointerEvent, HTMLAnchorElement>): void {
+function onReviewRequestedButtonClick(event: PointerEvent): void {
 	if (isNewFilesChangedExperienceEnabled()) {
 		void openReviewDialogWhenAvailable();
 		return;
 	}
 
 	// TODO [2027-01-01]: Drop after legacy PR files view is removed
-	event.delegateTarget.hash = openReviewMenuDeepLink;
+	(event.currentTarget as HTMLAnchorElement).hash = openReviewMenuDeepLink;
 }
 
 function initReviewRequestedButton(signal: AbortSignal): void {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -49,23 +49,20 @@ async function quickApprove(event: MouseEvent): Promise<void> {
 	triggerConversationUpdate();
 }
 
-async function openReviewDialogWhenAvailable(): Promise<void> {
+async function openReviewDialogWhenAvailable(event: MouseEvent): Promise<void> {
+	event.preventDefault();
+	$(prFilesChangedTabSelector).click();
+
 	const signal = AbortSignal.timeout(10_000);
 	const reviewMenuButton = await waitForElement(reviewMenuButtonSelector, {signal});
 	reviewMenuButton!.click();
-}
-
-function handleReviewClick(event: MouseEvent): void {
-	event.preventDefault();
-	void openReviewDialogWhenAvailable();
-	$(prFilesChangedTabSelector).click();
 }
 
 function preloadPrFilesTab(): void {
 	$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
 }
 
-async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {
+async function addButtons(reviewersSection: Element): Promise<void> {
 	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
 	await delay(300);
 
@@ -76,7 +73,7 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 				onApprove: quickApprove,
 			}
 			: {
-				onReview: filterAlteredClicks(handleReviewClick),
+				onReview: filterAlteredClicks(openReviewDialogWhenAvailable),
 				onApprove: quickApprove,
 				onPreload: preloadPrFilesTab,
 			},
@@ -113,16 +110,16 @@ function openReviewDialog(reviewMenuButton: HTMLButtonElement): void {
 	reviewMenuButton.click();
 }
 
-async function initDeepLinking(signal: AbortSignal): Promise<void> {
+async function initAutoOpenPopup(signal: AbortSignal): Promise<void> {
 	// TODO [2027-01-01]: Drop after legacy PR files view is removed
-	observe(reviewMenuButtonSelector, openReviewDialog, {signal});
+	observe(reviewMenuButtonSelector, openReviewDialog, {signal, once: true});
 
 	// Cannot target the [popover] itself because observe() can't see hidden elements
-	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
+	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal, once: true});
 }
 
 async function init(signal: AbortSignal): Promise<void> {
-	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading:not(#collapsible-reviewers-without-write)', addSidebarReviewButtons, {signal});
+	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading:not(#collapsible-reviewers-without-write)', addButtons, {signal});
 }
 
 void features.add(import.meta.url, {
@@ -146,7 +143,7 @@ void features.add(import.meta.url, {
 		() => location.hash === openReviewMenuDeepLinkSelector,
 		pageDetect.isPRFiles,
 	],
-	init: initDeepLinking,
+	init: initAutoOpenPopup,
 });
 
 /*

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -88,7 +88,8 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 }
 
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
-	observe('#reviewers-select-menu .discussion-sidebar-heading', addSidebarReviewButtons, {signal});
+	// "h3" required to exclude "x more reviewers without write access"
+	observe('[aria-label="Select reviewers"] h3.discussion-sidebar-heading', addSidebarReviewButtons, {signal});
 	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
 	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
 }

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,6 +1,5 @@
 import {mount} from 'svelte';
 import delegate, {type DelegateEvent} from 'delegate-it';
-import React from 'dom-chef';
 import elementReady from 'element-ready';
 import {isAlteredClick} from 'filter-altered-clicks';
 import * as pageDetect from 'github-url-detection';
@@ -78,11 +77,8 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
 	await delay(300);
 
-	const container = <div className="rgh-quick-review-container" />;
-	reviewersSection.append(container);
-
 	mount(QuickReviewComponent, {
-		target: container,
+		target: reviewersSection,
 		props: {
 			onReview: handleReviewClick,
 			onApprove: quickApprove,

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -3,7 +3,7 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import elementReady from 'element-ready';
 import {isAlteredClick} from 'filter-altered-clicks';
 import * as pageDetect from 'github-url-detection';
-import {$, $optional} from 'select-dom';
+import {$} from 'select-dom';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -22,10 +22,8 @@ const emojis = ['🚀', '🐿️', '⚡️', '🤌', '🥳', '🥰', '🤩', '�
 
 // Be careful not to select the "Submit review" button in the dialog
 const reviewMenuButtonSelector = 'button[class*="ReviewMenuButton-module__ReviewMenuButton"]';
-
 const openReviewMenuDeepLink = 'review-changes-modal';
 const openReviewMenuDeepLinkSelector = `#${openReviewMenuDeepLink}`;
-
 const prFilesChangedTabSelector = 'a#prs-files-anchor-tab';
 
 const isNewFilesChangedExperienceEnabled = (): boolean => $(prFilesChangedTabSelector).href.endsWith('changes');
@@ -62,7 +60,6 @@ function handleReviewClick(event: MouseEvent): void {
 		return;
 	}
 
-	event.preventDefault();
 	void openReviewDialogWhenAvailable();
 	$(prFilesChangedTabSelector).click();
 }
@@ -85,16 +82,6 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 			onPreload: preloadPrFilesTab,
 		},
 	});
-}
-
-function onReviewRequestedButtonClick(event: PointerEvent): void {
-	if (isNewFilesChangedExperienceEnabled()) {
-		void openReviewDialogWhenAvailable();
-		return;
-	}
-
-	// TODO [2027-01-01]: Drop after legacy PR files view is removed
-	(event.currentTarget as HTMLAnchorElement).hash = openReviewMenuDeepLink;
 }
 
 // TODO [2027-01-01]: Drop after the legacy PR files view is removed
@@ -135,13 +122,6 @@ async function initDeepLinking(signal: AbortSignal): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe('[aria-label="Select reviewers"] .discussion-sidebar-heading:not(#collapsible-reviewers-without-write)', addSidebarReviewButtons, {signal});
-
-	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
-	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
-	delegate('section[aria-label="Review Request Banner"] a[type="button"]', 'click', onReviewRequestedButtonClick, {
-		capture: true,
-		signal,
-	});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -87,13 +87,6 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 	});
 }
 
-async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {
-	// "h3" required to exclude "x more reviewers without write access"
-	observe('[aria-label="Select reviewers"] h3.discussion-sidebar-heading', addSidebarReviewButtons, {signal});
-	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
-	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
-}
-
 function onReviewRequestedButtonClick(event: PointerEvent): void {
 	if (isNewFilesChangedExperienceEnabled()) {
 		void openReviewDialogWhenAvailable();
@@ -102,13 +95,6 @@ function onReviewRequestedButtonClick(event: PointerEvent): void {
 
 	// TODO [2027-01-01]: Drop after legacy PR files view is removed
 	(event.currentTarget as HTMLAnchorElement).hash = openReviewMenuDeepLink;
-}
-
-function initReviewRequestedButton(signal: AbortSignal): void {
-	delegate('section[aria-label="Review Request Banner"] a[type="button"]', 'click', onReviewRequestedButtonClick, {
-		capture: true,
-		signal,
-	});
 }
 
 // TODO [2027-01-01]: Drop after the legacy PR files view is removed
@@ -147,16 +133,25 @@ async function initDeepLinking(signal: AbortSignal): Promise<void> {
 	observe(`[popovertarget="${openReviewMenuDeepLink}"]`, openReviewPopup, {signal});
 }
 
+async function init(signal: AbortSignal): Promise<void> {
+	// "h3" required to exclude "x more reviewers without write access"
+	observe('[aria-label="Select reviewers"] h3.discussion-sidebar-heading', addSidebarReviewButtons, {signal});
+	delegate('.rgh-quick-approve', 'click', quickApprove, {signal});
+	delegate('.rgh-quick-review', 'click', handleReviewClick, {signal});
+	delegate('section[aria-label="Review Request Banner"] a[type="button"]', 'click', onReviewRequestedButtonClick, {
+		capture: true,
+		signal,
+	});
+}
+
 void features.add(import.meta.url, {
+	shortcuts: {
+		v: 'Review PR',
+	},
 	include: [
 		pageDetect.isPRConversation,
 	],
-	init: initSidebarReviewButton,
-}, {
-	include: [
-		pageDetect.isPRConversation,
-	],
-	init: initReviewRequestedButton,
+	init,
 }, {
 	shortcuts: {
 		v: 'Open PR review popup',

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -68,9 +68,9 @@ function handleReviewClick(event: MouseEvent): void {
 }
 
 function preloadPrFilesTab(): void {
-	// Trigger data preloading
-	// TODO [2027-01-01]: Change `$optional` to `$()` once legacy PR files view is removed
-	$optional(prFilesChangedTabSelector)?.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+	if (isNewFilesChangedExperienceEnabled()) {
+		$(prFilesChangedTabSelector).dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+	}
 }
 
 async function addSidebarReviewButtons(reviewersSection: Element): Promise<void> {

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -1,3 +1,4 @@
+import {mount} from 'svelte';
 import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
 import elementReady from 'element-ready';
@@ -9,7 +10,6 @@ import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
 import {
 	getConversationNumber,
-	getLoggedInUser,
 	scrollIntoViewIfNeeded,
 	triggerConversationUpdate,
 } from '../github-helpers/index.js';
@@ -17,8 +17,7 @@ import showToast from '../github-helpers/toast.js';
 import delay from '../helpers/delay.js';
 import {randomArrayItem} from '../helpers/math.js';
 import observe, {waitForElement} from '../helpers/selector-observer.js';
-import {tooltipped} from '../helpers/tooltip.js';
-import {getToken} from '../options-storage.js';
+import QuickReviewComponent from './quick-review.svelte';
 
 const emojis = ['🚀', '🐿️', '⚡️', '🤌', '🥳', '🥰', '🤩', '🥸', '😎', '🤯', '🚢', '🛫', '🏳️', '🏁'];
 
@@ -79,52 +78,17 @@ async function addSidebarReviewButtons(reviewersSection: Element): Promise<void>
 	// Occasionally this button appears before "Reviewers", so let's wait a bit longer
 	await delay(300);
 
-	const quickReview = (
-		<span className="text-normal color-fg-muted">
-			{'– '}
-			{tooltipped(
-				{
-					label: 'Review now',
-					shortcut: 'v',
-				},
-				<a
-					// TODO [2027-01-01]: Change path to "changes" once Legacy PR files view is removed
-					href={`${location.pathname}/files#${openReviewMenuDeepLink}`}
-					className="rgh-quick-review btn-link Link--muted Link--inTextBlock"
-					data-turbo-frame="repo-content-turbo-frame"
-					data-hotkey="v"
-					onMouseEnter={preloadPrFilesTab}
-				>
-					review now
-				</a>,
-			)}
-		</span>
-	);
+	const container = <div className="rgh-quick-review-container" />;
+	reviewersSection.append(container);
 
-	reviewersSection.append(quickReview);
-
-	// Can't approve own PRs and closed PRs
-	// API required for this action
-	if (
-		getLoggedInUser() === $('.author').textContent
-		|| pageDetect.isClosedConversation()
-		|| !(await getToken())
-	) {
-		return;
-	}
-
-	quickReview.append(
-		' – ',
-		tooltipped(
-			{label: 'Hold alt to approve without confirmation', direction: 'nw'},
-			<button
-				type="button"
-				className="btn-link Link--muted Link--inTextBlock rgh-quick-approve"
-			>
-				approve now
-			</button>,
-		),
-	);
+	mount(QuickReviewComponent, {
+		target: container,
+		props: {
+			onReview: handleReviewClick,
+			onApprove: quickApprove,
+			onPreload: preloadPrFilesTab,
+		},
+	});
 }
 
 async function initSidebarReviewButton(signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
- part of #9810 
- enabled by #9844 


I don't think this fixes this issue, but potentially we'll be able to just call "remount" and svelte will not trigger the internal logic code:

- https://github.com/refined-github/refined-github/issues/9327

## Test URLs

- here
- https://togithub.com/react/react/pull/36378

## Screenshot

<img width="204" height="82" alt="Screenshot" src="https://github.com/user-attachments/assets/1072941b-3df1-4fad-af30-2f9b15623bc6" />

<img width="381" height="85" alt="Screenshot 1" src="https://github.com/user-attachments/assets/ecca6ff3-deae-4337-af50-a95d61dd4ef1" />
