### PR TITLE
Fix 	ab-size for embedded code in Issues

### DIFF
--- a/source/features/tab-size.css
+++ b/source/features/tab-size.css
@@ -14,7 +14,7 @@ There’s also one place where GitHub incorrectly uses the "user configuration" 
 */
 
 :root,
-.comment-body .tab-size[data-tab-size='8'] {
+:is(.comment-body, [data-testid='markdown-body'], .markdown-body) .tab-size[data-tab-size='8'] {
 	--tab-size: 4;
 
 	tab-size: var(--tab-size);
@@ -26,6 +26,7 @@ There’s also one place where GitHub incorrectly uses the "user configuration" 
 
 - Rendered documents: https://github.com/refined-github/refined-github/blob/154c0f8c86b23e52d1e1ee947b90bc36bc6188ba/contributing.md#featuresadd
 - Code blocks and embeds in conversations: https://github.com/refined-github/sandbox/pull/19
+- Code blocks and embeds in issues: https://github.com/refined-github/sandbox/issues/164
 - The comment field everywhere
 
 ### Unaffected URLs


### PR DESCRIPTION
Fixes #10031

### Description
GitHub's React issue view wraps comments and descriptions in `[data-testid='markdown-body']` and `.markdown-body` rather than `.comment-body` (which is used in PRs). As a result, embedded code blocks with `.tab-size[data-tab-size='8']` in issues missed the custom `--tab-size` override and reverted to GitHub's default 8-character tab stop.

This PR expands the selector to include `[data-testid='markdown-body']` and `.markdown-body`, ensuring 4-character tab size applies uniformly across issues, PRs, and discussions.

### Test URLs
- PRs: https://github.com/refined-github/sandbox/pull/19
- Issues: https://github.com/refined-github/sandbox/issues/164