### PR TITLE
`notifications-ui` - Support latest layout 

### DIFF
--- a/source/features/notifications-ui.css
+++ b/source/features/notifications-ui.css
@@ -1,5 +1,6 @@
 /* Matches the md query, but inverted */
 html:not([rgh-OFF-notifications-ui]) {
+	/* Mobile layout without sidebar */
 	@media screen and not (min-width: 768px) {
 		/* Place top 3 dropdown buttons in a row */
 		.js-notifications-container > h1.sr-only + .d-md-none {
@@ -14,7 +15,10 @@ html:not([rgh-OFF-notifications-ui]) {
 			margin: 0 !important;
 			order: 10;
 		}
+	}
 
+	/* Mobile + sidebar layout */
+	@media screen and not (min-width: 1012px) {
 		/* Keep the "Inbox" dropdown as wide as possible */
 		.manage-notifications-responsive + .d-flex {
 			flex-grow: 1;
@@ -25,21 +29,18 @@ html:not([rgh-OFF-notifications-ui]) {
 			display: none !important;
 		}
 
-		/* Allow the filters/sort/search to be ordered */
-		.js-check-all-container > .d-md-none:first-child {
-			display: flex !important;
+		/* Place "All | Unread", sort, group on one line */
+		.js-check-all-container > .flex-lg-row {
+			flex-direction: row !important;
 			flex-wrap: wrap;
-			column-gap: 12px;
-
-			/* Scale back "All | Unread" selector so it doesn't take the full width */
-			& > .BtnGroup:first-child {
-				width: auto;
-			}
 		}
 
-		/* Move "1 new notification" to the center */
 		.notification-sort-by {
+			/* Move "1 new notification" to the center */
 			order: 3;
+
+			/* Align sort/group to the right */
+			margin-left: auto;
 		}
 		.notification-group-by {
 			order: 6;

--- a/source/features/notifications-ui.css
+++ b/source/features/notifications-ui.css
@@ -1,11 +1,12 @@
 /* Matches the md query, but inverted */
 html:not([rgh-OFF-notifications-ui]) {
+	--gap: 8px;
 	/* Mobile layout without sidebar */
 	@media screen and not (min-width: 768px) {
 		/* Place top 3 dropdown buttons in a row */
 		.js-notifications-container > h1.sr-only + .d-md-none {
 			display: flex !important;
-			gap: 12px;
+			gap: var(--gap);
 			flex-wrap: wrap;
 		}
 
@@ -33,6 +34,12 @@ html:not([rgh-OFF-notifications-ui]) {
 		.js-check-all-container > .flex-lg-row {
 			flex-direction: row !important;
 			flex-wrap: wrap;
+			column-gap: var(--gap);
+		}
+
+		/* Drop margin on gear button */
+		[aria-label='Customize filters'] {
+			margin: 0 !important;
 		}
 
 		.notification-sort-by {
@@ -46,9 +53,15 @@ html:not([rgh-OFF-notifications-ui]) {
 			order: 6;
 		}
 
-		/* Move search box to the bottom */
-		.notifications-query-builder-wrapper {
+		/* Move search box to the bottom, unless it's missing "All|Unread" (any ?query= URL) */
+		.notifications-query-builder-wrapper:not(:first-child) {
 			order: 9;
+		}
+
+		/* Move search box inline when it's missing "All|Unread" (any ?query= URL) */
+		.notifications-query-builder-wrapper:first-child {
+			width: auto !important;
+			flex-grow: 1;
 		}
 	}
 

--- a/source/features/notifications-ui.css
+++ b/source/features/notifications-ui.css
@@ -29,7 +29,7 @@ html:not([rgh-OFF-notifications-ui]) {
 			display: none !important;
 		}
 
-		/* Place "All | Unread", sort, group on one line */
+		/* Place Unread, Sort, Group on one line */
 		.js-check-all-container > .flex-lg-row {
 			flex-direction: row !important;
 			flex-wrap: wrap;

--- a/source/features/notifications-ui.tsx
+++ b/source/features/notifications-ui.tsx
@@ -93,12 +93,11 @@ function unwrapActions(details: HTMLDetailsElement): void {
 }
 
 function init(signal: AbortSignal): void {
+	observe('.notification-sort-by', compactDropdown, {signal});
 	observe('.js-notifications-mark-selected-actions details.dropdown', unwrapActions, {signal});
 
-	// Unread, Sort, Group are only available on the Inbox tab.
-	// This leaves the row with just a small "sort by" dropdown, so it's best to disable `compactDropdown` as well.
+	// Grouping is only available on the Inbox tab
 	if (!new URLSearchParams(location.search).get('query')) {
-		observe('.notification-sort-by', compactDropdown, {signal});
 		observe('.notification-group-by', replaceDropdown, {signal});
 	}
 }

--- a/source/features/notifications-ui.tsx
+++ b/source/features/notifications-ui.tsx
@@ -93,11 +93,12 @@ function unwrapActions(details: HTMLDetailsElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.notification-sort-by', compactDropdown, {signal});
 	observe('.js-notifications-mark-selected-actions details.dropdown', unwrapActions, {signal});
 
-	// Grouping is only available on the Inbox tab
+	// Unread, Sort, Group are only available on the Inbox tab.
+	// This leaves the row with just a small "sort by" dropdown, so it's best to disable `compactDropdown` as well.
 	if (!new URLSearchParams(location.search).get('query')) {
+		observe('.notification-sort-by', compactDropdown, {signal});
 		observe('.notification-group-by', replaceDropdown, {signal});
 	}
 }

--- a/source/features/notifications-ui.tsx
+++ b/source/features/notifications-ui.tsx
@@ -93,9 +93,13 @@ function unwrapActions(details: HTMLDetailsElement): void {
 }
 
 function init(signal: AbortSignal): void {
-	observe('.notification-group-by', replaceDropdown, {signal});
 	observe('.notification-sort-by', compactDropdown, {signal});
 	observe('.js-notifications-mark-selected-actions details.dropdown', unwrapActions, {signal});
+
+	// Grouping is only available on the Inbox tab
+	if (!new URLSearchParams(location.search).get('query')) {
+		observe('.notification-group-by', replaceDropdown, {signal});
+	}
 }
 
 void features.addCssFeature(import.meta.url);


### PR DESCRIPTION
- fixes #9883




## Test URLs

https://github.com/notifications

## Wide


<img width="1162" height="82" alt="Screenshot 6" src="https://github.com/user-attachments/assets/8648f49f-1326-4100-9a23-b1652e5d9c75" />

## Medium



<img width="1156" height="119" alt="Screenshot 4" src="https://github.com/user-attachments/assets/24ce3b13-4a76-4da8-be66-3039d76f79f4" />

This is a new breakpoint for GitHub, they fixed this issue (old screenshot):

<img width="768" height="135" alt="Screenshot 12" src="https://github.com/user-attachments/assets/a76c753a-156e-41a5-b8c5-4f4c0a20aca0" />

## Small

<img width="842" height="153" alt="Screenshot 5" src="https://github.com/user-attachments/assets/20eee3ed-7a3f-41fc-a959-d345423eb18b" />

