### PR TITLE
`prevent-link-loss` - Workaround disappearing field Chrome bug

### DIFF
--- a/source/features/prevent-link-loss.svelte
+++ b/source/features/prevent-link-loss.svelte
@@ -41,7 +41,7 @@
 
 {#if visible}
 	<Banner
-		classes={['rgh-prevent-link-loss', 'flash-warn', 'my-2']}
+		classes={['rgh-prevent-link-loss', 'flash-warn', 'mt-2']}
 		icon={AlertIcon}
 	>
 		{#snippet text()}
@@ -60,6 +60,6 @@
 <style>
 	/* Old views (PRs) require extra margin #9402  */
 	:global(file-attachment ~ .rgh-prevent-link-loss) {
-		margin-inline: 10px !important;
+		margin: 0 8px !important;
 	}
 </style>

--- a/source/features/prevent-link-loss.svelte
+++ b/source/features/prevent-link-loss.svelte
@@ -60,6 +60,6 @@
 <style>
 	/* Old views (PRs) require extra margin #9402  */
 	:global(file-attachment ~ .rgh-prevent-link-loss) {
-		margin: 0 8px !important;
+		margin: 0 8px 8px !important;
 	}
 </style>

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -14,12 +14,11 @@ function attach(field: HTMLTextAreaElement): void {
 		// Editing PR body
 		'.CommentBox',
 	], field);
-	mount(Banner, {
-		target,
-		props: {
-			field,
-		},
-	});
+
+	const wrapper = document.createElement('div');
+	target.after(wrapper);
+
+	mount(Banner, { target: wrapper, props: { field } });
 }
 
 function init(signal: AbortSignal): void {

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -15,9 +15,23 @@ function attach(field: HTMLTextAreaElement): void {
 		'.CommentBox',
 	], field);
 
+	if (target instanceof HTMLFieldSetElement) {
+		// On the new Markdown editor mounting a child directly inside the `fieldset` collapses
+		// its height to 0, hiding the textarea entirely. Mounting as a sibling instead avoids the issues.
+		// https://github.com/refined-github/refined-github/issues/9955
+		mount(Banner, {
+			target: target.parentElement!,
+			anchor: target.nextSibling ?? undefined, props: {field},
+		});
+
+		return;
+	}
+
+	// Old Markdown editor doesn't have this bug, so we can keep mounting inside it.
+	// This also preserve the extra margin for old views (PR)
 	mount(Banner, {
-		target: target.parentElement!,
-		anchor: target.nextSibling ?? undefined, props: {field},
+		target,
+		props: {field},
 	});
 }
 

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -1,5 +1,5 @@
 import * as pageDetect from 'github-url-detection';
-import {closestElement} from 'select-dom';
+import {$optional, closestElement} from 'select-dom';
 import {mount} from 'svelte';
 
 import features from '../feature-manager.js';
@@ -9,28 +9,16 @@ import Banner from './prevent-link-loss.svelte';
 function attach(field: HTMLTextAreaElement): void {
 	const target = closestElement([
 		// Almost everywhere
-		'fieldset',
+		// Don't use only `fieldset` https://github.com/refined-github/refined-github/issues/9955
+		'*:has(> fieldset)',
 
 		// Editing PR body
 		'.CommentBox',
 	], field);
 
-	if (target instanceof HTMLFieldSetElement) {
-		// On the new Markdown editor mounting a child directly inside the `fieldset` collapses
-		// its height to 0, hiding the textarea entirely. Mounting as a sibling instead avoids the issues.
-		// https://github.com/refined-github/refined-github/issues/9955
-		mount(Banner, {
-			target: target.parentElement!,
-			anchor: target.nextSibling ?? undefined, props: {field},
-		});
-
-		return;
-	}
-
-	// Old Markdown editor doesn't have this bug, so we can keep mounting inside it.
-	// This also preserve the extra margin for old views (PR)
 	mount(Banner, {
 		target,
+		anchor: $optional(':scope > fieldset + *', target), // After fieldset, if found
 		props: {field},
 	});
 }

--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -15,10 +15,10 @@ function attach(field: HTMLTextAreaElement): void {
 		'.CommentBox',
 	], field);
 
-	const wrapper = document.createElement('div');
-	target.after(wrapper);
-
-	mount(Banner, { target: wrapper, props: { field } });
+	mount(Banner, {
+		target: target.parentElement!,
+		anchor: target.nextSibling ?? undefined, props: {field},
+	});
 }
 
 function init(signal: AbortSignal): void {


### PR DESCRIPTION
`prevent-link-loss` was mounting its banner directly inside the closest `fieldset` or `.CommentBox` element. That result on github to a markdown editor with height at 0 hiding the comment textarea.

Closes: https://github.com/refined-github/refined-github/issues/9955

Tested on Safari, Chrome and Firefox

## Test done to make my fix

The height will be 0 if we put the Banner direclty inside the target.

```tsx
function attach(field: HTMLTextAreaElement): void {
	const target = closestElement([
		// Almost everywhere
		'fieldset',

		// Editing PR body
		'.CommentBox',
	], field);

	const before = target.getBoundingClientRect().height;
	
	mount(Banner, {
		target,
		props: {field},
	});

	requestAnimationFrame(() => {
		const after = target.getBoundingClientRect().height;
		const textareaRect = field.getBoundingClientRect();

		console.log(
			'target:', target.tagName, target.className,
			'height before:', before,
			'height after:', after,
			'textarea rect after:', textareaRect,
		);
	});
}
```

Will result to :
``target: FIELDSET MarkdownEditor-module__fieldSet__RU0NL height before: 215.38284301757812 height after: 0 textarea rect after: DOMRect``

CF : **height after: 0**

So the easier fix was to mount the banner as a sibling of the target instead of inside it

## Test URLs
I will test with this link in my GIF : `https://github.com/refined-github/refined-github/pull/6954/commits/32d1c8b2e1b6971709fe273cfdd1f959b51e8d85`

- New issue form: https://github.com/refined-github/refined-github/issues/new?assignees=&labels=bug&projects=&template=1_bug_report.yml
- New comment form: https://github.com/refined-github/sandbox/issues/3
- New review form: https://github.com/refined-github/sandbox/pull/4/files#review-changes-modal
- New review comment form: https://github.com/refined-github/sandbox/pull/4/files

## Screenshot / GIF

Sorry for the screens they are at zoom 100% not 200% to see the entire feature. Hope this is still good

### New issue form

<img width="800" height="413" alt="CleanShot 2026-08-11 at 21 19 00" src="https://github.com/user-attachments/assets/b6744c78-cb20-4ca9-96fa-6cc5657587d4" />

### New comment form

<img width="800" height="413" alt="CleanShot 2026-08-11 at 21 19 48" src="https://github.com/user-attachments/assets/b51d66bf-2346-4189-a7d8-0f4f6dc86f19" />

### New review form

<img width="800" height="413" alt="CleanShot 2026-08-11 at 21 20 43" src="https://github.com/user-attachments/assets/7072fa8e-e671-46e0-baf2-85ea046a130f" />

### New review comment form

<img width="800" height="413" alt="CleanShot 2026-08-11 at 21 21 40" src="https://github.com/user-attachments/assets/1e6a8e44-8871-48af-b5c2-0b74434fdc84" />
