### PR TITLE
`hide-inactive-deployments` - Also hide failed deployments

### DIFF
--- a/build/__snapshots__/features-meta.json
+++ b/build/__snapshots__/features-meta.json
@@ -344,7 +344,7 @@
 	},
 	{
 		"id": "hide-inactive-deployments",
-		"description": "Hides inactive deployments in PRs.",
+		"description": "Hides inactive or failed deployments in PRs.",
 		"screenshot": null
 	},
 	{

--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ https://github.com/refined-github/refined-github/wiki/Contributing#metadata-guid
 - [](# "unclip-checks") [Automatically shows all checks without scrolling when expanding the checks panel.](https://github.com/user-attachments/assets/785fffab-43e8-4f79-8170-7c264111df9f)
 - [](# "pr-approvals-count") [Shows color-coded review counts in PR lists.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253125143-d10d95df-4a89-4692-b218-5eba5cd79906.png)
 - [](# "highlight-non-default-base-branch") [Shows the base branch in PR lists if it’s not the default branch.](https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png)
-- [](# "hide-inactive-deployments") [Hides inactive deployments in PRs.](https://github.com/refined-github/refined-github/issues/1144)
+- [](# "hide-inactive-deployments") [Hides inactive or failed deployments in PRs.](https://github.com/refined-github/refined-github/issues/1144)
 - [](# "previous-next-commit-buttons") [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
 - [](# "conflict-marker") [Shows which PRs have conflicts in PR lists.](https://github-production-user-asset-6210df.s3.amazonaws.com/83146190/253128438-d67c8f49-44f1-4e15-9363-a717109fef39.png)
 - [](# "pr-commit-lines-changed") [Adds diff stats on PR commits.](https://github.com/user-attachments/assets/eb0f5e6e-9870-4daf-8c00-f1f23f61ef0f)

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -10,7 +10,7 @@ function init(): void {
 	deployments.pop(); // Don't hide the last deployment, even if it is inactive
 
 	for (const deployment of deployments) {
-		if (elementExists('[title="Deployment Status Label: Inactive"]', deployment)) {
+		if (elementExists('[title="Deployment Status Label: Inactive"], [title="Deployment Status Label: Failure"]', deployment)) {
 			deployment.remove();
 		}
 	}
@@ -30,5 +30,6 @@ Test URLs:
 
 - All inactive: https://github.com/btkostner/btkostner.io/pull/10
 - Some active: https://github.com/fregante/bundle/pull/6
+- Failed deployment: https://github.com/fregante/webext-alert/pull/24
 
 */

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -10,7 +10,10 @@ function init(): void {
 	deployments.pop(); // Don't hide the last deployment, even if it is inactive
 
 	for (const deployment of deployments) {
-		if (elementExists('[title="Deployment Status Label: Inactive"], [title="Deployment Status Label: Failure"]', deployment)) {
+		if (elementExists([
+			'[title="Deployment Status Label: Inactive"]',
+			'[title="Deployment Status Label: Failure"]',
+		], deployment)) {
 			deployment.remove();
 		}
 	}


### PR DESCRIPTION
Closes #9440

## Test URLs

- Failed deployment (should now be hidden, matching the existing "inactive" behavior): https://github.com/fregante/webext-alert/pull/24
- All inactive (existing behavior, unchanged): https://github.com/btkostner/btkostner.io/pull/10
- Some active (existing behavior, unchanged): https://github.com/fregante/bundle/pull/6

## Screenshot


<img width="1295" height="687" alt="refined-github-fix-proof" src="https://github.com/user-attachments/assets/78cb36ec-7685-4675-adc6-98744bcad761" />

