### PR TITLE
`netiquette`: Fix crash on PR Files tab

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -180,9 +180,6 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // We're specifically looking for the last event
 	init: initBanner,
 }, {
-	asLongAs: [
-		pageDetect.isPRConversation,
-	],
 	include: [
 		pageDetect.isDraftPR,
 	],

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -180,6 +180,9 @@ void features.add(import.meta.url, {
 	awaitDomReady: true, // We're specifically looking for the last event
 	init: initBanner,
 }, {
+	asLongAs: [
+		pageDetect.isPRConversation,
+	],
 	include: [
 		pageDetect.isDraftPR,
 	],

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -202,7 +202,13 @@ export function getConversationBody(): Element {
 }
 
 export function getConversationAuthor(): string {
-	return getCommentAuthor(getConversationBody());
+	// The header is present on every PR tab (Conversation, Files, Commits, Checks) and reliably
+	// reflects the author, unlike the conversation body element, which only exists on the
+	// Conversation tab. The header is absent on merged/closed PRs, so we fall back to the body.
+	const headerAuthorLink = $optional('[class*="PullRequestHeaderSummary"] a[data-hovercard-type="user"]');
+	return headerAuthorLink
+		? headerAuthorLink.textContent!.trim()
+		: getCommentAuthor(getConversationBody());
 }
 
 export function isOwnConversation(): boolean {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -207,7 +207,7 @@ export function getConversationAuthor(): string {
 	// Conversation tab. The header is absent on merged/closed PRs, so we fall back to the body.
 	const headerAuthorLink = $optional('[class*="PullRequestHeaderSummary"] a[data-hovercard-type="user"]');
 	return headerAuthorLink
-		? headerAuthorLink.textContent!.trim()
+		? headerAuthorLink.textContent.trim()
 		: getCommentAuthor(getConversationBody());
 }
 


### PR DESCRIPTION
Closes #9833

## Test URLs

- https://github.com/refined-github/refined-github/pull/9832/changes (original repro link from the issue)
- https://github.com/refined-github/sandbox/pull/7 (Files tab, draft PR)
- https://github.com/refined-github/refined-github/pull/9862/changes (open draft PR, Files tab, no crash after fix)
- https://github.com/refined-github/refined-github/pull/9862 (same PR, Conversation tab, draft banner still renders correctly)

## Screenshot

<img width="1840" height="927" alt="image" src="https://github.com/user-attachments/assets/c1f996ef-3408-476f-b4eb-af442b8d6074" />
<img width="1840" height="927" alt="image" src="https://github.com/user-attachments/assets/57993a42-8922-4f4b-bc6b-d35d4d3bbab0" />



## Explanation

`isOwnConversation()` throws when `.react-issue-body`/`.js-command-palette-pull-body` isn't in the DOM, which is the case on the PR Files tab. The draft-banner block's `exclude: [isOwnConversation]` was still being evaluated there, since `exclude` conditions run through an async wrapper that loses sync short-circuiting (unlike `asLongAs`/`include`).

Fix: added `asLongAs: [pageDetect.isPRConversation]` to restrict the block to the Conversation tab, so `isOwnConversation` is never reached on the Files tab. Same pattern already used in `clear-pr-merge-commit-message.tsx` and `closing-remarks.tsx`.

Opened as draft per the contributing guidelines, reviewing it myself first.