### PR TITLE
`extend-repo-tabs` - Don't remove Agents tab for now

### DIFF
--- a/source/features/extend-repo-tabs.tsx
+++ b/source/features/extend-repo-tabs.tsx
@@ -70,7 +70,6 @@ async function updateActionsAndProjectsTabs(): Promise<void> {
 
 function init(): void {
 	overrideTab('pull-requests', {label: 'Pulls'});
-	overrideTab('agents', {demoted: true});
 	overrideTab('security-and-quality', {demoted: true});
 	overrideTab('insights', {demoted: true});
 


### PR DESCRIPTION
I mistakenly left this in. I think Agents is useful for now, maybe it can be demoted conditionally later on. Originally requested in:

- https://github.com/refined-github/refined-github/issues/8977