### PR TITLE
`table-input` - Restore feature in PR page

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -4,7 +4,7 @@ import delegate, {type DelegateEvent} from 'delegate-it';
 import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import TableIcon from 'octicons-plain-react/Table';
-import {$, closestElementOptional} from 'select-dom';
+import {$, closestElement, closestElementOptional} from 'select-dom';
 import {insertTextIntoField} from 'text-field-edit';
 
 import features from '../feature-manager.js';
@@ -14,6 +14,8 @@ import smartBlockWrap from '../helpers/smart-block-wrap.js';
 import {withTooltipRef} from '../components/tooltip.js';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
+	closestElement('details', square).open = false;
+
 	const container = closestElementOptional('fieldset', square) // Issue
 		?? square.form!.querySelector('.CommentBox-container')!; // PR
 	const field = $('textarea', container);

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -14,6 +14,9 @@ import smartBlockWrap from '../helpers/smart-block-wrap.js';
 import {withTooltipRef} from '../components/tooltip.js';
 
 function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
+	// In the PR's "Files changed" tab, the table input is in a `<details>` menu;
+	// when clicking a square, the menu closes and steals the focus from the textarea,
+	// so close it ourselves first to keep the focus on the field
 	closestElement('details', square).open = false;
 
 	const container = closestElementOptional('fieldset', square) // Issue

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -35,10 +35,10 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	field.selectionEnd = field.value.indexOf('<td>', cursorPosition) + '<td>'.length;
 }
 
-function add(container: HTMLElement): void {
+function add(container: HTMLElement, {signal}: SignalAsOptions): void {
 	container.classList.add('d-flex');
 
-	container.parentElement!.append(
+	const menu = (
 		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm my-auto">
 			<summary
 				ref={withTooltipRef('Add a table')}
@@ -47,7 +47,7 @@ function add(container: HTMLElement): void {
 				aria-haspopup="menu"
 			>
 				<TableIcon />
-			</summary>,
+			</summary>
 			<details-menu
 				className="select-menu-modal position-absolute right-0 hx_rsm-modal rgh-table-input"
 				role="menu"
@@ -62,13 +62,15 @@ function add(container: HTMLElement): void {
 					/>
 				))}
 			</details-menu>
-		</details>,
+		</details>
 	);
+
+	container.parentElement!.append(menu);
+	delegate('.rgh-tic', 'click', addTable, {base: menu, signal});
 }
 
 function init(signal: AbortSignal): void {
 	observe(actionBar, add, {signal});
-	delegate('.rgh-tic', 'click', addTable, {signal});
 }
 
 void features.add(import.meta.url, {

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -35,10 +35,10 @@ function addTable({delegateTarget: square}: DelegateEvent<MouseEvent, HTMLButton
 	field.selectionEnd = field.value.indexOf('<td>', cursorPosition) + '<td>'.length;
 }
 
-function add(container: HTMLElement, {signal}: SignalAsOptions): void {
+function add(container: HTMLElement): void {
 	container.classList.add('d-flex');
 
-	const menu = (
+	container.parentElement!.append(
 		<details className="details-reset details-overlay select-menu select-menu-modal-right hx_rsm my-auto">
 			<summary
 				ref={withTooltipRef('Add a table')}
@@ -62,15 +62,13 @@ function add(container: HTMLElement, {signal}: SignalAsOptions): void {
 					/>
 				))}
 			</details-menu>
-		</details>
+		</details>,
 	);
-
-	container.parentElement!.append(menu);
-	delegate('.rgh-tic', 'click', addTable, {base: menu, signal});
 }
 
 function init(signal: AbortSignal): void {
 	observe(actionBar, add, {signal});
+	delegate('.rgh-tic', 'click', addTable, {signal, capture: true});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
## Test URLs

Any PR page


## Screenshot

```md
.rgh-tic
  → <details-menu>
  → <details>                  ← the listener is now attached here (via `base`); the event is handled ✓
  → …editor layers…
  → div[data-inline-markers]   ← GitHub calls stopPropagation() here ✂️
  → React root → document      ← the old document-level `delegate` listener never hears it ✗
```


<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>
 

https://github.com/user-attachments/assets/5e44f167-1483-438a-9051-2cea7a50f0ec


 <td>

https://github.com/user-attachments/assets/54e5090c-c63b-4c5c-9a0f-cb5d7df13846


</table>

