### PR TITLE
fix(`sticky-notifications-actions`): avoid initial offset

### DIFF
--- a/source/features/sticky-notifications-actions.css
+++ b/source/features/sticky-notifications-actions.css
@@ -5,6 +5,9 @@
 		--shadow-spread-radius: 10px;
 
 		.Box:has(.js-notifications-mark-all-prompt) {
+			/* `.overflow-hidden` creates a scroll container that offsets the header at rest #9866 */
+			overflow: clip !important;
+
 			& .Box-header {
 				position: sticky;
 				top: var(--sticky-padding);


### PR DESCRIPTION
closes #9866 

I used GPT-5.6-Sol on Extra High to solve this, and confirmed it works.

GitHub's `.overflow-hidden` class turns the notification box into a scroll container, so the sticky action bar's `top: 10px` offset is applied before the page scrolls.

This changes the box to `overflow: clip`, which keeps the rounded box clipped without creating a scroll container. The action bar stays in its normal position until it becomes sticky.

## Test URLs
https://github.com/notifications

## Screenshot
<img width="836" height="168" alt="image" src="https://github.com/user-attachments/assets/02f63813-d84e-4d8d-a1c0-c2a3c0307575" />

