### PR TITLE
AI SPAM

### DIFF
--- a/source/github-helpers/token-options.test.ts
+++ b/source/github-helpers/token-options.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from 'vitest';
+
+import {getTokenForUser, getTokenOptionName, getTokenOptions, removeUnusedOptions} from './token-options.js';
+
+describe('getTokenOptionName', () => {
+	it('normalizes usernames for case-insensitive lookup', () => {
+		expect(getTokenOptionName('Some-User')).toBe('personalToken-some-user');
+	});
+});
+
+describe('getTokenOptions', () => {
+	it('returns only non-empty account tokens', () => {
+		expect(getTokenOptions({
+			personalToken: 'legacy',
+			'personalToken-first': 'first-token',
+			'personalToken-empty': '',
+			logging: true,
+		})).toEqual([
+			['personalToken-first', 'first-token'],
+		]);
+	});
+});
+
+describe('getTokenForUser', () => {
+	const options = {
+		personalToken: 'legacy',
+		'personalToken-first': 'first-token',
+		'personalToken-second': 'second-token',
+	};
+
+	it('selects the token belonging to the logged-in user', () => {
+		expect(getTokenForUser(options, 'second')).toBe('second-token');
+	});
+
+	it('matches usernames case-insensitively', () => {
+		expect(getTokenForUser(
+			{'personalToken-Some-User': 'token'},
+			'SOME-USER',
+		)).toBe('token');
+	});
+
+	it('uses the legacy token when no account token matches', () => {
+		expect(getTokenForUser(options, 'third')).toBe('legacy');
+	});
+
+	it('does not use another account token on GitHub pages', () => {
+		expect(getTokenForUser(
+			{'personalToken-first': 'first-token'},
+			'second',
+		)).toBeUndefined();
+	});
+
+	it('uses an account token when no username is available', () => {
+		expect(getTokenForUser(
+			{'personalToken-first': 'first-token'},
+		)).toBe('first-token');
+	});
+});
+
+describe('removeUnusedOptions', () => {
+	it('preserves account tokens while removing unknown options', () => {
+		const options = {
+			logging: true,
+			removedFeature: true,
+			'personalToken-user': 'token',
+		};
+
+		removeUnusedOptions(options, {logging: false});
+
+		expect(options).toEqual({
+			logging: true,
+			'personalToken-user': 'token',
+		});
+	});
+});

--- a/source/github-helpers/token-options.ts
+++ b/source/github-helpers/token-options.ts
@@ -1,0 +1,68 @@
+import type {Options} from 'webext-options-sync';
+
+export const tokenOptionPrefix = 'personalToken-';
+export type TokenOptionName = `personalToken-${string}`;
+
+export function getTokenOptionName(username: string): TokenOptionName {
+	return `${tokenOptionPrefix}${username.toLowerCase()}`;
+}
+
+export function isTokenOptionName(name: string): name is TokenOptionName {
+	return name.startsWith(tokenOptionPrefix)
+		&& name.length > tokenOptionPrefix.length;
+}
+
+export function getTokenOptionUsername(name: TokenOptionName): string {
+	return name.slice(tokenOptionPrefix.length);
+}
+
+export function getTokenOptions(
+	options: Options,
+): Array<[name: TokenOptionName, token: string]> {
+	return Object.entries(options)
+		.filter(
+			(entry): entry is [TokenOptionName, string] =>
+				isTokenOptionName(entry[0])
+				&& typeof entry[1] === 'string'
+				&& entry[1].length > 0,
+		);
+}
+
+export function getTokenForUser(
+	options: Options & {personalToken?: string},
+	username?: string,
+): string | undefined {
+	if (username) {
+		const token = options[getTokenOptionName(username)];
+		if (typeof token === 'string' && token.length > 0) {
+			return token;
+		}
+
+		// Accept keys written before usernames were normalized.
+		const normalizedName = getTokenOptionName(username);
+		const matchingEntry = getTokenOptions(options)
+			.find(([name]) => name.toLowerCase() === normalizedName.toLowerCase());
+		if (matchingEntry) {
+			return matchingEntry[1];
+		}
+	}
+
+	if (options.personalToken) {
+		return options.personalToken;
+	}
+
+	// Extension pages and the background do not expose the logged-in username.
+	if (!username) {
+		return getTokenOptions(options)[0]?.[1];
+	}
+
+	return undefined;
+}
+
+export function removeUnusedOptions(options: Options, defaults: Options): void {
+	for (const key of Object.keys(options)) {
+		if (!Reflect.has(defaults, key) && !isTokenOptionName(key)) {
+			Reflect.deleteProperty(options, key);
+		}
+	}
+}

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -1,12 +1,24 @@
+import * as pageDetect from 'github-url-detection';
+import {isWebPage} from 'webext-detect';
+import type {Options} from 'webext-options-sync';
 import OptionsSyncPerDomain from 'webext-options-sync-per-domain';
 
 import {importedFeatures} from './feature-data.js';
 import renamedFeatures from './feature-renames.json' with {type: 'json'};
