### PR TITLE
AI SPAM

### DIFF
--- a/source/github-helpers/pr-branches.test.ts
+++ b/source/github-helpers/pr-branches.test.ts
@@ -1,6 +1,6 @@
 import {assert, test} from 'vitest';
 
-import {parseReferenceRaw} from './pr-branches.js';
+import {getBranches, parseReferenceRaw} from './pr-branches.js';
 
 test('parseReferenceRaw', () => {
 	assert.deepEqual(parseReferenceRaw('fregante/mem:main', 'main'), {
@@ -35,4 +35,32 @@ test('parseReferenceRaw', () => {
 		TypeError,
 		'Expected `relative` to be either "main" or "fregante:main", got "main:main"',
 	);
+});
+
+test('getBranches uses the reference title when the adjacent element is empty', () => {
+	document.body.innerHTML = `
+		<span class="base-ref" title="refined-github/refined-github:main">main</span>
+		<span></span>
+		<span class="head-ref" title="fregante/refined-github:feature/restore-file">fregante:feature/restore-file</span>
+		<span></span>
+	`;
+
+	assert.deepEqual(getBranches(), {
+		base: {
+			absolute: 'refined-github/refined-github:main',
+			relative: 'main',
+			owner: 'refined-github',
+			name: 'refined-github',
+			nameWithOwner: 'refined-github/refined-github',
+			branch: 'main',
+		},
+		head: {
+			absolute: 'fregante/refined-github:feature/restore-file',
+			relative: 'fregante:feature/restore-file',
+			owner: 'fregante',
+			name: 'refined-github',
+			nameWithOwner: 'fregante/refined-github',
+			branch: 'feature/restore-file',
+		},
+	});
 });

--- a/source/github-helpers/pr-branches.ts
+++ b/source/github-helpers/pr-branches.ts
@@ -54,7 +54,13 @@ export function parseReferenceRaw(absolute: string, relative: string): PrReferen
 
 function parseReference(referenceElement: HTMLElement): PrReference {
 	const {textContent, nextElementSibling} = referenceElement;
-	return parseReferenceRaw(nextElementSibling!.textContent.trim(), textContent.trim());
+	const relative = textContent.trim();
+	const adjacentAbsolute = nextElementSibling?.textContent?.trim();
+	if (adjacentAbsolute) {
+		return parseReferenceRaw(adjacentAbsolute, relative);
+	}
+
+	return parseReferenceRaw(referenceElement.title, relative);
 }
 
 export function getBranches(): {base: PrReference; head: PrReference} {


### PR DESCRIPTION
Closes #9938.

## Summary

- Fall back to the branch reference element's `title` when the adjacent absolute-reference element is empty.
- Preserve the existing adjacent-element path for GitHub.com and other layouts.
- Add a regression test covering same-repository and cross-repository branch references in the empty-adjacent-element layout.

## Test URLs

- https://github.com/refined-github/refined-github/pull/9902/files
- https://github.com/refined-github/refined-github/issues/9938

## Validation

- `npm run vitest -- source/github-helpers/pr-branches.test.ts` — 2 passed
- `npm run vitest` — 565 passed, 28 skipped
- `npm exec -- eslint source/github-helpers/pr-branches.ts source/github-helpers/pr-branches.test.ts` — passed
- `npm exec -- dprint check source/github-helpers/pr-branches.ts source/github-helpers/pr-branches.test.ts` — passed
- `npm run build:typescript` — passed
- `npm run build:svelte` — 0 errors, 0 warnings
- `npm run build:bundle` — passed
- `npm run lint:biome` — passed
- `git diff --check` — passed

Assisted-by: ChatGPT
