### PR TITLE
fix(`pull-request-hotkeys`): support renamed aria-label and fix arrow-key navigation

### DIFF
--- a/source/features/pull-request-hotkeys.tsx
+++ b/source/features/pull-request-hotkeys.tsx
@@ -3,12 +3,13 @@ import * as pageDetect from 'github-url-detection';
 import {$$} from 'select-dom';
 
 import features from '../feature-manager.js';
-import {addHotkey} from '../github-helpers/hotkey.js';
+import {registerHotkey} from '../github-helpers/hotkey.js';
 
-async function init(): Promise<void> {
+async function init(signal: AbortSignal): Promise<void> {
 	const tabnav = await elementReady([
 		'[aria-label="Pull request tabs"]',
 		'[aria-label="Pull request navigation tabs"]', // Commits list tab
+		'[aria-label="Pull request navigation"]', // Renamed on Conversation/Commits sub-pages (issue #10006)
 	]);
 	const tabs = $$('a', tabnav);
 	const lastTab = tabs.length - 1;
@@ -17,15 +18,18 @@ async function init(): Promise<void> {
 	for (const [index, tab] of tabs.entries()) {
 		// Reset previous hotkeys because the DOM persists across soft navigations
 		// https://github.com/refined-github/refined-github/pull/9916#issuecomment-5157852083
-		delete tab.dataset.hotkey;
-		addHotkey(tab, `g ${index + 1}`);
-
-		if (index === selectedIndex - 1 || (selectedIndex === 0 && index === lastTab)) {
-			addHotkey(tab, 'g ArrowLeft');
-		} else if (index === selectedIndex + 1 || (selectedIndex === lastTab && index === 0)) {
-			addHotkey(tab, 'g ArrowRight');
-		}
+		tab.dataset.hotkey = `g ${index + 1}`;
 	}
+
+	// The previous/next hotkeys are registered on dedicated hidden elements instead of
+	// being combined with the tab's own `g <number>` hotkey via a comma-separated
+	// `data-hotkey` value. GitHub's native hotkey handler doesn't reliably resolve
+	// multiple `g`-prefixed sequences sharing one element (e.g. `g 1,g ArrowLeft`),
+	// which caused arrow-key navigation to jump to the wrong tab. See issue #10006.
+	const previousIndex = selectedIndex === 0 ? lastTab : selectedIndex - 1;
+	const nextIndex = selectedIndex === lastTab ? 0 : selectedIndex + 1;
+	registerHotkey('g ArrowLeft', tabs[previousIndex].href, {signal});
+	registerHotkey('g ArrowRight', tabs[nextIndex].href, {signal});
 }
 
 void features.add(import.meta.url, {


### PR DESCRIPTION
### Description

GitHub renamed the PR tab-nav's `aria-label` again (now `"Pull request navigation"` on the Conversation/Commits sub-pages, while `/files` still uses the old `"Pull request tabs"`), which broke tab detection and threw `ElementNotFoundError` in the console.

While fixing that, I also found that `g Left` / `g Right` navigated to the wrong tab. The previous code combined `g <number>` and `g Arrow*` on the same tab link via a comma-separated `data-hotkey` value (e.g. `"g 1,g ArrowLeft"`). This is the only place in the codebase using that pattern, and GitHub's native hotkey handler doesn't reliably resolve multiple `g`-prefixed sequences sharing one element. Registering the previous/next hotkeys on dedicated hidden elements (via the existing `registerHotkey` helper) fixes it.

### How to replicate the issue + URL

https://github.com/refined-github/refined-github/pull/9916

1. Open a PR with more than one tab.
2. Note the console error `ElementNotFoundError` and that `g <number>` hotkeys silently stop working.
3. Navigate to a middle tab (e.g. Commits) and press `g Left` / `g Right` - it lands on the wrong tab instead of the adjacent one.

### Testing

Manually tested on both the linked public PR and an internal company repository:
- `g 1`-`g 4` jump to the correct tab.
- `g Left` / `g Right` cycle correctly through all tabs in both directions, including wraparound (last &lt;-&gt; first).

Recording attached below (keystrokes shown for each navigation step):
<img width="2560" height="1042" alt="2026-08-28_11h44_03" src="https://github.com/user-attachments/assets/6e4b000d-a173-4dd5-a53e-8982d685232c" />

Fixes #10006
