### PR TITLE
`quick-comment-edit` - Improve support of repeated issue edits

### DIFF
--- a/source/github-helpers/with-menu-open.ts
+++ b/source/github-helpers/with-menu-open.ts
@@ -13,7 +13,13 @@ export default async function withMenuOpen<T>(
 	try {
 		// When executing concurrently, there might be multiple menus open, so we find the one that is associated with the given button
 		// If the button itself is labelled by another element, the menu will be labelled by that element too
-		const menu = $(`[aria-labelledby="${menuButton.getAttribute('aria-labelledby') ?? menuButton.id}"]`);
+		const menu = $([
+			`ul[aria-labelledby="${menuButton.id}"]`,
+			// This must be a double GitHub bug: the menu has the same "labelledby" as the `menuButton` itself.
+			// Note: this selector will select `menuButton` itself if it lacks a tag name
+			// https://github.com/refined-github/refined-github/issues/10003
+			`ul[aria-labelledby="${menuButton.getAttribute('aria-labelledby')}"]`,
+	]);
 		const result = callback(menu);
 		return result;
 	} finally {

--- a/source/github-helpers/with-menu-open.ts
+++ b/source/github-helpers/with-menu-open.ts
@@ -19,7 +19,7 @@ export default async function withMenuOpen<T>(
 			// Note: this selector will select `menuButton` itself if it lacks a tag name
 			// https://github.com/refined-github/refined-github/issues/10003
 			`ul[aria-labelledby="${menuButton.getAttribute('aria-labelledby')}"]`,
-	]);
+		]);
 		const result = callback(menu);
 		return result;
 	} finally {


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/10003


## Test URLs

https://github.com/refined-github/sandbox/issues/162

## Screenshot

<img width="945" height="170" alt="ok" src="https://github.com/user-attachments/assets/4a490225-97a6-4597-ad25-21d3c1eab4eb" />
