### PR TITLE
`extensible-nav` - Avoid duplicate nav

### DIFF
--- a/source/features/extensible-nav.css
+++ b/source/features/extensible-nav.css
@@ -1,3 +1,8 @@
+/* Hidden via .d-none, restored via content script CSS (applies to Firefox and Safari) */
+nav.rgh-extensible-nav.d-none {
+	display: flex !important;
+}
+
 .rgh-extensible-nav-removed {
 	position: absolute;
 	top: -200px;

--- a/source/features/extensible-nav.svelte
+++ b/source/features/extensible-nav.svelte
@@ -5,7 +5,7 @@
 	import Tooltip from '../components/tooltip.svelte';
 </script>
 
-<nav class="UnderlineNav rgh-extensible-nav px-4">
+<nav class="UnderlineNav rgh-extensible-nav d-none px-4">
 	<ul class="UnderlineNav-body">
 		{#each $tabs as tab (tab.id)}
 			{@const id = `rgh-extensible-nav-${tab.id}`}
@@ -31,9 +31,4 @@
 	</ul>
 </nav>
 <style>
-	nav {
-		/* Temporary indicator of successful replacement */
-		/* TODO: Remove after when the beta testing is complete. Also remove mention from readme and enable it by default */
-		border-left: 1px solid var(--borderColor-muted, fuchsia);
-	}
 </style>

--- a/source/options.css
+++ b/source/options.css
@@ -112,7 +112,7 @@ summary:hover {
 	white-space: pre-line;
 
 	box-sizing: border-box;
-	width: var(--content-width);
+	max-width: var(--content-width);
 	margin: var(--viewport-margin) auto;
 }
 


### PR DESCRIPTION
This is somewhat of a niche issue and I hope it doesn't come back to bite us.

Basically both Safari and Firefox will remove the stylesheet when the extension is unloaded/reloaded, re-exposing the old navigation.

The old navigation is not actually hidden via `d-none` because we're forcing GitHub to render the entire nav off screen and avoid any issues _reading_ from the nav.

## Before

This shows me disabling the extension in Firefox:

<img width="1058" height="173" alt="before" src="https://github.com/user-attachments/assets/d1c7bfb0-9d90-41b0-8e2c-dbb334131e6e" />

## After

This shows the native nav being restored. 

<img width="1058" height="173" alt="after" src="https://github.com/user-attachments/assets/53acf562-b8b9-406b-bbb8-f841587163ab" />
