### PR TITLE
Fix GitHub bug: Sponsor button overflow on mobile

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -267,3 +267,11 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 .empty-cell {
 	cursor: default !important;
 }
+
+/* Fix sponsor button overflowing on mobile repo home */
+/* Info: https://github.com/refined-github/refined-github/issues/9912 */
+/* Test: https://github.com/refined-github/refined-github */
+[data-testid='responsive-social-buttons'] {
+	flex-wrap: wrap;
+	max-width: 100%;
+}


### PR DESCRIPTION
Closes #9912

On narrow repo home layouts, `[data-testid='responsive-social-buttons']` is a nowrap flex row, so Watch/Fork/Star/Sponsor stay on one line and the Sponsor button spills past the header.

This lets that row wrap and caps its width at 100%.

## Test URLs

https://github.com/refined-github/refined-github

## Screenshot