### PR TITLE
fix(feature-manager): mark token-requiring features OFF when token is missing

### DIFF
--- a/source/feature-manager.tsx
+++ b/source/feature-manager.tsx
@@ -216,7 +216,16 @@ async function add(url: string, ...loaders: FeatureLoader[]): Promise<void> {
 			}
 
 			if (requiresToken) {
-				await expectToken();
+				try {
+					await expectToken();
+				} catch {
+					// No token: mark the feature as OFF so its CSS rules (e.g.
+					// repo-header-info's `html:not([rgh-OFF-…])` spacer) don't reserve
+					// space for content that will never render. Wait for the next
+					// navigation so a token added in the meantime gets picked up.
+					document.documentElement.setAttribute('rgh-OFF-' + id, '');
+					continue;
+				}
 			}
 
 			const featureController = new AbortController();


### PR DESCRIPTION
Fixes #9986 — `repo-header-info` leaves ~6em of dead space in the breadcrumbs when no personal token is configured.

## What's happening

- `repo-header-info.css` reserves `padding-right: 6em` on the last breadcrumb **while the feature loads**, and only releases it once the feature runs (by adding `rgh-repo-header-info-updated`).
- When there's no token, `expectToken()` in the feature-manager throws **before** the feature ever runs — so the spacer is reserved and never released.

## The fix

When a `requiresToken` feature can't run because `expectToken()` rejects, the feature-manager now sets the same `rgh-OFF-<feature>` attribute that the disabled CSS-only path already uses. Rules guarded by `html:not([rgh-OFF-repo-header-info])` stop applying, so the breadcrumb spacer collapses instead of staying empty.

It `continue`s to the next navigation event, so if the user adds a token later it gets picked up on the next page load (same re-check cadence as the existing CSS-only OFF loop).

## Verified

- `tsc --noEmit` clean
- `eslint .` + `biome lint` clean
- `npm run vitest` → 564 passed / 28 skipped

No UI change when a token **is** present (attribute only set on the missing-token path).