### PR TITLE
`html-preview-link` - Fix button style

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -15,7 +15,7 @@ function add(rawButton: HTMLAnchorElement): void {
 		.parentElement! // `div`
 		.parentElement! // `BtnGroup`
 		.prepend(
-			<div>
+			<div className={rawButton.parentElement!.className}>
 				<a
 					className={rawButton.className}
 					data-variant="default"


### PR DESCRIPTION
Closes: https://github.com/refined-github/refined-github/issues/9953

@fregante created an issue because the `Preview` button was not visually grouped with `Raw` button.
This bug was on Safari, Chrome and Firefox (Tested and fixed on all three)

## What I did
The wrapper `<div>` around the `Preview` link was missing the `ButtonGroup` item class that GitHub uses to merge adjacent buttons' border radius.

The fix copies the `className` from the existing `Raw` button's wrapper `div` onto the new `Preview` wrapper, so it picks up the same style and merges visually with the button group.

## Test URLs
- https://github.com/refined-github/refined-github/blob/main/source/options.html
- https://github.com/refined-github/sandbox/blob/html/preview-link/public/test.html
- https://github.com/CodingTrain/website/blob/4f90eedb9618257d9166241e92e51a7f3f00a08e/code_challenges/PerlinNoiseTerrain_p5.js/index.html


## Screenshot
Old version : 
<img width="414" height="134" alt="image" src="https://github.com/user-attachments/assets/040b2811-b42b-4f12-811d-db2381aa52f6" />

Now : 
<img width="336" height="75" alt="CleanShot 2026-08-08 at 20 41 32" src="https://github.com/user-attachments/assets/d5d35ef9-ed23-48e4-acd0-4c4a266f64b1" />
