### PR TITLE
`release-download-count` - Avoid overlap

### DIFF
--- a/source/features/release-download-count.css
+++ b/source/features/release-download-count.css
@@ -1,5 +1,8 @@
 /* Simulates fixed columns */
 .rgh-release-download-count {
+	/* `.flex-wrap` makes the element overflow. This prevents it */
+	max-width: 100%;
+
 	& > span:not(:last-child, [data-view-component]) {
 		flex-basis: 0 !important;
 		min-width: 5em;

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -48,10 +48,14 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		// Match the asset in the DOM to the asset in the API response
 		const downloadCount = assets[assetLink.pathname.split('/').pop()!] ?? 0;
 
+		// Avoid overflow/overlap
+		const row = closestElement('.Box-row', assetLink);
+		row.classList.add('flex-wrap');
+
 		// Re-align the asset size
 		const assetSize = $(
 			':scope > .flex-justify-end > span:has(+ span relative-time)',
-			closestElement('.Box-row', assetLink),
+			row
 		);
 		assertNodeContent(assetSize.firstChild, /^\d+(?:\.\d+)? \w{2,5}$/);
 
@@ -65,12 +69,6 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 
 		// Add class to parent in order to define "columns"
 		assetSize.parentElement!.classList.add('rgh-release-download-count', 'gap-4');
-
-		const hash = $optional(':scope > div:has(clipboard-copy)', assetSize.parentElement!);
-		// Hide sha on mobile. They have the classes but they're not correct (they hide in mid sizes, but show on smallest and largest)
-		hash?.classList.add('d-none', 'd-md-flex');
-		// Prevent sha from being clipped
-		hash?.style.setProperty('min-width', '100px');
 
 		const widget = (
 			<span className={cx(getClasses(assetSize))}>

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -55,7 +55,7 @@ async function addCounts(assetsList: HTMLElement): Promise<void> {
 		// Re-align the asset size
 		const assetSize = $(
 			':scope > .flex-justify-end > span:has(+ span relative-time)',
-			row
+			row,
 		);
 		assertNodeContent(assetSize.firstChild, /^\d+(?:\.\d+)? \w{2,5}$/);
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -196,16 +196,6 @@ a[class^='IssueItem-module__authorCreatedLink'] {
 	}
 }
 
-/* Untruncate long asset name */
-/* Info: https://github.com/refined-github/refined-github/issues/9184 */
-/* Test: https://github.com/hkint/xiaomi-ax3000t-immortalwrt-hanwckf-firmware-build/releases/tag/ImmortalWrt_2024.11.13-0026 */
-.col-12.col-lg-6:has(.octicon-package + a[href*='/releases/download/']) {
-	width: 100%;
-	.Truncate-text.text-bold {
-		white-space: wrap;
-	}
-}
-
 /* TODO [2027-01-01]: Drop after repo PR list becomes exclusively React-based */
 /* Hide label on Milestones link if there are zero milestones */
 /* Info: https://github.com/refined-github/refined-github/issues/5120 */


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9814

This component is cursed. So many inline classes. GitHub clips the sha. Fake columns. Crap by default.


## Test URLs

https://github.com/notepad-plus-plus/notepad-plus-plus/releases

## Screenshot

<img width="1566" height="325" alt="cursed" src="https://github.com/user-attachments/assets/3e50a0c0-a5d8-4c95-8b99-8391f85201f0" />
