### PR TITLE
`rgh-feature-description` - Move banner to svelte component

### DIFF
--- a/source/components/banner.svelte
+++ b/source/components/banner.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
 	import type {Snippet} from 'svelte';
+	import type {RequireAllOrNone} from 'type-fest';
 
-	type Props = {
-		icon?: Snippet;
+	import Dom from './dom-chef.svelte';
+
+	type Props = RequireAllOrNone<{
+		icon?: (..._props: any[]) => HTMLElement;
 		text: Snippet;
 		classes?: string[];
-		action?: string | ((_event: MouseEvent) => void);
-		buttonLabel?: Snippet | string;
-	};
+		action: string | ((_event: MouseEvent) => void);
+		buttonLabel: Snippet;
+	}, 'action' | 'buttonLabel'>;
 
 	const {icon, text, classes = [], action, buttonLabel}: Props = $props();
 
@@ -18,23 +21,17 @@
 <div class={['flash', ...classes].join(' ')}>
 	<div class="d-sm-flex flex-items-center gap-2">
 		<div class="d-flex flex-auto flex-self-center flex-items-center gap-2">
-			{#if icon}{@render icon()}{/if}
+			{#if icon}<Dom as={icon} class="mr-0 tmp-mr-0" />{/if}
 			<span>{@render text()}</span>
 		</div>
-		{#if action && buttonLabel}
-			{#if typeof action === 'string'}
-				<a href={action} class={buttonClasses}>
-					{#if typeof buttonLabel === 'string'}{
-							buttonLabel
-						}{:else}{@render buttonLabel()}{/if}
-				</a>
-			{:else}
-				<button type="button" class={buttonClasses} onclick={action}>
-					{#if typeof buttonLabel === 'string'}{
-							buttonLabel
-						}{:else}{@render buttonLabel()}{/if}
-				</button>
-			{/if}
+		{#if typeof action === 'string'}
+			<a href={action} class={buttonClasses}>
+				{@render buttonLabel()}
+			</a>
+		{:else if typeof action === 'function'}
+			<button type="button" class={buttonClasses} onclick={action}>
+				{@render buttonLabel()}
+			</button>
 		{/if}
 	</div>
 </div>

--- a/source/components/banner.svelte
+++ b/source/components/banner.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type {Snippet} from 'svelte';
+
+	type Props = {
+		icon?: Snippet;
+		text: Snippet;
+		classes?: string[];
+		action?: string | ((_event: MouseEvent) => void);
+		buttonLabel?: Snippet | string;
+	};
+
+	const {icon, text, classes = [], action, buttonLabel}: Props = $props();
+
+	const buttonClasses =
+		'flex-shrink-0 btn btn-sm ml-sm-3 mt-2 mt-sm-n2 mb-sm-n2 mr-sm-n1 flex-self-center';
+</script>
+
+<div class={['flash', ...classes].join(' ')}>
+	<div class="d-sm-flex flex-items-center gap-2">
+		<div class="d-flex flex-auto flex-self-center flex-items-center gap-2">
+			{#if icon}{@render icon()}{/if}
+			<span>{@render text()}</span>
+		</div>
+		{#if action && buttonLabel}
+			{#if typeof action === 'string'}
+				<a href={action} class={buttonClasses}>
+					{#if typeof buttonLabel === 'string'}{
+							buttonLabel
+						}{:else}{@render buttonLabel()}{/if}
+				</a>
+			{:else}
+				<button type="button" class={buttonClasses} onclick={action}>
+					{#if typeof buttonLabel === 'string'}{
+							buttonLabel
+						}{:else}{@render buttonLabel()}{/if}
+				</button>
+			{/if}
+		{/if}
+	</div>
+</div>

--- a/source/components/disabled-feature-banner.svelte
+++ b/source/components/disabled-feature-banner.svelte
@@ -2,11 +2,11 @@
 	import AlertIcon from 'octicons-plain-react/Alert';
 	import InfoIcon from 'octicons-plain-react/Info';
 
-	import Banner from '../components/banner.svelte';
 	import {brokenFeatures} from '../helpers/hotfix.js';
 	import openOptions from '../helpers/open-options.js';
 	import {createRghIssueLink} from '../helpers/rgh-links.js';
 	import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
+	import Banner from './banner.svelte';
 	import Dom from './dom-chef.svelte';
 
 	const {id}: {id: string} = $props();
@@ -40,29 +40,28 @@
 
 {#await disabledState then state}
 	{#if state.kind === 'hotfixed-temporary'}
-		<Banner classes={bannerClasses}>
-			{#snippet icon()}<Dom as={InfoIcon} class="mr-0 tmp-mr-0" />{/snippet}
+		<Banner classes={bannerClasses} icon={InfoIcon}>
 			{#snippet text()}
 				This feature was disabled until version {state.unaffectedVersion} due to
 				<Dom as={() => createRghIssueLink(state.issue)} />.
 			{/snippet}
 		</Banner>
 	{:else if state.kind === 'hotfixed-permanent'}
-		<Banner classes={[...bannerClasses, 'flash-warn']}>
-			{#snippet icon()}<Dom as={AlertIcon} class="mr-0 tmp-mr-0" />{/snippet}
+		<Banner classes={[...bannerClasses, 'flash-warn']} icon={AlertIcon}>
 			{#snippet text()}
-				This feature is disabled due to
-				<Dom as={() => createRghIssueLink(state.issue)} />.
+				This feature is disabled due to <Dom
+					as={() => createRghIssueLink(state.issue)}
+				/>.
 			{/snippet}
 		</Banner>
 	{:else if state.kind === 'user-disabled'}
 		<Banner
 			classes={[...bannerClasses, 'flash-warn']}
+			icon={AlertIcon}
 			action={(event) => openOptions(event, id)}
-			buttonLabel="Refined GitHub Options"
 		>
-			{#snippet icon()}<Dom as={AlertIcon} class="mr-0 tmp-mr-0" />{/snippet}
 			{#snippet text()}You disabled this feature on GitHub.com.{/snippet}
+			{#snippet buttonLabel()}Refined GitHub Options{/snippet}
 		</Banner>
 	{/if}
 {/await}

--- a/source/components/disabled-feature-banner.svelte
+++ b/source/components/disabled-feature-banner.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import AlertIcon from 'octicons-plain-react/Alert';
+	import InfoIcon from 'octicons-plain-react/Info';
+
+	import Banner from '../components/banner.svelte';
+	import {brokenFeatures} from '../helpers/hotfix.js';
+	import openOptions from '../helpers/open-options.js';
+	import {createRghIssueLink} from '../helpers/rgh-links.js';
+	import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
+	import Dom from './dom-chef.svelte';
+
+	const {id}: {id: string} = $props();
+
+	type DisabledState =
+		| {kind: 'hotfixed-permanent'; issue: string}
+		| {kind: 'hotfixed-temporary'; issue: string; unaffectedVersion: string}
+		| {kind: 'user-disabled'}
+		| {kind: 'enabled'};
+
+	async function getDisabledState(): Promise<DisabledState> {
+		const hotfixes = await brokenFeatures.get() ?? [];
+		const hotfixed = hotfixes.find(([feature]) => feature === id);
+		if (hotfixed) {
+			const [_name, issue, unaffectedVersion] = hotfixed;
+			return unaffectedVersion
+				? {kind: 'hotfixed-temporary', issue, unaffectedVersion}
+				: {kind: 'hotfixed-permanent', issue};
+		}
+
+		if (isFeatureDisabled(await optionsStorage.getAll(), id)) {
+			return {kind: 'user-disabled'};
+		}
+
+		return {kind: 'enabled'};
+	}
+
+	const disabledState = getDisabledState();
+	const bannerClasses = ['mb-3', 'd-inline-block', 'width-full'];
+</script>
+
+{#await disabledState then state}
+	{#if state.kind === 'hotfixed-temporary'}
+		<Banner classes={bannerClasses}>
+			{#snippet icon()}<Dom as={InfoIcon} class="mr-0 tmp-mr-0" />{/snippet}
+			{#snippet text()}
+				This feature was disabled until version {state.unaffectedVersion} due to
+				<Dom as={() => createRghIssueLink(state.issue)} />.
+			{/snippet}
+		</Banner>
+	{:else if state.kind === 'hotfixed-permanent'}
+		<Banner classes={[...bannerClasses, 'flash-warn']}>
+			{#snippet icon()}<Dom as={AlertIcon} class="mr-0 tmp-mr-0" />{/snippet}
+			{#snippet text()}
+				This feature is disabled due to
+				<Dom as={() => createRghIssueLink(state.issue)} />.
+			{/snippet}
+		</Banner>
+	{:else if state.kind === 'user-disabled'}
+		<Banner
+			classes={[...bannerClasses, 'flash-warn']}
+			action={(event) => openOptions(event, id)}
+			buttonLabel="Refined GitHub Options"
+		>
+			{#snippet icon()}<Dom as={AlertIcon} class="mr-0 tmp-mr-0" />{/snippet}
+			{#snippet text()}You disabled this feature on GitHub.com.{/snippet}
+		</Banner>
+	{/if}
+{/await}

--- a/source/features/rgh-feature-descriptions.svelte
+++ b/source/features/rgh-feature-descriptions.svelte
@@ -2,6 +2,7 @@
 	import * as pageDetect from 'github-url-detection';
 	import CopyIcon from 'octicons-plain-react/Copy';
 
+	import DisabledFeatureBanner from '../components/disabled-feature-banner.svelte';
 	import DomChef from '../components/dom-chef.svelte';
 	import RelatedIssuesCount from '../components/related-issues-count.svelte';
 	import {getOldFeatureNames} from '../feature-data.js';
@@ -127,3 +128,5 @@
 		{/if}
 	</div>
 </div>
+
+<DisabledFeatureBanner id={id} />

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -3,19 +3,12 @@ import './rgh-feature-descriptions.css';
 import delegate from 'delegate-it';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
-import AlertIcon from 'octicons-plain-react/Alert';
-import InfoIcon from 'octicons-plain-react/Info';
 import {mount} from 'svelte';
 
 import {featuresMeta, getNewFeatureName} from '../feature-data.js';
 import features from '../feature-manager.js';
-import createBanner from '../github-helpers/banner.js';
 import {isRefinedGitHubRepo} from '../github-helpers/index.js';
-import {brokenFeatures} from '../helpers/hotfix.js';
-import openOptions from '../helpers/open-options.js';
-import {createRghIssueLink} from '../helpers/rgh-links.js';
 import observe from '../helpers/selector-observer.js';
-import optionsStorage, {isFeatureDisabled} from '../options-storage.js';
 import {openInNewTab} from './prevent-comment-loss.js';
 import Description from './rgh-feature-descriptions.svelte';
 
@@ -23,52 +16,6 @@ function addDescription(anchor: HTMLElement, id: string, meta: FeatureMeta | und
 	const container = <div />;
 	mount(Description, {target: container, props: {id, meta}});
 	anchor.before(container);
-}
-
-async function getDisabledReason(id: string): Promise<JSX.Element | undefined> {
-	// Block and width classes required to avoid margin collapse
-	const classes = ['mb-3', 'd-inline-block', 'width-full'];
-	// Skip dev check present in `getLocalHotfixes`, we want to see this even when developing
-	const hotfixes = await brokenFeatures.get() ?? [];
-	const hotfixed = hotfixes.find(([feature]) => feature === id);
-	if (hotfixed) {
-		const [_name, issue, unaffectedVersion] = hotfixed;
-
-		if (unaffectedVersion) {
-			return createBanner({
-				text: <>This feature was disabled until version {unaffectedVersion} due to {createRghIssueLink(issue)}.</>,
-				classes,
-				icon: <InfoIcon className="mr-0 tmp-mr-0" />,
-			});
-		}
-
-		return createBanner({
-			text: <>This feature is disabled due to {createRghIssueLink(issue)}.</>,
-			classes: [...classes, 'flash-warn'],
-			icon: <AlertIcon className="mr-0 tmp-mr-0" />,
-		});
-	}
-
-	if (isFeatureDisabled(await optionsStorage.getAll(), id)) {
-		return createBanner({
-			text: 'You disabled this feature on GitHub.com.',
-			classes: [...classes, 'flash-warn'],
-			icon: <AlertIcon className="mr-0 tmp-mr-0" />,
-			action(event) {
-				openOptions(event, id);
-			},
-			buttonLabel: 'Refined GitHub Options',
-		});
-	}
-
-	return undefined;
-}
-
-async function addDisabledBanner(infoBanner: HTMLElement, id: string): Promise<void> {
-	const reason = await getDisabledReason(id);
-	if (reason) {
-		infoBanner.before(reason);
-	}
 }
 
 async function addFeatureInformationWidget(
@@ -83,7 +30,6 @@ async function addFeatureInformationWidget(
 	const id = meta?.id ?? latestId;
 
 	addDescription(infoBanner, id, meta);
-	await addDisabledBanner(infoBanner, id);
 }
 
 function getFeatureNameFromIssueTitle(): string | undefined {


### PR DESCRIPTION
- part of #9810 
- will enable #6554 
- will use #9858 


## Test URLs

- https://github.com/refined-github/refined-github/blob/main/source/features/bugs-tab.tsx
- https://github.com/refined-github/refined-github/issues/new?template=1_bug_report.yml&title=%60bugs-tab%60++&labels=bug%2C+help+wanted

## Screenshot

<img width="776" height="412" alt="Screenshot" src="https://github.com/user-attachments/assets/749f31ae-5da1-45be-aa28-72aad7e84c1f" />

<img width="332" height="610" alt="Screenshot 1" src="https://github.com/user-attachments/assets/5c98ff67-237c-4a5d-92a0-5a6dde7f0320" />
