### PR TITLE
AI SPAM

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -461,6 +461,7 @@
 	{
 		"id": "locked-issue",
 		"description": "Show a label on locked issues and PRs.",
+		"css": true,
 		"screenshot": "https://user-images.githubusercontent.com/1402241/283015579-0a04becc-9bff-4aef-8770-272d6804970b.png"
 	},
 	{

--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,7 +1,4 @@
-/* Match GitHub's medium StateLabel size next to Open/Closed badges */
-/* Info: https://github.com/refined-github/refined-github/issues/9911 */
-/* Test: https://github.com/refined-github/sandbox/issues/74 */
-/* Test: https://github.com/refined-github/sandbox/pull/48 */
+/* Match GitHub's medium StateLabel size next to Open/Closed #9911 */
 .rgh-locked-issue.State {
 	padding: 8px 12px;
 	font-weight: 600;

--- a/source/features/locked-issue.css
+++ b/source/features/locked-issue.css
@@ -1,0 +1,8 @@
+/* Match GitHub's medium StateLabel size next to Open/Closed badges */
+/* Info: https://github.com/refined-github/refined-github/issues/9911 */
+/* Test: https://github.com/refined-github/sandbox/issues/74 */
+/* Test: https://github.com/refined-github/sandbox/pull/48 */
+.rgh-locked-issue.State {
+	padding: 8px 12px;
+	font-weight: 600;
+}

--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -1,3 +1,5 @@
+import './locked-issue.css';
+
 import cx from 'clsx';
 import * as pageDetect from 'github-url-detection';
 import LockIcon from 'octicons-plain-react/Lock';


### PR DESCRIPTION
Fixes #9911

The Locked badge still uses the legacy `.State` class, so it looked smaller than GitHub's Open/Closed `prc-StateLabel` badges (`data-size="medium"`).

This adds companion CSS so `.rgh-locked-issue.State` uses the same padding (`8px 12px`) and font-weight (`600`) as the medium StateLabel.

## Test URLs
- https://github.com/refined-github/sandbox/issues/74
- https://github.com/refined-github/sandbox/pull/48