### PR TITLE
AI SPAM

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -282,3 +282,11 @@ review-thread-collapsible > .js-toggle-outdated-comments {
 	flex-wrap: wrap;
 	max-width: 100%;
 }
+
+/* Fix sticky header overlap when linking to a comment */
+/* Info: https://github.com/refined-github/refined-github/issues/9910 */
+/* Test: https://github.com/refined-github/sandbox/issues/47#issuecomment-1 */
+/* Test: https://github.com/refined-github/refined-github/pull/9910 */
+[id] {
+	scroll-margin-top: 80px;
+}


### PR DESCRIPTION
Fixes #9910

Adds `scroll-margin-top: 80px` to all elements with an `id` attribute in `github-bugs.css`, preventing the sticky header from obscuring the target when linking to a comment.

Verified on:
- Issue comments
- PR review comments
- PR conversation comments