### PR TITLE
`quick-repo-deletion` - Restore feature on repo root

### DIFF
--- a/source/components/tooltip.svelte
+++ b/source/components/tooltip.svelte
@@ -46,7 +46,9 @@
 	{#if shortcut}
 		<kbd class="rgh-shortcut">
 			{#each shortcut.split(' ') as key (key)}
-				<span data-kbd-chord="true">{upperCaseFirst(key)}</span>{' '}
+				<span data-kbd-chord="true">{upperCaseFirst(key)}</span>
+				<!-- eslint-disable-next-line svelte/no-useless-mustaches -- Literally wrong -->
+				{' '}
 			{/each}
 		</kbd>
 	{/if}

--- a/source/components/tooltip.svelte
+++ b/source/components/tooltip.svelte
@@ -46,7 +46,7 @@
 	{#if shortcut}
 		<kbd class="rgh-shortcut">
 			{#each shortcut.split(' ') as key (key)}
-				<span data-kbd-chord="true">{upperCaseFirst(key)}</span>
+				<span data-kbd-chord="true">{upperCaseFirst(key)}</span>{' '}
 			{/each}
 		</kbd>
 	{/if}

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -16,7 +16,7 @@ import addNotice from '../github-helpers/notice-bar.js';
 import observe from '../helpers/selector-observer.js';
 import addTooltip, {withTooltipRef} from '../components/tooltip.js';
 
-const tooltip = {label: 'Instant deletion via', shortcut: 'shift alt click'} as const;
+const tooltip = {label: 'Instant deletion via', shortcut: 'alt click'} as const;
 const buttonHashSelector = '#dialog-show-repo-delete-menu-dialog';
 
 // Only if the repository hasn't been starred
@@ -55,8 +55,8 @@ async function modifyUiAfterSuccessfulDeletion(): Promise<void> {
 	$('.application-main').remove();
 }
 
-async function handleShiftAltClick(event: DelegateEvent<MouseEvent, HTMLElement>): Promise<void> {
-	if (!event.shiftKey || !event.altKey) {
+async function handleAltClick(event: DelegateEvent<MouseEvent, HTMLElement>): Promise<void> {
+	if (!event.altKey) {
 		return;
 	}
 
@@ -106,11 +106,11 @@ function autoOpenModal(signal: AbortSignal): void {
 
 async function initRepoRoot(signal: AbortSignal): Promise<void | false> {
 	observe('[data-testid="repo-header-actions"]', addButton, {signal});
-	delegate('.rgh-quick-repo-deletion', 'click', handleShiftAltClick, {signal});
+	delegate('.rgh-quick-repo-deletion', 'click', handleAltClick, {signal});
 }
 
 async function initRepoSettings(signal: AbortSignal): Promise<void | false> {
-	delegate(buttonHashSelector, 'click', handleShiftAltClick, {signal});
+	delegate(buttonHashSelector, 'click', handleAltClick, {signal});
 	observe(buttonHashSelector, addShortcutTooltip, {signal});
 }
 

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -66,7 +66,8 @@ async function handleAltClick(event: DelegateEvent<MouseEvent, HTMLElement>): Pr
 	// https://github.com/refined-github/refined-github/pull/7866#issuecomment-2396270060
 	$optional<HTMLDialogElement>('#' + event.delegateTarget.getAttribute('data-show-dialog-id')!)?.close();
 
-	if (confirm('Are you sure you want to delete this repository?')) {
+	const {nameWithOwner} = getRepo()!;
+	if (confirm(`⚠️${nameWithOwner}⚠️ will be deleted. Are you sure?`)) {
 		await showToast(deleteRepository, {
 			message: 'Deleting repo…',
 			doneMessage: 'Repo deleted',

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -14,13 +14,14 @@ import {buildRepoUrl, getForkedRepo, getRepo} from '../github-helpers/index.js';
 import showToast from '../github-helpers/toast.js';
 import addNotice from '../github-helpers/notice-bar.js';
 import observe from '../helpers/selector-observer.js';
+import addTooltip, {withTooltipRef} from '../components/tooltip.js';
 
-const tooltip = 'Instant deletion: shift-alt-click';
+const tooltip = {label: 'Instant deletion via', shortcut: 'shift alt click'} as const;
 const buttonHashSelector = '#dialog-show-repo-delete-menu-dialog';
 
 // Only if the repository hasn't been starred
 async function isRepoUnpopular(): Promise<boolean> {
-	const counter = await elementReady('.starring-container .Counter');
+	const counter = await elementReady('[data-testid="star-button"] [data-component="CounterLabel"]');
 	return counter!.textContent === '0';
 }
 
@@ -76,7 +77,7 @@ async function handleShiftAltClick(event: DelegateEvent<MouseEvent, HTMLElement>
 }
 
 function addShortcutTooltip(button: HTMLElement): void {
-	button.setAttribute('title', tooltip);
+	addTooltip(tooltip, button);
 }
 
 function addButton(header: HTMLElement): void {
@@ -85,7 +86,7 @@ function addButton(header: HTMLElement): void {
 			<a
 				href={buildRepoUrl('settings', buttonHashSelector)}
 				className="btn btn-sm btn-danger rgh-quick-repo-deletion"
-				title={tooltip}
+				ref={withTooltipRef(tooltip)}
 			>
 				<TrashIcon className="mr-2 tmp-mr-2" />
 				Delete fork
@@ -104,7 +105,7 @@ function autoOpenModal(signal: AbortSignal): void {
 }
 
 async function initRepoRoot(signal: AbortSignal): Promise<void | false> {
-	observe('.pagehead-actions', addButton, {signal});
+	observe('[data-testid="repo-header-actions"]', addButton, {signal});
 	delegate('.rgh-quick-repo-deletion', 'click', handleShiftAltClick, {signal});
 }
 


### PR DESCRIPTION
- fixes #9917 


## Test URLs

1. Fork any repo
2. See repo header

## Screenshot

<img width="543" height="87" alt="Screenshot 2" src="https://github.com/user-attachments/assets/e97a6a5c-438e-4d45-a024-e5a9b4b9e0aa" />

Also the instant deletion:

<img width="825" height="347" alt="test" src="https://github.com/user-attachments/assets/cfdcc2b6-669e-4f33-96af-e86c26734ee4" />

