### PR TITLE
AI SPAM

### DIFF
--- a/source/github-helpers/index.test.ts
+++ b/source/github-helpers/index.test.ts
@@ -1,6 +1,12 @@
-import {assert, test} from 'vitest';
+import {assert, test, vi} from 'vitest';
 
-import {getConversationNumber, getLatestVersionTag, isUsernameAlreadyFullName, parseTag} from './index.js';
+import {
+	getConversationNumber,
+	getLatestVersionTag,
+	isUsernameAlreadyFullName,
+	parseTag,
+	scrollIntoViewIfNeeded,
+} from './index.js';
 
 test('getConversationNumber', () => {
 	const pairs = new Map<string, number | undefined>([
@@ -127,4 +133,14 @@ test('getLatestVersionTag', () => {
 		'lol v0.0.0',
 		'Non-version tags should short-circuit the sorting and return the first tag',
 	);
+});
+
+test('scrollIntoViewIfNeeded uses nearest alignment as the Firefox fallback', () => {
+	const element = document.createElement('div');
+	const scrollIntoView = vi.fn();
+	element.scrollIntoView = scrollIntoView;
+
+	scrollIntoViewIfNeeded(element);
+
+	assert.deepEqual(scrollIntoView.mock.calls, [[{block: 'nearest'}]]);
 });

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -191,8 +191,12 @@ export function multilineAriaLabel(...lines: string[]): string {
 }
 
 export function scrollIntoViewIfNeeded(element: Element): void {
-	// @ts-expect-error No Firefox support https://developer.mozilla.org/docs/Web/API/Element/scrollIntoViewIfNeeded
-	(element.scrollIntoViewIfNeeded ?? element.scrollIntoView).call(element);
+	const scrollIfNeeded = (element as Element & {scrollIntoViewIfNeeded?: () => void}).scrollIntoViewIfNeeded;
+	if (scrollIfNeeded) {
+		scrollIfNeeded.call(element);
+	} else {
+		element.scrollIntoView({block: 'nearest'});
+	}
 }
 
 export function getConversationBody(): Element {


### PR DESCRIPTION
  Closes #9981

Firefox does not support the non-standard `scrollIntoViewIfNeeded()` method, so the helper fell back to calling `scrollIntoView()` without options. Its default `block: "start"` alignment could scroll the whole document while focusing the active file in the repository sidebar.

This uses the standard `block: "nearest"` alignment for the fallback. Chromium keeps using its native `scrollIntoViewIfNeeded()` implementation unchanged.

A focused regression test was added before the implementation change. It failed against `main` because the fallback received no options, then passed after the fix.

## Test URLs

- https://github.com/refined-github/refined-github/blob/main/source/features/mark-private-repos.css
- https://github.com/refined-github/refined-github/tree/main/test/web-ext-profile

## Screenshot

Not included: the change prevents an unintended page-position jump and is covered at the browser-API boundary by the regression test.

## Validation

- `npm run vitest -- source/github-helpers/index.test.ts` (5 passed)
- `npm test` (565 passed, 28 skipped; lint, type checks, Svelte checks, and bundle build passed)
- `npm run format:check`
- `git diff --check`

This pull request was developed with AI assistance and reviewed against the repository's contribution instructions.

## Booger poem

A booger nudged the page astray,  
Nearest alignment held its place all day.
