### PR TITLE
AI SPAM

### DIFF
--- a/source/helpers/portal.ts
+++ b/source/helpers/portal.ts
@@ -1,7 +1,22 @@
 import type {Action} from 'svelte/action';
 
 const portal: Action<HTMLElement, () => Element> = (node, getTarget) => {
-	function move(): void {
+	let destroyed = false;
+
+	async function move(): Promise<void> {
+		if (!node.isConnected) {
+			// Some features attach their element to the DOM asynchronously (e.g. after a fetch),
+			// so the node might not be connected yet by the time this microtask runs.
+			// Give it one more frame before giving up.
+			await new Promise(resolve => {
+				requestAnimationFrame(resolve);
+			});
+		}
+
+		if (destroyed) {
+			return;
+		}
+
 		if (!node.isConnected) {
 			// This is a requirement for `tool-tip`
 			// https://github.com/refined-github/refined-github/pull/9668
@@ -12,13 +27,16 @@ const portal: Action<HTMLElement, () => Element> = (node, getTarget) => {
 	}
 
 	if (node.isConnected) {
-		move();
+		void move();
 	} else {
-		queueMicrotask(move);
+		queueMicrotask(() => {
+			void move();
+		});
 	}
 
 	return {
 		destroy() {
+			destroyed = true;
 			node.remove();
 		},
 	};


### PR DESCRIPTION
## Summary
- The \`portal\` action powering \`tool-tip\` throws \`The element was not added to the document in time\` whenever the node isn't connected by the time the queued microtask runs.
- Several features attach the element that hosts the tooltip to the DOM asynchronously (after a fetch, mutation observer callback, etc.), so the node can legitimately still be disconnected right after the microtask, even though it gets attached a moment later.
- Give the node one extra animation frame before treating it as a real failure, and guard \`move()\` against the action having been destroyed in the meantime (since it's now async).

Fixes #10071

## Test plan
- [ ] Visit https://github.com/dotnet/efcore/issues/12088 (repro from the issue) and confirm the error no longer appears in the console
- [ ] Confirm tooltips still render normally on regular issue/PR pages