### PR TITLE
`extend-repo-tabs` - Rename tab to PRs

### DIFF
--- a/source/features/extend-repo-tabs.tsx
+++ b/source/features/extend-repo-tabs.tsx
@@ -69,7 +69,7 @@ async function updateActionsAndProjectsTabs(): Promise<void> {
 }
 
 function init(): void {
-	overrideTab('pull-requests', {label: 'Pulls'});
+	overrideTab('pull-requests', {label: 'PRs'});
 	overrideTab('security-and-quality', {demoted: true});
 	overrideTab('insights', {demoted: true});
 


### PR DESCRIPTION
- closes https://github.com/refined-github/refined-github/issues/10026