### PR TITLE
`conversation-activity-filter`: race condition

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -115,13 +115,7 @@ function processItem(item: HTMLElement): void {
 }
 
 function applyState(targetState: State): void {
-	const container = $([
-		// PR
-		'[class^="prc-PageLayout-PageLayoutWrapper"]',
-		// Issue
-		'[class*="IssueViewer-module__mainContainer"]',
-	]);
-	container.setAttribute('data-rgh-conversation-activity-filter', targetState);
+	$('#repo-content-pjax-container').setAttribute('data-rgh-conversation-activity-filter', targetState);
 
 	activityFilterState.set(targetState);
 	SessionPageSetting.set(targetState);


### PR DESCRIPTION
I'm running into what seems to be a race condition, where resolved comments are loaded into the page after the activity-filter triggers, and they end up still showing

**browser**: zen browser 1.21.9b
**os**: NixOS

the fix in this PR works for me, though I'm not fully sure it should be necessary, or if it's the best approach


screenshot **before the fix**
<img width="1036" height="638" alt="image" src="https://github.com/user-attachments/assets/40c83f77-e805-45b9-b6db-cc2039bf02eb" />

the linear and vercel bot comments are hidden if I toggle the behavior. but after a hard refresh they consistently appear
with this fix they get consistently hidden


disclaimer: claude code used to help onboard myself to the repo and debug this. all the writing and manual testing is my own