### PR TITLE
`repo-header-info` - Remove stargazers link when unavailable

### DIFF
--- a/source/features/repo-header-info.gql
+++ b/source/features/repo-header-info.gql
@@ -3,6 +3,7 @@ query GetRepositoryInfo($owner: String!, $name: String!) {
 		stargazerCount
 		isPrivate
 		viewerHasStarred
+		viewerPermission
 		isEmpty
 		forked: parent {
 			url

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -23,7 +23,7 @@
 
 	{#if info.stargazerCount > 1}
 		<a
-			href={info.stargazerUrl || undefined}
+			href={info.stargazerUrl}
 			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
 				info.viewerHasStarred ? ', including you' : ''
 			}`}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -22,21 +22,38 @@
 	{/if}
 
 	{#if info.stargazerCount > 1}
-		<a
-			href={buildRepoUrl('stargazers')}
-			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
-				info.viewerHasStarred ? ', including you' : ''
-			}`}
-			class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
-		>
-			<DomChef
-				as={info.viewerHasStarred ? StarFillIcon : StarIcon}
-				width={12}
-				height={12}
-				color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
-			/>
-			<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
-		</a>
+		{#if ['ADMIN', 'MAINTAIN', 'TRIAGE', 'WRITE'].includes(info.viewerPermission)}
+			<a
+				href={buildRepoUrl('stargazers')}
+				title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
+					info.viewerHasStarred ? ', including you' : ''
+				}`}
+				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+			>
+				<DomChef
+					as={info.viewerHasStarred ? StarFillIcon : StarIcon}
+					width={12}
+					height={12}
+					color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
+				/>
+				<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
+			</a>
+		{:else}
+			<span
+				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+				title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
+					info.viewerHasStarred ? ', including you' : ''
+				}`}
+			>
+				<DomChef
+					as={info.viewerHasStarred ? StarFillIcon : StarIcon}
+					width={12}
+					height={12}
+					color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
+				/>
+				<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
+			</span>
+		{/if}
 	{/if}
 
 	{#if info.ciCommit}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -27,7 +27,7 @@
 			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
 				info.viewerHasStarred ? ', including you' : ''
 			}`}
-			class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted {info.stargazerUrl ? 'Button Button--invisible' : ''}"
+			class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted {info.stargazerUrl ? 'Button Button--invisible' : 'no-underline'}"
 		>
 			<DomChef
 				as={info.viewerHasStarred ? StarFillIcon : StarIcon}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -40,7 +40,7 @@
 			</a>
 		{:else}
 			<span
-				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
+				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted"
 				title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
 					info.viewerHasStarred ? ', including you' : ''
 				}`}

--- a/source/features/repo-header-info.svelte
+++ b/source/features/repo-header-info.svelte
@@ -22,38 +22,21 @@
 	{/if}
 
 	{#if info.stargazerCount > 1}
-		{#if ['ADMIN', 'MAINTAIN', 'TRIAGE', 'WRITE'].includes(info.viewerPermission)}
-			<a
-				href={buildRepoUrl('stargazers')}
-				title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
-					info.viewerHasStarred ? ', including you' : ''
-				}`}
-				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted Button Button--invisible"
-			>
-				<DomChef
-					as={info.viewerHasStarred ? StarFillIcon : StarIcon}
-					width={12}
-					height={12}
-					color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
-				/>
-				<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
-			</a>
-		{:else}
-			<span
-				class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted"
-				title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
-					info.viewerHasStarred ? ', including you' : ''
-				}`}
-			>
-				<DomChef
-					as={info.viewerHasStarred ? StarFillIcon : StarIcon}
-					width={12}
-					height={12}
-					color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
-				/>
-				<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
-			</span>
-		{/if}
+		<a
+			href={info.stargazerUrl || undefined}
+			title={`Repository starred by ${info.stargazerCount.toLocaleString('us')} people${
+				info.viewerHasStarred ? ', including you' : ''
+			}`}
+			class="d-flex flex-items-center flex-justify-center gap-1 p-1 tmp-p-1 color-fg-muted {info.stargazerUrl ? 'Button Button--invisible' : ''}"
+		>
+			<DomChef
+				as={info.viewerHasStarred ? StarFillIcon : StarIcon}
+				width={12}
+				height={12}
+				color={info.viewerHasStarred ? 'var(--button-star-iconColor)' : undefined}
+			/>
+			<span class="f5">{abbreviateNumber(info.stargazerCount)}</span>
+		</a>
 	{/if}
 
 	{#if info.ciCommit}

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -18,6 +18,7 @@ export type RepositoryInfo = {
 	isPrivate: boolean;
 	stargazerCount: number;
 	viewerHasStarred: boolean;
+	viewerPermission: string;
 	ciCommit?: string;
 };
 

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -12,7 +12,7 @@ import {appendBefore, isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetRepoInfo from './repo-header-info.gql';
 import RepoHeaderInfo from './repo-header-info.svelte';
-import { buildRepoUrl } from '../github-helpers';
+import {buildRepoUrl} from '../github-helpers/index.js';
 
 export type RepositoryInfo = {
 	forked?: {url: string};

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -12,6 +12,7 @@ import {appendBefore, isSmallDevice} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 import GetRepoInfo from './repo-header-info.gql';
 import RepoHeaderInfo from './repo-header-info.svelte';
+import { buildRepoUrl } from '../github-helpers';
 
 export type RepositoryInfo = {
 	forked?: {url: string};
@@ -20,6 +21,7 @@ export type RepositoryInfo = {
 	viewerHasStarred: boolean;
 	viewerPermission: string;
 	ciCommit?: string;
+	stargazerUrl?: string;
 };
 
 async function getRepositoryInfo(): Promise<RepositoryInfo> {
@@ -38,7 +40,11 @@ async function getRepositoryInfo(): Promise<RepositoryInfo> {
 		}
 	}
 
-	return {...repository, ciCommit};
+	return {
+		...repository,
+		ciCommit,
+		stargazerUrl: repository.viewerPermission !== 'READ' && buildRepoUrl('stargazers'),
+	};
 }
 
 async function add(breadcrumbs: HTMLElement): Promise<void> {

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -19,7 +19,6 @@ export type RepositoryInfo = {
 	isPrivate: boolean;
 	stargazerCount: number;
 	viewerHasStarred: boolean;
-	viewerPermission: string;
 	ciCommit?: string;
 	stargazerUrl?: string;
 };
@@ -43,7 +42,9 @@ async function getRepositoryInfo(): Promise<RepositoryInfo> {
 	return {
 		...repository,
 		ciCommit,
-		stargazerUrl: repository.viewerPermission !== 'READ' && buildRepoUrl('stargazers'),
+		stargazerUrl: repository.viewerPermission === 'READ'
+			? undefined // No access: https://github.com/refined-github/refined-github/issues/9964
+			: buildRepoUrl('stargazers'),
 	};
 }
 


### PR DESCRIPTION
Read https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
Closes #9964

## Test URLs
You should be able to see the stargazers for a repo where you're an author / contributor: https://github.com/refined-github/refined-github/stargazers
A 404 page for a repo where you're not a contributor: https://github.com/kerollosy/timedinput/stargazers