### PR TITLE
`repo-header-info` - Avoid breaking layout if token is missing

### DIFF
--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -49,8 +49,11 @@ async function getRepositoryInfo(): Promise<RepositoryInfo> {
 }
 
 async function add(breadcrumbs: HTMLElement): Promise<void> {
-	const info = await getRepositoryInfo();
-	breadcrumbs.classList.add('rgh-repo-header-info-updated');
+	const info = await getRepositoryInfo().finally(() => {
+		// Show the breadcrumbs even if the request fails
+		// https://github.com/refined-github/refined-github/issues/9986
+		breadcrumbs.classList.add('rgh-repo-header-info-loaded');
+	});
 
 	// GitHub may already show this icon natively, so we match its position
 	// It's generally missing when it's forked and private
@@ -87,7 +90,6 @@ void features.add(import.meta.url, {
 		// Disable the feature entirely on small screens
 		isSmallDevice,
 	],
-	requiresToken: true,
 	init,
 });
 

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -52,7 +52,7 @@ async function add(breadcrumbs: HTMLElement): Promise<void> {
 	const info = await getRepositoryInfo().finally(() => {
 		// Show the breadcrumbs even if the request fails
 		// https://github.com/refined-github/refined-github/issues/9986
-		breadcrumbs.classList.add('rgh-repo-header-info-loaded');
+		breadcrumbs.classList.add('rgh-repo-header-info-updated');
 	});
 
 	// GitHub may already show this icon natively, so we match its position

--- a/source/features/repo-header-info.tsx
+++ b/source/features/repo-header-info.tsx
@@ -90,6 +90,8 @@ void features.add(import.meta.url, {
 		// Disable the feature entirely on small screens
 		isSmallDevice,
 	],
+	// Not enabled due to https://github.com/refined-github/refined-github/issues/9986
+	// requiresToken: true,
 	init,
 });
 


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/9986


## Test URLs

here

## Before

<img width="527" height="68" alt="Screenshot" src="https://github.com/user-attachments/assets/68266ab0-b776-4267-b816-5d6f50841376" />


## After

<img width="527" height="68" alt="Screenshot 4" src="https://github.com/user-attachments/assets/991aed62-2841-460b-a33d-30fff0f5f548" />
