### PR TITLE
AI SPAM

### DIFF
--- a/source/features/last-update-sort.tsx
+++ b/source/features/last-update-sort.tsx
@@ -54,6 +54,34 @@ async function updateLink(link: HTMLAnchorElement): Promise<void> {
 	}
 }
 
+function shouldAddSort(url: URL): string | undefined {
+	if (url.host !== location.host) {
+		return;
+	}
+
+	const q = url.searchParams.get('q');
+	if (
+		!q
+		|| q.includes('sort:updated-desc')
+		|| q.includes('sort:updated-asc')
+		|| url.searchParams.has('page')
+	) {
+		return;
+	}
+
+	// Check if this is a conversation list URL
+	const isConversationList = url.pathname.includes('/issues')
+		|| url.pathname.includes('/pulls')
+		|| url.pathname.includes('/projects');
+	if (!isConversationList) {
+		return;
+	}
+
+	const searchQuery = new SearchQuery(url.href);
+	searchQuery.prepend('sort:updated-desc');
+	return searchQuery.href;
+}
+
 function init(signal: AbortSignal): void {
 	// Get links that don't already have a specific sorting or pagination applied
 	observe(
@@ -61,6 +89,23 @@ function init(signal: AbortSignal): void {
 		updateLink,
 		{signal},
 	);
+
+	// Intercept navigation to handle sidebar links that are rendered by React
+	// and not caught by the AnimationObserver. GitHub's own navigation ignores
+	// the modified href for these links.
+	// https://github.com/refined-github/refined-github/issues/9927
+	navigation?.addEventListener('navigate', (event: NavigateEvent) => {
+		// Skip history navigation (back/forward)
+		if (event.navigationType === 'traverse') {
+			return;
+		}
+
+		const sortedUrl = shouldAddSort(new URL(event.destination.url));
+		if (sortedUrl) {
+			event.preventDefault();
+			location.href = sortedUrl;
+		}
+	}, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
## Summary

The AnimationObserver that drives the `observe` helper does not catch React-rendered sidebar links (GitHub's new Primer NavList items). These links have their href modified by `last-update-sort`, but GitHub's own navigation ignores the modified href.

This PR adds a secondary handler using the Navigation API's `navigate` event. Before each navigation, it checks whether the destination is a conversation list page without `sort:updated-desc`, and if so, redirects to the properly sorted URL.

## Changes

- **source/features/last-update-sort.tsx**: Added `shouldAddSort()` helper and a `navigation.addEventListener('navigate', ...)` handler in `init()`

## Design decisions

- `navigation.addEventListener('navigate', ...)` (Navigation API) is used instead of click event listeners, which were rejected in the previous attempt (#9931) because they "slow down navigation"
- The Navigation API fires before any network request, adding no overhead to the page or to link clicks
- Back/forward navigation (`navigationType === 'traverse'`) is skipped to avoid interfering with history
- The existing `observe()` + `updateLink` approach is preserved for non-React links

## Test URLs

- https://github.com/refined-github/refined-github/issues (click sidebar links like "Assigned to me", "Created by me", "Mentioned")
- https://github.com/refined-github/refined-github/pulls
- https://github.com/refined-github/refined-github/labels/bug

Closes #9927