### PR TITLE
AI SPAM

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -20,7 +20,7 @@ const buttonHashSelector = '#dialog-show-repo-delete-menu-dialog';
 
 // Only if the repository hasn't been starred
 async function isRepoUnpopular(): Promise<boolean> {
-	const counter = await elementReady('.starring-container .Counter');
+	const counter = await elementReady('#repo-stars-counter-star');
 	return counter!.textContent === '0';
 }
 


### PR DESCRIPTION
Fixes #9917

GitHub's recent UI changes removed the `.starring-container` class from the star button area, which broke the `isRepoUnpopular` check in the `quick-repo-deletion` feature. The star count element now has an `id=repo-stars-counter-star` attribute.

This change updates the selector from `.starring-container .Counter` to `#repo-stars-counter-star`, which is the correct ID for the current star counter element.