### PR TITLE
AI SPAM

### DIFF
--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -2,7 +2,7 @@
 /* Use same font-family as GitHub style for `code` */
 
 /* Test URL: https://github.com/refined-github/sandbox/pull/16 */
-[class^='prc-PageLayout-Header'] input,
+[class^='prc-PageLayout-Header'] form input,
 [data-testid='mergebox-partial'] input[type='text'],
 /* Test URL: https://github.com/refined-github/sandbox/compare/default-a...new?expand=1 */
 input[name='pull_request[title]'],


### PR DESCRIPTION
## Description

Fixes #10064

The previous `[class^='prc-PageLayout-Header'] input` selector was too broad and also matched the search input in GitHub's new Pull Requests Dashboard.

This caused the search input to receive the monospace font styling intended for PR title editing, resulting in the search text and cursor becoming visually misaligned.

## Solution

Narrowed the selector to:

`[class^='prc-PageLayout-Header'] form input`

This keeps the styling targeted to the PR title editing input while avoiding the dashboard search input.

## Verification

- `npm run format:check`
- `npm run lint:biome`
- `npx vitest run build/features.test.ts` — 300/300 passing
- `npm run build:bundle`
- `npm run build:typescript`