### PR TITLE
`extensible-nav` - Fix duplicate nav when the header re-renders

### DIFF
--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -91,8 +91,6 @@ function replace(nativeNav: HTMLElement): () => void {
 
 	nativeNav.classList.add('rgh-extensible-nav-removed');
 
-	// GitHub re-renders the header when a repository feature is toggled, re-adding the native nav and
-	// firing this callback again. Unmount the previous instance so duplicate navs don't stack up.
 	return () => {
 		void unmount(nav);
 	};
@@ -103,7 +101,6 @@ async function initOnce(): Promise<void> {
 	await elementReady('.loaded nav[aria-label="Repository"]');
 
 	// Use `observe` because GitHub occasionally removes and re-adds the entire header.
-	// `singleton` keeps a single mounted nav by unmounting the previous one on each re-render.
 	observe('.loaded nav[aria-label="Repository"]', singleton(replace));
 }
 

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -21,7 +21,7 @@ import PlayIcon from 'octicons-plain-react/Play';
 import ShieldIcon from 'octicons-plain-react/Shield';
 import TableIcon from 'octicons-plain-react/Table';
 
-import features from '../feature-manager.js';
+import features from '../feature-manager.js'
 import {selectTab, setNativeTabs, updateCurrentTab, type Tab} from '../components/extensible-nav-store.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
@@ -100,7 +100,7 @@ async function initOnce(): Promise<void> {
 	// Use `element-ready` to ensure that the native navigation is fully loaded before replacing it for the first time.
 	await elementReady('.loaded nav[aria-label="Repository"]');
 
-	// Use `observe` because GitHub occasionally removes and re-adds the entire header.
+	// Use `observe` because GitHub occasionally removes and re-adds the entire header, for example when removing tabs #10038
 	observe('.loaded nav[aria-label="Repository"]', singleton(replace));
 }
 

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -4,7 +4,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {$$, $optional, elementExists} from 'select-dom';
 import {assertPresent} from 'ts-extras';
-import {mount} from 'svelte';
+import {mount, unmount} from 'svelte';
 import {readable} from 'svelte/store';
 
 import AiModel from 'octicons-plain-react/AiModel';
@@ -25,6 +25,7 @@ import features from '../feature-manager.js';
 import {selectTab, setNativeTabs, updateCurrentTab, type Tab} from '../components/extensible-nav-store.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';
+import singleton from '../helpers/singleton.js';
 import ExtensibleNav from './extensible-nav.svelte';
 
 const knownTabsIcons = new Map([
@@ -74,7 +75,7 @@ function generateTab(item: HTMLAnchorElement): Tab {
 	};
 }
 
-function replace(nativeNav: HTMLElement): void {
+function replace(nativeNav: HTMLElement): () => void {
 	const items = $$('a', nativeNav);
 
 	// Shouldn't be missing, but assert anyway
@@ -86,9 +87,15 @@ function replace(nativeNav: HTMLElement): void {
 	setNativeTabs(items.map(item => generateTab(item)));
 	selectTab(current);
 
-	mount(ExtensibleNav, {target: nativeNav.parentElement!});
+	const nav = mount(ExtensibleNav, {target: nativeNav.parentElement!});
 
 	nativeNav.classList.add('rgh-extensible-nav-removed');
+
+	// GitHub re-renders the header when a repository feature is toggled, re-adding the native nav and
+	// firing this callback again. Unmount the previous instance so duplicate navs don't stack up.
+	return () => {
+		void unmount(nav);
+	};
 }
 
 async function initOnce(): Promise<void> {
@@ -96,7 +103,8 @@ async function initOnce(): Promise<void> {
 	await elementReady('.loaded nav[aria-label="Repository"]');
 
 	// Use `observe` because GitHub occasionally removes and re-adds the entire header.
-	observe('.loaded nav[aria-label="Repository"]', replace);
+	// `singleton` keeps a single mounted nav by unmounting the previous one on each re-render.
+	observe('.loaded nav[aria-label="Repository"]', singleton(replace));
 }
 
 void features.add(import.meta.url, {

--- a/source/features/extensible-nav.tsx
+++ b/source/features/extensible-nav.tsx
@@ -21,7 +21,7 @@ import PlayIcon from 'octicons-plain-react/Play';
 import ShieldIcon from 'octicons-plain-react/Shield';
 import TableIcon from 'octicons-plain-react/Table';
 
-import features from '../feature-manager.js'
+import features from '../feature-manager.js';
 import {selectTab, setNativeTabs, updateCurrentTab, type Tab} from '../components/extensible-nav-store.js';
 import onetime from '../helpers/onetime.js';
 import observe from '../helpers/selector-observer.js';


### PR DESCRIPTION
Closes #10038

Toggling a repository feature (Issues, Wikis, ...) makes GitHub rebuild the header. The native `nav[aria-label="Repository"]` gets re-added, so `observe` runs `replace` again. Each `replace` mounted a fresh `ExtensibleNav` but never tore down the previous one, so the bars stack up.

`replace` now returns an unmount function and is wrapped in `singleton`, the same helper `rgh-feature-descriptions` uses to keep a single instance alive. On a rebuild the old nav is unmounted before the new one is mounted, so only one is ever present.

## Test URLs

The duplicate only shows on a repository's settings page, which needs admin access. On any repo you manage, open its settings and toggle "Issues" (or another feature) off and on: the repository nav stacks up before the fix and stays single after it. See the gif below.

A public page to confirm the nav still renders correctly (no regression):

https://github.com/sindresorhus/awesome

I checked this on Chromium (Edge on Windows). There is no Safari for Windows, so I could not run it here, and the report came from Safari. I'd appreciate someone confirming it on Safari. The change only affects how the nav component is mounted and torn down, which is the same on every browser, so I'd expect it to behave the same on Safari. :D

## Screenshot

Before
<img width="640" height="360" alt="before" src="https://github.com/user-attachments/assets/f73029b0-7579-46ec-9545-2e712fd7ec1c" />

After
<img width="640" height="360" alt="after" src="https://github.com/user-attachments/assets/4f6c87dc-4777-405f-9878-9a8bdbc37edd" />
