### PR TITLE
AI SPAM

### DIFF
--- a/source/features/pr-base-commit.tsx
+++ b/source/features/pr-base-commit.tsx
@@ -36,7 +36,10 @@ async function addInfo(statusMeta: Element): Promise<void> {
 
 	const previousMessage = statusMeta.firstChild!; // Extract now because it won't be the first child anymore
 	statusMeta.prepend(getBaseCommitNotice(prInfo));
-	if (isTextNodeContaining(previousMessage, 'Merging can be performed automatically.')) {
+	if (
+		previousMessage instanceof Text
+		&& isTextNodeContaining(previousMessage, 'Merging can be performed automatically.')
+	) {
 		previousMessage.remove();
 	}
 }


### PR DESCRIPTION
Fixes #9853

## What changed

Only run the legacy mergeability-message cleanup when the previous status child is a text node. GitHub now renders a structured `span` in this location, which should be preserved instead of being passed to `isTextNodeContaining`.

The base-commit notice continues to be inserted while avoiding the `Expected Text node, received SPAN` exception.

## Verification

- `npm test`
- 558 tests passed, 28 skipped
- TypeScript, ESLint, Biome, and bundle checks passed