### PR TITLE
Center the `unread-anywhere` icon

### DIFF
--- a/source/features/unread-anywhere.tsx
+++ b/source/features/unread-anywhere.tsx
@@ -78,9 +78,9 @@ async function addButton(nativeLink: HTMLAnchorElement): Promise<void> {
 			onClick={openUnreadNotifications}
 			// Show pointer cursor even when disabled
 			style={{width: 15, cursor: 'pointer'}}
-			className="rounded-left-0 border-left-0 d-block p-0 tmp-p-0"
+			className="rounded-left-0 border-left-0 d-flex flex-items-center flex-justify-center p-0 tmp-p-0"
 		>
-			<ArrowUpRightIcon className="mb-2 tmp-mb-2" style={{marginLeft: -1}} />
+			<ArrowUpRightIcon />
 		</button>
 	);
 


### PR DESCRIPTION
Follow-up to #9503 and #9508.

The button uses block layout and manual icon offsets. GitHub's current button styles place the arrow above the vertical center.

This PR changes only `unread-anywhere`. It uses flexbox to center the arrow. It removes the manual offsets. It keeps the button width, border, tooltip, and shortcut unchanged.

## Test URLs

- https://github.com/notifications?query=is%3Aunread
- https://github.com/refined-github/refined-github

## Screenshot


| Before | After |
| --- | --- |
| <img width="288" height="91" alt="image" src="https://github.com/user-attachments/assets/99817e61-e8f9-4465-a8cb-f270a6202ae5" /> | <img width="288" height="91" alt="image" src="https://github.com/user-attachments/assets/2e482e4d-0c65-40c0-8be6-13651458bf9e" /> |