### PR TITLE
`clean-readme-url` - Fix "Readme" link on repo home

### DIFF
--- a/source/features/clean-readme-url.tsx
+++ b/source/features/clean-readme-url.tsx
@@ -19,7 +19,7 @@ async function maybeCleanUrl(): Promise<void> {
 function init(signal: AbortSignal): void {
 	void maybeCleanUrl();
 
-	// TODO [2027-01-01]: Drop optional chaining, it's only needed to support Safari <26.2
+	// TODO [2027-01-01]: Only needed to avoid breaking on Safari <26.2 (<2026)
 	navigation?.addEventListener('navigatesuccess', maybeCleanUrl, {signal});
 }
 

--- a/source/features/clean-readme-url.tsx
+++ b/source/features/clean-readme-url.tsx
@@ -1,29 +1,26 @@
 import * as pageDetect from 'github-url-detection';
 
+import delay from '../helpers/delay.js';
 import features from '../feature-manager.js';
 
-function maybeCleanUrl(event?: NavigateEvent): void {
-	// TODO [2027-01-01]: Drop setInterval and optional chaining, it's only needed to support Safari <26.2
-	const parsed = new URL(event?.destination.url ?? location.href);
-	if (parsed.searchParams.get('tab') === 'readme-ov-file') {
-		parsed.searchParams.delete('tab');
-		history.replaceState(history.state, '', parsed.href);
+async function maybeCleanUrl(): Promise<void> {
+	const parsed = new URL(location.href);
+	if (parsed.searchParams.get('tab') !== 'readme-ov-file') {
+		return;
 	}
+
+	// GitHub has some delayed logic to deal with this internally
+	// https://github.com/refined-github/refined-github/issues/9908
+	await delay(500);
+	parsed.searchParams.delete('tab');
+	history.replaceState(history.state, '', parsed.href);
 }
 
 function init(signal: AbortSignal): void {
-	maybeCleanUrl();
-	let interval: NodeJS.Timeout;
-	if ('navigation' in globalThis) {
-		navigation.addEventListener('navigate', maybeCleanUrl, {signal});
-	} else {
-		interval = setInterval(() => {
-			maybeCleanUrl();
-		}, 1000);
-		signal.addEventListener('abort', () => {
-			clearInterval(interval);
-		});
-	}
+	void maybeCleanUrl();
+
+	// TODO [2027-01-01]: Drop optional chaining, it's only needed to support Safari <26.2
+	navigation?.addEventListener('navigatesuccess', maybeCleanUrl, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9908


## Test URLs

1. Visit https://github.com/refined-github/refined-github
2. click "Readme" in the sidebar

