### PR TITLE
AI SPAM

### DIFF
--- a/source/features/locked-issue.tsx
+++ b/source/features/locked-issue.tsx
@@ -13,7 +13,7 @@ export const {class: featureClass, selector: featureSelector} = getIdentifiers(i
 
 function LockedIndicator(): JSX.Element {
 	return (
-		<span title="Locked" className={cx('State d-flex flex-items-center flex-shrink-0', featureClass)}>
+		<span title="Locked" className={cx('prc-StateLabel prc-StateLabel--medium d-flex flex-items-center flex-shrink-0', featureClass)}>
 			<LockIcon className="flex-items-center mr-1 tmp-mr-1" />
 			Locked
 		</span>

--- a/source/locked-issue.test.ts
+++ b/source/locked-issue.test.ts
@@ -1,0 +1,9 @@
+import {readFileSync} from 'node:fs';
+
+import {expect, test} from 'vitest';
+
+test('renders the locked indicator with GitHub’s medium StateLabel classes', () => {
+	const source = readFileSync('source/features/locked-issue.tsx', 'utf8');
+
+	expect(source).toContain("'prc-StateLabel prc-StateLabel--medium");
+});


### PR DESCRIPTION
## Summary

- render the locked conversation indicator with GitHub’s medium `StateLabel` classes
- add a regression test for the required classes

Fixes #9911

## Test URLs

- https://github.com/refined-github/sandbox/issues/74
- https://github.com/refined-github/sandbox/pull/48

## Verification

- `npm run vitest -- source/locked-issue.test.ts`
- `npm run vitest`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `git diff --check`