### PR TITLE
`conflict-marker` - Restore on new PR lists

### DIFF
--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -68,6 +68,7 @@ void features.add(import.meta.url, {
 /*
 Test URLs
 https://github.com/pulls
+https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+conflict
 https://github.com/refined-github/sandbox/issues?q=conflict
 https://github.com/kubernetes/kubernetes/milestone/62
 */

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -68,6 +68,8 @@ export const openPrsListLink = [
 	css`
 		li[role="listitem"] h3 a[data-hovercard-url*="/pull"]
 	`,
+	// New PR lists
+	'a[data-hovercard-type="pull_request"][data-testid="listitem-title-link"]',
 ];
 
 export const openPrsListLink_ = [

--- a/source/github-helpers/selectors.ts
+++ b/source/github-helpers/selectors.ts
@@ -64,12 +64,12 @@ export const openPrsListLink = [
 			.octicon-git-pull-request-draft
 		) a.js-navigation-open
 	`,
-	// React view
+	// React issue list
 	css`
 		li[role="listitem"] h3 a[data-hovercard-url*="/pull"]
 	`,
-	// New PR lists
-	'a[data-hovercard-type="pull_request"][data-testid="listitem-title-link"]',
+	// React PR list
+	css`a[data-hovercard-type="pull_request"][data-testid="listitem-title-link"]`,
 ];
 
 export const openPrsListLink_ = [


### PR DESCRIPTION
## Description

Restores the conflict marker on the list view of the new PR page.
Related to:
- #10065 


## Test URLs
https://github.com/refined-github/sandbox/pulls?q=is%3Apr+state%3Aopen+conflict

## Screenshot
<img width="534" height="177" alt="image" src="https://github.com/user-attachments/assets/ce9d0695-8518-4fa6-8404-819dd1d7f06e" />
