### PR TITLE
`clean-repo-sidebar` - Preserve repository edit button

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,12 +1,13 @@
 [rgh-clean-repo-sidebar] [class*='PageLayout-Pane'] {
-	/* Hide "About" header */
-	[class*='SidebarSection-module__sidebarSection']:first-child > h2 {
+	/* Hide "About" header unless it contains repository edit controls #10027 */
+	[class*='SidebarSection-module__sidebarSection']:first-child
+		> h2:not(:has([aria-label='Edit repository metadata'])) {
 		display: none;
-	}
 
-	/* Align the top of the repo root sidebar with the main page content */
-	[class*='SidebarSection-module__sidebarSection']:first-child > h2 + p {
-		margin-top: 0 !important;
+		/* Align the top of the repo root sidebar with the main page content */
+		& + p {
+			margin-top: 0 !important;
+		}
 	}
 
 	/*


### PR DESCRIPTION
Fixes #10027

GitHub renders the repository metadata edit control inside the About heading, so hiding the heading also hid the control. This keeps the heading when it contains that control and only removes the description margin when the heading is hidden.

Tested with `npm test`.

Controlled owner-DOM reproduction using GitHub’s current Edit repository metadata button markup. Both captures use the same page, viewport, and sidebar crop. Only the clean-repo-sidebar CSS differs.

Before
<img width="272" height="228" alt="owned-sidebar-before-9e86fd7f-owner-emulation" src="https://github.com/user-attachments/assets/d6990819-20a4-450c-8bbf-dafa416417c4" />

After
<img width="272" height="252" alt="owned-sidebar-after-9e05e857-owner-emulation" src="https://github.com/user-attachments/assets/4000dcea-3752-40a1-93d3-d5a5bd1415fd" />
