### PR TITLE
`last-update-sort` - Disable on custom and pre-defined Views

### DIFF
--- a/source/features/last-update-sort.tsx
+++ b/source/features/last-update-sort.tsx
@@ -23,12 +23,6 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 		return;
 	}
 
-	// Exclude /pulls/ global pages since they're already sorted by update time #9604
-	// This also breaks the feature on the header button regardless of the PR inbox beta status. This is because the feature breaks the inbox, overriding the user's preference.
-	if (/^[/]pulls[/]\w+$/.test(link.pathname) || link.matches('[href="/pulls"][class*="appHeaderButton"]')) {
-		return;
-	}
-
 	// Pick only links to lists, not single issues
 	// + skip pagination links
 	// + skip pr/issue filter dropdowns (some are lazyloaded)

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -104,6 +104,7 @@ export const codeSearchHeader_ = [
 	[0, 'https://github.com/search?q=repo%3Arefined-github%2Frefined-github&type=code'],
 ] satisfies UrlMatch[];
 
+// Excludes /pulls/* and /issues/* global pages since they're already sorted by update time #9604
 export const linksToConversationLists = `
 	a:is(
 		[href*="/issues"],
@@ -111,8 +112,9 @@ export const linksToConversationLists = `
 		[href*="/projects"],
 		[href*="/labels/"]
 	):not(
-		[href^="/pulls/"],
-		[href^="/issues/"],
+		[href^="/pulls"],
+		[href^="/issues"],
+
 		[href*="/issues/labels"],
 		[href*="/issues/views"],
 		[href*="sort%3A"],

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -111,6 +111,8 @@ export const linksToConversationLists = `
 		[href*="/projects"],
 		[href*="/labels/"]
 	):not(
+		[href^="/pulls/"],
+		[href^="/issues/"],
 		[href*="/issues/labels"],
 		[href*="/issues/views"],
 		[href*="sort%3A"],

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -112,6 +112,7 @@ export const linksToConversationLists = `
 		[href*="/labels/"]
 	):not(
 		[href*="/issues/labels"],
+		[href*="/issues/views"],
 		[href*="sort%3A"],
 		[href*="page="],
 		.issues-reset-query,


### PR DESCRIPTION
- close https://github.com/refined-github/refined-github/issues/9922
- related to https://github.com/refined-github/refined-github/issues/9604

Note: the links were altered, but when left-clicking them, React would load the correct view regardless of the link's `href`. This bug only affected cmd-clicks etc

## Test URLs

https://github.com/refined-github/refined-github/issues/views
https://github.com/issues