+import {getTokenForUser, removeUnusedOptions} from './github-helpers/token-options.js';
 
-export type RghOptions = typeof defaults;
+export type RghOptions = Options & {
+	actionUrl: string;
+	customCss: string;
+	personalToken: string;
+	logging: boolean;
+	logHttp: boolean;
+	logHTTP?: boolean;
+	customCSS?: string;
+};
 
 // eslint-disable-next-line prefer-object-spread -- TypeScript hates this one weird trick
-const defaults = Object.assign({
+const defaults: RghOptions = Object.assign({
 	actionUrl: 'https://github.com/',
 	customCss: '',
 	personalToken: '',
@@ -17,7 +29,6 @@ const defaults = Object.assign({
 
 export function isFeatureDisabled(options: RghOptions, id: string): boolean {
 	// Must check if it's specifically `false`: It could be undefined if not yet in the readme or if misread from the entry point #6606
-	// eslint-disable-next-line unicorn/no-unnecessary-boolean-comparison
 	return options[`feature:${id}`] === false;
 }
 
@@ -37,12 +48,12 @@ const migrations = [
 		}
 
 		if (options.customCSS) {
-			options.customCss = options.customCSS as unknown as string;
+			options.customCss = options.customCSS;
 		}
 	},
 
 	// Removed features will be automatically removed from the options as well
-	OptionsSyncPerDomain.migrations.removeUnused,
+	removeUnusedOptions,
 ];
 
 export const perDomainOptions = new OptionsSyncPerDomain({defaults, migrations});
@@ -52,8 +63,11 @@ export default optionsStorage;
 const cachedSettings = optionsStorage.getAll();
 
 export async function getToken(): Promise<string | undefined> {
-	const {personalToken} = await cachedSettings;
-	return personalToken;
+	const options = await cachedSettings;
+	const username = isWebPage()
+		? pageDetect.utils.getLoggedInUser()
+		: undefined;
+	return getTokenForUser(options, username);
 }
 
 export async function hasToken(): Promise<boolean> {

--- a/source/options.svelte
+++ b/source/options.svelte
@@ -22,7 +22,7 @@
 	import HotFixes from './options/hot-fixes.svelte';
 	import RateLink from './options/rate-link.svelte';
 	import StorageUsage from './options/storage-usage.svelte';
-	import TokenInput from './options/token-input.svelte';
+	import TokenInputManager from './options/token-input-manager.svelte';
 	import VersionInfo from './options/version-info.svelte';
 
 	const {domain = 'default'} = $props();
@@ -68,7 +68,7 @@
 				>the wiki.</a>
 			</p>
 			<p><strong>Token-less usage is not officially supported.</strong></p>
-			<TokenInput />
+			<TokenInputManager {domain} />
 		</details>
 	</HandleExpand>
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -40,12 +40,14 @@ function updateListDom(): void {
 	globalThis.dispatchEvent(new CustomEvent('rgh:update-count'));
 }
 
-function informComponentOfExternalUpdate(field: HTMLInputElement | HTMLTextAreaElement): void {
-	field.dispatchEvent(new InputEvent('input', {bubbles: true}));
-}
-
 assertDefined(
 	await elementReady('.js-features', {
+		stopOnDomReady: false,
+		signal: AbortSignal.timeout(1000),
+	}),
+);
+assertDefined(
+	await elementReady('[data-token-input-manager][data-ready="true"]', {
 		stopOnDomReady: false,
 		signal: AbortSignal.timeout(1000),
 	}),
@@ -53,12 +55,6 @@ assertDefined(
 
 // Update list from saved options
 const syncedForm = await perDomainOptions.syncForm('form');
-
-// <token-input> runs before the value is set, so it detects `firstRun` to avoid validation on an empty form.
-// This triggers a proper run
-for (const tokenField of $$('input[name="personalToken"]')) {
-	informComponentOfExternalUpdate(tokenField);
-}
 
 // Decorate list
 updateListDom();
@@ -75,10 +71,6 @@ syncedForm.onChange(async domain => {
 	$('a#personal-token-link').host = host;
 
 	$('rgh-options').domain = domain;
-
-	for (const input of $$('input[name="personalToken"]')) {
-		informComponentOfExternalUpdate(input);
-	}
 
 	updateListDom();
 });

--- a/source/options/token-input-manager.svelte
+++ b/source/options/token-input-manager.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import {
+		getTokenOptionName,
+		getTokenOptions,
+		getTokenOptionUsername,
+		isTokenOptionName,
+	} from '../github-helpers/token-options.js';
+	import {perDomainOptions} from '../options-storage.js';
+
+	import TokenInput from './token-input.svelte';
+
+	type TokenEntry = {
+		id: number;
+		domain: string;
+		name: string;
+		token: string;
+	};
+
+	const {domain = 'default'}: {domain?: string} = $props();
+
+	let entries = $state<TokenEntry[]>([]);
+	let ready = $state(false);
+	let loadId = 0;
+	let nextEntryId = 0;
+
+	const host = $derived(domain === 'default' ? 'github.com' : domain);
+
+	function createEntry(
+		selectedDomain: string,
+		name = '',
+		token = '',
+	): TokenEntry {
+		return {
+			id: nextEntryId++,
+			domain: selectedDomain,
+			name,
+			token,
+		};
+	}
+
+	async function getStorageForDomain(selectedDomain: string) {
+		const origins = await perDomainOptions.getAllOrigins();
+		const storage = origins.get(selectedDomain);
+		if (!storage) {
+			throw new Error(`Options storage not found for ${selectedDomain}`);
+		}
+
+		return storage;
+	}
+
+	async function loadTokens(selectedDomain: string): Promise<void> {
+		const currentLoadId = ++loadId;
+		ready = false;
+
+		const storage = await getStorageForDomain(selectedDomain);
+		const options = await storage.getAll();
+		if (currentLoadId !== loadId) {
+			return;
+		}
+
+		const loadedEntries = getTokenOptions(options)
+			.map(([name, token]) => createEntry(selectedDomain, name, token));
+		if (options.personalToken) {
+			loadedEntries.unshift(
+				createEntry(selectedDomain, 'personalToken', options.personalToken),
+			);
+		}
+
+		entries = loadedEntries.length > 0
+			? loadedEntries
+			: [createEntry(selectedDomain)];
+		ready = true;
+	}
+
+	async function saveValidatedToken(
+		entry: TokenEntry,
+		username: string,
+		token: string,
+	): Promise<void> {
+		if (entry.domain !== domain || !entries.includes(entry)) {
+			return;
+		}
+
+		const previousName = entry.name;
+		const name = getTokenOptionName(username);
+		const duplicate = entries.find(
+			item => item !== entry && item.name.toLowerCase() === name.toLowerCase(),
+		);
+
+		if (duplicate) {
+			duplicate.token = token;
+			entries = entries.filter(item => item !== entry);
+		} else {
+			entry.name = name;
+		}
+
+		const storage = await getStorageForDomain(entry.domain);
+		const options = await storage.getAll();
+		if (previousName && previousName !== name) {
+			Reflect.deleteProperty(options, previousName);
+		}
+
+		options[name] = token;
+		await storage.setAll(options);
+	}
+
+	async function removeStoredToken(entry: TokenEntry): Promise<void> {
+		const {name} = entry;
+		entry.name = '';
+		if (!name) {
+			return;
+		}
+
+		const storage = await getStorageForDomain(entry.domain);
+		const options = await storage.getAll();
+		Reflect.deleteProperty(options, name);
+		await storage.setAll(options);
+	}
+
+	async function removeEntry(entry: TokenEntry): Promise<void> {
+		entries = entries.filter(item => item !== entry);
+		await removeStoredToken(entry);
+
+		if (entries.length === 0) {
+			entries = [createEntry(domain)];
+		}
+	}
+
+	function addEntry(): void {
+		entries.push(createEntry(domain));
+	}
+
+	function getEntryUsername(entry: TokenEntry): string | undefined {
+		return isTokenOptionName(entry.name)
+			? getTokenOptionUsername(entry.name)
+			: undefined;
+	}
+
+	$effect(() => {
+		loadTokens(domain);
+	});
+</script>
+
+<div data-token-input-manager data-ready={ready}>
+	{#if ready}
+		{#each entries as entry, index (entry.id)}
+			<div class="token-entry">
+				<TokenInput
+					{host}
+					name={entry.name}
+					bind:value={entry.token}
+					onEmpty={() => removeStoredToken(entry)}
+					onValidated={(username, token) => saveValidatedToken(entry, username, token)}
+				>
+					{#snippet actions()}
+						{#if index === 0 && entry.name}
+							<button type="button" onclick={addEntry}>
+								+ {entries.length === 1 ? 'multiple users' : 'add user'}
+							</button>
+						{:else if index > 0}
+							<button type="button" onclick={() => removeEntry(entry)}>
+								- remove {
+									getEntryUsername(entry)
+									? `@${getEntryUsername(entry)}`
+									: 'user'
+								}
+							</button>
+						{/if}
+					{/snippet}
+				</TokenInput>
+			</div>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.token-entry + .token-entry {
+		margin-top: 1.5em;
+	}
+</style>

--- a/source/options/token-input.svelte
+++ b/source/options/token-input.svelte
@@ -1,20 +1,36 @@
 <script lang="ts">
 	import {closestElement} from 'select-dom';
+	import {type Snippet, tick} from 'svelte';
 	import {SvelteMap} from 'svelte/reactivity';
 	import {assertError} from 'ts-extras';
+	import type {Promisable} from 'type-fest';
 
 	import {getTokenInfo, tokenUser} from '../github-helpers/github-token.js';
 
-	const {host}: {host?: string} = $props();
+	type Props = {
+		host?: string;
+		name?: string;
+		value?: string;
+		actions?: Snippet;
+		onEmpty?: () => Promisable<void>;
+		onValidated?: (_username: string, _token: string) => Promisable<void>;
+	};
+
+	let {
+		host,
+		name = '',
+		value = $bindable(''),
+		actions,
+		onEmpty,
+		onValidated,
+	}: Props = $props();
 
 	const rtf = new Intl.RelativeTimeFormat('en', {numeric: 'auto'});
 	const apiFeaturesUrl =
 		'https://github.com/search?q=repo%3Arefined-github%2Frefined-github+%28api.js+OR+does-file-exist.js+OR+get-default-branch.js+OR+get-pr-info.js+OR+pr-ci-status.js%29+path%3A%2F%5Esource%5C%2Ffeatures%5C%2F%2F&type=code';
 
-	const initialMagicValue = ' '; // Initial non-empty value to avoid validation on first run
 	let focused = $state(false);
 	let tokenField: HTMLInputElement;
-	let tokenValue = $state(initialMagicValue);
 	let validationText = $state('');
 	let validationError = $state(false);
 	let scopes = $state<string[]>(['unknown']);
@@ -53,17 +69,14 @@
 		closestElement('details', tokenField).open = true;
 	}
 
-	async function validateToken(value: string): Promise<void> {
+	async function validateToken(token: string): Promise<void> {
+		const validatedValue = token;
 		validationText = '';
 		validationError = false;
 		scopes = ['unknown'];
 
-		// Silence first run
-		if (value === initialMagicValue) {
-			return;
-		}
-
-		if (value === '') {
+		if (token === '') {
+			await onEmpty?.();
 			expandTokenSection();
 			return;
 		}
@@ -73,9 +86,13 @@
 		try {
 			const base = getApiUrl();
 			const [tokenInfo, user] = await Promise.all([
-				getTokenInfo(base, value),
-				tokenUser.get(base, value),
+				getTokenInfo(base, token),
+				tokenUser.get(base, token),
 			]);
+
+			if (validatedValue !== value) {
+				return;
+			}
 
 			if (
 				tokenInfo.expiration
@@ -102,7 +119,14 @@
 
 			validationText = statusMessage;
 			scopes = tokenInfo.scopes;
+			await onValidated?.(user, token);
+			await tick();
+			tokenField.dispatchEvent(new InputEvent('input', {bubbles: true}));
 		} catch (error) {
+			if (validatedValue !== value) {
+				return;
+			}
+
 			assertError(error);
 			validationText = error.message + ' (expired?)';
 			validationError = true;
@@ -112,16 +136,16 @@
 	}
 
 	$effect(() => {
-		validateToken(tokenValue);
+		validateToken(value);
 	});
 </script>
 
 <p>
 	<input
 		bind:this={tokenField}
-		bind:value={tokenValue}
+		bind:value
 		type={focused ? 'text' : 'password'}
-		name="personalToken"
+		{name}
 		spellcheck="false"
 		autocomplete="off"
 		autocapitalize="off"
@@ -137,6 +161,9 @@
 	<span data-validation={validationError ? 'invalid' : undefined}>
 		{validationText}
 	</span>
+	{#if actions}
+		{@render actions()}
+	{/if}
 </p>
 <ul>
 	<li data-validation={scopeStates.get('valid_token')}>

--- a/source/welcome.svelte
+++ b/source/welcome.svelte
@@ -5,7 +5,8 @@
 	import 'webext-bugs/target-blank';
 	import {onMount} from 'svelte';
 
-	import {hasValidGitHubComToken} from './github-helpers/github-token.js';
+	import {tokenUser} from './github-helpers/github-token.js';
+	import {getTokenOptionName} from './github-helpers/token-options.js';
 	import optionsStorage from './options-storage.js';
 	import Header from './options/header.svelte';
 
@@ -31,10 +32,7 @@
 			return;
 		}
 
-		verifyToken();
-
-		// @ts-expect-error TS and its index signatures...
-		optionsStorage.set({personalToken: tokenInput});
+		verifyAndSaveToken(tokenInput);
 	});
 
 	const origins = ['https://github.com/*', 'https://gist.github.com/*'];
@@ -58,11 +56,23 @@
 		}, 1000);
 	}
 
-	async function verifyToken() {
-		if (await hasValidGitHubComToken(tokenInput)) {
+	async function verifyAndSaveToken(token: string) {
+		try {
+			const username = await tokenUser.get('https://api.github.com/', token);
+			if (token !== tokenInput) {
+				return;
+			}
+
+			await optionsStorage.set({
+				[getTokenOptionName(username)]: token,
+			});
 			stepValid = 3;
 			tokenError = '';
-		} else {
+		} catch {
+			if (token !== tokenInput) {
+				return;
+			}
+
 			tokenError = 'Invalid token';
 		}
 	}


### PR DESCRIPTION
Closes #8436

## Summary

- Store each validated token under its inferred GitHub username.
- Select the token matching the user currently logged in on the page.
- Add and remove accounts from the existing token options UI.
- Preserve legacy single-token storage and migrate it after successful validation.
- Preserve account-specific token keys during option cleanup.

## Test URLs

- https://github.com/refined-github/refined-github
- https://github.com/refined-github/refined-github/issues/8436

The token selection applies to every github.com page. I exercised the options flow in a local extension-page harness.

## Testing

- `npm test` (572 passed, 28 skipped)
- Browser-tested adding two tokens, inferred names (`personalToken-fregante` and `personalToken-otheruser`), removing the second account, and clearing the final token
- Confirmed TypeScript, Svelte diagnostics, ESLint, Biome, formatting, and the production bundle pass

## Self-review

Reviewed migration, per-domain storage, duplicate-account handling, stale async validation, legacy fallback, and cross-account token isolation.

## AI disclosure

Implemented and reviewed with OpenAI Codex under the authenticated contributor account owner’s direction.

## Required poem

My boogers are sticky, my test suite is bright;
I clear every edge case before calling it night.