### PR TITLE
`pull-request-hotkeys` - Restore feature

### DIFF
--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -10,12 +10,9 @@ async function init(): Promise<void> {
 		'[aria-label="Pull request tabs"]',
 		'[aria-label="Pull request navigation tabs"]', // Commits list tab
 	]);
-	const tabs = $$([
-		'a.tabnav-tab',
-		'a[role="tab"]', // Commits list tab
-	], tabnav);
+	const tabs = $$('a', tabnav);
 	const lastTab = tabs.length - 1;
-	const selectedIndex = tabs.findIndex(tab => tab.classList.contains('selected'));
+	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
 
 	for (const [index, tab] of tabs.entries()) {
 		addHotkey(tab, `g ${index + 1}`);

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -3,26 +3,32 @@ import * as pageDetect from 'github-url-detection';
 import {$$} from 'select-dom';
 
 import features from '../feature-manager.js';
-import {addHotkey} from '../github-helpers/hotkey.js';
+import {addHotkey, registerHotkey} from '../github-helpers/hotkey.js';
 
-async function init(): Promise<void> {
+async function init(signal: AbortSignal): Promise<void> {
 	const tabnav = await elementReady([
 		'[aria-label="Pull request tabs"]',
 		'[aria-label="Pull request navigation tabs"]', // Commits list tab
 	]);
 	const tabs = $$('a', tabnav);
-	const lastTab = tabs.length - 1;
-	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
 
 	for (const [index, tab] of tabs.entries()) {
 		addHotkey(tab, `g ${index + 1}`);
-
-		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {
-			addHotkey(tab, 'g ArrowLeft');
-		} else if (index === selectedIndex + 1 || (selectedIndex === lastTab && index === 0)) {
-			addHotkey(tab, 'g ArrowRight');
-		}
 	}
+
+	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
+	if (selectedIndex === -1) {
+		return;
+	}
+
+	const previousTab = tabs.at(selectedIndex - 1) ?? tabs.at(-1)!;
+	const nextTab = tabs.at(selectedIndex + 1) ?? tabs[0];
+	registerHotkey('g ArrowLeft', () => {
+		previousTab.click();
+	}, {signal});
+	registerHotkey('g ArrowRight', () => {
+		nextTab.click();
+	}, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -3,32 +3,26 @@ import * as pageDetect from 'github-url-detection';
 import {$$} from 'select-dom';
 
 import features from '../feature-manager.js';
-import {addHotkey, registerHotkey} from '../github-helpers/hotkey.js';
+import {addHotkey} from '../github-helpers/hotkey.js';
 
-async function init(signal: AbortSignal): Promise<void> {
+async function init(): Promise<void> {
 	const tabnav = await elementReady([
 		'[aria-label="Pull request tabs"]',
 		'[aria-label="Pull request navigation tabs"]', // Commits list tab
 	]);
 	const tabs = $$('a', tabnav);
+	const lastTab = tabs.length - 1;
+	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
 
 	for (const [index, tab] of tabs.entries()) {
 		addHotkey(tab, `g ${index + 1}`);
-	}
 
-	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
-	if (selectedIndex === -1) {
-		return;
+		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {
+			addHotkey(tab, 'g ArrowLeft');
+		} else if (index === selectedIndex + 1 || (selectedIndex === lastTab && index === 0)) {
+			addHotkey(tab, 'g ArrowRight');
+		}
 	}
-
-	const previousTab = tabs.at(selectedIndex - 1) ?? tabs.at(-1)!;
-	const nextTab = tabs.at(selectedIndex + 1) ?? tabs[0];
-	registerHotkey('g ArrowLeft', () => {
-		previousTab.click();
-	}, {signal});
-	registerHotkey('g ArrowRight', () => {
-		nextTab.click();
-	}, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -15,6 +15,9 @@ async function init(): Promise<void> {
 	const selectedIndex = tabs.findIndex(tab => tab.matches('.selected, [aria-current]'));
 
 	for (const [index, tab] of tabs.entries()) {
+		// Reset previous hotkeys because the DOM persists across soft navigations
+		// https://github.com/refined-github/refined-github/pull/9916#issuecomment-5157852083
+		delete tab.dataset.hotkey;
 		addHotkey(tab, `g ${index + 1}`);
 
 		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {


### PR DESCRIPTION
Closes #9907

Updates the pull request tab selectors to support GitHub's current navigation markup.

The feature now finds links within the scoped pull request navigation and recognizes the active tab through `aria-current`, while preserving compatibility with the previous `selected` class.

## Test URLs

- https://github.com/TheBestPessimist/AutoHotKey-Scripts/pull/18
- https://github.com/TheBestPessimist/AutoHotKey-Scripts/pull/18/commits
- https://github.com/TheBestPessimist/AutoHotKey-Scripts/pull/18/checks
- https://github.com/TheBestPessimist/AutoHotKey-Scripts/pull/18/files

## Screenshot

Not applicable; this change does not modify the interface.