### PR TITLE
`tags-on-commits-list` - Improve code and visibility

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -50,7 +50,7 @@ function updateCommitIcon(commit: HTMLElement, replace: boolean): void {
 	if (replace) {
 		$('.octicon-git-commit', commit).replaceWith(<GitMergeIcon />);
 	} else {
-		$(commitTitleInLists, commit).prepend(<GitMergeIcon className="mr-1 tmp-mr-1" />);
+		$(commitTitleInLists, commit).prepend(<GitMergeIcon className="mr-2 tmp-mr-2" />);
 	}
 }
 

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -48,15 +48,16 @@ async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}
 	}
 
 	const lastTag = nodes.at(-1)!.target;
-	const isLastTagYounger = new Date(repository.object.committedDate)
-		< new Date('tagger' in lastTag ? lastTag.tagger.date : lastTag.committedDate);
+	const lastCommitDate = new Date(repository.object.committedDate);
+	const lastTagDate = new Date('tagger' in lastTag ? lastTag.tagger.date : lastTag.committedDate);
 
 	// If the last tag is newer than last commit on the page, then not all commits are accounted for, keep looking
-	if (isLastTagYounger && repository.refs.pageInfo.hasNextPage) {
-		await getTags(lastCommit, repository.refs.pageInfo.endCursor, tags);
+	if (!(lastCommitDate < lastTagDate && repository.refs.pageInfo.hasNextPage)) {
+		return tags;
 	}
 
-	return tags;
+	// eslint-disable-next-line unicorn/no-useless-recursion -- Not much better
+	return getTags(lastCommit, repository.refs.pageInfo.endCursor, tags);
 }
 
 function renderTags(commit: HTMLElement, tags: Set<string>): void {

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -52,11 +52,12 @@ async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}
 
 function renderTags(commit: HTMLElement, tags: Set<string>): void {
 	const tagLinks = [...tags].map(tag =>
+		// .markdown-title enables the background color
 		<a
-			className="text-bold Link--primary no-underline"
+			className="Link--muted markdown-title"
 			href={buildRepoUrl('releases/tag', tag)}
 		>
-			{tag}
+			<code>{tag}</code>
 		</a>,
 	);
 
@@ -65,7 +66,7 @@ function renderTags(commit: HTMLElement, tags: Set<string>): void {
 		'[class^="Description-module__container"]',
 	], commit).append(
 		<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
-			<TagIcon className="mr-1 tmp-mr-1 color-fg-muted" />
+			<TagIcon />
 			<span className="d-flex flex-wrap gap-1">
 				{joinJsx(', ', tagLinks)}
 			</span>

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -68,7 +68,7 @@ function renderTags(commit: HTMLElement, tags: Set<string>): void {
 		<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
 			<TagIcon />
 			<span className="d-flex flex-wrap gap-1">
-				{joinJsx(', ', tagLinks)}
+				{joinJsx(' ', tagLinks)}
 			</span>
 		</div>,
 	);

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -13,22 +13,7 @@ import joinJsx from '../helpers/join-jsx.js';
 import {getCommitHash} from './mark-merge-commits-in-list.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
 
-type TagNode = {
-	name: string;
-	target: {
-		commitResourcePath: string;
-	} & ({tagger: {date: Date}} | {committedDate: Date});
-};
-
 type CommitTags = Record<string, Set<string>>;
-
-function addTag(tags: CommitTags, commit: string, tag: string): void {
-	if (tag === 'nightly') {
-		return;
-	}
-
-	(tags[commit] ??= new Set()).add(tag);
-}
 
 async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}): Promise<CommitTags> {
 	const {repository} = await api.v4(GetTagsOnCommit, {
@@ -37,14 +22,18 @@ async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}
 			...after && {after},
 		},
 	});
-	const nodes = repository.refs.nodes as TagNode[];
-
-	if (nodes.length === 0) {
-		return tags;
-	}
+	const {nodes} = repository.refs;
 
 	for (const node of nodes) {
-		addTag(tags, node.target.commitResourcePath.split('/', 5)[4], node.name);
+		const commit = node.target.commitResourcePath.split('/', 5)[4];
+		if (node.name !== 'nightly') {
+			tags[commit] ??= new Set();
+			tags[commit].add(node.name);
+		}
+	}
+
+	if (nodes.length === 0 || !repository.refs.pageInfo.hasNextPage) {
+		return tags;
 	}
 
 	const lastTag = nodes.at(-1)!.target;
