### PR TITLE
`monospace-textareas` - Exclude PR search box

### DIFF
--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -1,8 +1,10 @@
 /* Use monospace font in various fields */
 /* Use same font-family as GitHub style for `code` */
 
-/* Test URL: https://github.com/refined-github/sandbox/pull/16 */
-[class^='prc-PageLayout-Header'] input,
+/* PR title input: https://github.com/refined-github/sandbox/pull/16 */
+/* `form` excludes PR lists #10064 */
+[class^='prc-PageLayout-Header'] form input,
+/* Merge commit title input: https://github.com/refined-github/sandbox/pull/16 */
 [data-testid='mergebox-partial'] input[type='text'],
 /* Test URL: https://github.com/refined-github/sandbox/compare/default-a...new?expand=1 */
 input[name='pull_request[title]'],


### PR DESCRIPTION
- fixes https://github.com/refined-github/refined-github/issues/10064
- closes https://github.com/refined-github/refined-github/pull/10077


## Test URLs

https://github.com/refined-github/refined-github/pulls


## Before


<img width="272" height="71" alt="Screenshot" src="https://github.com/user-attachments/assets/5c20fa76-2de4-43b7-8e99-76221a7bfbb9" />

## After

<img width="272" height="71" alt="Screenshot" src="https://github.com/user-attachments/assets/bbcb5eaa-4aa8-4a91-a6df-3f09c4a7ca1d" />

