### PR TITLE
`netiquette` - Restore support for the PR Files tab

### DIFF
--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -200,6 +200,6 @@ Test URLs
 - Old issue: https://togithub.com/facebook/react/issues/227
 - Old PR: https://togithub.com/facebook/react/pull/209
 - Popular issue: https://togithub.com/facebook/react/issues/13991
-- Draft PR: https://github.com/refined-github/sandbox/pull/7
+- Draft PR: https://togithub.com/react/react/pull/19377
 
 */

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -9,6 +9,7 @@ import twas from 'twas';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
+import createBanner from '../github-helpers/banner.js';
 import {userIsModerator} from '../github-helpers/get-user-permission.js';
 import {
 	areDiscussionsEnabled,
@@ -70,48 +71,57 @@ export function getResolvedText(closingDate: Date): JSX.Element {
 	);
 }
 
-type BannerOptions = {
-	Icon: typeof InfoIcon;
-	text: JSX.Element | string;
-};
-
-function addBanner(commentField: HTMLElement, {Icon, text}: BannerOptions): void {
-	const banner = (
-		<div className='flash d-flex flex-items-center gap-2 p-3 text-small color-fg-muted rounded-0 border-0 m-0'>
-			<Icon className='m-0 tmp-m-0' />
-			<span>{text}</span>
-		</div>
-	);
+function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
+	if (elementExists('.rgh-resolved-banner')) {
+		return;
+	}
 
 	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
+	const banner = createBanner({
+		icon: <InfoIcon className="m-0 tmp-m-0" />,
+		classes: 'm-0 p-2 text-small color-fg-muted border-0 rounded-0 rgh-resolved-banner'.split(' '),
+		text: getResolvedText(closingDate),
+	});
+
 	if (reactWrapper) {
 		reactWrapper.prepend(banner);
 	} else {
 		banner.classList.replace('rounded-0', 'm-2');
-		banner.classList.replace('p-3', 'p-2');
 		commentField.prepend(banner);
 	}
 }
 