@@ -52,7 +41,7 @@ async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}
 	const lastTagDate = new Date('tagger' in lastTag ? lastTag.tagger.date : lastTag.committedDate);
 
 	// If the last tag is newer than last commit on the page, then not all commits are accounted for, keep looking
-	if (!(lastCommitDate < lastTagDate && repository.refs.pageInfo.hasNextPage)) {
+	if (lastCommitDate >= lastTagDate) {
 		return tags;
 	}
 

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -30,12 +30,11 @@ function addTag(tags: CommitTags, commit: string, tag: string): void {
 	(tags[commit] ??= new Set()).add(tag);
 }
 
-async function getTags(lastCommit: string, after?: string): Promise<CommitTags> {
+async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}): Promise<CommitTags> {
 	const {repository} = await api.v4(GetTagsOnCommit, {
 		variables: {commit: lastCommit, after},
 	});
 	const nodes = repository.refs.nodes as TagNode[];
-	const tags: CommitTags = {};
 
 	if (nodes.length === 0) {
 		return tags;
@@ -51,11 +50,7 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 
 	// If the last tag is newer than last commit on the page, then not all commits are accounted for, keep looking
 	if (isLastTagYounger && repository.refs.pageInfo.hasNextPage) {
-		for (const [commit, tagNames] of Object.entries(await getTags(lastCommit, repository.refs.pageInfo.endCursor))) {
-			for (const tag of tagNames) {
-				addTag(tags, commit, tag);
-			}
-		}
+		await getTags(lastCommit, repository.refs.pageInfo.endCursor, tags);
 	}
 
 	return tags;

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -12,6 +12,7 @@ import observe from '../helpers/selector-observer.js';
 import joinJsx from '../helpers/join-jsx.js';
 import {getCommitHash} from './mark-merge-commits-in-list.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
+import {commitTitleInLists} from '../github-helpers/selectors.js';
 
 type CommitTags = Record<string, Set<string>>;
 
@@ -66,10 +67,12 @@ function renderTags(commit: HTMLElement, tags: Set<string>): void {
 		<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
 			<TagIcon className="mr-1 tmp-mr-1 color-fg-muted" />
 			<span className="d-flex flex-wrap gap-1">
-				{joinJsx(' ', tagLinks)}
+				{joinJsx(', ', tagLinks)}
 			</span>
 		</div>,
 	);
+
+	$(commitTitleInLists, commit).prepend(<TagIcon className="mr-2 tmp-mr-2" />);
 	commit.classList.add('rgh-tagged');
 }
 

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -32,7 +32,10 @@ function addTag(tags: CommitTags, commit: string, tag: string): void {
 
 async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}): Promise<CommitTags> {
 	const {repository} = await api.v4(GetTagsOnCommit, {
-		variables: {commit: lastCommit, after},
+		variables: {
+			commit: lastCommit,
+			...after && {after},
+		},
 	});
 	const nodes = repository.refs.nodes as TagNode[];
 
@@ -86,6 +89,7 @@ async function markTags(commits: HTMLElement[]): Promise<void> {
 
 	for (const commit of commits) {
 		const commitTags = tags[getCommitHash(commit)];
+		// `commitTags` can be undefined if a commit has no associated release tags in the GraphQL response
 		if (commitTags?.size) {
 			renderTags(commit, commitTags);
 		}

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -51,12 +51,11 @@ async function getTags(lastCommit: string, after?: string, tags: CommitTags = {}
 
 function renderTags(commit: HTMLElement, tags: Set<string>): void {
 	const tagLinks = [...tags].map(tag =>
-		// .markdown-title enables the background color
 		<a
-			className="Link--muted markdown-title"
+			className="text-bold Link--primary no-underline"
 			href={buildRepoUrl('releases/tag', tag)}
 		>
-			<code>{tag}</code>
+			{tag}
 		</a>,
 	);
 
@@ -65,7 +64,7 @@ function renderTags(commit: HTMLElement, tags: Set<string>): void {
 		'[class^="Description-module__container"]',
 	], commit).append(
 		<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
-			<TagIcon />
+			<TagIcon className="mr-1 tmp-mr-1 color-fg-muted" />
 			<span className="d-flex flex-wrap gap-1">
 				{joinJsx(' ', tagLinks)}
 			</span>

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -1,166 +1,114 @@
 import React from 'dom-chef';
-import {$, $$, $$optional} from 'select-dom';
-import cache from 'webext-storage-cache/legacy.js';
+import {$} from 'select-dom';
+import batchedFunction from 'batched-function';
 
 import * as pageDetect from 'github-url-detection';
 import TagIcon from 'octicons-plain-react/Tag';
 
 import features from '../feature-manager.js';
 import api from '../github-helpers/api.js';
-import {buildRepoUrl, getRepo} from '../github-helpers/index.js';
-import delay from '../helpers/delay.js';
+import {buildRepoUrl} from '../github-helpers/index.js';
+import observe from '../helpers/selector-observer.js';
 import joinJsx from '../helpers/join-jsx.js';
 import {getCommitHash} from './mark-merge-commits-in-list.js';
 import GetTagsOnCommit from './tags-on-commits-list.gql';
 
-type CommitTags = Record<string, string[]>;
-
-const arrayUnion = (x: string[], y: string[]): string[] => [...new Set([...x, ...y])];
-
-type BaseTarget = {
-	commitResourcePath: string;
-};
-
-type TagTarget = BaseTarget & {
-	tagger: {
-		date: Date;
-	};
-};
-
-type CommitTarget = BaseTarget & {
-	committedDate: Date;
-};
-
-type CommonTarget = TagTarget | CommitTarget;
 type TagNode = {
 	name: string;
-	target: CommonTarget;
+	target: {
+		commitResourcePath: string;
+	} & ({tagger: {date: Date}} | {committedDate: Date});
 };
 
-function mergeTags(oldTags: CommitTags, newTags: CommitTags): CommitTags {
-	const result: CommitTags = {...oldTags};
-	for (const [commit, tags] of Object.entries(newTags)) {
-		result[commit] = Object.hasOwn(result, commit)
-			? arrayUnion(result[commit], tags)
-			: tags;
+type CommitTags = Record<string, Set<string>>;
+
+function addTag(tags: CommitTags, commit: string, tag: string): void {
+	if (tag === 'nightly') {
+		return;
 	}
 
-	return result;
-}
-
-function isTagTarget(target: CommonTarget): target is TagTarget {
-	return 'tagger' in target;
+	(tags[commit] ??= new Set()).add(tag);
 }
 
 async function getTags(lastCommit: string, after?: string): Promise<CommitTags> {
 	const {repository} = await api.v4(GetTagsOnCommit, {
-		variables: {
-			commit: lastCommit,
-			...after && {after},
-		},
+		variables: {commit: lastCommit, after},
 	});
 	const nodes = repository.refs.nodes as TagNode[];
+	const tags: CommitTags = {};
 
-	// If there are no tags in the repository
 	if (nodes.length === 0) {
-		return {};
+		return tags;
 	}
 
-	let tags: CommitTags = {};
 	for (const node of nodes) {
-		if (node.name === 'nightly') {
-			continue;
-		}
-
-		const commit = node.target.commitResourcePath.split('/', 5)[4];
-		tags[commit] ||= [];
-
-		tags[commit].push(node.name);
+		addTag(tags, node.target.commitResourcePath.split('/', 5)[4], node.name);
 	}
 
 	const lastTag = nodes.at(-1)!.target;
 	const isLastTagYounger = new Date(repository.object.committedDate)
-		< new Date(isTagTarget(lastTag) ? lastTag.tagger.date : lastTag.committedDate);
+		< new Date('tagger' in lastTag ? lastTag.tagger.date : lastTag.committedDate);
 
 	// If the last tag is newer than last commit on the page, then not all commits are accounted for, keep looking
 	if (isLastTagYounger && repository.refs.pageInfo.hasNextPage) {
-		tags = mergeTags(tags, await getTags(lastCommit, repository.refs.pageInfo.endCursor));
+		for (const [commit, tagNames] of Object.entries(await getTags(lastCommit, repository.refs.pageInfo.endCursor))) {
+			for (const tag of tagNames) {
+				addTag(tags, commit, tag);
+			}
+		}
 	}
 
-	// There are no tags for this commit
 	return tags;
 }
 
-async function init(): Promise<void | false> {
-	const cacheKey = `tags:${getRepo()!.nameWithOwner}`;
+function renderTags(commit: HTMLElement, tags: Set<string>): void {
+	const tagLinks = [...tags].map(tag =>
+		// .markdown-title enables the background color
+		<a
+			className="Link--muted markdown-title"
+			href={buildRepoUrl('releases/tag', tag)}
+		>
+			<code>{tag}</code>
+		</a>,
+	);
 
-	let commitsOnPage = $$optional('[data-testid="commit-row-item"]');
-	if (commitsOnPage.length === 0) {
-		// Try waiting a bit longer
-		// https://github.com/refined-github/refined-github/issues/7954
-		await delay(1000);
-		commitsOnPage = $$('[data-testid="commit-row-item"]');
-	}
+	$([
+		'div[data-testid="list-view-item-description"]',
+		'[class^="Description-module__container"]',
+	], commit).append(
+		<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
+			<TagIcon />
+			<span className="d-flex flex-wrap gap-1">
+				{joinJsx(' ', tagLinks)}
+			</span>
+		</div>,
+	);
+	commit.classList.add('rgh-tagged');
+}
 
-	const lastCommitOnPage = getCommitHash(commitsOnPage.at(-1)!);
-	let cached = await cache.get<Record<string, string[]>>(cacheKey) ?? {};
-	const commitsWithNoTags = [];
-	for (const commit of commitsOnPage) {
-		const targetCommit = getCommitHash(commit);
-		let targetTags = cached[targetCommit];
+async function markTags(commits: HTMLElement[]): Promise<void> {
+	const tags = await getTags(getCommitHash(commits.at(-1)!));
 
-		if (!targetTags) {
-			// No tags for this commit found in the cache, check in GitHub
-			cached = mergeTags(cached, await getTags(lastCommitOnPage)); // eslint-disable-line no-await-in-loop
-			targetTags = cached[targetCommit];
-		}
-
-		if (!targetTags) {
-			// There was no tag for this commit, save that info to the cache
-			commitsWithNoTags.push(targetCommit);
-		} else if (targetTags.length > 0) {
-			const commitMeta = $([
-				'div[data-testid="list-view-item-description"]',
-				'[class^="Description-module__container"]',
-			], commit);
-
-			const tags = targetTags.map(tag =>
-				// .markdown-title enables the background color
-				<a
-					className="Link--muted markdown-title"
-					href={buildRepoUrl('releases/tag', tag)}
-				>
-					<code>{tag}</code>
-				</a>,
-			);
-
-			commitMeta.append(
-				<div className="ml-1 tmp-ml-1 d-flex flex-items-center gap-1">
-					<TagIcon />
-					<span className="d-flex flex-wrap gap-1">
-						{joinJsx(' ', tags)}
-					</span>
-				</div>,
-			);
-			commit.classList.add('rgh-tagged');
+	for (const commit of commits) {
+		const commitTags = tags[getCommitHash(commit)];
+		if (commitTags?.size) {
+			renderTags(commit, commitTags);
 		}
 	}
+}
 
-	if (commitsWithNoTags.length > 0) {
-		for (const commit of commitsWithNoTags) {
-			cached[commit] = [];
-		}
-	}
-
-	await cache.set(cacheKey, cached, {days: 1});
+async function init(signal: AbortSignal): Promise<void> {
+	observe(
+		'[data-testid="commit-row-item"]',
+		batchedFunction(markTags, {delay: 100}),
+		{signal},
+	);
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoCommitList,
 	],
-	awaitDomReady: true,
-	deduplicate: 'has-rgh-inner',
 	requiresToken: true,
 	init,
 });


### PR DESCRIPTION
Thank god. I always hated this feature. A few rounds of Claude and maybe we got something cleaner.

<img width="146" height="47" alt="Screenshot" src="https://github.com/user-attachments/assets/d300bfe1-b285-4857-acef-32abb4a872c2" />



### Test URLs

https://github.com/refined-github/refined-github/commits/19.5.21.1921

### Screenshot

I also added a tag icon like `mark-merge-commits-in-list` does to make it more visible, even if it kinda looks duplicated now:

<img width="470" height="65" alt="Screenshot 1" src="https://github.com/user-attachments/assets/aab8d951-f13c-4f9c-bee1-32fcbf6b32b5" />
<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign=top><img width="773" height="530" alt="Screenshot 3" src="https://github.com/user-attachments/assets/c38fb1aa-3069-4bea-b91b-10a07735142a" />
 <td valign=top><img width="773" height="530" alt="Screenshot 4" src="https://github.com/user-attachments/assets/d4826aff-bd0c-47d6-ac56-fcb911384849" />
</table>


I had tried to match the new tag style but it ended up looking [worse](https://github.com/user-attachments/assets/f37efdde-8846-4b5f-9cfd-e8d92757ee00) I think


