### PR TITLE
`pr-base-commit` - Fix TypeError on PRs with conflicts

### DIFF
--- a/source/features/pr-base-commit.tsx
+++ b/source/features/pr-base-commit.tsx
@@ -36,7 +36,8 @@ async function addInfo(statusMeta: Element): Promise<void> {
 
 	const previousMessage = statusMeta.firstChild!; // Extract now because it won't be the first child anymore
 	statusMeta.prepend(getBaseCommitNotice(prInfo));
-	if (isTextNodeContaining(previousMessage, 'Merging can be performed automatically.')) {
+	// When there are conflicts, GitHub wraps the text in a span, so only attempt removal on text nodes
+	if (previousMessage instanceof Text && isTextNodeContaining(previousMessage, 'Merging can be performed automatically.')) {
 		previousMessage.remove();
 	}
 }


### PR DESCRIPTION
Closes #9853

## Problem

On PRs with merge conflicts, GitHub wraps the mergeability message in a span instead of a plain text node. The feature calls `isTextNodeContaining` on `firstChild` which throws when it hits that span.

## Fix

Added an `instanceof Text` check before calling `isTextNodeContaining`, so the "Merging can be performed automatically" text removal is skipped when the node is not a text node.

## Test URLs

- PR with conflicts: https://github.com/refined-github/sandbox/pull/9
- PR without conflicts: https://github.com/refined-github/sandbox/pull/60