### PR TITLE
`clean-conversation-headers` - Fix base branch detection 

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -122,7 +122,7 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
-		'.d-flex[class*="PullRequestHeaderSummary"]',
+		'.d-flex[class*="PullRequestHeaderSummary"]:has([class^="PullRequestBranchName"] ~ div [class^="PullRequestBranchName"])',
 		cleanPrHeader,
 		{signal},
 	);

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -4,7 +4,7 @@ import React from 'dom-chef';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import ArrowLeftIcon from 'octicons-plain-react/ArrowLeft';
-import {$, closestElementOptional} from 'select-dom';
+import {$, closestElement, closestElementOptional} from 'select-dom';
 
 import features from '../feature-manager.js';
 import getDefaultBranch from '../github-helpers/get-default-branch.js';
@@ -90,7 +90,8 @@ function replaceFromWithArrow(base: HTMLElement): void {
 	);
 }
 
-async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
+async function cleanPrHeader(headRef: HTMLElement): Promise<void> {
+	const summaryRow = closestElement('.d-flex[class*="PullRequestHeaderSummary"]', headRef);
 	summaryRow.classList.add('rgh-clean-conversation-headers');
 
 	if (isStickyHeader(summaryRow)) {
@@ -122,7 +123,7 @@ async function cleanPrHeader(summaryRow: HTMLElement): Promise<void> {
 
 async function init(signal: AbortSignal): Promise<void> {
 	observe(
-		'.d-flex[class*="PullRequestHeaderSummary"]:has([class^="PullRequestBranchName"] ~ div [class^="PullRequestBranchName"])',
+		'[class^="PullRequestBranchName"] ~ div [class^="PullRequestBranchName"]',
 		cleanPrHeader,
 		{signal},
 	);


### PR DESCRIPTION
Closes: https://github.com/refined-github/refined-github/issues/9952

This PR is here to solve the issues, that sometime the wrong ref is highlighted (posted by @fregante)
This bug happened when `Edit title` was clicked before RGH has finished loading.

I tested it on Chromium, Firefox and Safari.

## What I did

We were picking the first element matching `[class^="PullRequestBranchName"]` as the base branch, without checking if the head was also in the DOM. Now, we check in the `observe` if both branches are in the DOM.

## Test URLs

- Open PR (default branch): https://github.com/refined-github/sandbox/pull/4
- Open PR (non-default branch): https://github.com/Kenshin/simpread/pull/698

- Merged PR (same author): https://github.com/sindresorhus/refined-github/pull/3402
- Merged PR (different author): https://github.com/parcel-bundler/parcel/pull/78
- Merged PR (different author + first published tag): https://github.com/sindresorhus/refined-github/pull/3227

- Closed PR: https://github.com/sindresorhus/refined-github/pull/4141

## Screenshot / GIF

GIF from my Chromium
<img width="800" height="282" alt="CleanShot 2026-08-08 at 22 40 54" src="https://github.com/user-attachments/assets/0719e0fe-4797-4a08-857e-616d60f77d06" />

Tell me if this looks correct for you.