### PR TITLE
Fix font mismatch in new pull request search box

### DIFF
--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -2,7 +2,9 @@
 /* Use same font-family as GitHub style for `code` */
 
 /* Test URL: https://github.com/refined-github/sandbox/pull/16 */
-[class^='prc-PageLayout-Header'] input,
+/* Test URL: https://github.com/refined-github/refined-github/pulls */
+/* Only PR headers: list headers also contain a search input with a separate text overlay. */
+[class^='prc-PageLayout-Header']:has(.js-pull-header-details) input,
 [data-testid='mergebox-partial'] input[type='text'],
 /* Test URL: https://github.com/refined-github/sandbox/compare/default-a...new?expand=1 */
 input[name='pull_request[title]'],


### PR DESCRIPTION
# Description

The monospacing was adding extra padding to the cursor in the search window. This made editing searches really disorienting, as your text appeared behind the cursor
Before:
<img width="966" height="85" alt="image" src="https://github.com/user-attachments/assets/1cb5f778-bdd7-436e-ae89-6b0a21f8ec68" />

Related to:
- #10065 

## Test URLs
https://github.com/refined-github/sandbox/pulls?q=is%3Apr+is%3Aopen+try+to+add+anything+here

## Screenshot
<img width="966" height="85" alt="image" src="https://github.com/user-attachments/assets/9b5ce95e-2022-4d15-8385-42586aed3f94" />
Monospace still appearing where it should:
<img width="1145" height="99" alt="image" src="https://github.com/user-attachments/assets/e3aef441-a6da-4531-ba38-a00ddfa9a3b5" />

