### PR TITLE
`sticky-comment-header` - Remove rounded corners when stuck

### DIFF
--- a/source/features/sticky-comment-header.css
+++ b/source/features/sticky-comment-header.css
@@ -15,6 +15,7 @@ html:not([rgh-OFF-sticky-comment-header]) {
 		/* PR header */
 		.timeline-comment-header {
 			position: sticky;
+			container-type: scroll-state; /* eslint-disable-line css/no-invalid-properties -- Supported since Chrome 133 */
 			/* Prevent header from being covered by media */
 			z-index: 3;
 			/* `base-sticky-header-height` is applied when coming from notifications. Missing otherwise */
@@ -34,6 +35,17 @@ html:not([rgh-OFF-sticky-comment-header]) {
 				background: /*  eslint-disable-next-line css/no-invalid-properties -- Buggy https://github.com/eslint/css/issues/434 */
 					linear-gradient(var(--rgh-bg-accent), var(--rgh-bg-accent)),
 					var(--rgh-background);
+			}
+
+			@container scroll-state(stuck: top) {
+				/* Container queries only style descendants, so fill the rounded corners from behind. */
+				&::before {
+					position: absolute;
+					inset: 0;
+					z-index: -1;
+					background: inherit;
+					content: '';
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #9973

The sticky comment header keeps its rounded top corners after reaching the viewport edge, which leaves visible gaps above the header. This adds a scroll-state container query and paints an inherited background behind those corners only while the header is actually stuck.

A pseudo-element is used because a container query cannot style its own query container. Browsers without scroll-state query support keep the existing appearance as a progressive fallback.

## Test URLs

- https://github.com/refined-github/sandbox/issues/117

## Screenshot

Before scrolling:

![The comment header has rounded top corners before it becomes sticky](https://litter.catbox.moe/wy5dh3.png)

After the header becomes sticky:

![The stuck comment header has square top corners and no gaps](https://litter.catbox.moe/f8ci2s.png)

This change was AI-assisted and then reviewed in the built extension on Chrome for Testing 152. The full project test suite passes with 564 tests passed and 28 skipped.
