### PR TITLE
`linkify-text` - Avoid error in organization Discussions

### DIFF
--- a/source/features/linkify-text.tsx
+++ b/source/features/linkify-text.tsx
@@ -29,6 +29,9 @@ function init(signal: AbortSignal): void {
 }
 
 void features.add(import.meta.url, {
+	asLongAs: [
+		pageDetect.isRepo,
+	],
 	include: [
 		pageDetect.isPR,
 		pageDetect.isIssue,


### PR DESCRIPTION
`isDiscussion` cover repo discussions and org discussions. This is the only feature that exclusively supports repos since there are no "org issues" to linkify.

Orgs have projects but they link to org repo issues: https://github.com/orgs/twbs/projects/38


## Test URLs

https://github.com/orgs/community/discussions/204563

## Screenshot

<img width="513" height="145" alt="Screenshot" src="https://github.com/user-attachments/assets/5ff9a1c6-88e6-4807-910a-a50f5bf696a8" />
