### PR TITLE
fix(`one-click-pr-or-gist`): attach Mod+Enter hotkey to primary action button

### DIFF
--- a/.github/workflows/conversation.yml
+++ b/.github/workflows/conversation.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           message: |
             Token required to open bug reports.
-          
+
             [![Token required to open issues](https://github.com/user-attachments/assets/f417264f-f230-4156-b020-16e4390562bd)](https://www.youtube.com/watch?v=YWdD206eSv0)
       - if: steps.liars.outputs.matches == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/conversation.yml
+++ b/.github/workflows/conversation.yml
@@ -31,3 +31,31 @@ jobs:
         with:
           token: ${{ github.token }}
           keywords-path: source/features
+
+  TokenRequirement:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      # https://github.com/refined-github/refined-github/blob/6cf3c431a85632b6f3c59ae002b2ed05bb918c8e/source/features/rgh-improve-new-issue-form.tsx#L92-L93
+      - id: liars
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.title))
+      - if: steps.liars.outputs.matches == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          message: |
+            Token required to open bug reports.
+          
+            [![Token required to open issues](https://github.com/user-attachments/assets/f417264f-f230-4156-b020-16e4390562bd)](https://www.youtube.com/watch?v=YWdD206eSv0)
+      - if: steps.liars.outputs.matches == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+            })

--- a/.github/workflows/conversation.yml
+++ b/.github/workflows/conversation.yml
@@ -31,31 +31,3 @@ jobs:
         with:
           token: ${{ github.token }}
           keywords-path: source/features
-
-  TokenRequirement:
-    if: github.event_name == 'issues' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      # https://github.com/refined-github/refined-github/blob/6cf3c431a85632b6f3c59ae002b2ed05bb918c8e/source/features/rgh-improve-new-issue-form.tsx#L92-L93
-      - id: liars
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.title))
-      - if: steps.liars.outputs.matches == 'true'
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          message: |
-            Token required to open bug reports.
-
-            [![Token required to open issues](https://github.com/user-attachments/assets/f417264f-f230-4156-b020-16e4390562bd)](https://www.youtube.com/watch?v=YWdD206eSv0)
-      - if: steps.liars.outputs.matches == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            await github.rest.issues.update({
-              ...context.repo,
-              issue_number: context.payload.issue.number,
-              state: 'closed',
-            })

--- a/source/features/one-click-pr-or-gist.tsx
+++ b/source/features/one-click-pr-or-gist.tsx
@@ -24,16 +24,19 @@ function init(): void | false {
 		const radioButton = $('input[type=radio]', dropdownItem);
 		const classList = ['btn', 'ml-2'];
 
-		if (/\bdraft\b/i.test(title)) {
-			title = 'Create draft PR';
-		} else {
+		const isPrimary = !/\bdraft\b/i.test(title);
+
+		if (isPrimary) {
 			classList.push('btn-primary');
+		} else {
+			title = 'Create draft PR';
 		}
 
 		initialGroupedButtons.after(
 			<button
 				ref={withTooltipRef(description)}
 				data-disable-invalid
+				data-hotkey={isPrimary ? 'Mod+Enter' : undefined}
 				className={cx(classList)}
 				type="submit"
 				name={radioButton.name}


### PR DESCRIPTION
Fixes #9501

### Description
When creating a PR with `one-click-pr-or-gist` enabled, submitting via `Cmd+Enter` / `Ctrl+Enter` triggered a different submission path than standard `Enter` if the draft radio option was default in native UI.

Adding `data-hotkey="Mod+Enter"` explicitly to the unrolled primary button ensures `Cmd+Enter` always targets the primary action consistently with `Enter`.

## Test URLs
https://github.com/refined-github/sandbox/compare/default-a...fregante-patch-1
