### PR TITLE
`clean-repo-sidebar` - Restore feature

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,6 +1,9 @@
 [rgh-clean-repo-sidebar] [class*='PageLayout-Pane'] {
 	/* Hide "About" header */
-	.BorderGrid-row:first-child h2 {
+	:is(
+		.BorderGrid-row:first-child h2,
+		[class*='SidebarSection-module__sidebarSection']:first-child > h2
+	) {
 		display: none;
 	}
 
@@ -10,7 +13,10 @@
 	}
 
 	/* Align the top of the repo root sidebar with the main page content */
-	.BorderGrid-row:first-child h2 + p.f4 {
+	:is(
+		.BorderGrid-row:first-child h2 + p.f4,
+		[class*='SidebarSection-module__sidebarSection']:first-child > h2 + p
+	) {
 		margin-top: 0 !important;
 	}
 
@@ -27,8 +33,11 @@
 	 * Hide "+ 123 contributors" link
 	 * Don't hide "Create new release" link #8442
 	 */
-	.BorderGrid-cell
-		> div:is(.tmp-mt-3, .mt-3):has(> a:not([href$='releases/new'])) {
+	:is(
+		.BorderGrid-cell
+			> div:is(.tmp-mt-3, .mt-3):has(> a:not([href$='releases/new'])),
+		[class*='SidebarSection-module__moreLink']
+	) {
 		display: none;
 	}
 
@@ -38,5 +47,10 @@
 		[href$='/code_of_conduct.md' i] {
 			display: none;
 		}
+	}
+
+	[class*='SidebarSection-module__sidebarSection']
+		:is([href$='/code-of-conduct.md' i], [href$='/code_of_conduct.md' i]) {
+		display: none;
 	}
 }

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,54 +1,24 @@
 [rgh-clean-repo-sidebar] [class*='PageLayout-Pane'] {
 	/* Hide "About" header */
-	:is(
-		.BorderGrid-row:first-child h2,
-		[class*='SidebarSection-module__sidebarSection']:first-child > h2
-	) {
-		display: none;
-	}
-
-	/* Hide "Packages" if empty */
-	.BorderGrid-row:has(a[href*='/packages?repo_name'] .Counter[title='0']) {
+	[class*='SidebarSection-module__sidebarSection']:first-child > h2 {
 		display: none;
 	}
 
 	/* Align the top of the repo root sidebar with the main page content */
-	:is(
-		.BorderGrid-row:first-child h2 + p.f4,
-		[class*='SidebarSection-module__sidebarSection']:first-child > h2 + p
-	) {
+	[class*='SidebarSection-module__sidebarSection']:first-child > h2 + p {
 		margin-top: 0 !important;
-	}
-
-	@media (width >= 768px) {
-		/* Align data section with latest tag/release link #5428 */
-		.Link--muted .octicon {
-			margin-right: 4px !important;
-		}
 	}
 
 	/*
 	 * Hide "+ 65 releases" link
 	 * Hide "Learn more about GitHub Sponsors" link
 	 * Hide "+ 123 contributors" link
-	 * Don't hide "Create new release" link #8442
 	 */
-	:is(
-		.BorderGrid-cell
-			> div:is(.tmp-mt-3, .mt-3):has(> a:not([href$='releases/new'])),
-		[class*='SidebarSection-module__moreLink']
-	) {
+	[class*='SidebarSection-module__moreLink'] {
 		display: none;
 	}
 
 	/* Hide Code of conduct links */
-	.Link--muted {
-		[href$='/code-of-conduct.md' i],
-		[href$='/code_of_conduct.md' i] {
-			display: none;
-		}
-	}
-
 	[class*='SidebarSection-module__sidebarSection']
 		:is([href$='/code-of-conduct.md' i], [href$='/code_of_conduct.md' i]) {
 		display: none;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -21,6 +21,11 @@ function cleanSidebarSection(section: HTMLElement): void {
 		return;
 	}
 
+	const emptyMeta = $optional('[class*="SidebarAbout-module__noDescription"]', section);
+	if (emptyMeta && !pageDetect.canUserAccessRepoSettings()) {
+		emptyMeta.remove();
+	}
+
 	// Your own repos don't include this link
 	const reportLink = $optional('a[href^="/contact/report-content"]', section);
 	if (reportLink) {
@@ -50,5 +55,6 @@ Test URLs:
 - Repo with 1 package: https://github.com/recyclarr/recyclarr
 - Repo with tags but not releases: https://github.com/fregante/bin-dir
 - Repo with no tags: https://github.com/refined-github/yolo
+- Repo with no description: https://github.com/shadcn/Ant
 
 */

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -9,7 +9,7 @@ import {assertNodeContent} from '../helpers/dom-utils.js';
 
 // The h2 is to avoid hiding website links that include '/releases' #4424
 async function cleanReleases(signal: AbortSignal): Promise<void> {
-	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] :is(.BorderGrid-cell, [class*="SidebarSection-module__sidebarSection"]) h2 a[href$="/releases"]', {
+	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"] h2 a[href$="/releases"]', {
 		signal,
 		stopOnDomReady: false,
 		waitForChildren: false,
@@ -18,10 +18,7 @@ async function cleanReleases(signal: AbortSignal): Promise<void> {
 		return;
 	}
 
-	const releasesSection = closestElement([
-		'.BorderGrid-cell', // Legacy repository sidebar
-		'[class*="SidebarSection-module__sidebarSection"]', // React repository sidebar
-	], sidebarReleases);
+	const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
 	if (
 		// Hide the whole section if there's no releases
 		!elementExists('.octicon-tag', releasesSection)
@@ -33,11 +30,7 @@ async function cleanReleases(signal: AbortSignal): Promise<void> {
 }
 
 async function hideLanguageHeader(signal: AbortSignal): Promise<void> {
-	const languageHeaderSelector = [
-		"[class*='PageLayout-Pane'] .BorderGrid-row:has(.Progress-item) h2", // Legacy repository sidebar
-		"[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", // React repository sidebar
-	].join(', ');
-	const languageHeader = await elementReady(languageHeaderSelector, {
+	const languageHeader = await elementReady("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", {
 		signal,
 		stopOnDomReady: false,
 		waitForChildren: false,
@@ -50,23 +43,13 @@ async function hideLanguageHeader(signal: AbortSignal): Promise<void> {
 	languageHeader.classList.add('sr-only');
 }
 
-// Hide empty meta if it’s not editable by the current user
-async function hideEmptyMeta(): Promise<void> {
-	await domLoaded;
-
-	if (!pageDetect.canUserAccessRepoSettings()) {
-		// Selector only matches if it's empty
-		$optional("[class*='PageLayout-Pane'] .BorderGrid-cell > .text-italic")?.remove();
-	}
-}
-
 async function moveReportLink(): Promise<void> {
 	await domLoaded;
 
 	// Your own repos don't include this link
 	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
 	if (reportLink) {
-		$("[class*='PageLayout-Pane'] :is(.BorderGrid-row:last-of-type .BorderGrid-cell, [class*='SidebarSection-module__sidebarSection']:last-child)").append(reportLink);
+		$("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child").append(reportLink);
 	}
 }
 
@@ -83,7 +66,6 @@ void features.add(import.meta.url, {
 		init,
 		cleanReleases,
 		hideLanguageHeader,
-		hideEmptyMeta,
 		moveReportLink,
 	],
 });

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -24,7 +24,7 @@ function cleanSidebarSection(section: HTMLElement): void {
 	const emptyMeta = $optional('[class*="SidebarAbout-module__noDescription"]', section);
 	if (emptyMeta && !pageDetect.canUserAccessRepoSettings()) {
 		emptyMeta.remove();
-		return;
+		// Don't return here because the next condition applies to the same block
 	}
 
 	// Your own repos don't include this link

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -8,16 +8,20 @@ import features from '../feature-manager.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
 
 // The h2 is to avoid hiding website links that include '/releases' #4424
-// It's broken: https://github.com/refined-github/refined-github/issues/9339
-async function cleanReleases(): Promise<void> {
-	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] .BorderGrid-cell h2 a[href$="/releases"]', {
+async function cleanReleases(signal: AbortSignal): Promise<void> {
+	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] :is(.BorderGrid-cell, [class*="SidebarSection-module__sidebarSection"]) h2 a[href$="/releases"]', {
+		signal,
+		stopOnDomReady: false,
 		waitForChildren: false,
 	});
 	if (!sidebarReleases) {
 		return;
 	}
 
-	const releasesSection = closestElement('.BorderGrid-cell', sidebarReleases);
+	const releasesSection = closestElement([
+		'.BorderGrid-cell', // Legacy repository sidebar
+		'[class*="SidebarSection-module__sidebarSection"]', // React repository sidebar
+	], sidebarReleases);
 	if (
 		// Hide the whole section if there's no releases
 		!elementExists('.octicon-tag', releasesSection)
@@ -28,10 +32,20 @@ async function cleanReleases(): Promise<void> {
 	}
 }
 
-async function hideLanguageHeader(): Promise<void> {
-	await domLoaded;
+async function hideLanguageHeader(signal: AbortSignal): Promise<void> {
+	const languageHeaderSelector = [
+		"[class*='PageLayout-Pane'] .BorderGrid-row:has(.Progress-item) h2", // Legacy repository sidebar
+		"[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", // React repository sidebar
+	].join(', ');
+	const languageHeader = await elementReady(languageHeaderSelector, {
+		signal,
+		stopOnDomReady: false,
+		waitForChildren: false,
+	});
+	if (!languageHeader) {
+		return;
+	}
 
-	const languageHeader = $("[class*='PageLayout-Pane'] .BorderGrid-row:has(.Progress-item) h2");
 	assertNodeContent(languageHeader.firstChild, 'Languages');
 	languageHeader.classList.add('sr-only');
 }
@@ -52,7 +66,7 @@ async function moveReportLink(): Promise<void> {
 	// Your own repos don't include this link
 	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
 	if (reportLink) {
-		$("[class*='PageLayout-Pane'] .BorderGrid-row:last-of-type .BorderGrid-cell").append(reportLink);
+		$("[class*='PageLayout-Pane'] :is(.BorderGrid-row:last-of-type .BorderGrid-cell, [class*='SidebarSection-module__sidebarSection']:last-child)").append(reportLink);
 	}
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -24,6 +24,7 @@ function cleanSidebarSection(section: HTMLElement): void {
 	const emptyMeta = $optional('[class*="SidebarAbout-module__noDescription"]', section);
 	if (emptyMeta && !pageDetect.canUserAccessRepoSettings()) {
 		emptyMeta.remove();
+		return;
 	}
 
 	// Your own repos don't include this link

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -1,62 +1,41 @@
 import './clean-repo-sidebar.css';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {$optional, closestElement, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
+import observe from '../helpers/selector-observer.js';
 
 // The h2 is to avoid hiding website links that include '/releases' #4424
-async function cleanReleases(signal: AbortSignal): Promise<void> {
-	const sidebarReleases = await elementReady('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"] h2 a[href$="/releases"]', {
-		signal,
-		stopOnDomReady: false,
-		waitForChildren: false,
-	});
-	if (!sidebarReleases) {
-		return;
-	}
-
-	const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
-	if (
-		// Hide the whole section if there's no releases
-		!elementExists('.octicon-tag', releasesSection)
-		// Don't hide the section if it has a "Create new release" link
-		&& !elementExists('a[href$="releases/new"]', releasesSection)
-	) {
-		releasesSection.hidden = true;
-	}
+function cleanReleases(signal: AbortSignal): void {
+	observe('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]:not(:has([data-component="SkeletonText"])) h2 a[href$="/releases"]', sidebarReleases => {
+		const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
+		if (
+			// Hide the whole section if there's no releases
+			!elementExists('.octicon-tag', releasesSection)
+			// Don't hide the section if it has a "Create new release" link
+			&& !elementExists('a[href$="releases/new"]', releasesSection)
+		) {
+			releasesSection.hidden = true;
+		}
+	}, {signal, once: true});
 }
 
-async function hideLanguageHeader(signal: AbortSignal): Promise<void> {
-	const languageHeader = await elementReady("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", {
-		signal,
-		stopOnDomReady: false,
-		waitForChildren: false,
-	});
-	if (!languageHeader) {
-		return;
-	}
-
-	assertNodeContent(languageHeader.firstChild, 'Languages');
-	languageHeader.classList.add('sr-only');
+function hideLanguageHeader(signal: AbortSignal): void {
+	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", languageHeader => {
+		assertNodeContent(languageHeader.firstChild, 'Languages');
+		languageHeader.classList.add('sr-only');
+	}, {signal, once: true});
 }
 
-async function moveReportLink(signal: AbortSignal): Promise<void> {
-	const lastSection = await elementReady("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", {
-		signal,
-		stopOnDomReady: false,
-		waitForChildren: false,
-	});
-	if (!lastSection) {
-		return;
-	}
-
-	// Your own repos don't include this link
-	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
-	if (reportLink) {
-		lastSection.append(reportLink);
-	}
+function moveReportLink(signal: AbortSignal): void {
+	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", lastSection => {
+		// Your own repos don't include this link
+		const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
+		if (reportLink) {
+			lastSection.append(reportLink);
+		}
+	}, {signal, once: true});
 }
 
 async function init(): Promise<void> {
@@ -67,7 +46,6 @@ void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoRoot,
 	],
-	deduplicate: 'has-rgh-inner',
 	init: [
 		init,
 		cleanReleases,

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -6,52 +6,45 @@ import features from '../feature-manager.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
-// The h2 is to avoid hiding website links that include '/releases' #4424
-function cleanReleases(signal: AbortSignal): void {
-	observe('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]:not(:has([data-component="SkeletonText"])) h2 a[href$="/releases"]', sidebarReleases => {
-		const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
-		if (
-			// Hide the whole section if there's no releases
-			!elementExists('.octicon-tag', releasesSection)
-			// Don't hide the section if it has a "Create new release" link
-			&& !elementExists('a[href$="releases/new"]', releasesSection)
-		) {
-			releasesSection.hidden = true;
-		}
-	}, {signal, once: true});
+function cleanReleases(sidebarReleases: HTMLElement): void {
+	const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
+	if (
+		// Hide the whole section if there's no releases
+		!elementExists('.octicon-tag', releasesSection)
+		// Don't hide the section if it has a "Create new release" link
+		&& !elementExists('a[href$="releases/new"]', releasesSection)
+	) {
+		releasesSection.hidden = true;
+	}
 }
 
-function hideLanguageHeader(signal: AbortSignal): void {
-	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", languageHeader => {
-		assertNodeContent(languageHeader.firstChild, 'Languages');
-		languageHeader.classList.add('sr-only');
-	}, {signal, once: true});
+function hideLanguageHeader(languageHeader: HTMLElement): void {
+	assertNodeContent(languageHeader.firstChild, 'Languages');
+	languageHeader.classList.add('sr-only');
 }
 
-function moveReportLink(signal: AbortSignal): void {
-	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", lastSection => {
-		// Your own repos don't include this link
-		const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
-		if (reportLink) {
-			lastSection.append(reportLink);
-		}
-	}, {signal, once: true});
+function moveReportLink(lastSection: HTMLElement): void {
+	// Your own repos don't include this link
+	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
+	if (reportLink) {
+		lastSection.append(reportLink);
+	}
 }
 
-async function init(): Promise<void> {
+async function init(signal: AbortSignal): Promise<void> {
 	document.documentElement.setAttribute('rgh-clean-repo-sidebar', '');
+
+	// The h2 is to avoid hiding website links that include '/releases' #4424
+	observe('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]:not(:has([data-component="SkeletonText"])) h2 a[href$="/releases"]', cleanReleases, {signal, once: true});
+	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", hideLanguageHeader, {signal, once: true});
+	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", moveReportLink, {signal, once: true});
 }
 
 void features.add(import.meta.url, {
 	include: [
 		pageDetect.isRepoRoot,
 	],
-	init: [
-		init,
-		cleanReleases,
-		hideLanguageHeader,
-		moveReportLink,
-	],
+	init,
 });
 
 /*

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -1,8 +1,7 @@
 import './clean-repo-sidebar.css';
-import domLoaded from 'dom-loaded';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
-import {$, $optional, closestElement, elementExists} from 'select-dom';
+import {$optional, closestElement, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
@@ -43,13 +42,20 @@ async function hideLanguageHeader(signal: AbortSignal): Promise<void> {
 	languageHeader.classList.add('sr-only');
 }
 
-async function moveReportLink(): Promise<void> {
-	await domLoaded;
+async function moveReportLink(signal: AbortSignal): Promise<void> {
+	const lastSection = await elementReady("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", {
+		signal,
+		stopOnDomReady: false,
+		waitForChildren: false,
+	});
+	if (!lastSection) {
+		return;
+	}
 
 	// Your own repos don't include this link
 	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
 	if (reportLink) {
-		$("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child").append(reportLink);
+		lastSection.append(reportLink);
 	}
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -1,43 +1,37 @@
 import './clean-repo-sidebar.css';
 import * as pageDetect from 'github-url-detection';
-import {$optional, closestElement, elementExists} from 'select-dom';
+import {$, $optional, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import {assertNodeContent} from '../helpers/dom-utils.js';
 import observe from '../helpers/selector-observer.js';
 
-function cleanReleases(sidebarReleases: HTMLElement): void {
-	const releasesSection = closestElement('[class*="SidebarSection-module__sidebarSection"]', sidebarReleases);
-	if (
-		// Hide the whole section if there's no releases
-		!elementExists('.octicon-tag', releasesSection)
-		// Don't hide the section if it has a "Create new release" link
-		&& !elementExists('a[href$="releases/new"]', releasesSection)
-	) {
-		releasesSection.hidden = true;
+function cleanSidebarSection(section: HTMLElement): void {
+	// The h2 is to avoid hiding website links that include '/releases' #4424
+	// Hide the whole section if there's no releases, unless it has a "Create new release" link
+	if (elementExists('h2 a[href$="/releases"]', section) && !elementExists('.octicon-tag, a[href$="releases/new"]', section)) {
+		section.hidden = true;
+		return;
 	}
-}
 
-function hideLanguageHeader(languageHeader: HTMLElement): void {
-	assertNodeContent(languageHeader.firstChild, 'Languages');
-	languageHeader.classList.add('sr-only');
-}
+	const languageHeader = $optional(':scope > h2', section);
+	if (languageHeader && elementExists('[data-component="ProgressBar"]', section)) {
+		assertNodeContent(languageHeader.firstChild, 'Languages');
+		languageHeader.classList.add('sr-only');
+		return;
+	}
 
-function moveReportLink(lastSection: HTMLElement): void {
 	// Your own repos don't include this link
-	const reportLink = $optional("[class*='PageLayout-Pane'] a[href^='/contact/report-content']")?.parentElement;
+	const reportLink = $optional('a[href^="/contact/report-content"]', section);
 	if (reportLink) {
-		lastSection.append(reportLink);
+		$('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]:last-child').append(reportLink.parentElement!);
 	}
 }
 
 async function init(signal: AbortSignal): Promise<void> {
 	document.documentElement.setAttribute('rgh-clean-repo-sidebar', '');
 
-	// The h2 is to avoid hiding website links that include '/releases' #4424
-	observe('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]:not(:has([data-component="SkeletonText"])) h2 a[href$="/releases"]', cleanReleases, {signal, once: true});
-	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:has([data-component='ProgressBar']) > h2", hideLanguageHeader, {signal, once: true});
-	observe("[class*='PageLayout-Pane'] [class*='SidebarSection-module__sidebarSection']:last-child:not(:has([data-component='SkeletonText']))", moveReportLink, {signal, once: true});
+	observe('[class*="PageLayout-Pane"] [class*="SidebarSection-module__sidebarSection"]', cleanSidebarSection, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
Closes #9909

Tested in Firefox on:

- https://github.com/NUber-dev/YTubic
- https://github.com/fregante/bin-dir
- https://github.com/refined-github/yolo

GitHub's current repository sidebar uses React module classes and renders its sections asynchronously. Refined GitHub 26.8.8 still looks for `.BorderGrid-row` and `.Progress-item`, so the feature leaves the "About" and "Languages" headings visible and throws:

```text
ElementNotFoundError: Expected element not found: [class*='PageLayout-Pane'] .BorderGrid-row:has(.Progress-item) h2
```

This PR updates `clean-repo-sidebar` for GitHub's current sidebar. It observes each sidebar section so it handles the initial markup and React replacements without polling for optional elements.

Runtime checks after React finished rendering:

```text
Sidebar skeletons: 0
About heading display: none
Languages heading class: sr-only
Report repository section: Languages (last section)
Console warnings and errors: 0
```

## Tests

```text
Test Files  32 passed | 1 skipped (33)
Tests       564 passed | 28 skipped (592)
ESLint      passed
Biome       passed
TypeScript  passed
Svelte      0 errors and 0 warnings
Bundle      passed
```

## Before with Refined GitHub 26.8.8

![The About and Languages headings remain visible](https://github.com/user-attachments/assets/5cac8814-889a-46c1-8e07-ab739c9bd2c6)

## After with the current build

<img width="768" height="2092" alt="refined-after-b005a8e4-cropped" src="https://github.com/user-attachments/assets/0bcee65d-d155-4002-b53c-7dfc1ffe8462" />

## Console logs

The clean post-install console capture in `refined-after-console.json` has no sidebar selector error. Its only entries are the existing `read:project` token scope messages, which are unrelated to this change.

[refined-before-console.json](https://github.com/user-attachments/files/31308790/refined-before-console.json)
[refined-after-console.json](https://github.com/user-attachments/files/31308791/refined-after-console.json)
