### PR TITLE
`rerun-workflow-from-pr` - Add feature

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -835,6 +835,12 @@
 		"screenshot": "https://github.com/user-attachments/assets/67331112-f5b2-4a2b-af43-800d46bd6bf7"
 	},
 	{
+		"id": "rerun-workflow-from-pr",
+		"description": "Adds a button to re-run a completed GitHub Actions job directly from the pull request page, without opening the workflow run.",
+		"css": true,
+		"screenshot": "https://github.com/user-attachments/assets/TODO-add-screenshot-of-the-re-run-button-in-the-PR-merge-box"
+	},
+	{
 		"id": "restore-file",
 		"description": "Adds a button to discard all the changes to a file in a PR.",
 		"screenshot": "https://user-images.githubusercontent.com/1402241/236630610-e11a64f6-5e70-4353-89b8-39aae830dd16.gif"

--- a/build/__snapshots__/imported-features.json
+++ b/build/__snapshots__/imported-features.json
@@ -140,6 +140,7 @@
 	"repo-header-info",
 	"repo-wide-file-finder",
 	"rerun-workflow",
+	"rerun-workflow-from-pr",
 	"restore-file",
 	"rgh-deduplicator",
 	"rgh-dim-commits",

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "visit-tag") [When navigating a repo's file on a specific tag, it adds a link to see the release/tag itself.](https://github-production-user-asset-6210df.s3.amazonaws.com/1402241/285123739-e5f4fa0a-3f48-49ef-9b87-2fd6f183c923.png)
 - [](# "actions-run-removal") [Lets you cancel or delete workflow runs faster from the workflow list.](https://github.com/user-attachments/assets/a054f9b4-9d56-40c0-9aac-09a8b07bbb3b)
 - [](# "rerun-workflow") [Unwraps the "Re-run jobs" dropdown into individual buttons and adds a keyboard shortcut to re-run failed jobs: <kbd>r</kbd> <kbd>f</kbd>](https://github.com/user-attachments/assets/67331112-f5b2-4a2b-af43-800d46bd6bf7).
+- [](# "rerun-workflow-from-pr") [Adds a button to re-run a completed GitHub Actions job directly from the pull request page, without opening the workflow run.](https://github.com/user-attachments/assets/TODO-add-screenshot-of-the-re-run-button-in-the-PR-merge-box)
 - [](# "extend-repo-tabs") [Collapses repository tabs if rarely used (Insights, Security) or when empty (Projects, Wiki, Actions). It also adds counters to Projects and Wiki.](https://github.com/user-attachments/assets/e7fa93ff-fc01-410d-b4da-f1fb96a85326)
 
 <!--

--- a/source/features/rerun-workflow-from-pr.css
+++ b/source/features/rerun-workflow-from-pr.css
@@ -1,0 +1,21 @@
+/* Sizing, hover square and muted color are inherited from the cloned kebab button */
+.rgh-rerun-workflow-from-pr[disabled] {
+	opacity: 50%;
+	cursor: default;
+}
+
+/* The job is queued but GitHub hasn't re-rendered the row yet. Spin the icon so the
+   disabled state reads as "work in flight" rather than as a dead button. */
+.rgh-rerun-workflow-from-pr-queued .octicon {
+	animation: rgh-rerun-workflow-from-pr-spin 1s linear infinite;
+}
+
+@keyframes rgh-rerun-workflow-from-pr-spin {
+	from {
+		rotate: 0deg;
+	}
+
+	to {
+		rotate: 360deg;
+	}
+}

--- a/source/features/rerun-workflow-from-pr.tsx
+++ b/source/features/rerun-workflow-from-pr.tsx
@@ -1,0 +1,202 @@
+import './rerun-workflow-from-pr.css';
+
+import React from 'dom-chef';
+import * as pageDetect from 'github-url-detection';
+import SyncIcon from 'octicons-plain-react/Sync';
+import {$optional, elementExists} from 'select-dom';
+import {assertError} from 'ts-extras';
+
+import features from '../feature-manager.js';
+import api from '../github-helpers/api.js';
+import showToast from '../github-helpers/toast.js';
+import observe from '../helpers/selector-observer.js';
+
+// The row's label is GitHub's display string: "<workflow> / <job> (<event>)", e.g.
+// "Check: ClickUp Ticket Validation / validate-ticket / Validate ClickUp Ticket (pull_request)".
+// Only the trailing event is dropped; the leading text belongs to `workflow_name`
+// (which really can start with "Check:"), so stripping it would break the exact match.
+function normalizeLabel(label: string): string {
+	return label
+		.replace(/\s*\((?:pull_request|push|pull_request_target|merge_group|schedule|workflow_dispatch)\)\s*$/v, '')
+		.trim();
+}
+
+export function getActionsRunId(url: string): string | undefined {
+	const parsedUrl = new URL(url, location.href);
+	if (parsedUrl.origin !== location.origin) {
+		return;
+	}
+
+	return /\/actions\/runs\/(\d+)(?:\/|$)/v.exec(parsedUrl.pathname)?.[1];
+}
+
+export function findWorkflowJob(jobs: AnyObject[], label: string): AnyObject | undefined {
+	const wanted = normalizeLabel(label);
+	const exactMatch = jobs.find(job =>
+		wanted === `${job.workflow_name as string} / ${job.name as string}`);
+	if (exactMatch) {
+		return exactMatch;
+	}
+
+	const matches = jobs.filter(job =>
+		wanted === job.name
+		|| wanted.endsWith(` / ${job.name as string}`));
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+async function getJobId(label: string, runId: string): Promise<number> {
+	// Paginated manually because `api.v3paginated` delegates to the memoized `v3`,
+	// which would resolve a job from an earlier attempt after a re-run. Large matrix
+	// runs exceed one page, so stopping at the first would lose those jobs.
+	const latestJobs: AnyObject[] = [];
+	for (let page = 1; ; page++) {
+		// eslint-disable-next-line no-await-in-loop
+		const {jobs, total_count: totalCount} = await api.v3uncached(
+			`actions/runs/${runId}/jobs?filter=latest&per_page=100&page=${page}`,
+		);
+
+		latestJobs.push(...jobs as AnyObject[]);
+		if (latestJobs.length >= (totalCount as number) || (jobs as AnyObject[]).length === 0) {
+			break;
+		}
+	}
+
+	const current = findWorkflowJob(latestJobs, label);
+	if (!current) {
+		throw new Error(`Could not find a re-runnable Actions job for \u201C${normalizeLabel(label)}\u201D`);
+	}
+
+	// Only finished jobs can be re-run; GitHub rejects the rest anyway
+	if (current.status !== 'completed') {
+		throw new Error('This job is still running. Wait for it to finish before re-running it.');
+	}
+
+	return current.id as number;
+}
+
+async function rerunJob(event: Event): Promise<void> {
+	const button = event.currentTarget as HTMLButtonElement;
+	const label = button.dataset.checkName!;
+	const runId = button.dataset.runId!;
+
+	// Disable immediately so a double-click can't queue the job twice
+	button.disabled = true;
+	try {
+		await showToast(async () => {
+			const jobId = await getJobId(label, runId);
+			// `v3uncached` because `v3` memoizes by arguments: re-clicking the same
+			// job would otherwise replay the first response without a new request.
+			// `responseFormat: 'text'` because a 201 comes back with an empty body,
+			// which `JSON.parse` would choke on.
+			const response = await api.v3uncached(`actions/jobs/${jobId}/rerun`, {
+				method: 'POST',
+				responseFormat: 'text',
+				ignoreHttpStatus: true,
+			});
+
+			if (!response.ok) {
+				// `responseFormat: 'text'` leaves the body unparsed, and an error page can
+				// be empty or HTML, so a failed parse must fall back to a generic message
+				let message: string | undefined;
+				try {
+					({message} = JSON.parse(response.content as string) as {message?: string});
+				} catch {}
+
+				throw new Error(message ?? 'Unable to re-run this job.');
+			}
+		}, {
+			message: 'Re-running…',
+			doneMessage: 'Job queued. Reload to see the new run.',
+		});
+	} catch (error) {
+		// Only a failure returns control to the user: re-enable so they can retry
+		assertError(error);
+		button.disabled = false;
+		return;
+	}
+
+	// The job is queued, but GitHub's merge-box takes a few seconds to poll and
+	// re-render the row. Leaving the button enabled in that window invites a second
+	// re-run that would fail ("already running"), so it stays disabled and switches
+	// to a spinner until GitHub replaces the row on its own.
+	button.setAttribute('aria-label', 'Re-run queued. Reload the page if the check doesn\u2019t update.');
+	button.title = 'Re-run queued. Reload the page if the check doesn\u2019t update.';
+	button.classList.add('rgh-rerun-workflow-from-pr-queued');
+}
+
+// Running checks show a spinner instead of one of the terminal state icons. The
+// icon is the reliable signal; the text is only a fallback for states whose icon
+// isn't in the list, and it deliberately excludes the check's own name, which can
+// itself contain words like "pending".
+function isInProgress(row: HTMLElement): boolean {
+	if (elementExists('.octicon-check, .octicon-x, .octicon-skip, .octicon-square-fill, .octicon-stop, .octicon-alert, .octicon-dot-fill, .octicon-clock', row)) {
+		return false;
+	}
+
+	// e.g. "Failing after 33s", "Successful in 3m", "in progress \u2014 ..."
+	const status = $optional('[class*="StatusMeta"], .text-italic, .color-fg-muted', row)?.textContent ?? '';
+	return /\b(in progress|queued|waiting|expected)\b/iv.test(status);
+}
+
+function addRerunButton(menuButton: HTMLButtonElement): void {
+	const row = menuButton.closest('li') ?? menuButton.parentElement!;
+	const actionLink = $optional<HTMLAnchorElement>('a[href*="/actions/runs/"]', row);
+	const checkName = actionLink?.textContent.trim();
+	const runId = actionLink && getActionsRunId(actionLink.href);
+	if (!checkName || !runId) {
+		return;
+	}
+
+	if (isInProgress(row)) {
+		return;
+	}
+
+	// Cloning GitHub's own kebab button inherits its exact size, hover square and
+	// muted color, which its CSS-module classes don't expose to us any other way
+	const button = menuButton.cloneNode(true);
+	button.removeAttribute('id');
+	button.removeAttribute('aria-labelledby');
+	button.removeAttribute('aria-controls');
+	button.removeAttribute('aria-expanded');
+	button.removeAttribute('aria-haspopup');
+	button.removeAttribute('data-hotkey');
+	button.classList.add('rgh-rerun-workflow-from-pr');
+	button.title = `Re-run “${checkName}”`;
+	button.setAttribute('aria-label', `Re-run “${checkName}”`);
+	button.dataset.checkName = checkName;
+	button.dataset.runId = runId;
+	button.replaceChildren(<SyncIcon />);
+	button.addEventListener('click', event => void rerunJob(event));
+
+	menuButton.before(button);
+}
+
+function init(signal: AbortSignal): void {
+	// Scoped to the Checks section; a bare kebab selector also matches unrelated
+	// menus like comment headers (#9771). Both the React and legacy rows are covered.
+	observe(
+		[
+			'section[aria-label="Checks"] button:has(> .octicon-kebab-horizontal)',
+			'[data-testid="check-run-item"] button:has(> .octicon-kebab-horizontal)',
+		],
+		addRerunButton,
+		{signal},
+	);
+}
+
+void features.add(import.meta.url, {
+	include: [
+		pageDetect.isPRConversation,
+	],
+	init,
+});
+
+/*
+
+Test URLs:
+
+https://github.com/refined-github/refined-github/pull/6794
+
+Any PR with a failing GitHub Actions check.
+
+*/

--- a/source/helpers/rerun-workflow-from-pr.test.ts
+++ b/source/helpers/rerun-workflow-from-pr.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {findWorkflowJob, getActionsRunId} from '../features/rerun-workflow-from-pr.js';
+
+vi.mock('../feature-manager.js', () => ({
+	default: {add: vi.fn()},
+}));
+vi.mock('../github-helpers/api.js', () => ({default: {v3uncached: vi.fn()}}));
+vi.mock('../github-helpers/toast.js', () => ({default: vi.fn()}));
+vi.mock('./selector-observer.js', () => ({default: vi.fn()}));
+
+describe('getActionsRunId', () => {
+	it('extracts the run ID from a GitHub Actions URL', () => {
+		expect(getActionsRunId('/refined-github/refined-github/actions/runs/123/job/456')).toBe('123');
+	});
+
+	it('rejects third-party check URLs', () => {
+		expect(getActionsRunId('https://example.com/checks/123')).toBeUndefined();
+	});
+});
+
+describe('findWorkflowJob', () => {
+	it('uses the workflow-qualified job name', () => {
+		const jobs = [
+			{id: 1, name: 'test', workflow_name: 'CI'},
+			{id: 2, name: 'unit test', workflow_name: 'CI'},
+		];
+
+		expect(findWorkflowJob(jobs, 'CI / unit test (pull_request)')?.id).toBe(2);
+	});
+
+	// Regression: `Check:` is part of the workflow name, not a decoration to strip
+	it('matches a workflow whose name starts with "Check:"', () => {
+		const jobs = [
+			{id: 1, name: 'validate-ticket / Validate ClickUp Ticket', workflow_name: 'Check: ClickUp Ticket Validation'},
+		];
+
+		expect(findWorkflowJob(jobs, 'Check: ClickUp Ticket Validation / validate-ticket / Validate ClickUp Ticket (pull_request)')?.id).toBe(1);
+	});
+
+	it('does not select a same-named job from another workflow', () => {
+		const jobs = [
+			{id: 1, name: 'build', workflow_name: 'Release'},
+			{id: 2, name: 'build', workflow_name: 'CI'},
+		];
+
+		expect(findWorkflowJob(jobs, 'CI / build (pull_request)')?.id).toBe(2);
+	});
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -218,3 +218,4 @@ import './features/extensible-nav.js';
 import './features/notifications-ui.js';
 import './features/easy-toggle-hidden-comments.js';
 import './features/extend-repo-tabs.js';
+import './features/rerun-workflow-from-pr.js';


### PR DESCRIPTION
Adds a **Re-run** button next to each check's `…` menu in the PR merge-box, so a failed GitHub Actions job can be re-run without opening the workflow-run page.

The existing `rerun-workflow` feature only runs on `isActionRun` and clones GitHub's own "Re-run jobs" button. The PR page has no such button, so this feature triggers the re-run itself via the API.

## How it works

- Gated on `pageDetect.isPRConversation`, scoped to `section[aria-label="Checks"]`, so it doesn't touch the unrelated `…` menus in comment headers (#9771).
- The button is a clone of GitHub's own kebab button, so it inherits the exact size, muted color and hover square that its CSS-module classes don't otherwise expose.
- The check row's `run_id` comes from its `/actions/runs/…` link; the job is then resolved from `actions/runs/{run_id}/jobs?filter=latest` and re-run via `actions/jobs/{job_id}/rerun`.

## Notes for reviewers

A few things that look odd but are deliberate:

- **Every API call is `v3uncached`.** `api.v3` is memoized by arguments, so a second click without a page reload would replay the first response and resolve a job from an already-superseded attempt — which the API rejects with *"Only jobs from the current attempt can be re-run"*.
- **The job ID is re-resolved on every click, from the run ID.** Re-running creates a new attempt with a new job ID, so the run ID is the only stable anchor.
- **Jobs are paginated manually** rather than with `api.v3paginated`, because that helper delegates to the memoized `v3` and would reintroduce the stale-attempt problem. Large matrix runs exceed one page.
- **`normalizeLabel` only strips the trailing event.** The leading text belongs to `workflow_name`, which really can start with `Check:` — stripping that prefix breaks the exact match.
- **`responseFormat: 'text'`** because a successful re-run returns `201` with an empty body, which `JSON.parse` would choke on. Error bodies are parsed defensively since they can be empty or HTML.
- **On success the button stays disabled** and spins until GitHub re-renders the row, since it stays clickable for a few seconds while the merge-box catches up and a second click would fail.
- Only completed jobs get a button; in-progress ones are skipped. GitHub itself does *not* reject re-running an in-progress job — it silently queues another attempt — so this is guarded on our side.

`requiresToken` is intentionally **not** set: the button renders for everyone, and only the click needs a token (the write goes through `assertCurrentUser()`).

## Test URLs

Any PR with a failing GitHub Actions

### ADDED: 
1. The re-run button in the PR merge-box, next to a failing check's "…" menu
<img width="877" height="389" alt="gh-re-run-workflow-from-pr" src="https://github.com/user-attachments/assets/aea16a2b-49ef-489e-85e5-102803154f86" />


2. Hover state: The button's hover state, showing it matches the neighbouring kebab button
<img width="881" height="165" alt="image" src="https://github.com/user-attachments/assets/9660befd-17af-408f-aaaa-f1eb0778fe9c" />

3. Screen recording: <clicking Re-run on a failed check: toast appears, button spins, GitHub's row updates to "in progress">

https://github.com/user-attachments/assets/706fc0b1-d7b8-4f40-8949-8c1527b27fa3


## Screenshot

<img width="877" height="389" alt="image" src="https://github.com/user-attachments/assets/c0ba17ee-2191-4a40-82bf-075ede9d5c54" />