### PR TITLE
`bugs-tab` - Hide when issues are disabled

### DIFF
--- a/source/features/bugs-tab.gql
+++ b/source/features/bugs-tab.gql
@@ -8,7 +8,10 @@ query CountBugs($owner: String!, $name: String!) {
 				}
 			}
 		}
-		issues(filterBy: { type: "Bug", states: OPEN }) {
+		typeBug: issues(filterBy: { type: "Bug", states: OPEN }) {
+			totalCount
+		}
+		issues: issues(states: [OPEN]) {
 			totalCount
 		}
 	}

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -14,6 +14,9 @@ import onetime from '../helpers/onetime.js';
 import CountBugs from './bugs-tab.gql';
 
 type ApiResponse = {
+	typeBug: {
+		totalCount: number;
+	};
 	issues: {
 		totalCount: number;
 	};
@@ -34,7 +37,7 @@ type Bugs = {
 
 async function countBugs(): Promise<Bugs> {
 	const {repository} = await api.v4(CountBugs) as {repository: ApiResponse};
-	const bugTypeCount = repository.issues.totalCount;
+	const bugTypeCount = repository.typeBug.totalCount;
 
 	let label = repository.labels.nodes.find(({name}) => name === 'bug');
 	label ??= repository.labels.nodes.find(({name}) => isBugLabel(name));
@@ -43,8 +46,13 @@ async function countBugs(): Promise<Bugs> {
 	const bugLabelCount = label?.issues.totalCount ?? 0;
 	const bugCount = Math.max(bugTypeCount, bugLabelCount);
 
-	// Label might not be found if the repo uses a non-standard bug label name
-	return {label: label?.name ?? 'bug', count: bugCount};
+	return {
+		// Label might not be found if the repo uses a non-standard bug label name
+		label: label?.name ?? 'bug',
+
+		// GitHub bug: labelled issues are counted even if issues are disabled
+		count: Math.min(bugCount, repository.issues.totalCount),
+	};
 }
 
 const bugs = new CachedFunction('bugs', {
@@ -162,6 +170,6 @@ Test URLs:
 - label:bug https://github.com/refined-github/refined-github/issues
 - label:"Type: Bug" https://github.com/react/react/issues
 - type:Bug: https://github.com/keepassxreboot/keepassxc/issues
-- Issues disabled: https://github.com/refined-github/yolo
+- Issues disabled: https://github.com/bfred-it-org/no-issues/labels
 
 */


### PR DESCRIPTION
- closes #10036 


## Test URLs


- Issues disabled: https://github.com/bfred-it-org/no-issues/labels


## Screenshot

Before

<img width="263" height="107" alt="Screenshot 5" src="https://github.com/user-attachments/assets/0fc41848-b173-498d-b087-4b5e43e12591" />

After:

<img width="263" height="107" alt="Screenshot 4" src="https://github.com/user-attachments/assets/deed522a-421d-4ff2-b5ae-254ba4dfaf05" />

