### PR TITLE
`clean-repo-sidebar` - Remove broken Readme link

### DIFF
--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -18,6 +18,12 @@
 		display: none;
 	}
 
+	/* Hide broken Readme link #10030 */
+	[class*='SidebarSection-module__sidebarSection']
+		> div:has(> a[href^='#readme']) {
+		display: none;
+	}
+
 	/* Hide Code of conduct links */
 	[class*='SidebarSection-module__sidebarSection']
 		:is([href$='/code-of-conduct.md' i], [href$='/code_of_conduct.md' i]) {


### PR DESCRIPTION
Closes #10030

GitHub currently renders the broken Readme link in its own wrapper. This hides the wrapper so it does not leave an empty margin in the sidebar.

I verified the selector against the current live repository DOM: it matched one element and changed its display from `block` to `none`. Tested with `npm test`.