### PR TITLE
`clean-readme-url` - Fix Readme sidebar link

### DIFF
--- a/source/features/clean-readme-url.tsx
+++ b/source/features/clean-readme-url.tsx
@@ -1,11 +1,39 @@
 import * as pageDetect from 'github-url-detection';
+import {$optional} from 'select-dom';
 
 import delay from '../helpers/delay.js';
+import observe from '../helpers/selector-observer.js';
 import features from '../feature-manager.js';
+
+const readmeTab = 'readme-ov-file';
+
+function scrollToReadme(): void {
+	// The asynchronously rendered link can be ready before the target
+	$optional('#readme')?.scrollIntoView({behavior: 'instant'});
+}
+
+function scrollToReadmeOnClick(event: MouseEvent): void {
+	if (event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+		scrollToReadme();
+	}
+}
+
+function addReadmeTarget(target: HTMLElement): void {
+	target.id = 'readme';
+	if (location.hash === '#readme') {
+		scrollToReadme();
+	}
+}
+
+function addReadmeScrollFallback(link: HTMLAnchorElement, {signal}: SignalAsOptions): void {
+	// This pseudo-fragment switches back from other overview tabs, so it must remain unchanged
+	link.addEventListener('click', scrollToReadmeOnClick, {signal});
+}
 
 async function maybeCleanUrl(): Promise<void> {
 	const parsed = new URL(location.href);
-	if (parsed.searchParams.get('tab') !== 'readme-ov-file') {
+	// README is the default view; other overview tabs must keep their parameter
+	if (parsed.searchParams.get('tab') !== readmeTab) {
 		return;
 	}
 
@@ -14,6 +42,7 @@ async function maybeCleanUrl(): Promise<void> {
 	await delay(500);
 	parsed.searchParams.delete('tab');
 	history.replaceState(history.state, '', parsed.href);
+	scrollToReadme();
 }
 
 function init(signal: AbortSignal): void {
@@ -21,6 +50,13 @@ function init(signal: AbortSignal): void {
 
 	// TODO [2027-01-01]: Only needed to avoid breaking on Safari <26.2 (<2026)
 	navigation?.addEventListener('navigatesuccess', maybeCleanUrl, {signal});
+
+	observe('nav[aria-label="Repository files"]', addReadmeTarget, {signal});
+	observe(
+		'[class*="SidebarSection-module__sidebarSection"] a[href="#readme-ov-file"]',
+		addReadmeScrollFallback,
+		{signal},
+	);
 }
 
 void features.add(import.meta.url, {
@@ -35,5 +71,7 @@ void features.add(import.meta.url, {
 Test URLs:
 
 https://github.com/refined-github/refined-github?tab=readme-ov-file
+https://github.com/refined-github/refined-github?tab=MIT-1-ov-file
+https://github.com/refined-github/refined-github#readme
 
 */


### PR DESCRIPTION
Fixes #10030

I kept GitHub's `#readme-ov-file` link unchanged. It looks like a broken anchor while README is already selected, but GitHub also uses it to switch from License, Contributing, Security, and other overview tabs back to README. This matches the original reproduction in #6904 and the tab behavior described in https://github.com/refined-github/refined-github/pull/8370#discussion_r2030221109.

The fix adds a real `#readme` target when the asynchronously rendered repository-files navigation appears, plus a click fallback that scrolls without preventing GitHub's tab handler. After GitHub selects README, the existing cleaner still removes only the redundant `?tab=readme-ov-file` parameter and corrects the final scroll position. Other `?tab=…-ov-file` URLs remain untouched.

I tested removing the existing 500 ms delay separately. The correct tab was selected, but the target finished 111 px too low in Chrome and 202 px too low in Firefox, so this keeps the delay.

Tested in Chrome 151 and Firefox 154:

- Clicking Readme from the default repository view
- Switching from License back to Readme
- Loading a direct `#readme` URL
- Preserving the License tab and its URL
- React-rendered element replacement

`npm test`: 564 passed, 28 skipped.

## Test URLs

- Default and sidebar transitions: https://github.com/refined-github/refined-github
- Direct README query: https://github.com/refined-github/refined-github?tab=readme-ov-file
- Preserved License tab: https://github.com/refined-github/refined-github?tab=MIT-1-ov-file
- Direct anchor: https://github.com/refined-github/refined-github#readme
