### PR TITLE
Fix GitHub bug: Bad wrap in PR lists

### DIFF
--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -51,10 +51,6 @@ html:not([rgh-OFF-align-issue-labels]) {
 			order: 1;
 		}
 
-		.min-width-0 .text-small {
-			flex-basis: 100%; /* #4949 */
-		}
-
 		/* Build status */
 		.commit-build-statuses {
 			margin-left: 4px;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -267,3 +267,10 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 .empty-cell {
 	cursor: default !important;
 }
+
+/* Fix bad wrap in PR lists */
+/* Info: https://github.com/refined-github/refined-github/issues/9919 */
+/* Test: https://github.com/refined-github/refined-github/pulls?q=sort%3Aupdated-desc+is%3Apr++created%3A2026-07-31 */
+.js-issue-row div.d-flex.text-small.color-fg-muted {
+	display: block !important;
+}


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/9919


## Test URLs

https://github.com/refined-github/refined-github/pulls?q=sort%3Aupdated-desc+is%3Apr++created%3A2026-07-31


## Screenshot

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="876" height="403" alt="Screenshot 10" src="https://github.com/user-attachments/assets/dfbb4eb3-f40d-48e9-b837-f0b2993bf2ab" />
 <td valign=top><img width="876" height="403" alt="Screenshot 9" src="https://github.com/user-attachments/assets/dd7f6781-b9dd-4181-9208-1385a5680817" />
</table>