-function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
-	addBanner(commentField, {
-		Icon: InfoIcon,
-		text: getResolvedText(closingDate),
-	});
-}
-
 function addPopularBanner(commentField: HTMLElement): void {
-	addBanner(commentField, {
-		Icon: FlameIcon,
-		text: 'This issue is highly active. Reconsider commenting unless you have read all the comments and have something to add.',
+	if (elementExists('.rgh-popular-banner')) {
+		return;
+	}
+
+	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
+	const banner = createBanner({
+		icon: <FlameIcon className="m-0 tmp-m-0" />,
+		classes: 'p-2 text-small color-fg-muted border-0 rounded-0 rgh-popular-banner'.split(' '),
+		text:
+			'This issue is highly active. Reconsider commenting unless you have read all the comments and have something to add.',
 	});
+
+	if (reactWrapper) {
+		reactWrapper.prepend(banner);
+	} else {
+		banner.classList.replace('rounded-0', 'm-2');
+		commentField.prepend(banner);
+	}
 }
 
 function addDraftBanner(commentField: HTMLElement): void {
-	addBanner(commentField, {
-		Icon: GitPullRequestDraftIcon,
-		text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
-	});
+	commentField.prepend(
+		createBanner({
+			icon: <GitPullRequestDraftIcon className="m-0 tmp-m-0" />,
+			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
+			text: <>
+				This is a <strong>draft PR</strong>, it might not be ready for review.
+			</>,
+		}),
+	);
 }
 
 function initDraft(signal: AbortSignal): void {
@@ -192,6 +202,6 @@ Test URLs
 - Old issue: https://togithub.com/facebook/react/issues/227
 - Old PR: https://togithub.com/facebook/react/pull/209
 - Popular issue: https://togithub.com/facebook/react/issues/13991
-- Draft PR: https://togithub.com/react/react/pull/19377
+- Draft PR: https://github.com/refined-github/sandbox/pull/7
 
 */

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -6,7 +6,6 @@ import GitPullRequestDraftIcon from 'octicons-plain-react/GitPullRequestDraft';
 import InfoIcon from 'octicons-plain-react/Info';
 import {$optional, closestElementOptional, countElements, elementExists} from 'select-dom';
 import twas from 'twas';
-import cx from 'clsx';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
@@ -72,18 +71,13 @@ export function getResolvedText(closingDate: Date): JSX.Element {
 }
 
 type BannerOptions = {
-	className: string;
 	Icon: typeof InfoIcon;
 	text: JSX.Element | string;
 };
 
-function addBanner(commentField: HTMLElement, {className, Icon, text}: BannerOptions): void {
-	if (elementExists(`.${className}`)) {
-		return;
-	}
-
+function addBanner(commentField: HTMLElement, {Icon, text}: BannerOptions): void {
 	const banner = (
-		<div className={cx('flash d-flex flex-items-center gap-2 p-2 text-small color-fg-muted rounded-0 border-0 m-0', className)}>
+		<div className='flash d-flex flex-items-center gap-2 p-3 text-small color-fg-muted rounded-0 border-0 m-0'>
 			<Icon className='m-0 tmp-m-0' />
 			<span>{text}</span>
 		</div>
@@ -94,13 +88,13 @@ function addBanner(commentField: HTMLElement, {className, Icon, text}: BannerOpt
 		reactWrapper.prepend(banner);
 	} else {
 		banner.classList.replace('rounded-0', 'm-2');
+		banner.classList.replace('p-3', 'p-2');
 		commentField.prepend(banner);
 	}
 }
 
 function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
 	addBanner(commentField, {
-		className: 'rgh-resolved-banner',
 		Icon: InfoIcon,
 		text: getResolvedText(closingDate),
 	});
@@ -108,21 +102,21 @@ function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
 
 function addPopularBanner(commentField: HTMLElement): void {
 	addBanner(commentField, {
-		className: 'rgh-popular-banner',
 		Icon: FlameIcon,
 		text: 'This issue is highly active. Reconsider commenting unless you have read all the comments and have something to add.',
 	});
 }
 
 function addDraftBanner(commentField: HTMLElement): void {
+	console.log('addDraftBanner');
 	addBanner(commentField, {
-		className: 'rgh-draft-banner',
 		Icon: GitPullRequestDraftIcon,
 		text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
 	});
 }
 
 function initDraft(signal: AbortSignal): void {
+	console.log('initDraft');
 	observe(newCommentField, addDraftBanner, {signal});
 }
 

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -113,15 +113,25 @@ function addPopularBanner(commentField: HTMLElement): void {
 }
 
 function addDraftBanner(commentField: HTMLElement): void {
-	commentField.prepend(
-		createBanner({
-			icon: <GitPullRequestDraftIcon className="m-0 tmp-m-0" />,
-			classes: 'p-2 my-2 mx-md-2 text-small color-fg-muted border-0'.split(' '),
-			text: <>
-				This is a <strong>draft PR</strong>, it might not be ready for review.
-			</>,
-		}),
-	);
+	if (elementExists('.rgh-draft-banner')) {
+		return;
+	}
+
+	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
+	const banner = createBanner({
+		icon: <GitPullRequestDraftIcon className="m-0 tmp-m-0" />,
+		classes: 'p-2 text-small color-fg-muted border-0 rounded-0 rgh-draft-banner'.split(' '),
+		text: <>
+			This is a <strong>draft PR</strong>, it might not be ready for review.
+		</>,
+	});
+
+	if (reactWrapper) {
+		reactWrapper.prepend(banner);
+	} else {
+		banner.classList.replace('rounded-0', 'm-2');
+		commentField.prepend(banner);
+	}
 }
 
 function initDraft(signal: AbortSignal): void {

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -108,7 +108,6 @@ function addPopularBanner(commentField: HTMLElement): void {
 }
 
 function addDraftBanner(commentField: HTMLElement): void {
-	console.log('addDraftBanner');
 	addBanner(commentField, {
 		Icon: GitPullRequestDraftIcon,
 		text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
@@ -116,7 +115,6 @@ function addDraftBanner(commentField: HTMLElement): void {
 }
 
 function initDraft(signal: AbortSignal): void {
-	console.log('initDraft');
 	observe(newCommentField, addDraftBanner, {signal});
 }
 

--- a/source/features/netiquette.tsx
+++ b/source/features/netiquette.tsx
@@ -6,10 +6,10 @@ import GitPullRequestDraftIcon from 'octicons-plain-react/GitPullRequestDraft';
 import InfoIcon from 'octicons-plain-react/Info';
 import {$optional, closestElementOptional, countElements, elementExists} from 'select-dom';
 import twas from 'twas';
+import cx from 'clsx';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import createBanner from '../github-helpers/banner.js';
 import {userIsModerator} from '../github-helpers/get-user-permission.js';
 import {
 	areDiscussionsEnabled,
@@ -71,67 +71,55 @@ export function getResolvedText(closingDate: Date): JSX.Element {
 	);
 }
 
-function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
-	if (elementExists('.rgh-resolved-banner')) {
+type BannerOptions = {
+	className: string;
+	Icon: typeof InfoIcon;
+	text: JSX.Element | string;
+};
+
+function addBanner(commentField: HTMLElement, {className, Icon, text}: BannerOptions): void {
+	if (elementExists(`.${className}`)) {
 		return;
 	}
 
-	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
-	const banner = createBanner({
-		icon: <InfoIcon className="m-0 tmp-m-0" />,
-		classes: 'm-0 p-2 text-small color-fg-muted border-0 rounded-0 rgh-resolved-banner'.split(' '),
-		text: getResolvedText(closingDate),
-	});
+	const banner = (
+		<div className={cx('flash d-flex flex-items-center gap-2 p-2 text-small color-fg-muted rounded-0 border-0 m-0', className)}>
+			<Icon className='m-0 tmp-m-0' />
+			<span>{text}</span>
+		</div>
+	);
 
+	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
 	if (reactWrapper) {
 		reactWrapper.prepend(banner);
 	} else {
 		banner.classList.replace('rounded-0', 'm-2');
 		commentField.prepend(banner);
 	}
+}
+
+function addResolvedBanner(commentField: HTMLElement, closingDate: Date): void {
+	addBanner(commentField, {
+		className: 'rgh-resolved-banner',
+		Icon: InfoIcon,
+		text: getResolvedText(closingDate),
+	});
 }
 
 function addPopularBanner(commentField: HTMLElement): void {
-	if (elementExists('.rgh-popular-banner')) {
-		return;
-	}
-
-	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
-	const banner = createBanner({
-		icon: <FlameIcon className="m-0 tmp-m-0" />,
-		classes: 'p-2 text-small color-fg-muted border-0 rounded-0 rgh-popular-banner'.split(' '),
-		text:
-			'This issue is highly active. Reconsider commenting unless you have read all the comments and have something to add.',
+	addBanner(commentField, {
+		className: 'rgh-popular-banner',
+		Icon: FlameIcon,
+		text: 'This issue is highly active. Reconsider commenting unless you have read all the comments and have something to add.',
 	});
-
-	if (reactWrapper) {
-		reactWrapper.prepend(banner);
-	} else {
-		banner.classList.replace('rounded-0', 'm-2');
-		commentField.prepend(banner);
-	}
 }
 
 function addDraftBanner(commentField: HTMLElement): void {
-	if (elementExists('.rgh-draft-banner')) {
-		return;
-	}
-
-	const reactWrapper = closestElementOptional('[class^="InlineAutocomplete"]', commentField);
-	const banner = createBanner({
-		icon: <GitPullRequestDraftIcon className="m-0 tmp-m-0" />,
-		classes: 'p-2 text-small color-fg-muted border-0 rounded-0 rgh-draft-banner'.split(' '),
-		text: <>
-			This is a <strong>draft PR</strong>, it might not be ready for review.
-		</>,
+	addBanner(commentField, {
+		className: 'rgh-draft-banner',
+		Icon: GitPullRequestDraftIcon,
+		text: <>This is a <strong>draft PR</strong>, it might not be ready for review.</>,
 	});
-
-	if (reactWrapper) {
-		reactWrapper.prepend(banner);
-	} else {
-		banner.classList.replace('rounded-0', 'm-2');
-		commentField.prepend(banner);
-	}
 }
 
 function initDraft(signal: AbortSignal): void {

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -3,8 +3,8 @@ import * as pageDetect from 'github-url-detection';
 import mem from 'memoize';
 import {$, $optional, closestElement, closestElementOptional, elementExists} from 'select-dom';
 import compareVersions from 'tiny-version-compare';
-import type {RequireAtLeastOne} from 'type-fest';
 import {assert} from 'ts-extras';
+import type {RequireAtLeastOne} from 'type-fest';
 
 import {is} from '../helpers/css-selectors.js';
 import getCommentAuthor from './get-comment-author.js';

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -4,6 +4,7 @@ import mem from 'memoize';
 import {$, $optional, closestElement, closestElementOptional, elementExists} from 'select-dom';
 import compareVersions from 'tiny-version-compare';
 import type {RequireAtLeastOne} from 'type-fest';
+import {assert} from 'ts-extras';
 
 import {is} from '../helpers/css-selectors.js';
 import getCommentAuthor from './get-comment-author.js';
@@ -201,7 +202,15 @@ export function getConversationBody(): Element {
 	]);
 }
 
+// Issues don't include the author in the title. PRs don't have a "conversation body" on the Files tab.
+const prTitleExtractionRegex = /\bby (?<author>[^·]+?) · Pull Request #\d+ · [^/\\]+\/[^/\\]+$/;
 export function getConversationAuthor(): string {
+	if (pageDetect.isPR()) {
+		const match = prTitleExtractionRegex.exec(document.title);
+		assert(match, `Failed to extract PR author from title: ${document.title}`);
+		return match.groups!.author;
+	}
+
 	return getCommentAuthor(getConversationBody());
 }
 

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -125,9 +125,17 @@ export const linksToConversationLists_ = [
 ] satisfies UrlMatch[];
 
 export const newCommentField = [
-	'[input="fc-new_comment_field"]',
-	'[input^="fc-new_inline_comment_discussion"]',
-	'[aria-labelledby="comment-composer-heading"]',
+	// PR comment
+	'file-attachment[input="fc-new_comment_field"]',
+
+	// PR review comment, conversation tab
+	'file-attachment[input^="fc-new_inline_comment_discussion"]',
+
+	// PR Review comment, files tab
+	'div[class*="AddCommentEditor"] textarea',
+
+	// Issue comment
+	'textarea[aria-labelledby="comment-composer-heading"]',
 ];
 
 export const newCommentField_ = requiresLogin;


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9833


## Test URLs
Files: https://github.com/react/react/pull/19377/changes
Conversation: https://togithub.com/react/react/pull/19377

## Screenshot PR files

<img width="464" height="365" alt="Screenshot" src="https://github.com/user-attachments/assets/b95a86a5-d9a2-40be-8f59-fff3302d06c4" />


## Screenshot PR Conversation

<img width="301" height="290" alt="Screenshot 5" src="https://github.com/user-attachments/assets/38b38e07-0230-48f5-889a-2dfb3e38b86c" />
