### PR TITLE
`linkify-code` - Restore feature in comments

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -45,8 +45,8 @@ void features.add(import.meta.url, {
 
 - URLs/issues in comments: https://github.com/refined-github/sandbox/pull/98
 - URLs in PR files: https://github.com/refined-github/refined-github/pull/546/files#diff-7296d5f600098588b0af5ec9c84486593be79164f97406a0fc3c4ef5211ab2f9
-- URLs in regular files: https://github.com/refined-github/refined-github/blob/3f5fc489e417d4f4a14da5ea423775e9ca9246fd/source/features/copy-markdown.js#L45
-- Issue reference in file: https://github.com/refined-github/refined-github/blob/2ade9a84b1894c7879fab9d3e2d045e876f941a6/source/features/sort-issues-by-update-time.tsx#L18
+- URLs in regular files: https://github.com/refined-github/refined-github/blob/3f5fc489e417d4f4a14da5ea423775e9ca9246fd/source/features/copy-markdown.js#L45 (broken: #6336)
+- Issue reference in file: https://github.com/refined-github/refined-github/blob/2ade9a84b1894c7879fab9d3e2d045e876f941a6/source/features/sort-issues-by-update-time.tsx#L18 (broken: #6336)
 - Code Search: https://github.com/search?q=repo%3AKatsuteDev%2FBackground+marketplace&type=code
 - Code Search: https://github.com/search?q=%2F%23%5Cd%7B4%2C%7D%2F+language%3Atypescript&type=code
 - Code Search that might break: https://github.com/search?q=path%3A.npmrc&type=code

--- a/source/github-helpers/dom-formatters.tsx
+++ b/source/github-helpers/dom-formatters.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import {linkifyIssuesToDom, type Options as LinkifyIssuesOptions} from 'linkify-issues';
 import {linkifyUrlsToDom} from 'linkify-urls';
-import {$$, closestElement, closestElementOptional, elementExists} from 'select-dom';
+import {closestElementOptional, elementExists} from 'select-dom';
 import {applyToLink} from 'shorten-repo-url';
 import zipTextNodes from 'zip-text-nodes';
 
@@ -49,39 +49,6 @@ export function shortenLink(link: HTMLAnchorElement): void {
 	}
 }
 
-// https://github.com/refined-github/refined-github/issues/6336#issuecomment-1498645639
-export function repositionAnchors(element: HTMLElement): void {
-	// TODO [2027-01-01]: bump min firefox version to 147 and safari to 26
-	if (!CSS.supports('anchor-name: --test')) {
-		return;
-	}
-
-	// Safety measure
-	// DOM changes made by this function is unnecessary if the textarea doesn't exist and can cause issues
-	if (!elementExists('#read-only-cursor-text-area')) {
-		return;
-	}
-
-	const container = closestElement('.react-code-file-contents', element).parentElement!;
-
-	const codeLine = closestElementOptional('[id]', element);
-	if (!codeLine) {
-		throw new Error('Could not find parent code line');
-	}
-
-	const links = $$('a', codeLine);
-	for (const [index, link] of links.entries()) {
-		const anchor = `--rgh-${codeLine.id}-${index}`;
-		link.replaceWith(<span style={{anchorName: anchor, opacity: 0}}>{link.textContent}</span>);
-		link.className = 'react-code-text rgh-anchored-link';
-		link.style.positionAnchor = anchor;
-		container.prepend(link);
-	}
-
-	// Hide overflow
-	container.style.position = 'relative';
-}
-
 export function linkifyIssues(
 	currentRepo: {owner?: string; name?: string},
 	element: HTMLElement,
@@ -114,7 +81,6 @@ export function linkifyIssues(
 	}
 
 	zipTextNodes(element, linkified);
-	repositionAnchors(element);
 }
 
 export function linkifyUrls(element: HTMLElement): void {
@@ -139,7 +105,6 @@ export function linkifyUrls(element: HTMLElement): void {
 	}
 
 	zipTextNodes(element, linkified);
-	repositionAnchors(element);
 }
 
 export function parseBackticks(element: Element): void {


### PR DESCRIPTION
- reverts #8878
- closes https://github.com/refined-github/refined-github/issues/9136
- reopens https://github.com/refined-github/refined-github/issues/6336

The feature had to be disabled entirely due to https://github.com/refined-github/refined-github/issues/9136 introduced by #8878. It's better to revert those changes and have the feature _partially working_ than completely disabled.

It also seems that the existing code is not currently working even without the hotfix on https://togithub.com/refined-github/refined-github/blob/be756e68dd4bf24d53e802e1fec126506979fa80/test/linkify-urls-in-code.js#L32

## Test URLs

https://github.com/refined-github/sandbox/pull/98

## Screenshot

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="508" height="240" alt="Screenshot 4" src="https://github.com/user-attachments/assets/cc6e0911-ab9d-47a2-bcbc-ff15610c5a0c" />
 <td valign=top>
<img width="508" height="240" alt="Screenshot 3" src="https://github.com/user-attachments/assets/7bf85552-613f-402e-a0c6-d2d73f610aa2" />
</table>