### PR TITLE
`clean-readme-url` - Avoid racing sidebar Readme scroll

### DIFF
--- a/source/features/clean-readme-url.tsx
+++ b/source/features/clean-readme-url.tsx
@@ -1,22 +1,33 @@
 import * as pageDetect from 'github-url-detection';
 
 import features from '../feature-manager.js';
+import delay from '../helpers/delay.js';
+import preserveScroll from '../helpers/preserve-scroll.js';
 
-function maybeCleanUrl(event?: NavigateEvent): void {
-	// TODO [2027-01-01]: Drop setInterval and optional chaining, it's only needed to support Safari <26.2
-	const parsed = new URL(event?.destination.url ?? location.href);
-	if (parsed.searchParams.get('tab') === 'readme-ov-file') {
-		parsed.searchParams.delete('tab');
-		history.replaceState(history.state, '', parsed.href);
+function maybeCleanUrl(): void {
+	const parsed = new URL(location.href);
+	if (parsed.searchParams.get('tab') !== 'readme-ov-file') {
+		return;
 	}
+
+	parsed.searchParams.delete('tab');
+	// Preserve scroll: replaceState can shift the viewport (#9908)
+	const resetScroll = preserveScroll();
+	history.replaceState(history.state, '', parsed.href);
+	resetScroll();
 }
 
-function init(signal: AbortSignal): void {
+async function init(signal: AbortSignal): Promise<void> {
+	// Let GitHub scroll to the readme before stripping the tab (#9908)
+	await delay(100, signal);
 	maybeCleanUrl();
+
 	let interval: NodeJS.Timeout;
 	if ('navigation' in globalThis) {
-		navigation.addEventListener('navigate', maybeCleanUrl, {signal});
+		// Clean after navigation completes so the sidebar Readme link can scroll first (#9908)
+		navigation.addEventListener('navigatesuccess', maybeCleanUrl, {signal});
 	} else {
+		// TODO [2027-01-01]: Drop setInterval, it's only needed to support Safari <26.2
 		interval = setInterval(() => {
 			maybeCleanUrl();
 		}, 1000);
@@ -38,5 +49,8 @@ void features.add(import.meta.url, {
 Test URLs:
 
 https://github.com/refined-github/refined-github?tab=readme-ov-file
+
+Also click "Readme" in the repo sidebar on:
+https://github.com/refined-github/refined-github
 
 */


### PR DESCRIPTION
Fixes #9908

`clean-readme-url` was listening to `navigate` and calling `replaceState` immediately, which raced GitHub's handling of the sidebar Readme link (`?tab=readme-ov-file`) and cancelled the scroll.

This waits for `navigatesuccess` (and a short delay on init), then strips the tab while preserving scroll position.

## Test URLs
- https://github.com/refined-github/refined-github?tab=readme-ov-file
- Click "Readme" in the repo sidebar on https://github.com/refined-github/refined-github