### PR TITLE
Hide loading error in options on Firefox

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -119,5 +119,9 @@ summary:hover {
 @keyframes show {
 	from {
 		display: none;
+
+		/* Freaking firefox still does not support discrete animations */
+		/* https://caniuse.com/wf-display-animation */
+		opacity: 0;
 	}
 }

--- a/source/options.html
+++ b/source/options.html
@@ -7,7 +7,7 @@
 <title>Refined GitHub options</title>
 <link href="options.css" rel="stylesheet">
 <script src="options-preflight.js"></script>
-<script type="module" defer src="options.js"></script>
+<script type="module" src="options.js"></script>
 
 <div id="js-failed" class="error-banner">JavaScript failed to load. Your development build failed or your browser has some issue.</div>
 <rgh-options></rgh-options>


### PR DESCRIPTION
## Before

<img width="509" height="474" alt="before" src="https://github.com/user-attachments/assets/e1097e84-7cc8-49cf-96cb-7fa04ba0bba8" />

## After

<img width="509" height="474" alt="after" src="https://github.com/user-attachments/assets/08ecc54d-42c3-41fe-b58b-c68821570ceb" />
