### PR TITLE
`comments-time-machine-links` - Restore support for Issues

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -130,7 +130,7 @@ function addDropdownLink(menu: HTMLElement, timestamp: string): void {
 function addDropdownLinkReact({delegateTarget}: DelegateEvent): void {
 	const timestamp = $(
 		'relative-time[datetime]',
-		closestElement('[class^="Box"]', delegateTarget),
+		closestElement(commentSelector, delegateTarget),
 	).attributes.datetime.value;
 	const menuItemList = $('[class^="prc-ActionList-ActionList"]');
 	const menuItem = $('[class^="prc-ActionList-ActionListItem"]', menuItemList).cloneNode(true);


### PR DESCRIPTION
Closes #10016

## What changed

The React action-menu handler now finds the timestamp from the existing semantic comment selector instead of relying on GitHub's removed Box class prefix.

This keeps issue bodies, issue comments, review-thread comments, and legacy comments on the same container lookup already used elsewhere in the feature.

## Verification

- Replayed the current #10016 page DOM: the menu button has no Box-prefixed ancestor, while the semantic comment container and its relative-time element are both found.
- Ran the full npm test command: 564 tests passed, 28 skipped.
- ESLint, Biome, TypeScript, Svelte, and bundle checks passed.

## Test URLs

- https://github.com/refined-github/refined-github/issues/10016
- https://github.com/refined-github/sandbox/issues/108

## Screenshot

Loaded the extension build from this branch in Playwright Chromium against the live #10016 page. The React action menu opens and includes the restored "View repo at this time" item.

![Browser verification](https://raw.githubusercontent.com/libaojiang/refined-github/pr-10018-proof/proof/refined-github-10018.png)

## Agent note

Per agents.md:

> My booger looked for Box in vain,
> A stable comment led it home again.