### PR TITLE
Meta: fix closing tokenless bug reports

### DIFF
--- a/.github/workflows/conversation.yml
+++ b/.github/workflows/conversation.yml
@@ -42,7 +42,7 @@ jobs:
       - id: liars
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.body))
+          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.body) && !(/ghes?/i.test(context.payload.issue.body)) && !(/enterprise/i.test(context.payload.issue.body)))
       - if: steps.liars.outputs.matches == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:

--- a/.github/workflows/conversation.yml
+++ b/.github/workflows/conversation.yml
@@ -42,7 +42,7 @@ jobs:
       - id: liars
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.title))
+          script: core.setOutput('matches', /\(2\d(,\d{1,2}){1,2}\)/.test(context.payload.issue.body))
       - if: steps.liars.outputs.matches == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:


### PR DESCRIPTION
The parenthetical version number gets inserted into the body, not the title.
