### PR TITLE
`sticky-notifications-actions` - Restore feature in Date view

### DIFF
--- a/source/features/sticky-notifications-actions.css
+++ b/source/features/sticky-notifications-actions.css
@@ -4,6 +4,12 @@
 		--shadow-blur-radius: 10px;
 		--shadow-spread-radius: 10px;
 
+		/* By date */
+		.Box.js-notifications-list {
+			/* Enables position:sticky and allows the "shadow" to be visible */
+			overflow: visible !important;
+		}
+
 		.Box:has(.js-notifications-mark-all-prompt) {
 			& .Box-header {
 				position: sticky;


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9876


## Test URLs

https://github.com/notifications

## Screenshot



<table>
<tr>
 <td>Date
 <td>Repo
<tr>
 <td><img width="300" alt="date" src="https://github.com/user-attachments/assets/180520cd-6b82-4641-8cbc-b979d93082a9" />
 <td><img width="300" alt="repo" src="https://github.com/user-attachments/assets/7a3e4494-53dc-462c-85e7-981fee6434f7" />
</table>



