### PR TITLE
AI SPAM

### DIFF
--- a/source/features/mark-pinned.tsx
+++ b/source/features/mark-pinned.tsx
@@ -10,8 +10,8 @@ import observe from '../helpers/selector-observer.js';
 import {issueIcons} from './select-notifications.js';
 
 function mark(issueLink: HTMLAnchorElement): void {
-	// The href attribute in the pinned issue list contains the absolute URL
-	if (!elementExists(`[class*='PinnedIssues-module__container'] a[href="${issueLink.href}"]`)) {
+	// The href attribute in the pinned issue list may be relative or absolute, so match by pathname
+	if (!elementExists(`[class*='PinnedIssues-module__container'] a[href$="${issueLink.pathname}"]`)) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- `mark-pinned` stopped highlighting pinned issues in the issue list.
- GitHub's issue list now renders pinned-issue links with relative `href` values instead of absolute URLs.
- The feature matched pinned links with an exact `href="${issueLink.href}"` selector, where `issueLink.href` is the DOM-resolved absolute URL — so it never matched the relative href anymore.
- Fix: match by `issueLink.pathname` using an ends-with selector (`href$=`), which works for both relative and absolute hrefs.

Fixes #10081

## Test plan
- [ ] Visit an issues list with pinned issues and confirm the pin icon reappears on matching rows