### PR TITLE
`rgh-netiquette` - Fix spacing

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,12 +73,10 @@ const rollup = {
 			return;
 		}
 
-    // Fail the build immediately on unresolved dependencies. How is this not a default?!
-    if (warning.code === 'UNRESOLVED_IMPORT') {
-      throw new Error(
-        `Failed to resolve import "${warning.source}" from ${warning.importer}. Please check your setup.`
-      );
-    }
+		// Fail the build immediately on unresolved dependencies. How is this not a default?!
+		if (warning.code === 'UNRESOLVED_IMPORT') {
+			throw new Error(warning.message);
+		}
 
 		defaultHandler(warning);
 	},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,6 +73,13 @@ const rollup = {
 			return;
 		}
 
+    // Fail the build immediately on unresolved dependencies. How is this not a default?!
+    if (warning.code === 'UNRESOLVED_IMPORT') {
+      throw new Error(
+        `Failed to resolve import "${warning.source}" from ${warning.importer}. Please check your setup.`
+      );
+    }
+
 		defaultHandler(warning);
 	},
 

--- a/source/components/timeline-item.svelte
+++ b/source/components/timeline-item.svelte
@@ -1,5 +1,5 @@
 <script>
-	import cx from 'classnames';
+	import cx from 'clsx';
 	import * as pageDetect from 'github-url-detection';
 </script>
 <div

--- a/source/components/timeline-item.svelte
+++ b/source/components/timeline-item.svelte
@@ -1,6 +1,15 @@
-<!-- Classes copied from #issuecomment-new + mt-3 added (TimelineItem) -->
+<script>
+	import cx from 'classnames';
+	import * as pageDetect from 'github-url-detection';
+</script>
 <div
-	class="ml-0 tmp-ml-0 pl-0 tmp-pl-0 ml-md-6 tmp-ml-md-6 pl-md-3 tmp-pl-md-3 mt-3 tmp-mt-3"
+	class={cx(
+		'mt-3 tmp-mt-3',
+		// TODO: Drop after the legacy PR conversation is gone
+		// https://github.com/refined-github/refined-github/pull/9901
+		pageDetect.isPRConversation()
+			&& 'ml-0 tmp-ml-0 pl-0 tmp-pl-0 ml-md-6 tmp-ml-md-6 pl-md-3 tmp-pl-md-3 mt-3 tmp-mt-3',
+	)}
 >
 	<slot></slot>
 </div>

--- a/source/features/rgh-netiquette.tsx
+++ b/source/features/rgh-netiquette.tsx
@@ -47,7 +47,7 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isConversation,
 	],
-	awaitDomReady: true, // We're specifically looking for the last event
+	awaitDomReady: true, // The comment field is at the end
 	init,
 });
 


### PR DESCRIPTION
- follows #9900 
- related to #9752 

I thought `timeline-item` was used by more components but only `rgh-netiquette` is affected at this point.

## Test URLs

- Old issue: https://github.com/refined-github/refined-github/issues/3076


<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="362" height="243" alt="Screenshot 10" src="https://github.com/user-attachments/assets/9c648f57-08fb-476e-9018-4ae3c91578ca" />
 <td valign=top><img width="362" height="243" alt="Screenshot 9" src="https://github.com/user-attachments/assets/ed041a93-4033-4a52-b998-9384126db7db" />
</table>
