### PR TITLE
AI SPAM

### DIFF
--- a/source/features/last-update-sort.tsx
+++ b/source/features/last-update-sort.tsx
@@ -40,6 +40,17 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 		// Preserve relative attributes as such #5435
 		const isRelativeAttribute = link.getAttribute('href')!.startsWith('/');
 		link.href = isRelativeAttribute ? newUrl.replace(location.origin, '') : newUrl;
+
+		// GitHub's Turbo navigation intercepts clicks on sidebar links and ignores
+		// the modified href. This override ensures left-click uses the modified URL.
+		// https://github.com/refined-github/refined-github/issues/9927
+		link.addEventListener('click', (clickEvent: MouseEvent) => {
+			if (clickEvent.button === 0 && !clickEvent.metaKey && !clickEvent.ctrlKey && !clickEvent.altKey && !clickEvent.shiftKey) {
+				clickEvent.preventDefault();
+				clickEvent.stopImmediatePropagation();
+				location.assign(link.href);
+			}
+		}, {once: true});
 	}
 
 	// Also sort projects #4957


### PR DESCRIPTION
Fixes #9927

## Problem
The `last-update-sort` feature correctly modifies the `href` of sidebar links to include `sort:updated-desc`, but GitHub's Turbo navigation intercepts left-clicks and ignores the modified `href`, loading the default view instead.

## Solution
After modifying the `href`, add a click event listener that prevents Turbo's default navigation for regular left-clicks and uses `location.assign(link.href)` to navigate to the modified URL. Altered clicks (cmd+click, middle-click, etc.) are left untouched so they still open in new tabs normally.

## Test URLs
- https://github.com/refined-github/refined-github/issues