### PR TITLE
`quick-comment-edit` - Disable on hidden comments

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -34,6 +34,11 @@ async function addQuickEditButton(menuButton: HTMLButtonElement, {signal}: Signa
 		return;
 	}
 
+	// Disable feature on hidden comments #9857
+	if (elementExists('.octicon-fold, .octicon-unfold', closestElement('[data-testid="comment-header-right-side-items"]', menuButton))) {
+		return;
+	}
+
 	const editButton = (
 		<button
 			ref={withTooltipRef('Edit comment')}
@@ -67,12 +72,8 @@ async function addQuickEditButtonLegacy(commentDropdown: HTMLDetailsElement, {si
 		return;
 	}
 
-	if (elementExists([
-		// We can't rely on `observe` for deduplication because the anchor might be replaced by GitHub while leaving the edit button behind #5572
-		'.rgh-quick-comment-edit-button',
-		// Disable feature on hidden comments #9857
-		'.octicon-fold',
-	], commentBody)) {
+	// We can't rely on `observe` for deduplication because the anchor might be replaced by GitHub while leaving the edit button behind #5572
+	if (elementExists('.rgh-quick-comment-edit-button', commentBody)) {
 		return;
 	}
 

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -67,8 +67,12 @@ async function addQuickEditButtonLegacy(commentDropdown: HTMLDetailsElement, {si
 		return;
 	}
 
-	// We can't rely on `observe` for deduplication because the anchor might be replaced by GitHub while leaving the edit button behind #5572
-	if (elementExists('.rgh-quick-comment-edit-button', commentBody)) {
+	if (elementExists([
+		// We can't rely on `observe` for deduplication because the anchor might be replaced by GitHub while leaving the edit button behind #5572
+		'.rgh-quick-comment-edit-button',
+		// Disable feature on hidden comments #9857
+		'.octicon-fold',
+	], commentBody)) {
 		return;
 	}
 


### PR DESCRIPTION
- closes #9857 


## Test URLs

#9857 

## Screenshot

Before:

<img width="691" height="69" alt="Screenshot" src="https://github.com/user-attachments/assets/38d35b31-a5aa-4446-928b-f6e785b9ce94" />

After:

<img width="691" height="69" alt="Screenshot 1" src="https://github.com/user-attachments/assets/7f8f09ea-984e-47c8-99bd-1e32c1d412b2" />

