### PR TITLE
Restore Escape to cancel review comments

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -257,7 +257,7 @@
 	},
 	{
 		"id": "esc-to-cancel",
-		"description": "Adds a shortcut to cancel editing a PR title: <kbd>esc</kbd>.",
+		"description": "Adds a shortcut to cancel editing a PR title or review comment: <kbd>esc</kbd>.",
 		"screenshot": "https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif"
 	},
 	{

--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "quick-label-removal") [Adds one-click buttons to remove labels in issues/PRs.](https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif)
 - [](# "clean-conversation-headers") [Removes duplicate information in the header of PRs ("User wants to merge X commits from Y into Z")](https://user-images.githubusercontent.com/44045911/112314137-a34b0680-8ce3-11eb-9e0e-8afd6c8235c2.png)
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/220607557-f8ea0863-f05b-48c8-a447-1fec42af0afd.gif)
-- [](# "esc-to-cancel") [Adds a shortcut to cancel editing a PR title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
+- [](# "esc-to-cancel") [Adds a shortcut to cancel editing a PR title or review comment: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
 - [](# "no-duplicate-list-update-time") [Hides the update time of issues/PRs in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
 - [](# "linkify-user-labels") [Links the "Contributor", "Member" and "Collaborator" labels on comments and PRs to the author’s commits on the repo.](https://user-images.githubusercontent.com/1402241/177033344-4d4eea63-e075-4096-b2d4-f4b879f1df31.png)
 - [](# "jump-to-conversation-close-event") [Adds a link to jump to the latest close event of a issue/PR.](https://user-images.githubusercontent.com/16872793/177792713-64219754-f8df-4629-a9ec-33259307cfe7.gif)

--- a/source/features/esc-to-cancel.tsx
+++ b/source/features/esc-to-cancel.tsx
@@ -1,45 +1,65 @@
 import type {DelegateEvent} from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
-import {$} from 'select-dom';
+import {$, $$optional, closestElementOptional} from 'select-dom';
 
 import features from '../feature-manager.js';
-import {onConversationTitleFieldKeydown} from '../github-events/on-field-keydown.js';
+import {onCommentFieldKeydown, onConversationTitleFieldKeydown} from '../github-events/on-field-keydown.js';
 
-function handleEscPress(event: DelegateEvent<KeyboardEvent>): void {
+function handleEscPress(event: DelegateEvent<KeyboardEvent, HTMLInputElement | HTMLTextAreaElement>): void {
 	if (event.key !== 'Escape') {
 		return;
 	}
 
-	if (!(event.delegateTarget instanceof HTMLInputElement)) {
-		return;
+	const field = event.delegateTarget;
+	if (field instanceof HTMLInputElement) {
+		const cancelButton = $([
+			'div[class^="prc-PageLayout-HeaderContent"] > form button[data-variant="invisible"]',
+			// TODO [2027-01-01]: Remove after legacy PR files view is removed
+			'.js-cancel-issue-edit',
+		]);
+		if (cancelButton.textContent.trim() !== 'Cancel') {
+			throw new Error('Expected to find a cancel button');
+		}
+
+		cancelButton.click();
+	} else {
+		const editor = closestElementOptional('form, fieldset', field);
+		const cancelButton = $$optional('button:not([disabled])', editor ?? undefined)
+			.find(button => button.textContent.trim() === 'Cancel');
+
+		// Some comment fields are always visible and don't have a cancel button
+		if (cancelButton) {
+			cancelButton.click();
+		} else {
+			field.blur();
+		}
 	}
 
-	const cancelButton = $([
-		'div[class^="prc-PageLayout-HeaderContent"] > form button[data-variant="invisible"]',
-		// TODO [2027-01-01]: Remove after legacy PR files view is removed
-		'.js-cancel-issue-edit',
-	]);
-	if (cancelButton.textContent.trim() !== 'Cancel') {
-		throw new Error('Expected to find a cancel button');
-	}
-
-	cancelButton.click();
 	event.stopImmediatePropagation();
 	event.preventDefault();
 }
 
-function init(signal: AbortSignal): void {
+function initTitle(signal: AbortSignal): void {
 	onConversationTitleFieldKeydown(handleEscPress, signal);
+}
+
+function initComments(signal: AbortSignal): void {
+	onCommentFieldKeydown(handleEscPress, signal);
 }
 
 void features.add(import.meta.url, {
 	shortcuts: {
-		esc: 'Cancel editing a conversation title',
+		esc: 'Cancel editing a conversation title or review comment',
 	},
 	include: [
 		pageDetect.isPR,
 	],
-	init,
+	init: initTitle,
+}, {
+	include: [
+		pageDetect.isPRFiles,
+	],
+	init: initComments,
 });
 
 /*
@@ -50,5 +70,11 @@ Test URLs:
 2. Open any PR
 3. Try to edit the title
 4. Press Esc
+
+Review comments:
+
+1. Visit https://github.com/refined-github/sandbox/pull/4/files
+2. Start an inline review comment
+3. Press Esc
 
 */

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -38,6 +38,7 @@ import './features/sticky-comment-header.js';
 import './features/useful-not-found-page.js';
 import './features/releases-tab.js';
 import './features/one-key-formatting.js';
+import './features/esc-to-cancel.js'; // Must be before tab-to-indent, which stops Escape propagation
 import './features/tab-to-indent.js';
 import './features/hide-navigation-hover-highlight.js';
 import './features/selection-in-new-tab.js';
@@ -150,7 +151,6 @@ import './features/table-input.js';
 import './features/link-to-github-io.js';
 import './features/github-actions-indicators.js';
 import './features/unfinished-comments.js';
-import './features/esc-to-cancel.js';
 import './features/easy-toggle-files.js';
 import './features/quick-repo-deletion.js';
 import './features/clean-repo-sidebar.js';


### PR DESCRIPTION




Closes #9792

Restores Escape-to-cancel for review comments in the current PR files view.

The existing `esc-to-cancel` feature now handles review comment fields and activates the editor’s enabled Cancel button. It continues to blur always-visible comment fields that do not offer cancellation.

Manually verified that pressing Escape closes the review comment editor instead of only removing focus.

## Test URLs

- Review comment editor: https://github.com/refined-github/sandbox/pull/4/files

## Working!
https://github.com/user-attachments/assets/dbbea86c-bf90-4f9e-8279-73cfec4db3be