### PR TITLE
AI SPAM

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import * as pageDetect from 'github-url-detection';
 import memoize from 'memoize';
 import PencilIcon from 'octicons-plain-react/Pencil';
-import {$, closestElement, elementExists} from 'select-dom';
+import {$, closestElement, closestElementOptional, elementExists} from 'select-dom';
 
 import features from '../feature-manager.js';
 import {userIsModerator} from '../github-helpers/get-user-permission.js';
@@ -35,7 +35,7 @@ async function addQuickEditButton(menuButton: HTMLButtonElement, {signal}: Signa
 	}
 
 	// Disable feature on hidden comments #9857
-	if (elementExists(['.octicon-fold', '.octicon-unfold'], closestElement('[data-testid="comment-header-right-side-items"]', menuButton))) {
+	if (elementExists(['.octicon-fold', '.octicon-unfold'], closestElementOptional('[data-testid="comment-header-right-side-items"]', menuButton))) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #10028

The hidden-comment check added in #10024 does `closestElement('[data-testid="comment-header-right-side-items"]', menuButton)`. That `data-testid` only exists on regular timeline comments; the issue body's kebab menu sits under a different `IssueBodyHeader-module` structure and has no such ancestor. `closestElement` throws `ElementNotFoundError` when nothing matches (unlike `closestElementOptional`, which returns `undefined`), and `selector-observer` calls this listener without awaiting or catching it, so the throw becomes an unhandled rejection and the function returns before it ever appends the edit button. That's why the button is missing specifically on the issue body, and it matches the error text in the issue.

Fix: use `closestElementOptional` instead, which returns `undefined` when there's no matching ancestor. `elementExists(selectors, undefined)` already short-circuits to `false` in that case, so the rest of the logic is unchanged.

## Test URLs

#10028

## Screenshot

No browser available in this sandbox, so no before/after screenshot. Verified by reading `select-dom`'s source directly (`closestElement` throws on no match, `closestElementOptional` returns `undefined`, and `elementExists` treats an `undefined` base element as "not found" rather than throwing) and by tracing `selector-observer.tsx`'s listener call, which isn't awaited or wrapped in try/catch, so an uncaught error there matches the exact symptom. Also ran `eslint` and `tsc --noEmit` on the changed file, both clean.
